### PR TITLE
Fix issue that the position of QuickSetting is improper on DUT (IVI)

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0012-Fix-issue-that-the-position-of-QuickSetting-is-impro.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0012-Fix-issue-that-the-position-of-QuickSetting-is-impro.patch
@@ -1,0 +1,48 @@
+From 95e6f152de386978b3d2a6702699804ff44686c6 Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Fri, 3 Aug 2018 16:04:48 +0800
+Subject: [PATCH] Fix issue that the position of QuickSetting is improper on
+ DUT (IVI)
+
+NotificationPanelView uses the width of notification stack Scroller to
+estimate if notification stack Scroller and QuickSetting to be applied
+the offset. That may cause the position of QuickSetting is improper if
+the width of notification stack Scroller is smaller than the width of
+QuickSetting.
+
+The solution is that comparing the width of notification stack Scroller
+with the width of QuickSetting and using the larger one to estimate if
+notification stack Scroller and QuickSetting to be applied the offset.
+
+Test:
+1. Click on the top right of Status Bar.
+2. Show notifications
+
+Tracked-On: OAM-67772
+
+Change-Id: I5039d0ae24f93ca4d9e3b412ea257773372adad9
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ .../com/android/systemui/statusbar/phone/NotificationPanelView.java | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
+index 2f18aad..70219c5 100644
+--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
++++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
+@@ -2469,7 +2469,11 @@ public class NotificationPanelView extends PanelView implements
+      * @param x the x-coordinate the touch event
+      */
+     protected void updateVerticalPanelPosition(float x) {
+-        if (mNotificationStackScroller.getWidth() * 1.75f > getWidth()) {
++        int width = mQsFrame.getWidth();
++        if (width < mNotificationStackScroller.getWidth()) {
++            width = mNotificationStackScroller.getWidth();
++        }
++        if (width * 1.75f > getWidth()) {
+             resetVerticalPanelPosition();
+             return;
+         }
+-- 
+1.9.1
+


### PR DESCRIPTION
NotificationPanelView uses the width of notification stack Scroller to
estimate if notification stack Scroller and QuickSetting to be applied
the offset. That may cause the position of QuickSetting is improper if
the width of notification stack Scroller is smaller than the width of
QuickSetting.

The solution is that comparing the width of notification stack Scroller
with the width of QuickSetting and using the larger one to estimate if
notification stack Scroller and QuickSetting to be applied the offset.

Test:
1. Click on the top right of Status Bar.
2. Show notifications

Tracked-On: OAM-67772

Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>