### PR TITLE
Fix the audio rack is not removed from notification after pause music.

### DIFF
--- a/android_p/google_diff/cel_apl/packages/apps/Car/LocalMediaPlayer/0002-Fix-the-audio-rack-is-not-removed-from-notification-.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Car/LocalMediaPlayer/0002-Fix-the-audio-rack-is-not-removed-from-notification-.patch
@@ -1,0 +1,32 @@
+From a6f6a441155e56bcd75bbcfe107f1c25036a0cb2 Mon Sep 17 00:00:00 2001
+From: "Yan, WalterX" <walterx.yan@intel.com>
+Date: Mon, 10 Sep 2018 16:56:34 +0800
+Subject: [PATCH] Fix the audio rack is not removed from notification after
+ pause music.
+
+When paused, to remove the notification should be allowed.
+
+Tracked-On: OAM-68130
+Signed-off-by: Yan, WalterX <walterx.yan@intel.com>
+---
+ src/com/android/car/media/localmediaplayer/Player.java | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/car/media/localmediaplayer/Player.java b/src/com/android/car/media/localmediaplayer/Player.java
+index 0aade15..58862bb 100644
+--- a/src/com/android/car/media/localmediaplayer/Player.java
++++ b/src/com/android/car/media/localmediaplayer/Player.java
+@@ -363,7 +363,9 @@ public class Player extends MediaSession.Callback {
+                 .setContentText(current.getSubtitle())
+                 .setShowWhen(false)
+                 .build();
+-        notification.flags |= Notification.FLAG_NO_CLEAR;
++        if(builder != mPausedNotificationBuilder) {
++            notification.flags |= Notification.FLAG_NO_CLEAR;
++        }
+         mNotificationManager.notify(NOTIFICATION_ID, notification);
+     }
+ 
+-- 
+1.9.1
+


### PR DESCRIPTION
When paused, to remove the notification should be allowed.

Tracked-On: OAM-68130
Signed-off-by: Yan, WalterX <walterx.yan@intel.com>