### PR TITLE
Enable Add button after cancel by clicking outside of dialog.

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0015-Enable-Add-button-after-cancel-by-clicking-outside-o.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0015-Enable-Add-button-after-cancel-by-clicking-outside-o.patch
@@ -1,0 +1,60 @@
+From 6501735fb6ae7a8a310c3a365dbff70c73328ae1 Mon Sep 17 00:00:00 2001
+From: "Yan, WalterX" <walterx.yan@intel.com>
+Date: Mon, 15 Oct 2018 15:07:22 +0800
+Subject: [PATCH] Enable Add button after cancel by clicking outside of dialog.
+
+If not to enable the Add button after the dialog cancel by clicking
+outside of the dialog, the user is not able to click the Add button
+anymore. setOnCancelListener to fix this bug.
+
+Change-Id: I42efe15d5a2067eb7d0d526a49800f14afb7ea4c
+Tracked-On: OAM-69585
+Signed-off-by: Yan, WalterX <walterx.yan@intel.com>
+---
+ .../systemui/statusbar/car/UserGridRecyclerView.java     | 16 +++++++++++-----
+ 1 file changed, 11 insertions(+), 5 deletions(-)
+
+diff --git a/packages/SystemUI/src/com/android/systemui/statusbar/car/UserGridRecyclerView.java b/packages/SystemUI/src/com/android/systemui/statusbar/car/UserGridRecyclerView.java
+index a49d507..35575d2 100644
+--- a/packages/SystemUI/src/com/android/systemui/statusbar/car/UserGridRecyclerView.java
++++ b/packages/SystemUI/src/com/android/systemui/statusbar/car/UserGridRecyclerView.java
+@@ -157,7 +157,7 @@ public class UserGridRecyclerView extends PagedListView implements
+      * Adapter to populate the grid layout with the available user profiles
+      */
+     public final class UserAdapter extends RecyclerView.Adapter<UserAdapter.UserAdapterViewHolder>
+-            implements Dialog.OnClickListener {
++            implements Dialog.OnClickListener, Dialog.OnCancelListener {
+ 
+         private final Context mContext;
+         private List<UserRecord> mUsers;
+@@ -235,6 +235,7 @@ public class UserGridRecyclerView extends PagedListView implements
+                         .setMessage(message)
+                         .setNegativeButton(android.R.string.cancel, this)
+                         .setPositiveButton(android.R.string.ok, this)
++                        .setOnCancelListener(this)
+                         .create();
+                     // Sets window flags for the SysUI dialog
+                     SystemUIDialog.applyFlags(mDialog);
+@@ -274,10 +275,15 @@ public class UserGridRecyclerView extends PagedListView implements
+                 notifyUserSelected(mAddUserRecord);
+                 new AddNewUserTask().execute(mNewUserName);
+             } else if (which == BUTTON_NEGATIVE) {
+-                // Enable the add button only if cancel
+-                if (mAddUserView != null) {
+-                    mAddUserView.setEnabled(true);
+-                }
++                onCancel(dialog);
++            }
++        }
++
++        @Override
++        public void onCancel(DialogInterface dialog) {
++            // Enable the add button only if cancel
++            if (mAddUserView != null) {
++                mAddUserView.setEnabled(true);
+             }
+         }
+ 
+-- 
+1.9.1
+


### PR DESCRIPTION
If not to enable the Add button after the dialog cancel by clicking
outside of the dialog, the user is not able to click the Add button
anymore. setOnCancelListener to fix this bug.

Tracked-On: OAM-69585
Signed-off-by: Yan, WalterX <walterx.yan@intel.com>