### PR TITLE
Fix the audio and video flicker problem when seeking.

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/av/0003-Fix-the-flicker-on-single-touch.patch
+++ b/android_p/google_diff/cel_apl/frameworks/av/0003-Fix-the-flicker-on-single-touch.patch
@@ -1,0 +1,56 @@
+From 32afa3a87d9f2e641358bf797845395b2dd0fd2d Mon Sep 17 00:00:00 2001
+From: Jin Xue <jin.xue@intel.com>
+Date: Tue, 22 May 2018 15:00:38 +0800
+Subject: [PATCH] Fix the flicker on single touch
+
+Filter out the dupliate call to seekTo with the same seek time
+when seeking with a "touch and leave" manner.
+
+Tracked-On: OAM-68571
+Signed-off-by: Jin Xue <jin.xue@intel.com>
+Signed-off-by: Yan, WalterX <walterx.yan@intel.com>
+---
+ media/libmedia/include/media/mediaplayer.h | 1 +
+ media/libmedia/mediaplayer.cpp             | 7 +++++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/media/libmedia/include/media/mediaplayer.h b/media/libmedia/include/media/mediaplayer.h
+index 2335c5a..3b235ee 100644
+--- a/media/libmedia/include/media/mediaplayer.h
++++ b/media/libmedia/include/media/mediaplayer.h
+@@ -294,6 +294,7 @@ private:
+     int                         mCurrentPosition;
+     MediaPlayerSeekMode         mCurrentSeekMode;
+     int                         mSeekPosition;
++    int                         mSeekTime;
+     MediaPlayerSeekMode         mSeekMode;
+     bool                        mPrepareSync;
+     status_t                    mPrepareStatus;
+diff --git a/media/libmedia/mediaplayer.cpp b/media/libmedia/mediaplayer.cpp
+index 26908e5..e53361b 100644
+--- a/media/libmedia/mediaplayer.cpp
++++ b/media/libmedia/mediaplayer.cpp
+@@ -60,6 +60,7 @@ MediaPlayer::MediaPlayer()
+     mCurrentPosition = -1;
+     mCurrentSeekMode = MediaPlayerSeekMode::SEEK_PREVIOUS_SYNC;
+     mSeekPosition = -1;
++    mSeekTime = -1;
+     mSeekMode = MediaPlayerSeekMode::SEEK_PREVIOUS_SYNC;
+     mCurrentState = MEDIA_PLAYER_IDLE;
+     mPrepareSync = false;
+@@ -584,6 +585,12 @@ status_t MediaPlayer::seekTo_l(int msec, MediaPlayerSeekMode mode)
+ 
+ status_t MediaPlayer::seekTo(int msec, MediaPlayerSeekMode mode)
+ {
++    if (mSeekTime == msec) {
++        ALOGW("Duplicate seek time: %d", msec);
++        return NO_ERROR;
++    } else {
++        mSeekTime = msec;
++    }
+     mLockThreadId = getThreadId();
+     Mutex::Autolock _l(mLock);
+     status_t result = seekTo_l(msec, mode);
+-- 
+1.9.1
+

--- a/android_p/google_diff/cel_apl/packages/apps/Gallery2/0003-Fix-the-audio-and-video-flicker-problem-when-seeking.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Gallery2/0003-Fix-the-audio-and-video-flicker-problem-when-seeking.patch
@@ -1,0 +1,58 @@
+From 85bf66e280534012f44a7985e0431c2049fcabfe Mon Sep 17 00:00:00 2001
+From: yingzhex <yingzhenx.li@intel.com>
+Date: Wed, 23 May 2018 16:37:47 +0800
+Subject: [PATCH] Fix the audio and video flicker problem when seeking.
+
+Tracked-On: OAM-68571
+Signed-off-by: yingzhex <yingzhenx.li@intel.com>
+Signed-off-by: Yan, WalterX <walterx.yan@intel.com>
+---
+ src/com/android/gallery3d/app/CommonControllerOverlay.java | 7 +++++++
+ src/com/android/gallery3d/app/MoviePlayer.java             | 6 ++++++
+ 2 files changed, 13 insertions(+)
+
+diff --git a/src/com/android/gallery3d/app/CommonControllerOverlay.java b/src/com/android/gallery3d/app/CommonControllerOverlay.java
+index 9adb4e7..97085b9 100644
+--- a/src/com/android/gallery3d/app/CommonControllerOverlay.java
++++ b/src/com/android/gallery3d/app/CommonControllerOverlay.java
+@@ -132,6 +132,13 @@ public abstract class CommonControllerOverlay extends FrameLayout implements
+         return view;
+     }
+ 
++    public boolean getPlayingState() {
++        if(mState == State.PLAYING){
++            return true;
++        }
++        return false;
++    }
++
+     @Override
+     public void setListener(Listener listener) {
+         this.mListener = listener;
+diff --git a/src/com/android/gallery3d/app/MoviePlayer.java b/src/com/android/gallery3d/app/MoviePlayer.java
+index f6bd367..a3c478d 100644
+--- a/src/com/android/gallery3d/app/MoviePlayer.java
++++ b/src/com/android/gallery3d/app/MoviePlayer.java
+@@ -378,6 +378,9 @@ public class MoviePlayer implements
+     @Override
+     public void onSeekStart() {
+         mDragging = true;
++        if(mController.getPlayingState()){
++            mVideoView.pause();
++        }
+     }
+ 
+     @Override
+@@ -388,6 +391,9 @@ public class MoviePlayer implements
+     @Override
+     public void onSeekEnd(int time, int start, int end) {
+         mDragging = false;
++        if(mController.getPlayingState()){
++            mVideoView.start();
++        }
+         mVideoView.seekTo(time);
+         setProgress();
+     }
+-- 
+1.9.1
+


### PR DESCRIPTION
1. Fix the audio and video flicker problem when seeking.
2. Filter out the dupliate call to seekTo with the same
seek time when seeking with a "touch and leave" manner.

Tracked-On: OAM-68571
Signed-off-by: Yan, WalterX <walterx.yan@intel.com>