### PR TITLE
Fix navigation bar not scaling up/down when the display size changed.

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0013-Fix-navigation-bar-not-scaling-up-down-when-the-disp.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0013-Fix-navigation-bar-not-scaling-up-down-when-the-disp.patch
@@ -1,0 +1,45 @@
+From ad8886e5be7b55c397597a367d763947cd3eb192 Mon Sep 17 00:00:00 2001
+From: rleix <rayx.lei@intel.com>
+Date: Tue, 14 Aug 2018 10:57:39 +0800
+Subject: [PATCH] Fix navigation bar not scaling up/down when the display size
+ changed
+
+Restart the navigation bar when the density or font scale changed
+
+Test:
+1. goto Settings->Display->Advanced->Display size->Largest
+2. check whether scaling up for the facet buttons of navigation bar
+
+Change-Id: I6d2d7ac4a801fac6f30bb78acee4c00ec2c4e507
+Tracked-On:
+Signed-off-by: Lei,RayX <rayx.lei@intel.com>
+---
+ .../src/com/android/systemui/statusbar/car/CarStatusBar.java         | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/packages/SystemUI/src/com/android/systemui/statusbar/car/CarStatusBar.java b/packages/SystemUI/src/com/android/systemui/statusbar/car/CarStatusBar.java
+index 83021ca..2eb3aca 100644
+--- a/packages/SystemUI/src/com/android/systemui/statusbar/car/CarStatusBar.java
++++ b/packages/SystemUI/src/com/android/systemui/statusbar/car/CarStatusBar.java
+@@ -120,7 +120,9 @@ public class CarStatusBar extends StatusBar implements
+      * before and after the device is provisioned
+      */
+     private void restartNavBars() {
+-        mCarFacetButtonController.removeAll();
++        if (mCarFacetButtonController != null) {
++            mCarFacetButtonController.removeAll();
++        }
+         if (ENABLE_HVAC_CONNECTION) {
+             Dependency.get(HvacController.class).removeAllComponents();
+         }
+@@ -513,6 +515,7 @@ public class CarStatusBar extends StatusBar implements
+     @Override
+     public void onDensityOrFontScaleChanged() {
+         super.onDensityOrFontScaleChanged();
++        restartNavBars();
+         // Need to update the background on density changed in case the change was due to night
+         // mode.
+         mNotificationPanelBackground = getDefaultWallpaper();
+-- 
+1.9.1
+


### PR DESCRIPTION
Restart the navigation bar when the density or font scale changed

Test:
1. goto Settings->Display->Advanced->Display size->Largest
2. check whether scaling up for the facet buttons of navigation bar

Tracked-On: OAM-67836
Signed-off-by: Yan, WalterX <walterx.yan@intel.com>