### PR TITLE
[CELADON] Fix the time zone list is incomplete

### DIFF
--- a/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0001-Fix-the-time-zone-list-is-incomplete.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0001-Fix-the-time-zone-list-is-incomplete.patch
@@ -1,0 +1,33 @@
+From 70a2f84caccff5f5dbcfd16b2e4b12c8cc67fb11 Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Tue, 4 Sep 2018 14:03:14 +0800
+Subject: [PATCH] Fix the time zone list is incomplete
+
+The time zone list only display 20 items due to the PagedListView
+limits the page number of list, the default number of pages is 5,
+only 4 items can be displayed per page.
+
+Set the default number of pages to unlimited pages.
+
+Change-Id: I0fa48d0e2ae819565d10381283e6e0f8e231410b
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-68101
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ src/com/android/car/settings/common/ListItemSettingsFragment.java | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/com/android/car/settings/common/ListItemSettingsFragment.java b/src/com/android/car/settings/common/ListItemSettingsFragment.java
+index 829b1c1..d200805 100644
+--- a/src/com/android/car/settings/common/ListItemSettingsFragment.java
++++ b/src/com/android/car/settings/common/ListItemSettingsFragment.java
+@@ -51,6 +51,7 @@ public abstract class ListItemSettingsFragment extends BaseFragment implements L
+         PagedListView listView = getView().findViewById(R.id.list);
+         listView.setAdapter(mListAdapter);
+         listView.setDividerVisibilityManager(mListAdapter);
++        listView.setMaxPages(PagedListView.UNLIMITED_PAGES);
+     }
+ 
+     @Override
+-- 
+1.9.1
+


### PR DESCRIPTION
Add the padding between Button3(NeutralButton) and Button2(NegativeButton),
avoiding these two buttons display so closely.

Tracked-On: OAM-67832
Signed-off-by: Swaroop Balan <swaroop.balan@intel.com>