### PR TITLE
Fix BT paired icon is not displayed on the New User's status bar

### DIFF
--- a/android_p/google_diff/cel_apl/packages/apps/Bluetooth/0003-Fix-BT-paired-icon-is-not-displayed-on-the-New-User-.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Bluetooth/0003-Fix-BT-paired-icon-is-not-displayed-on-the-New-User-.patch
@@ -1,0 +1,41 @@
+From 541268527632570e6b318aa7c5f4ffc093c5aac2 Mon Sep 17 00:00:00 2001
+From: "Yue, VincentX" <vincentx.yue@intel.com>
+Date: Fri, 12 Jan 2018 17:43:21 +0800
+Subject: [PATCH] Fix BT paired icon is not displayed on the New User's status
+ bar
+
+When switch to new user, systemUI is owner process, unable to
+get the bluetooth connectition device update information throung broadcast.
+so, send the connection information to all user like intent ACTION_CONNECTION_STATE_CHANGED.
+
+Tracked-On:OAM-67838
+
+Signed-off-by: Yue, VincentX <vincentx.yue@intel.com>
+---
+ src/com/android/bluetooth/hfpclient/HeadsetClientStateMachine.java | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/bluetooth/hfpclient/HeadsetClientStateMachine.java b/src/com/android/bluetooth/hfpclient/HeadsetClientStateMachine.java
+index 844c470..5db6baf 100644
+--- a/src/com/android/bluetooth/hfpclient/HeadsetClientStateMachine.java
++++ b/src/com/android/bluetooth/hfpclient/HeadsetClientStateMachine.java
+@@ -49,6 +49,7 @@ import android.os.Message;
+ import android.os.ParcelUuid;
+ import android.os.SystemClock;
+ import android.support.annotation.VisibleForTesting;
++import android.os.UserHandle;
+ import android.util.Log;
+ import android.util.Pair;
+ 
+@@ -1806,7 +1807,7 @@ public class HeadsetClientStateMachine extends StateMachine {
+                 intent.putExtra(BluetoothHeadsetClient.EXTRA_AG_FEATURE_MERGE_AND_DETACH, true);
+             }
+         }
+-        mService.sendBroadcast(intent, ProfileService.BLUETOOTH_PERM);
++        mService.sendBroadcastAsUser(intent, UserHandle.ALL, ProfileService.BLUETOOTH_PERM);
+     }
+ 
+     boolean isConnected() {
+-- 
+1.9.1
+


### PR DESCRIPTION
    When switch to new user, systemUI is owner process, unable to
    get the bluetooth connectition device update information throung broadcast.
    so, send the connection information to all user like intent ACTION_CONNECTION_STATE_CHANGED.

    Tracked-On:OAM-67838

    Signed-off-by: Yue, VincentX <vincentx.yue@intel.com>