### PR TITLE
Adjust sendObject parameter's data type.

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/av/0004-Adjust-sendObject-parameter-s-data-type.patch
+++ b/android_p/google_diff/cel_apl/frameworks/av/0004-Adjust-sendObject-parameter-s-data-type.patch
@@ -1,0 +1,60 @@
+From e658c8b74a311cdfaf9a164d683be3808f841ae5 Mon Sep 17 00:00:00 2001
+From: "Yan, WalterX" <walterx.yan@intel.com>
+Date: Wed, 19 Sep 2018 17:36:28 +0800
+Subject: [PATCH] Adjust sendObject parameter's data type.
+
+Now the MtpDevice#sendObject is using int to define object size,
+if the object size is bigger than 2GB, the size will be type cast to
+a negative number in MtpDevice#sendObject. And it will cause a endless
+loop in MtpDataPacket#write until DUT auto reboot.
+
+Due to the JNI api android_mtp_MtpDevice_send_object is using uint32_t
+to define object size, so adjust the native api MtpDevice#sendObject
+size parameter's data type to uint32_t.
+
+Change-Id: I890d79dad431ffc099406c0544af68586277b894
+Tracked-On: OAM-68165
+Signed-off-by: Yan, WalterX <walterx.yan@intel.com>
+---
+ media/mtp/MtpDevice.cpp | 4 ++--
+ media/mtp/MtpDevice.h   | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/media/mtp/MtpDevice.cpp b/media/mtp/MtpDevice.cpp
+index 993797a..ff36dcc 100644
+--- a/media/mtp/MtpDevice.cpp
++++ b/media/mtp/MtpDevice.cpp
+@@ -516,7 +516,7 @@ MtpObjectHandle MtpDevice::sendObjectInfo(MtpObjectInfo* info) {
+     return (MtpObjectHandle)-1;
+ }
+ 
+-bool MtpDevice::sendObject(MtpObjectHandle handle, int size, int srcFD) {
++bool MtpDevice::sendObject(MtpObjectHandle handle, uint32_t size, int srcFD) {
+     std::lock_guard<std::mutex> lg(mMutex);
+ 
+     if (mLastSendObjectInfoTransactionID + 1 != mTransactionID ||
+@@ -529,7 +529,7 @@ bool MtpDevice::sendObject(MtpObjectHandle handle, int size, int srcFD) {
+     if (sendRequest(MTP_OPERATION_SEND_OBJECT)) {
+         mData.setOperationCode(mRequest.getOperationCode());
+         mData.setTransactionID(mRequest.getTransactionID());
+-        const int writeResult = mData.write(mRequestOut, mPacketDivisionMode, srcFD, size);
++        const uint32_t writeResult = mData.write(mRequestOut, mPacketDivisionMode, srcFD, size);
+         const MtpResponseCode ret = readResponse();
+         return ret == MTP_RESPONSE_OK && writeResult > 0;
+     }
+diff --git a/media/mtp/MtpDevice.h b/media/mtp/MtpDevice.h
+index 8cf9e5e..01bc3db 100644
+--- a/media/mtp/MtpDevice.h
++++ b/media/mtp/MtpDevice.h
+@@ -104,7 +104,7 @@ public:
+     MtpObjectInfo*          getObjectInfo(MtpObjectHandle handle);
+     void*                   getThumbnail(MtpObjectHandle handle, int& outLength);
+     MtpObjectHandle         sendObjectInfo(MtpObjectInfo* info);
+-    bool                    sendObject(MtpObjectHandle handle, int size, int srcFD);
++    bool                    sendObject(MtpObjectHandle handle, uint32_t size, int srcFD);
+     bool                    deleteObject(MtpObjectHandle handle);
+     MtpObjectHandle         getParent(MtpObjectHandle handle);
+     MtpStorageID            getStorageID(MtpObjectHandle handle);
+-- 
+1.9.1
+


### PR DESCRIPTION
Now the MtpDevice#sendObject is using int to define object size,
if the object size is bigger than 2GB, the size will be type cast to
a negative number in MtpDevice#sendObject. And it will cause a endless
loop in MtpDataPacket#write until DUT auto reboot.

Due to the JNI api android_mtp_MtpDevice_send_object is using uint32_t
to define object size, so adjust the native api MtpDevice#sendObject
size parameter's data type to uint32_t.

Tracked-On: OAM-68165
Signed-off-by: Yan, WalterX <walterx.yan@intel.com>