### PR TITLE
Fix the TimePickerClock display is incomplete

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0014-Fix-the-TimePickerClock-display-is-incomplete.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0014-Fix-the-TimePickerClock-display-is-incomplete.patch
@@ -1,0 +1,123 @@
+From 56527fbb302ce05df51c6ec3bed3b4a300b79291 Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Tue, 25 Sep 2018 18:34:43 +0800
+Subject: [PATCH] Fix the TimePickerClock display is incomplete
+
+The AOSP widget TimePickerClock include the alert_dialog_button_bar_material.
+The alert_dialog_button_bar_material is overlaid by the automotive UI. Due to
+the automotive UI don't make the car TimePickerClock, hence, remove the
+alert_dialog_button_bar_material automotive changes from the TimePickerClock.
+
+Change-Id: Ic14dbc9b1c03daf0f6be8721630014aefdd3d6b3
+Tracked-On: OAM-67760
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ core/res/res/layout-land/time_picker_material.xml  |  4 +-
+ .../alert_dialog_button_bar_material_phone.xml     | 62 ++++++++++++++++++++++
+ core/res/res/layout/time_picker_material.xml       |  2 +-
+ 3 files changed, 65 insertions(+), 3 deletions(-)
+ create mode 100644 core/res/res/layout/alert_dialog_button_bar_material_phone.xml
+
+diff --git a/core/res/res/layout-land/time_picker_material.xml b/core/res/res/layout-land/time_picker_material.xml
+index f3d4a84..96088c8 100644
+--- a/core/res/res/layout-land/time_picker_material.xml
++++ b/core/res/res/layout-land/time_picker_material.xml
+@@ -174,11 +174,11 @@
+                 android:layout_weight="1" />
+             <ViewStub
+                 android:id="@id/buttonPanel"
+-                android:layout="@layout/alert_dialog_button_bar_material"
++                android:layout="@layout/alert_dialog_button_bar_material_phone"
+                 android:layout_width="wrap_content"
+                 android:layout_height="wrap_content"
+                 android:layoutDirection="locale" />
+         </LinearLayout>
+     </LinearLayout>
+ 
+-</LinearLayout>
+\ No newline at end of file
++</LinearLayout>
+diff --git a/core/res/res/layout/alert_dialog_button_bar_material_phone.xml b/core/res/res/layout/alert_dialog_button_bar_material_phone.xml
+new file mode 100644
+index 0000000..e879d81
+--- /dev/null
++++ b/core/res/res/layout/alert_dialog_button_bar_material_phone.xml
+@@ -0,0 +1,62 @@
++<?xml version="1.0" encoding="utf-8"?>
++<!--
++     Copyright (C) 2014 The Android Open Source Project
++
++     Licensed under the Apache License, Version 2.0 (the "License");
++     you may not use this file except in compliance with the License.
++     You may obtain a copy of the License at
++
++          http://www.apache.org/licenses/LICENSE-2.0
++
++     Unless required by applicable law or agreed to in writing, software
++     distributed under the License is distributed on an "AS IS" BASIS,
++     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++     See the License for the specific language governing permissions and
++     limitations under the License.
++-->
++
++<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
++            android:id="@+id/buttonPanel"
++            android:layout_width="match_parent"
++            android:layout_height="wrap_content"
++            android:scrollbarAlwaysDrawVerticalTrack="true"
++            android:scrollIndicators="top|bottom"
++            android:fillViewport="true"
++            style="?attr/buttonBarStyle">
++    <com.android.internal.widget.ButtonBarLayout
++        android:layout_width="match_parent"
++        android:layout_height="wrap_content"
++        android:layoutDirection="locale"
++        android:orientation="horizontal"
++        android:paddingStart="12dp"
++        android:paddingEnd="12dp"
++        android:paddingTop="4dp"
++        android:paddingBottom="4dp"
++        android:gravity="bottom">
++
++        <Button
++            android:id="@+id/button3"
++            style="?attr/buttonBarNeutralButtonStyle"
++            android:layout_width="wrap_content"
++            android:layout_height="wrap_content" />
++
++        <Space
++            android:id="@+id/spacer"
++            android:layout_width="0dp"
++            android:layout_height="0dp"
++            android:layout_weight="1"
++            android:visibility="invisible" />
++
++        <Button
++            android:id="@+id/button2"
++            style="?attr/buttonBarNegativeButtonStyle"
++            android:layout_width="wrap_content"
++            android:layout_height="wrap_content" />
++
++        <Button
++            android:id="@+id/button1"
++            style="?attr/buttonBarPositiveButtonStyle"
++            android:layout_width="wrap_content"
++            android:layout_height="wrap_content" />
++    </com.android.internal.widget.ButtonBarLayout>
++</ScrollView>
+diff --git a/core/res/res/layout/time_picker_material.xml b/core/res/res/layout/time_picker_material.xml
+index 7597379..81edfa5 100644
+--- a/core/res/res/layout/time_picker_material.xml
++++ b/core/res/res/layout/time_picker_material.xml
+@@ -77,7 +77,7 @@
+             android:layout_weight="1" />
+         <ViewStub
+             android:id="@id/buttonPanel"
+-            android:layout="@layout/alert_dialog_button_bar_material"
++            android:layout="@layout/alert_dialog_button_bar_material_phone"
+             android:layout_width="wrap_content"
+             android:layout_height="wrap_content"
+             android:layoutDirection="locale" />
+-- 
+1.9.1
+


### PR DESCRIPTION
The AOSP widget TimePickerClock include the alert_dialog_button_bar_material.
The alert_dialog_button_bar_material is overlaid by the automotive UI. Due to
the automotive UI don't make the car TimePickerClock, hence, remove the
alert_dialog_button_bar_material automotive changes from the TimePickerClock.

Tracked-On: OAM-67760
Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>