### PR TITLE
Fix for Audio resumed once message is received

### DIFF
--- a/android_p/google_diff/cel_apl/packages/apps/Bluetooth/0004-Fix-for-Audio-resumed-once-message-is-received.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Bluetooth/0004-Fix-for-Audio-resumed-once-message-is-received.patch
@@ -1,0 +1,58 @@
+From 70e54488df68f5617c132abb4c84ee61c3fb2511 Mon Sep 17 00:00:00 2001
+From: Gaganpreet kaur <gaganpreetx.kaur@intel.com>
+Date: Mon, 15 Oct 2018 16:20:30 +0530
+Subject: [PATCH 4/4] Fix for Audio resumed once message is received
+
+Issue: When message readout is done, paused audio resumes
+automatically.
+
+Reason: When audio Focus changes, pausing of the audio is done
+on the basis of mStreamAvailable variable. This variable was
+not handled properly. It is made true at SRC_STR_START command.
+When message is received, to start readout, again SRC_STR_START
+is received which again makes mStreamavailable true and the
+previous state of mStreamAvailable was lost. Due to which on
+recepetion of AudioFocus Loss Transient, always a pause commmand
+was sent and audio resumes when message readout happens.
+
+Fix: Changed handling of mStreamAvailable from SRC_STR_START to
+SRC_PLAY and SNK_PLAY.
+
+Tracked-On: OAM-68209
+
+Signed-off-by: Gaganpreet kaur <gaganpreetx.kaur@intel.com>
+---
+ src/com/android/bluetooth/a2dpsink/A2dpSinkStreamHandler.java | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/bluetooth/a2dpsink/A2dpSinkStreamHandler.java b/src/com/android/bluetooth/a2dpsink/A2dpSinkStreamHandler.java
+index ae913e5..a44cf47 100644
+--- a/src/com/android/bluetooth/a2dpsink/A2dpSinkStreamHandler.java
++++ b/src/com/android/bluetooth/a2dpsink/A2dpSinkStreamHandler.java
+@@ -111,7 +111,6 @@ public class A2dpSinkStreamHandler extends Handler {
+         }
+         switch (message.what) {
+             case SRC_STR_START:
+-                mStreamAvailable = true;
+                 // Always request audio focus if on TV.
+                 if (isTvDevice() || isAutomotiveDevice()) {
+                     if (mAudioFocus == AudioManager.AUDIOFOCUS_NONE) {
+@@ -133,6 +132,7 @@ public class A2dpSinkStreamHandler extends Handler {
+                 break;
+ 
+             case SNK_PLAY:
++                mStreamAvailable = true;
+                 // Local play command, gain focus and start avrcp updates.
+                 if (mAudioFocus == AudioManager.AUDIOFOCUS_NONE) {
+                     requestAudioFocus();
+@@ -146,6 +146,7 @@ public class A2dpSinkStreamHandler extends Handler {
+                 break;
+ 
+             case SRC_PLAY:
++                mStreamAvailable = true;
+                 // Remote play command.
+                 // If is an iot device gain focus and start avrcp updates.
+                 if (isIotDevice() || isTvDevice()) {
+-- 
+2.7.4
+


### PR DESCRIPTION
Issue: When message readout is done, paused audio resumes
automatically.

Reason: When audio Focus changes, pausing of the audio is done
on the basis of mStreamAvailable variable. This variable was
not handled properly. It is made true at SRC_STR_START command.
When message is received, to start readout, again SRC_STR_START
is received which again makes mStreamavailable true and the
previous state of mStreamAvailable was lost. Due to which on
recepetion of AudioFocus Loss Transient, always a pause commmand
was sent and audio resumes when message readout happens.

Fix: Changed handling of mStreamAvailable from SRC_STR_START to
SRC_PLAY and SNK_PLAY.

Tracked-On: OAM-68209

Signed-off-by: Gaganpreet kaur <gaganpreetx.kaur@intel.com>