### PR TITLE
Add DISALLOW_ADD_USER restriction for default user and guest user

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0011-CELADON-Add-DISALLOW_ADD_USER-restriction-for-defaul.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0011-CELADON-Add-DISALLOW_ADD_USER-restriction-for-defaul.patch
@@ -1,10 +1,11 @@
-Add DISALLOW_ADD_USER restriction for default user and
- guest user
+From e3240ca5886bef6c5c77465b6ad6cd046b51adf3 Mon Sep 17 00:00:00 2001
+From: Swaroop Balan <swaroop.balan@intel.com>
+Date: Wed, 5 Sep 2018 15:06:48 +0530
+Subject: [PATCH] [CELADON] Add DISALLOW_ADD_USER restriction for default user
+ and  guest user
 
-The default user and guest user is missing DISALLOW_ADD_USER restriction,
-lead to canCurrentProcessAddUsers() always return true. So add DISALLOW_ADD_USER
-restriction for default user and guest user.
-
+Change-Id: I5b2b9a9888f51c657682fa8afe1755e8b4d52845
+Tracked-On: None
 ---
  core/java/android/os/UserManager.java                            | 1 +
  services/core/java/com/android/server/pm/UserManagerService.java | 1 +


### PR DESCRIPTION
The default user and guest user is missing DISALLOW_ADD_USER restriction,
lead to canCurrentProcessAddUsers() always return true. So add DISALLOW_ADD_USER
restriction for default user and guest user.

Tracked-On: OAM-67841