### PR TITLE
[DocumentUI]Fix file cannot be accessed using mouse right click 'Open'.

### DIFF
--- a/android_p/google_diff/cel_apl/packages/apps/DocumentsUI/0001-DocumentUI-Fix-file-cannot-be-accessed-using-mouse-r.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/DocumentsUI/0001-DocumentUI-Fix-file-cannot-be-accessed-using-mouse-r.patch
@@ -1,0 +1,36 @@
+From d7d3be8cb8b7be815ce42244be5dede54339450c Mon Sep 17 00:00:00 2001
+From: "Jin, JasonX" <jasonx.jin@intel.com>
+Date: Mon, 13 Aug 2018 14:44:53 +0800
+Subject: [PATCH] [DocumentUI]Fix file cannot be accessed using mouse right
+ click 'Open'.
+
+DocumentUI don't implement onDocumentPicked() in FilesActivity.java yet.
+The solution is that sending ACTION_VIEW intent to system and system
+start the right application to open the file.
+
+Signed-off-by: Jin, JasonX <jasonx.jin@intel.com>
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-65923
+Change-Id: Ica7c24fb22130562ca241350fde04726be43df06
+---
+ src/com/android/documentsui/files/FilesActivity.java | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/documentsui/files/FilesActivity.java b/src/com/android/documentsui/files/FilesActivity.java
+index a6efbb0..c23a155 100644
+--- a/src/com/android/documentsui/files/FilesActivity.java
++++ b/src/com/android/documentsui/files/FilesActivity.java
+@@ -389,7 +389,10 @@ public class FilesActivity extends BaseActivity implements ActionHandler.Addons
+ 
+     @Override
+     public void onDocumentPicked(DocumentInfo doc) {
+-        throw new UnsupportedOperationException();
++        Intent intent = new Intent(Intent.ACTION_VIEW);
++        intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
++        intent.setDataAndType(doc.derivedUri, doc.mimeType);
++        startActivity(intent);
+     }
+ 
+     @Override
+-- 
+1.9.1
+


### PR DESCRIPTION
DocumentUI don't implement onDocumentPicked() in FilesActivity.java yet.
The solution is that sending ACTION_VIEW intent to system and system
start the right application to open the file.

Tracked-On: OAM-68477
Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>