### PR TITLE
A work around fix for incorrect controller response.

### DIFF
--- a/android_p/google_diff/cel_apl/system/bt/0005-A-work-around-fix-for-incorrect-controller-response.patch
+++ b/android_p/google_diff/cel_apl/system/bt/0005-A-work-around-fix-for-incorrect-controller-response.patch
@@ -1,0 +1,53 @@
+From 0d07e4d6090c3574a03b4c36bacce17f3542bb8b Mon Sep 17 00:00:00 2001
+From: anitha3x <anithax.h.chandrasekar@intel.com>
+Date: Tue, 16 Oct 2018 14:22:07 +0530
+Subject: [PATCH 5/5] A work around fix for incorrect controller response.
+
+Reason: The controller did not send correct response
+for read remote extended features for "page 1" request.
+Since lmp extended features ssp was not true, the sm4
+was not enabled. Therefore host did not initiate
+authentication request. When L2CAP AVDTP connection
+was established, the controller returned disconnect
+complete with authentication failed reason.
+
+Fix: Provided a retry of read remote extended features
+request from host, when response for 'page 1' was
+incorrect. This enabled authentication from host and
+hence L2CAP AVDTP connection was successful.
+Revert the changes, once contoller fix is available
+
+Tracked-On: OAM-69566
+
+Signed-off-by: anitha3x <anithax.h.chandrasekar@intel.com>
+---
+ stack/btm/btm_acl.cc | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/stack/btm/btm_acl.cc b/stack/btm/btm_acl.cc
+index ee2530a..c59ec2b 100644
+--- a/stack/btm/btm_acl.cc
++++ b/stack/btm/btm_acl.cc
+@@ -936,9 +936,16 @@ void btm_process_remote_ext_features(tACL_CONN* p_acl_cb,
+       BTM_TRACE_ERROR("%s: page=%d unexpected", __func__, page_idx);
+       break;
+     }
+-    memcpy(p_dev_rec->feature_pages[page_idx],
+-           p_acl_cb->peer_lmp_feature_pages[page_idx],
+-           HCI_FEATURE_BYTES_PER_PAGE);
++    if ((page_idx == 1) && !HCI_SSP_HOST_SUPPORTED(
++        p_acl_cb->peer_lmp_feature_pages[page_idx])) {
++      BTM_TRACE_ERROR("Not received response for Page 1, retry");
++      btm_read_remote_ext_features(handle, page_idx);
++      return;
++    } else {
++      memcpy(p_dev_rec->feature_pages[page_idx],
++             p_acl_cb->peer_lmp_feature_pages[page_idx],
++             HCI_FEATURE_BYTES_PER_PAGE);
++    }
+   }
+ 
+   if (!(p_dev_rec->sec_flags & BTM_SEC_NAME_KNOWN) ||
+-- 
+2.7.4
+


### PR DESCRIPTION
Reason: The controller did not send correct response
for read remote extended features for "page 1" request.
Since lmp extended features ssp was not true, the sm4
was not enabled. Therefore host did not initiate
authentication request. When L2CAP AVDTP connection
was established, the controller returned disconnect
complete with authentication failed reason.

Fix: Provided a retry of read remote extended features
request from host, when response for 'page 1' was
incorrect. This enabled authentication from host and
hence L2CAP AVDTP connection was successful.
Revert the changes, once contoller fix is available

Tracked-On: OAM-69566

Signed-off-by: anitha3x <anithax.h.chandrasekar@intel.com>