### PR TITLE
Add DISALLOW_ADD_USER restriction for default user and guest user

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0011-Add-DISALLOW_ADD_USER-restriction-for-default-user-a.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0011-Add-DISALLOW_ADD_USER-restriction-for-default-user-a.patch
@@ -1,0 +1,39 @@
+Add DISALLOW_ADD_USER restriction for default user and
+ guest user
+
+The default user and guest user is missing DISALLOW_ADD_USER restriction,
+lead to canCurrentProcessAddUsers() always return true. So add DISALLOW_ADD_USER
+restriction for default user and guest user.
+
+---
+ core/java/android/os/UserManager.java                            | 1 +
+ services/core/java/com/android/server/pm/UserManagerService.java | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/core/java/android/os/UserManager.java b/core/java/android/os/UserManager.java
+index b591851..ed315bf 100644
+--- a/core/java/android/os/UserManager.java
++++ b/core/java/android/os/UserManager.java
+@@ -1821,6 +1821,7 @@ public class UserManager {
+             if (user != null && !user.isAdmin() && !user.isDemo()) {
+                 mService.setUserRestriction(DISALLOW_SMS, true, user.id);
+                 mService.setUserRestriction(DISALLOW_OUTGOING_CALLS, true, user.id);
++                mService.setUserRestriction(DISALLOW_ADD_USER, true, user.id);
+             }
+         } catch (RemoteException re) {
+             throw re.rethrowFromSystemServer();
+diff --git a/services/core/java/com/android/server/pm/UserManagerService.java b/services/core/java/com/android/server/pm/UserManagerService.java
+index 06c56a0..5c1682e 100644
+--- a/services/core/java/com/android/server/pm/UserManagerService.java
++++ b/services/core/java/com/android/server/pm/UserManagerService.java
+@@ -1358,6 +1358,7 @@ public class UserManagerService extends IUserManager.Stub {
+                 mGuestRestrictions.putBoolean(UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES, true);
+                 mGuestRestrictions.putBoolean(UserManager.DISALLOW_OUTGOING_CALLS, true);
+                 mGuestRestrictions.putBoolean(UserManager.DISALLOW_SMS, true);
++                mGuestRestrictions.putBoolean(UserManager.DISALLOW_ADD_USER, true);
+             }
+         }
+     }
+-- 
+1.9.1
+


### PR DESCRIPTION
The default user and guest user is missing DISALLOW_ADD_USER restriction,
lead to canCurrentProcessAddUsers() always return true. So add DISALLOW_ADD_USER
restriction for default user and guest user.

Tracked-On: OAM-67841