### PR TITLE
trusty: Add fix for L1TF and refine clang build

### DIFF
--- a/android_p/google_diff/cel_apl/trusty/external/lk/0001-x64-64-enabling-patch-for-google-diff.patch
+++ b/android_p/google_diff/cel_apl/trusty/external/lk/0001-x64-64-enabling-patch-for-google-diff.patch
@@ -1,10 +1,9 @@
-From a8db1faa226fef84693903d05d1adacc0dab7c75 Mon Sep 17 00:00:00 2001
+From a641dd35bc4baf83d50749d15b24407aa6096423 Mon Sep 17 00:00:00 2001
 From: Zhong,Fangjian <fangjian.zhong@intel.com>
 Date: Mon, 23 Apr 2018 08:20:33 +0800
 Subject: [PATCH] x64-64 enabling patch for Google diff
 
 Change-Id: I2b4c0d513d24b6d913d0273a31ee5f2485d9a76b
-Tracked-On: https://jira01.devtools.intel.com/browse/OAM-63646
 Signed-off-by: Zhong,Fangjian <fangjian.zhong@intel.com>
 ---
 
@@ -126,7 +125,7 @@ index f06d1a3..27d280c 100644
  {
      . = %KERNEL_BASE% + %KERNEL_LOAD_OFFSET%;
 diff --git a/arch/x86/64/mmu.c b/arch/x86/64/mmu.c
-index 60a10c8..f09ee74 100644
+index 60a10c8..006abf3 100644
 --- a/arch/x86/64/mmu.c
 +++ b/arch/x86/64/mmu.c
 @@ -1,6 +1,6 @@
@@ -247,7 +246,31 @@ index 60a10c8..f09ee74 100644
          }
  
          update_pd_entry(vaddr, pdpe, X86_VIRT_TO_PHYS(m), get_x86_arch_flags(mmu_flags));
-@@ -569,6 +605,11 @@
+@@ -481,7 +517,7 @@
+ static void x86_mmu_unmap_entry(vaddr_t vaddr, int level, vaddr_t table_entry)
+ {
+     uint32_t offset = 0, next_level_offset = 0;
+-    vaddr_t *table, *next_table_addr, value;
++    vaddr_t *table, *next_table_addr;
+ 
+     LTRACEF("vaddr 0x%lx level %d table_entry 0x%lx\n", vaddr, level, table_entry);
+ 
+@@ -545,12 +581,10 @@
+         }
+         pmm_free_page(paddr_to_vm_page(X86_VIRT_TO_PHYS(next_table_addr)));
+     }
+-    /* All present bits for all entries in next level table for this address are 0 */
++    /* zero PTE to avoid L1TF issue */
+     if ((X86_PHYS_TO_VIRT(table[offset]) & X86_MMU_PG_P) != 0) {
+         arch_disable_ints();
+-        value = table[offset];
+-        value = value & X86_PTE_NOT_PRESENT;
+-        table[offset] = value;
++        table[offset] = 0;
+         arch_enable_ints();
+     }
+ }
+@@ -569,6 +603,11 @@
      next_aligned_v_addr = vaddr;
      while (count > 0) {
          x86_mmu_unmap_entry(next_aligned_v_addr, X86_PAGING_LEVELS, pml4);
@@ -259,7 +282,7 @@ index 60a10c8..f09ee74 100644
          next_aligned_v_addr += PAGE_SIZE;
          count--;
      }
-@@ -589,8 +630,8 @@
+@@ -589,8 +628,8 @@
      if (count == 0)
          return NO_ERROR;
  
@@ -270,7 +293,7 @@ index 60a10c8..f09ee74 100644
  
      return (x86_mmu_unmap(X86_PHYS_TO_VIRT(current_cr3_val), vaddr, count));
  }
-@@ -648,17 +689,15 @@
+@@ -648,17 +687,15 @@
  
      DEBUG_ASSERT(aspace);
  
@@ -292,7 +315,7 @@ index 60a10c8..f09ee74 100644
      LTRACEF("paddr 0x%llx\n", last_valid_entry);
  
      /* converting x86 arch specific flags to arch mmu flags */
-@@ -686,8 +725,8 @@
+@@ -686,8 +723,8 @@
      if (count == 0)
          return NO_ERROR;
  
@@ -303,7 +326,7 @@ index 60a10c8..f09ee74 100644
  
      range.start_vaddr = vaddr;
      range.start_paddr = paddr;
-@@ -714,9 +753,9 @@
+@@ -714,9 +751,9 @@
      x86_set_cr4(cr4);
  
      /* Set NXE bit in MSR_EFER*/
@@ -316,7 +339,7 @@ index 60a10c8..f09ee74 100644
  
      /* getting the address width from CPUID instr */
      /* Bits 07-00: Physical Address width info */
-@@ -730,12 +769,25 @@
+@@ -730,6 +767,8 @@
      /* unmap the lower identity mapping */
      pml4[0] = 0;
  
@@ -325,42 +348,43 @@ index 60a10c8..f09ee74 100644
      /* tlb flush */
      x86_set_cr3(x86_get_cr3());
  }
- 
- void x86_mmu_init(void)
+@@ -738,16 +777,29 @@
  {
-+}
-+
+ }
+ 
+-/*
+- * x86-64 does not support multiple address spaces at the moment, so fail if these apis
+- * are used for it.
+- */
 +static paddr_t x86_create_page_table(void)
 +{
 +    addr_t *new_table = NULL;
 +
 +    new_table = (addr_t *)_map_alloc_page();
-+    DEBUG_ASSERT(new_table);
++    ASSERT(new_table);
 +    new_table[511] = pml4[511];
 +
 +    return (paddr_t)X86_VIRT_TO_PHYS(new_table);
- }
- 
- /*
-@@ -746,8 +798,15 @@
++}
++
+ status_t arch_mmu_init_aspace(arch_aspace_t *aspace, vaddr_t base, size_t size, uint flags)
  {
      DEBUG_ASSERT(aspace);
  
 -    if ((flags & ARCH_ASPACE_FLAG_KERNEL) == 0) {
 -        return ERR_NOT_SUPPORTED;
++    aspace->size = size;
++    aspace->base = base;
++
 +    if ((flags & ARCH_ASPACE_FLAG_KERNEL)) {
-+        aspace->size = size;
-+        aspace->base = base;
 +        aspace->page_table = x86_kernel_page_table;
 +    } else {
-+        aspace->size = size;
-+        aspace->base = base;
 +        if (0 == aspace->page_table)
 +            aspace->page_table = x86_create_page_table();
      }
  
      return NO_ERROR;
-@@ -755,13 +814,20 @@
+@@ -755,13 +807,20 @@
  
  status_t arch_mmu_destroy_aspace(arch_aspace_t *aspace)
  {
@@ -586,7 +610,7 @@ index 0000000..33fd918
 +    return act_len;
 +}
 diff --git a/arch/x86/arch.c b/arch/x86/arch.c
-index 721c57e..3ff2fbd 100644
+index 721c57e..cc81b93 100644
 --- a/arch/x86/arch.c
 +++ b/arch/x86/arch.c
 @@ -1,6 +1,6 @@
@@ -597,7 +621,7 @@ index 721c57e..3ff2fbd 100644
   *
   * Permission is hereby granted, free of charge, to any person obtaining
   * a copy of this software and associated documentation files
-@@ -27,6 +27,7 @@
+@@ -27,42 +27,108 @@
  #include <arch/ops.h>
  #include <arch/x86.h>
  #include <arch/x86/mmu.h>
@@ -605,8 +629,10 @@ index 721c57e..3ff2fbd 100644
  #include <arch/x86/descriptor.h>
  #include <arch/fpu.h>
  #include <arch/mmu.h>
-@@ -35,34 +36,94 @@
+ #include <platform.h>
+ #include <sys/types.h>
  #include <string.h>
++#include <assert.h>
  
  /* early stack */
 -uint8_t _kstack[PAGE_SIZE] __ALIGNED(8);
@@ -635,6 +661,7 @@ index 721c57e..3ff2fbd 100644
 +void *get_tss_base(void)
 +{
 +    volatile uint cpu = arch_curr_cpu_num();
++    ASSERT(cpu < SMP_MAX_CPUS);
 +
 +    if (cpu < SMP_MAX_CPUS)
 +        return &system_tss[cpu];
@@ -648,6 +675,9 @@ index 721c57e..3ff2fbd 100644
 +    /* Get system tss segment */
 +    tss_t *tss_base = get_tss_base();
 +    uint cpu_id = arch_curr_cpu_num();
++
++    ASSERT(tss_base);
++    ASSERT(cpu_id < SMP_MAX_CPUS);
 +
 +    addr = (uint64_t)&__tss_end - (uint64_t)(cpu_id * PAGE_SIZE);
 +
@@ -715,7 +745,7 @@ index 721c57e..3ff2fbd 100644
  
      x86_mmu_early_init();
  }
-@@ -70,6 +131,9 @@
+@@ -70,6 +136,9 @@
  void arch_init(void)
  {
      x86_mmu_init();
@@ -725,7 +755,7 @@ index 721c57e..3ff2fbd 100644
  
  #ifdef X86_WITH_FPU
      fpu_init();
-@@ -83,37 +147,40 @@
+@@ -83,37 +152,42 @@
  
  void arch_enter_uspace(vaddr_t entry_point, vaddr_t user_stack_top, uint32_t flags, ulong arg0)
  {
@@ -788,6 +818,8 @@ index 721c57e..3ff2fbd 100644
 +void arch_syscall_stack_switch(vaddr_t new_thread_syscall)
 +{
 +    tss_t *tss_base= get_tss_base();
++
++    ASSERT(tss_base);
 +
 +    if (0 == new_thread_syscall) {
 +        tss_base->rsp0 = x86_get_syscall_stack();
@@ -1935,7 +1967,7 @@ index 0000000..434cc0a
 +    return !!BIT(val, bit);
 +}
 diff --git a/arch/x86/rules.mk b/arch/x86/rules.mk
-index e26dfb9..39e7898 100644
+index e26dfb9..b14afff 100644
 --- a/arch/x86/rules.mk
 +++ b/arch/x86/rules.mk
 @@ -24,8 +24,8 @@
@@ -1980,7 +2012,17 @@ index e26dfb9..39e7898 100644
  
  include $(LOCAL_DIR)/toolchain.mk
  
-@@ -84,6 +91,7 @@
+@@ -74,6 +81,9 @@
+ $(warning ARCH_x86_64_TOOLCHAIN_PREFIX = $(ARCH_x86_64_TOOLCHAIN_PREFIX))
+ $(warning TOOLCHAIN_PREFIX = $(TOOLCHAIN_PREFIX))
+ 
++ifeq ($(call TOBOOL,$(CLANGBUILD)), true)
++ARCH_COMPILEFLAGS += $(ARCH_$(ARCH)_COMPILEFLAGS)
++endif
+ 
+ cc-option = $(shell if test -z "`$(1) $(2) -S -o /dev/null -xc /dev/null 2>&1`"; \
+ 	then echo "$(2)"; else echo "$(3)"; fi ;)
+@@ -84,6 +94,7 @@
  GLOBAL_COMPILEFLAGS += -fasynchronous-unwind-tables
  GLOBAL_COMPILEFLAGS += -gdwarf-2
  GLOBAL_COMPILEFLAGS += -fno-pic
@@ -2068,10 +2110,10 @@ index e75f199..85eb57f 100644
      x86_64_context_switch(&oldthread->arch.sp, newthread->arch.sp);
  }
 diff --git a/arch/x86/toolchain.mk b/arch/x86/toolchain.mk
-index dba751e..0725bec 100644
+index dba751e..aa041fd 100644
 --- a/arch/x86/toolchain.mk
 +++ b/arch/x86/toolchain.mk
-@@ -22,9 +22,9 @@
+@@ -22,13 +22,30 @@
  
  ifndef ARCH_x86_64_TOOLCHAIN_PREFIX
  ARCH_x86_64_TOOLCHAIN_PREFIX := x86_64-elf-
@@ -2082,6 +2124,27 @@ index dba751e..0725bec 100644
  ifeq ($(FOUNDTOOL),)
  $(error cannot find toolchain, please set ARCH_x86_64_TOOLCHAIN_PREFIX or add it to your path)
  endif
+ 
++ifeq ($(call TOBOOL,$(CLANGBUILD)),true)
++
++CLANG_X86_64_TARGET_SYS ?= linux
++CLANG_X86_64_TARGET_ABI ?= gnu
++
++CLANG_X86_64_AS_DIR := $(shell dirname $(shell dirname $(ARCH_x86_64_TOOLCHAIN_PREFIX)))
++
++AS_PATH := $(wildcard $(CLANG_X86_64_AS_DIR)/*/bin/as)
++ifeq ($(AS_PATH),)
++$(error Could not find $(CLANG_X86_64_AS_DIR)/*/bin/as, did the directory structure change?)
++endif
++
++ARCH_x86_COMPILEFLAGS += -target x86_64-$(CLANG_X86_64_TARGET_SYS)-$(CLANG_X86_64_TARGET_ABI) \
++                         --gcc-toolchain=$(CLANG_X86_64_AS_DIR)/
++
++endif
++
+ endif
+ endif
+ 
 diff --git a/engine.mk b/engine.mk
 index c0a45fa..527c149 100644
 --- a/engine.mk

--- a/android_p/google_diff/celadon/trusty/external/lk/0001-x64-64-enabling-patch-for-google-diff.patch
+++ b/android_p/google_diff/celadon/trusty/external/lk/0001-x64-64-enabling-patch-for-google-diff.patch
@@ -1,10 +1,9 @@
-From a8db1faa226fef84693903d05d1adacc0dab7c75 Mon Sep 17 00:00:00 2001
+From a641dd35bc4baf83d50749d15b24407aa6096423 Mon Sep 17 00:00:00 2001
 From: Zhong,Fangjian <fangjian.zhong@intel.com>
 Date: Mon, 23 Apr 2018 08:20:33 +0800
 Subject: [PATCH] x64-64 enabling patch for Google diff
 
 Change-Id: I2b4c0d513d24b6d913d0273a31ee5f2485d9a76b
-Tracked-On: https://jira01.devtools.intel.com/browse/OAM-63646
 Signed-off-by: Zhong,Fangjian <fangjian.zhong@intel.com>
 ---
 
@@ -126,7 +125,7 @@ index f06d1a3..27d280c 100644
  {
      . = %KERNEL_BASE% + %KERNEL_LOAD_OFFSET%;
 diff --git a/arch/x86/64/mmu.c b/arch/x86/64/mmu.c
-index 60a10c8..f09ee74 100644
+index 60a10c8..006abf3 100644
 --- a/arch/x86/64/mmu.c
 +++ b/arch/x86/64/mmu.c
 @@ -1,6 +1,6 @@
@@ -247,7 +246,31 @@ index 60a10c8..f09ee74 100644
          }
  
          update_pd_entry(vaddr, pdpe, X86_VIRT_TO_PHYS(m), get_x86_arch_flags(mmu_flags));
-@@ -569,6 +605,11 @@
+@@ -481,7 +517,7 @@
+ static void x86_mmu_unmap_entry(vaddr_t vaddr, int level, vaddr_t table_entry)
+ {
+     uint32_t offset = 0, next_level_offset = 0;
+-    vaddr_t *table, *next_table_addr, value;
++    vaddr_t *table, *next_table_addr;
+ 
+     LTRACEF("vaddr 0x%lx level %d table_entry 0x%lx\n", vaddr, level, table_entry);
+ 
+@@ -545,12 +581,10 @@
+         }
+         pmm_free_page(paddr_to_vm_page(X86_VIRT_TO_PHYS(next_table_addr)));
+     }
+-    /* All present bits for all entries in next level table for this address are 0 */
++    /* zero PTE to avoid L1TF issue */
+     if ((X86_PHYS_TO_VIRT(table[offset]) & X86_MMU_PG_P) != 0) {
+         arch_disable_ints();
+-        value = table[offset];
+-        value = value & X86_PTE_NOT_PRESENT;
+-        table[offset] = value;
++        table[offset] = 0;
+         arch_enable_ints();
+     }
+ }
+@@ -569,6 +603,11 @@
      next_aligned_v_addr = vaddr;
      while (count > 0) {
          x86_mmu_unmap_entry(next_aligned_v_addr, X86_PAGING_LEVELS, pml4);
@@ -259,7 +282,7 @@ index 60a10c8..f09ee74 100644
          next_aligned_v_addr += PAGE_SIZE;
          count--;
      }
-@@ -589,8 +630,8 @@
+@@ -589,8 +628,8 @@
      if (count == 0)
          return NO_ERROR;
  
@@ -270,7 +293,7 @@ index 60a10c8..f09ee74 100644
  
      return (x86_mmu_unmap(X86_PHYS_TO_VIRT(current_cr3_val), vaddr, count));
  }
-@@ -648,17 +689,15 @@
+@@ -648,17 +687,15 @@
  
      DEBUG_ASSERT(aspace);
  
@@ -292,7 +315,7 @@ index 60a10c8..f09ee74 100644
      LTRACEF("paddr 0x%llx\n", last_valid_entry);
  
      /* converting x86 arch specific flags to arch mmu flags */
-@@ -686,8 +725,8 @@
+@@ -686,8 +723,8 @@
      if (count == 0)
          return NO_ERROR;
  
@@ -303,7 +326,7 @@ index 60a10c8..f09ee74 100644
  
      range.start_vaddr = vaddr;
      range.start_paddr = paddr;
-@@ -714,9 +753,9 @@
+@@ -714,9 +751,9 @@
      x86_set_cr4(cr4);
  
      /* Set NXE bit in MSR_EFER*/
@@ -316,7 +339,7 @@ index 60a10c8..f09ee74 100644
  
      /* getting the address width from CPUID instr */
      /* Bits 07-00: Physical Address width info */
-@@ -730,12 +769,25 @@
+@@ -730,6 +767,8 @@
      /* unmap the lower identity mapping */
      pml4[0] = 0;
  
@@ -325,42 +348,43 @@ index 60a10c8..f09ee74 100644
      /* tlb flush */
      x86_set_cr3(x86_get_cr3());
  }
- 
- void x86_mmu_init(void)
+@@ -738,16 +777,29 @@
  {
-+}
-+
+ }
+ 
+-/*
+- * x86-64 does not support multiple address spaces at the moment, so fail if these apis
+- * are used for it.
+- */
 +static paddr_t x86_create_page_table(void)
 +{
 +    addr_t *new_table = NULL;
 +
 +    new_table = (addr_t *)_map_alloc_page();
-+    DEBUG_ASSERT(new_table);
++    ASSERT(new_table);
 +    new_table[511] = pml4[511];
 +
 +    return (paddr_t)X86_VIRT_TO_PHYS(new_table);
- }
- 
- /*
-@@ -746,8 +798,15 @@
++}
++
+ status_t arch_mmu_init_aspace(arch_aspace_t *aspace, vaddr_t base, size_t size, uint flags)
  {
      DEBUG_ASSERT(aspace);
  
 -    if ((flags & ARCH_ASPACE_FLAG_KERNEL) == 0) {
 -        return ERR_NOT_SUPPORTED;
++    aspace->size = size;
++    aspace->base = base;
++
 +    if ((flags & ARCH_ASPACE_FLAG_KERNEL)) {
-+        aspace->size = size;
-+        aspace->base = base;
 +        aspace->page_table = x86_kernel_page_table;
 +    } else {
-+        aspace->size = size;
-+        aspace->base = base;
 +        if (0 == aspace->page_table)
 +            aspace->page_table = x86_create_page_table();
      }
  
      return NO_ERROR;
-@@ -755,13 +814,20 @@
+@@ -755,13 +807,20 @@
  
  status_t arch_mmu_destroy_aspace(arch_aspace_t *aspace)
  {
@@ -586,7 +610,7 @@ index 0000000..33fd918
 +    return act_len;
 +}
 diff --git a/arch/x86/arch.c b/arch/x86/arch.c
-index 721c57e..3ff2fbd 100644
+index 721c57e..cc81b93 100644
 --- a/arch/x86/arch.c
 +++ b/arch/x86/arch.c
 @@ -1,6 +1,6 @@
@@ -597,7 +621,7 @@ index 721c57e..3ff2fbd 100644
   *
   * Permission is hereby granted, free of charge, to any person obtaining
   * a copy of this software and associated documentation files
-@@ -27,6 +27,7 @@
+@@ -27,42 +27,108 @@
  #include <arch/ops.h>
  #include <arch/x86.h>
  #include <arch/x86/mmu.h>
@@ -605,8 +629,10 @@ index 721c57e..3ff2fbd 100644
  #include <arch/x86/descriptor.h>
  #include <arch/fpu.h>
  #include <arch/mmu.h>
-@@ -35,34 +36,94 @@
+ #include <platform.h>
+ #include <sys/types.h>
  #include <string.h>
++#include <assert.h>
  
  /* early stack */
 -uint8_t _kstack[PAGE_SIZE] __ALIGNED(8);
@@ -635,6 +661,7 @@ index 721c57e..3ff2fbd 100644
 +void *get_tss_base(void)
 +{
 +    volatile uint cpu = arch_curr_cpu_num();
++    ASSERT(cpu < SMP_MAX_CPUS);
 +
 +    if (cpu < SMP_MAX_CPUS)
 +        return &system_tss[cpu];
@@ -648,6 +675,9 @@ index 721c57e..3ff2fbd 100644
 +    /* Get system tss segment */
 +    tss_t *tss_base = get_tss_base();
 +    uint cpu_id = arch_curr_cpu_num();
++
++    ASSERT(tss_base);
++    ASSERT(cpu_id < SMP_MAX_CPUS);
 +
 +    addr = (uint64_t)&__tss_end - (uint64_t)(cpu_id * PAGE_SIZE);
 +
@@ -715,7 +745,7 @@ index 721c57e..3ff2fbd 100644
  
      x86_mmu_early_init();
  }
-@@ -70,6 +131,9 @@
+@@ -70,6 +136,9 @@
  void arch_init(void)
  {
      x86_mmu_init();
@@ -725,7 +755,7 @@ index 721c57e..3ff2fbd 100644
  
  #ifdef X86_WITH_FPU
      fpu_init();
-@@ -83,37 +147,40 @@
+@@ -83,37 +152,42 @@
  
  void arch_enter_uspace(vaddr_t entry_point, vaddr_t user_stack_top, uint32_t flags, ulong arg0)
  {
@@ -788,6 +818,8 @@ index 721c57e..3ff2fbd 100644
 +void arch_syscall_stack_switch(vaddr_t new_thread_syscall)
 +{
 +    tss_t *tss_base= get_tss_base();
++
++    ASSERT(tss_base);
 +
 +    if (0 == new_thread_syscall) {
 +        tss_base->rsp0 = x86_get_syscall_stack();
@@ -1935,7 +1967,7 @@ index 0000000..434cc0a
 +    return !!BIT(val, bit);
 +}
 diff --git a/arch/x86/rules.mk b/arch/x86/rules.mk
-index e26dfb9..39e7898 100644
+index e26dfb9..b14afff 100644
 --- a/arch/x86/rules.mk
 +++ b/arch/x86/rules.mk
 @@ -24,8 +24,8 @@
@@ -1980,7 +2012,17 @@ index e26dfb9..39e7898 100644
  
  include $(LOCAL_DIR)/toolchain.mk
  
-@@ -84,6 +91,7 @@
+@@ -74,6 +81,9 @@
+ $(warning ARCH_x86_64_TOOLCHAIN_PREFIX = $(ARCH_x86_64_TOOLCHAIN_PREFIX))
+ $(warning TOOLCHAIN_PREFIX = $(TOOLCHAIN_PREFIX))
+ 
++ifeq ($(call TOBOOL,$(CLANGBUILD)), true)
++ARCH_COMPILEFLAGS += $(ARCH_$(ARCH)_COMPILEFLAGS)
++endif
+ 
+ cc-option = $(shell if test -z "`$(1) $(2) -S -o /dev/null -xc /dev/null 2>&1`"; \
+ 	then echo "$(2)"; else echo "$(3)"; fi ;)
+@@ -84,6 +94,7 @@
  GLOBAL_COMPILEFLAGS += -fasynchronous-unwind-tables
  GLOBAL_COMPILEFLAGS += -gdwarf-2
  GLOBAL_COMPILEFLAGS += -fno-pic
@@ -2068,10 +2110,10 @@ index e75f199..85eb57f 100644
      x86_64_context_switch(&oldthread->arch.sp, newthread->arch.sp);
  }
 diff --git a/arch/x86/toolchain.mk b/arch/x86/toolchain.mk
-index dba751e..0725bec 100644
+index dba751e..aa041fd 100644
 --- a/arch/x86/toolchain.mk
 +++ b/arch/x86/toolchain.mk
-@@ -22,9 +22,9 @@
+@@ -22,13 +22,30 @@
  
  ifndef ARCH_x86_64_TOOLCHAIN_PREFIX
  ARCH_x86_64_TOOLCHAIN_PREFIX := x86_64-elf-
@@ -2082,6 +2124,27 @@ index dba751e..0725bec 100644
  ifeq ($(FOUNDTOOL),)
  $(error cannot find toolchain, please set ARCH_x86_64_TOOLCHAIN_PREFIX or add it to your path)
  endif
+ 
++ifeq ($(call TOBOOL,$(CLANGBUILD)),true)
++
++CLANG_X86_64_TARGET_SYS ?= linux
++CLANG_X86_64_TARGET_ABI ?= gnu
++
++CLANG_X86_64_AS_DIR := $(shell dirname $(shell dirname $(ARCH_x86_64_TOOLCHAIN_PREFIX)))
++
++AS_PATH := $(wildcard $(CLANG_X86_64_AS_DIR)/*/bin/as)
++ifeq ($(AS_PATH),)
++$(error Could not find $(CLANG_X86_64_AS_DIR)/*/bin/as, did the directory structure change?)
++endif
++
++ARCH_x86_COMPILEFLAGS += -target x86_64-$(CLANG_X86_64_TARGET_SYS)-$(CLANG_X86_64_TARGET_ABI) \
++                         --gcc-toolchain=$(CLANG_X86_64_AS_DIR)/
++
++endif
++
+ endif
+ endif
+ 
 diff --git a/engine.mk b/engine.mk
 index c0a45fa..527c149 100644
 --- a/engine.mk


### PR DESCRIPTION
Update memory unmap entry mechanism, set entry value to
zero instread of clear Present bit.

Test: Boot to android GUI
Tracked-On: None
Signed-off-by: Zhong,Fangjian <fangjian.zhong@intel.com>
Signed-off-by: Zhang, Qi <qi1.zhang@intel.com>