### PR TITLE
Fix the status bar icons disappear.

### DIFF
--- a/android_p/google_diff/cel_apl/packages/services/Car/0005-Fix-the-status-bar-icons-disappear.patch
+++ b/android_p/google_diff/cel_apl/packages/services/Car/0005-Fix-the-status-bar-icons-disappear.patch
@@ -1,0 +1,69 @@
+From 217c26195128b679c1ac8adb81e0a50128074384 Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Fri, 21 Sep 2018 11:22:41 +0800
+Subject: [PATCH] Fix the status bar icons disappear
+
+The status bar icons disappear due to the statusBar is overlaid by a
+Head-Up Notification's ticker text. Reference to the phone status bar
+layout, Head-up notifications only use the 1/2 of the statusBar width
+to display the notification ticker text.
+
+Test:
+1. Turn on WIFI
+2. Show a Head_Up notification
+
+Change-Id: I66c42d0fdc0d16cbb8b325f97407f62c8acbdc58
+Tracked-On: OAM-69584
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ .../packages/SystemUI/res/layout/status_bar.xml    | 30 ++++++++++++++--------
+ 1 file changed, 19 insertions(+), 11 deletions(-)
+
+diff --git a/car_product/overlay/frameworks/base/packages/SystemUI/res/layout/status_bar.xml b/car_product/overlay/frameworks/base/packages/SystemUI/res/layout/status_bar.xml
+index b99bfe8..bb9fc03 100644
+--- a/car_product/overlay/frameworks/base/packages/SystemUI/res/layout/status_bar.xml
++++ b/car_product/overlay/frameworks/base/packages/SystemUI/res/layout/status_bar.xml
+@@ -48,21 +48,29 @@
+         android:orientation="horizontal"
+         >
+ 
+-        <include layout="@layout/heads_up_status_bar_layout" />
+-
+-        <!-- The alpha of this area is controlled from both PhoneStatusBarTransitions and
+-             PhoneStatusBar (DISABLE_NOTIFICATION_ICONS). -->
+-        <com.android.systemui.statusbar.AlphaOptimizedFrameLayout
+-            android:id="@+id/notification_icon_area"
+-            android:layout_width="0dip"
++        <FrameLayout
+             android:layout_height="match_parent"
+-            android:layout_weight="1"
+-            android:orientation="horizontal"
+-            android:visibility="gone" />
++            android:layout_width="0dp"
++            android:layout_weight="1">
++
++            <include layout="@layout/heads_up_status_bar_layout" />
++
++            <!-- The alpha of this area is controlled from both PhoneStatusBarTransitions and
++                 PhoneStatusBar (DISABLE_NOTIFICATION_ICONS). -->
++            <com.android.systemui.statusbar.AlphaOptimizedFrameLayout
++                android:id="@+id/notification_icon_area"
++                android:layout_width="0dip"
++                android:layout_height="match_parent"
++                android:layout_weight="1"
++                android:orientation="horizontal"
++                android:visibility="gone" />
++
++       </FrameLayout>
+ 
+         <com.android.keyguard.AlphaOptimizedLinearLayout android:id="@+id/system_icon_area"
+-            android:layout_width="match_parent"
++            android:layout_width="0dp"
+             android:layout_height="match_parent"
++            android:layout_weight="1"
+             android:orientation="horizontal"
+             >
+ 
+-- 
+1.9.1
+


### PR DESCRIPTION
The status bar icons disappear due to the statusBar is overlaid by a
Head-Up Notification's ticker text. Reference to the phone status bar
layout, Head-up notifications only use the 1/2 of the statusBar width
to display the notification ticker text.

Test:
1. Turn on WIFI
2. Show a Head_Up notification

Tracked-On: OAM-69584
Signed-off-by: Yan, WalterX <walterx.yan@intel.com>