### PR TITLE
Fix unable to input PIN password with the physical keyboard

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0015-Fix-unable-to-input-PIN-password-with-the-physical-k.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0015-Fix-unable-to-input-PIN-password-with-the-physical-k.patch
@@ -1,0 +1,49 @@
+From dc0b5aba8a9c7c66e65ff7c2f0332f7d0223d316 Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Thu, 13 Sep 2018 11:17:55 +0800
+Subject: [PATCH] Fix unable to input PIN password with the physical keyboard
+
+If inputting a wrong password, the Pin's input editText view will be
+disabled by the verifyPassword function. Then the viewGroup will clear
+the editText view's focus and find another focus view(ScrimView), it
+leads to being unable to input pin password again.
+
+Test:
+1. Set a PIN from Settings->security & location->screen lock->PIN
+2. Lock the device by pressing the ignition button
+3. Enter a wrong PIN from a physical keyboard
+4. For the next attempt, the physical keyboard cannot be used
+
+Change-Id: I04df523c19c99bef75ea481b44154f7ba2270689
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-68479
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ .../src/com/android/keyguard/KeyguardPinBasedInputView.java         | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/packages/SystemUI/src/com/android/keyguard/KeyguardPinBasedInputView.java b/packages/SystemUI/src/com/android/keyguard/KeyguardPinBasedInputView.java
+index cb8c119..f400f60 100644
+--- a/packages/SystemUI/src/com/android/keyguard/KeyguardPinBasedInputView.java
++++ b/packages/SystemUI/src/com/android/keyguard/KeyguardPinBasedInputView.java
+@@ -68,12 +68,18 @@ public abstract class KeyguardPinBasedInputView extends KeyguardAbsKeyInputView
+     protected void setPasswordEntryEnabled(boolean enabled) {
+         mPasswordEntry.setEnabled(enabled);
+         mOkButton.setEnabled(enabled);
++        if (enabled && !mPasswordEntry.hasFocus()) {
++            mPasswordEntry.requestFocus();
++        }
+     }
+ 
+     @Override
+     protected void setPasswordEntryInputEnabled(boolean enabled) {
+         mPasswordEntry.setEnabled(enabled);
+         mOkButton.setEnabled(enabled);
++        if (enabled && !mPasswordEntry.hasFocus()) {
++            mPasswordEntry.requestFocus();
++        }
+     }
+ 
+     @Override
+-- 
+1.9.1
+

--- a/android_p/google_diff/celadon/frameworks/base/0009-Fix-unable-to-input-PIN-password-with-the-physical-k.patch
+++ b/android_p/google_diff/celadon/frameworks/base/0009-Fix-unable-to-input-PIN-password-with-the-physical-k.patch
@@ -1,0 +1,49 @@
+From dc0b5aba8a9c7c66e65ff7c2f0332f7d0223d316 Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Thu, 13 Sep 2018 11:17:55 +0800
+Subject: [PATCH] Fix unable to input PIN password with the physical keyboard
+
+If inputting a wrong password, the Pin's input editText view will be
+disabled by the verifyPassword function. Then the viewGroup will clear
+the editText view's focus and find another focus view(ScrimView), it
+leads to being unable to input pin password again.
+
+Test:
+1. Set a PIN from Settings->security & location->screen lock->PIN
+2. Lock the device by pressing the ignition button
+3. Enter a wrong PIN from a physical keyboard
+4. For the next attempt, the physical keyboard cannot be used
+
+Change-Id: I04df523c19c99bef75ea481b44154f7ba2270689
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-68479
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ .../src/com/android/keyguard/KeyguardPinBasedInputView.java         | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/packages/SystemUI/src/com/android/keyguard/KeyguardPinBasedInputView.java b/packages/SystemUI/src/com/android/keyguard/KeyguardPinBasedInputView.java
+index cb8c119..f400f60 100644
+--- a/packages/SystemUI/src/com/android/keyguard/KeyguardPinBasedInputView.java
++++ b/packages/SystemUI/src/com/android/keyguard/KeyguardPinBasedInputView.java
+@@ -68,12 +68,18 @@ public abstract class KeyguardPinBasedInputView extends KeyguardAbsKeyInputView
+     protected void setPasswordEntryEnabled(boolean enabled) {
+         mPasswordEntry.setEnabled(enabled);
+         mOkButton.setEnabled(enabled);
++        if (enabled && !mPasswordEntry.hasFocus()) {
++            mPasswordEntry.requestFocus();
++        }
+     }
+ 
+     @Override
+     protected void setPasswordEntryInputEnabled(boolean enabled) {
+         mPasswordEntry.setEnabled(enabled);
+         mOkButton.setEnabled(enabled);
++        if (enabled && !mPasswordEntry.hasFocus()) {
++            mPasswordEntry.requestFocus();
++        }
+     }
+ 
+     @Override
+-- 
+1.9.1
+


### PR DESCRIPTION
If inputting a wrong password, the Pin's input editText view will be
disabled by the verifyPassword function. Then the viewGroup will clear
the editText view's focus and find another focus view(ScrimView), it
leads to being unable to input pin password again.

Test:
1. Set a PIN from Settings->security & location->screen lock->PIN
2. Lock the device by pressing the ignition button
3. Enter a wrong PIN from a physical keyboard
4. For the next attempt, the physical keyboard cannot be used

Tracked-On: OAM-69586
Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>