### PR TITLE
Fix duration time incorrect by new format.

### DIFF
--- a/android_p/google_diff/cel_apl/packages/apps/Car/Media/0001-Fix-duration-time-incorrect-by-new-format.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Car/Media/0001-Fix-duration-time-incorrect-by-new-format.patch
@@ -1,0 +1,96 @@
+From 1dc1b77194a15f3f3cbe1c246a6dcf0a587a201e Mon Sep 17 00:00:00 2001
+From: "Yan, WalterX" <walterx.yan@intel.com>
+Date: Thu, 6 Sep 2018 19:05:59 +0800
+Subject: [PATCH] Fix duration time incorrect by new format.
+
+Duration time is not date format, using h:mm:ss to format it.
+
+Tracked-On: OAM-68261
+Signed-off-by: Yan, WalterX <walterx.yan@intel.com>
+---
+ res/layout/metadata_normal.xml                    |  4 ++--
+ src/com/android/car/media/MetadataController.java | 25 +++++++++++++++--------
+ 2 files changed, 19 insertions(+), 10 deletions(-)
+
+diff --git a/res/layout/metadata_normal.xml b/res/layout/metadata_normal.xml
+index c0e414e..9757507 100644
+--- a/res/layout/metadata_normal.xml
++++ b/res/layout/metadata_normal.xml
+@@ -50,7 +50,7 @@
+         tools:text="Body 2"/>
+     <TextView
+         android:id="@+id/time"
+-        android:layout_width="160dp"
++        android:layout_width="220dp"
+         android:layout_height="wrap_content"
+         android:layout_marginTop="@dimen/car_padding_1"
+         android:ellipsize="end"
+@@ -60,7 +60,7 @@
+         android:textAppearance="@style/TextAppearance.Car.Body2.Light"
+         app:layout_constraintEnd_toEndOf="parent"
+         app:layout_constraintTop_toBottomOf="@+id/title"
+-        tools:text="3:27 / 4:03"/>
++        tools:text="10:03:27 / 11:04:03"/>
+     <SeekBar
+         android:id="@+id/seek_bar"
+         android:layout_width="match_parent"
+diff --git a/src/com/android/car/media/MetadataController.java b/src/com/android/car/media/MetadataController.java
+index 59e4d9d..ce74b52 100644
+--- a/src/com/android/car/media/MetadataController.java
++++ b/src/com/android/car/media/MetadataController.java
+@@ -12,18 +12,13 @@ import android.widget.TextView;
+ import com.android.car.media.common.MediaItemMetadata;
+ import com.android.car.media.common.PlaybackModel;
+ 
+-import java.text.DateFormat;
+-import java.text.SimpleDateFormat;
+-import java.util.Date;
+-import java.util.Locale;
++import java.time.Duration;
+ 
+ /**
+  * Common controller for displaying current track's metadata.
+  */
+ public class MetadataController {
+ 
+-    private static final DateFormat TIME_FORMAT = new SimpleDateFormat("m:ss", Locale.US);
+-
+     @NonNull
+     private final TextView mTitle;
+     @NonNull
+@@ -152,9 +147,11 @@ public class MetadataController {
+         int visibility = maxProgress > 0 && progress != PlaybackState.PLAYBACK_POSITION_UNKNOWN
+                 ? View.VISIBLE : View.INVISIBLE;
+         if (mTime != null) {
++            Duration progressDuration = Duration.ofMillis(progress);
++            Duration maxDuration = Duration.ofMillis(maxProgress);
+             String time = String.format("%s / %s",
+-                    TIME_FORMAT.format(new Date(progress)),
+-                    TIME_FORMAT.format(new Date(maxProgress)));
++                    formatDuration(progressDuration, maxDuration.toHours() > 0),
++                    formatDuration(maxDuration, false));
+             mTime.setVisibility(visibility);
+             mTime.setText(time);
+         }
+@@ -163,6 +160,18 @@ public class MetadataController {
+         mSeekBar.setProgress((int) progress);
+     }
+ 
++    private static String formatDuration(Duration duration, boolean forceShowHours) {
++        long seconds = duration.getSeconds();
++
++        long h = duration.toHours();
++        long m = (seconds % 3600) / 60;
++        long s = seconds % 60;
++
++        return ( forceShowHours || h > 0 ) ?
++                String.format("%d:%02d:%02d", h, m, s) :
++                String.format("%02d:%02d", m, s);
++    }
++
+ 
+     public void pauseUpdates() {
+         mUpdatesPaused = true;
+-- 
+1.9.1
+


### PR DESCRIPTION
Duration time is not date format, using h:mm:ss to format it.

Tracked-On: OAM-68261
Signed-off-by: Yan, WalterX <walterx.yan@intel.com>