### PR TITLE
Fix input wrong wait time after input wrong key

### DIFF
--- a/android_p/google_diff/cel_apl/system/gatekeeper/0001-fix-input-wrong-wait-time-after-input-wrong-key.patch
+++ b/android_p/google_diff/cel_apl/system/gatekeeper/0001-fix-input-wrong-wait-time-after-input-wrong-key.patch
@@ -1,0 +1,80 @@
+From 089663b832c545cb3b2fa5a65a66908d86e8cff1 Mon Sep 17 00:00:00 2001
+From: yingbinx <yingbinx.zeng@intel.com>
+Date: Wed, 28 Jun 2017 15:57:50 +0800
+Subject: [PATCH] [AIA]Fix input wrong wait time after input wrong key
+
+Wrong wait time after input wrong key over 5 times.
+The patch is to fix the wrong wait time after input
+wrong key.
+
+Change-Id: Id363cd01a44093ed8e6a76d4c9138882ba509511
+Tracked-On:
+Signed-off-by: yingbinx <yingbinx.zeng@intel.com>
+---
+
+diff --git a/gatekeeper.cpp b/gatekeeper.cpp
+index 5d55fc7..714528e 100644
+--- a/gatekeeper.cpp
++++ b/gatekeeper.cpp
+@@ -120,25 +120,9 @@
+ 
+     uint64_t timestamp = GetMillisecondsSinceBoot();
+ 
+-    uint32_t timeout = 0;
+     bool throttle = (password_handle->version >= HANDLE_VERSION_THROTTLE);
+     bool throttle_secure = password_handle->flags & HANDLE_FLAG_THROTTLE_SECURE;
+-    if (throttle) {
+-        failure_record_t record;
+-        if (!GetFailureRecord(uid, user_id, &record, throttle_secure)) {
+-            response->error = ERROR_UNKNOWN;
+-            return;
+-        }
+-
+-        if (ThrottleRequest(uid, timestamp, &record, throttle_secure, response)) return;
+-
+-        if (!IncrementFailureRecord(uid, user_id, timestamp, &record, throttle_secure)) {
+-            response->error = ERROR_UNKNOWN;
+-            return;
+-        }
+-
+-        timeout = ComputeRetryTimeout(&record);
+-    } else {
++    if (!throttle) {
+         response->request_reenroll = true;
+     }
+ 
+@@ -155,8 +139,23 @@
+         if (throttle) ClearFailureRecord(uid, user_id, throttle_secure);
+     } else {
+         // compute the new timeout given the incremented record
+-        if (throttle && timeout > 0) {
+-            response->SetRetryTimeout(timeout);
++        if (throttle) {
++            failure_record_t record;
++            if (!GetFailureRecord(uid, user_id, &record, throttle_secure)) {
++                response->error = ERROR_UNKNOWN;
++                return;
++            }
++
++
++            if (!IncrementFailureRecord(uid, user_id, timestamp, &record, throttle_secure)) {
++                response->error = ERROR_UNKNOWN;
++                return;
++            }
++
++            if (ThrottleRequest(uid, timestamp, &record, throttle_secure, response)) {
++                return;
++            }
++            //response->SetRetryTimeout(timeout);
+         } else {
+             response->error = ERROR_INVALID;
+         }
+@@ -282,7 +281,7 @@
+         // we have a pending timeout
+         if (timestamp < last_checked + timeout && timestamp > last_checked) {
+             // attempt before timeout expired, return remaining time
+-            response->SetRetryTimeout(timeout - (timestamp - last_checked));
++            response->SetRetryTimeout(timeout - (uint32_t)(timestamp - last_checked));
+             return true;
+         } else if (timestamp <= last_checked) {
+             // device was rebooted or timer reset, don't count as new failure but


### PR DESCRIPTION
Wrong wait time after input wrong key over 5 times.
The patch is to fix the wrong wait time after input
wrong key.

Test: Boot to android GUI
Tracked-On: OAM-68280
Signed-off-by: yingbinx <yingbinx.zeng@intel.com>