### PR TITLE
[CELADON] f2fs filesystem support enabled

### DIFF
--- a/android_p/google_diff/cel_apl/device/intel/project-celadon/0004-f2fs-filesystem-support-enabled.patch
+++ b/android_p/google_diff/cel_apl/device/intel/project-celadon/0004-f2fs-filesystem-support-enabled.patch
@@ -1,0 +1,39 @@
+From 123bc311b93e8d89332ec235c19ed53d88703599 Mon Sep 17 00:00:00 2001
+From: shyjumon <shyjumon.n@intel.com>
+Date: Tue, 30 Jan 2018 02:15:47 +0530
+Subject: [PATCH] f2fs filesystem support enabled
+
+f2fs filesystem support is enabled for using in adoptable storage
+as per google AOSP CDD adoptable storage shall use both ext4 and f2fs. so enabling f2fs
+
+Jira: None
+Test: mount cmd
+      1. create a storage volume with mkfs.f2fs utility
+      2. mount -t f2fs <dev entry> <mount point>
+      3. check mount cmd output and check for mount type as f2fs
+
+Signed-off-by: shyjumon <shyjumon.n@intel.com>
+---
+ kernel_config/kernel_64_defconfig | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/kernel_config/kernel_64_defconfig b/kernel_config/kernel_64_defconfig
+index a9f2cd9..b890a1a 100644
+--- a/kernel_config/kernel_64_defconfig
++++ b/kernel_config/kernel_64_defconfig
+@@ -6886,7 +6886,11 @@ CONFIG_BTRFS_FS=m
+ # CONFIG_BTRFS_DEBUG is not set
+ # CONFIG_BTRFS_ASSERT is not set
+ # CONFIG_NILFS2_FS is not set
+-# CONFIG_F2FS_FS is not set
++CONFIG_F2FS_FS=y
++CONFIG_F2FS_STAT_FS=y
++CONFIG_F2FS_FS_XATTR=y
++CONFIG_F2FS_FS_POSIX_ACL=y
++CONFIG_F2FS_FS_SECURITY=y
+ # CONFIG_FS_DAX is not set
+ CONFIG_FS_POSIX_ACL=y
+ CONFIG_EXPORTFS=m
+-- 
+1.9.1
+

--- a/android_p/google_diff/celadon/device/intel/project-celadon/0001-f2fs-filesystem-support-enabled.patch
+++ b/android_p/google_diff/celadon/device/intel/project-celadon/0001-f2fs-filesystem-support-enabled.patch
@@ -1,0 +1,39 @@
+From 123bc311b93e8d89332ec235c19ed53d88703599 Mon Sep 17 00:00:00 2001
+From: shyjumon <shyjumon.n@intel.com>
+Date: Tue, 30 Jan 2018 02:15:47 +0530
+Subject: [PATCH] f2fs filesystem support enabled
+
+f2fs filesystem support is enabled for using in adoptable storage
+as per google AOSP CDD adoptable storage shall use both ext4 and f2fs. so enabling f2fs
+
+Jira: None
+Test: mount cmd
+      1. create a storage volume with mkfs.f2fs utility
+      2. mount -t f2fs <dev entry> <mount point>
+      3. check mount cmd output and check for mount type as f2fs
+
+Signed-off-by: shyjumon <shyjumon.n@intel.com>
+---
+ kernel_config/kernel_64_defconfig | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/kernel_config/kernel_64_defconfig b/kernel_config/kernel_64_defconfig
+index a9f2cd9..b890a1a 100644
+--- a/kernel_config/kernel_64_defconfig
++++ b/kernel_config/kernel_64_defconfig
+@@ -6886,7 +6886,11 @@ CONFIG_BTRFS_FS=m
+ # CONFIG_BTRFS_DEBUG is not set
+ # CONFIG_BTRFS_ASSERT is not set
+ # CONFIG_NILFS2_FS is not set
+-# CONFIG_F2FS_FS is not set
++CONFIG_F2FS_FS=y
++CONFIG_F2FS_STAT_FS=y
++CONFIG_F2FS_FS_XATTR=y
++CONFIG_F2FS_FS_POSIX_ACL=y
++CONFIG_F2FS_FS_SECURITY=y
+ # CONFIG_FS_DAX is not set
+ CONFIG_FS_POSIX_ACL=y
+ CONFIG_EXPORTFS=m
+-- 
+1.9.1
+


### PR DESCRIPTION
f2fs filesystem support is enabled for using in adoptable storage
as per google AOSP CDD adoptable storage shall use both ext4 and f2fs. so enabling f2fs

Jira: None
Test: mount cmd
      1. create a storage volume with mkfs.f2fs utility
      2. mount -t f2fs <dev entry> <mount point>
      3. check mount cmd output and check for mount type as f2fs

Tracked-On: None