### PR TITLE
[HTMLViewer] supports a larger screen aspect ratio

### DIFF
--- a/android_p/google_diff/cel_apl/packages/apps/HTMLViewer/0001-HTMLViewer-supports-a-larger-screen-aspect-ratio.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/HTMLViewer/0001-HTMLViewer-supports-a-larger-screen-aspect-ratio.patch
@@ -1,0 +1,36 @@
+From eca05eb377725a9e1a111cc6ed54976709845a6c Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Thu, 13 Sep 2018 14:48:27 +0800
+Subject: [PATCH] [HTMLViewer] supports a larger screen aspect ratio
+
+The maximum aspect ratio defaults to 1.86 (roughly 16:9) and
+application will not take advantage of the extra screen space.
+
+using android.max_aspect element in the app's <application> element to
+increase maximum supported aspect ratio.
+
+Tracked-On: OAM-67747
+
+Change-Id: I6354c8b8a2dbb548814a327f7adcebf6697e6a45
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ AndroidManifest.xml | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/AndroidManifest.xml b/AndroidManifest.xml
+index bc618d5..165c94e 100644
+--- a/AndroidManifest.xml
++++ b/AndroidManifest.xml
+@@ -27,6 +27,9 @@
+     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+ 
+     <application android:label="@string/app_label">
++
++        <meta-data android:name="android.max_aspect" android:value="2.1" />
++
+         <activity android:name="HTMLViewerActivity"
+                 android:label="@string/app_label"
+                 android:theme="@android:style/Theme.DeviceDefault">
+-- 
+1.9.1
+


### PR DESCRIPTION
The maximum aspect ratio defaults to 1.86 (roughly 16:9) and
application will not take advantage of the extra screen space.

using android.max_aspect element in the app's <application> element to
increase maximum supported aspect ratio.

Tracked-On: OAM-67747

Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>