### PR TITLE
Keep statusBar window height same with SystemUI statusBar height

### DIFF
--- a/android_p/google_diff/cel_apl/packages/services/Car/0003-Keep-statusBar-window-height-same-with-SystemUI-stat.patch
+++ b/android_p/google_diff/cel_apl/packages/services/Car/0003-Keep-statusBar-window-height-same-with-SystemUI-stat.patch
@@ -1,0 +1,57 @@
+From e02cb40c3bfb11419c938358eb774cc08efb9d17 Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Thu, 26 Jul 2018 11:52:08 +0800
+Subject: [PATCH] Keep statusBar window height same with SystemUI statusBar
+ height
+
+status_bar_height is use for set systemUI statusBar view height.
+status_bar_height_landscape and status_bar_height_portrait are use for
+setting statusBar window height.
+
+Test: Observer the statusBar height at a 1080P display
+
+Tracked-On: OAM-67784
+
+Change-Id: I8f4f13b7a8f9f8ed32e01aaf8918e6b1756a16fa
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ .../overlay/frameworks/base/core/res/res/values-w1920dp/dimens.xml  | 6 +++++-
+ car_product/overlay/frameworks/base/core/res/res/values/dimens.xml  | 6 +++++-
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/car_product/overlay/frameworks/base/core/res/res/values-w1920dp/dimens.xml b/car_product/overlay/frameworks/base/core/res/res/values-w1920dp/dimens.xml
+index dcb92dc..623ef05 100644
+--- a/car_product/overlay/frameworks/base/core/res/res/values-w1920dp/dimens.xml
++++ b/car_product/overlay/frameworks/base/core/res/res/values-w1920dp/dimens.xml
+@@ -15,6 +15,10 @@
+ -->
+ 
+ <resources>
+-    <dimen name="status_bar_height">56dp</dimen>
++    <dimen name="status_bar_height">@dimen/status_bar_height_portrait</dimen>
++    <!-- Height of the status bar in portrait -->
++    <dimen name="status_bar_height_portrait">56dp</dimen>
++    <!-- Height of the status bar in landscape -->
++    <dimen name="status_bar_height_landscape">@dimen/status_bar_height_portrait</dimen>
+     <dimen name="car_keyline_4">184dp</dimen>
+ </resources>
+diff --git a/car_product/overlay/frameworks/base/core/res/res/values/dimens.xml b/car_product/overlay/frameworks/base/core/res/res/values/dimens.xml
+index 2adc535..54fbcb9 100644
+--- a/car_product/overlay/frameworks/base/core/res/res/values/dimens.xml
++++ b/car_product/overlay/frameworks/base/core/res/res/values/dimens.xml
+@@ -17,7 +17,11 @@
+ */
+ -->
+ <resources>
+-    <dimen name="status_bar_height">36dp</dimen>
++    <dimen name="status_bar_height">@dimen/status_bar_height_portrait</dimen>
++    <!-- Height of the status bar in portrait -->
++    <dimen name="status_bar_height_portrait">36dp</dimen>
++    <!-- Height of the status bar in landscape -->
++    <dimen name="status_bar_height_landscape">@dimen/status_bar_height_portrait</dimen>
+ 
+     <!-- Both of these are used in separate positions so make sure that they remain the same. -->
+     <dimen name="navigation_bar_height_car_mode">112dp</dimen>
+-- 
+1.9.1
+


### PR DESCRIPTION
status_bar_height is use for set systemUI statusBar view height.
status_bar_height_landscape and status_bar_height_portrait are use for
setting statusBar window height.

Test: Observer the statusBar height at a 1080P display

Tracked-On: OAM-67784

Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>