### PR TITLE
Fix can't drag in car setting sound

### DIFF
--- a/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0001-Fix-can-t-drag-in-car-setting-sound.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0001-Fix-can-t-drag-in-car-setting-sound.patch
@@ -1,0 +1,87 @@
+From 6b61d7cb86862a9491303a8cde559e566238f1cd Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Mon, 30 Jul 2018 16:14:01 +0800
+Subject: [PATCH] Fix can't drag in car setting sound
+
+The adapter notifyDataSetChanged will relayout UI.
+But the SoundSettingsFragment called notifyDataSetChanged while receiving
+a volume size change. Lead to the AbsSeekBar get MotionEvent.ACTION_CANCEL.
+
+Test:
+1. Go to car settings->sound
+2. Adjust a item by dragging
+3. Expected volume adjustment should happen when dragging
+
+Tracked-On: OAM-67867
+
+Change-Id: I3f193100917e363ffe491f49d6d8c030e50fe4df
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ src/com/android/car/settings/sound/SoundSettingsFragment.java | 6 +++++-
+ src/com/android/car/settings/sound/VolumeLineItem.java        | 9 +++++++--
+ 2 files changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/src/com/android/car/settings/sound/SoundSettingsFragment.java b/src/com/android/car/settings/sound/SoundSettingsFragment.java
+index b1bf654..6713f41 100644
+--- a/src/com/android/car/settings/sound/SoundSettingsFragment.java
++++ b/src/com/android/car/settings/sound/SoundSettingsFragment.java
+@@ -99,13 +99,17 @@ public class SoundSettingsFragment extends BaseFragment {
+     private final ICarVolumeCallback mVolumeChangeCallback = new ICarVolumeCallback.Stub() {
+         @Override
+         public void onGroupVolumeChanged(int groupId, int flags) {
++            boolean isDragging = false;
+             for (ListItem lineItem : mVolumeLineItems) {
+                 VolumeLineItem volumeLineItem = (VolumeLineItem) lineItem;
+                 if (volumeLineItem.getVolumeGroupId() == groupId) {
+                     volumeLineItem.updateProgress();
+                 }
++                isDragging |= volumeLineItem.getIsDragging();
++            }
++            if(!isDragging) {
++                updateList();
+             }
+-            updateList();
+         }
+ 
+         @Override
+diff --git a/src/com/android/car/settings/sound/VolumeLineItem.java b/src/com/android/car/settings/sound/VolumeLineItem.java
+index a628ad5..920584c 100644
+--- a/src/com/android/car/settings/sound/VolumeLineItem.java
++++ b/src/com/android/car/settings/sound/VolumeLineItem.java
+@@ -45,6 +45,7 @@ public class VolumeLineItem extends SeekbarListItem implements SeekBar.OnSeekBar
+     private final Ringtone mRingtone;
+     private final int mVolumeGroupId;
+     private final CarAudioManager mCarAudioManager;
++    private boolean mIsDragging = false;
+ 
+     public VolumeLineItem(
+             Context context,
+@@ -68,12 +69,12 @@ public class VolumeLineItem extends SeekbarListItem implements SeekBar.OnSeekBar
+ 
+     @Override
+     public void onStartTrackingTouch(SeekBar seekBar) {
+-        // no-op
++        mIsDragging = true;
+     }
+ 
+     @Override
+     public void onStopTrackingTouch(SeekBar seekBar) {
+-        // no-op
++        mIsDragging = false;
+     }
+ 
+     @Override
+@@ -110,6 +111,10 @@ public class VolumeLineItem extends SeekbarListItem implements SeekBar.OnSeekBar
+         return mVolumeGroupId;
+     }
+ 
++    public boolean getIsDragging() {
++        return mIsDragging;
++    }
++
+     /**
+      * Gets the latest progress.
+      */
+-- 
+1.9.1
+

--- a/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0002-Fix-the-time-zone-list-is-incomplete.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0002-Fix-the-time-zone-list-is-incomplete.patch
@@ -1,0 +1,34 @@
+From 9d8d35534323fc2f3b253b422ef3ba54cf624f26 Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Tue, 4 Sep 2018 14:03:14 +0800
+Subject: [PATCH] Fix the time zone list is incomplete
+
+The time zone list only display 20 items due to the PagedListView
+limits the page number of list, the default number of pages is 5,
+only 4 items can be displayed per page.
+
+Set the default number of pages to unlimited pages.
+
+Tracked-On: OAM-68129
+
+Change-Id: Iae4979cf904695f358041ff46f56cfff7f8e17f5
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ src/com/android/car/settings/common/ListItemSettingsFragment.java | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/com/android/car/settings/common/ListItemSettingsFragment.java b/src/com/android/car/settings/common/ListItemSettingsFragment.java
+index 829b1c1..d200805 100644
+--- a/src/com/android/car/settings/common/ListItemSettingsFragment.java
++++ b/src/com/android/car/settings/common/ListItemSettingsFragment.java
+@@ -51,6 +51,7 @@ public abstract class ListItemSettingsFragment extends BaseFragment implements L
+         PagedListView listView = getView().findViewById(R.id.list);
+         listView.setAdapter(mListAdapter);
+         listView.setDividerVisibilityManager(mListAdapter);
++        listView.setMaxPages(PagedListView.UNLIMITED_PAGES);
+     }
+ 
+     @Override
+-- 
+1.9.1
+


### PR DESCRIPTION
The adapter notifyDataSetChanged will relayout UI.
But the SoundSettingsFragment called notifyDataSetChanged while receiving
a volume size change. Lead to the AbsSeekBar get MotionEvent.ACTION_CANCEL.

Test:
1. Go to car settings->sound
2. Adjust a item by dragging
3. Expected volume adjustment should happen when dragging

Tracked-On: OAM-67867

Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>