### PR TITLE
supports a larger screen aspect ratio for Email and Calendar

### DIFF
--- a/android_p/google_diff/cel_apl/packages/apps/Calendar/0001-Calendar-supports-a-larger-screen-aspect-ratio.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Calendar/0001-Calendar-supports-a-larger-screen-aspect-ratio.patch
@@ -1,0 +1,35 @@
+From 24f4da102eb681df0bfa2badb6a45ef713474788 Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Fri, 14 Sep 2018 10:34:27 +0800
+Subject: [PATCH] [Calendar] supports a larger screen aspect ratio
+
+The maximum aspect ratio defaults to 1.86 (roughly 16:9) and
+application will not take advantage of the extra screen space.
+
+using android.max_aspect element in the app's <application> element to
+increase maximum supported aspect ratio.
+
+Tracked-On: OAM-68598
+
+Change-Id: Icf9f4a0f11316dc0f5fb9edf18c3c8f73ec3dafe
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ AndroidManifest.xml | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/AndroidManifest.xml b/AndroidManifest.xml
+index 5673a3b..8864b23 100644
+--- a/AndroidManifest.xml
++++ b/AndroidManifest.xml
+@@ -51,6 +51,8 @@
+         <meta-data android:name="com.google.android.backup.api_key"
+                 android:value="AEdPqrEAAAAIM256oVOGnuSel5QKDpL8je_T65ZI8rFnDinssA" />
+ 
++        <meta-data android:name="android.max_aspect" android:value="2.1" />
++
+         <activity
+             android:name="AllInOneActivity"
+             android:theme="@style/CalendarTheme.WithActionBar"
+-- 
+1.9.1
+

--- a/android_p/google_diff/cel_apl/packages/apps/Email/0001-Email-supports-a-larger-screen-aspect-ratio.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Email/0001-Email-supports-a-larger-screen-aspect-ratio.patch
@@ -1,0 +1,36 @@
+From 46c60708c7cfab16e742d0ea0c2f1656fdbe9f3f Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Mon, 23 Jul 2018 17:12:50 +0800
+Subject: [PATCH] [Email] supports a larger screen aspect ratio
+
+The maximum aspect ratio defaults to 1.86 (roughly 16:9) and
+application will not take advantage of the extra screen space.
+
+using android.max_aspect element in the app's <application> element to
+increase maximum supported aspect ratio.
+
+Change-Id: Ibd8e8e5cbcc312561b3feecce47761c1dbee773f
+
+Tracked-On: OAM-68598
+
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ AndroidManifest.xml | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/AndroidManifest.xml b/AndroidManifest.xml
+index bbe02d4..cb7ab4c 100644
+--- a/AndroidManifest.xml
++++ b/AndroidManifest.xml
+@@ -87,6 +87,8 @@
+         android:supportsRtl="true"
+         android:usesCleartextTraffic="true" >
+ 
++        <meta-data android:name="android.max_aspect" android:value="2.1" />
++
+         <uses-library android:name="org.apache.http.legacy" android:required="false" />
+         <activity
+             android:name="com.android.email.activity.ComposeActivityEmail"
+-- 
+1.9.1
+


### PR DESCRIPTION
The maximum aspect ratio defaults to 1.86 (roughly 16:9) and
application will not take advantage of the extra screen space.

using android.max_aspect element in the app's <application> element to
increase maximum supported aspect ratio.

Tracked-On: OAM-68598

Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>