### PR TITLE
Correct the seekbar value by min volume of the stream.

### DIFF
--- a/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0002-Correct-the-seekbar-value-by-min-volume-of-the-strea.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0002-Correct-the-seekbar-value-by-min-volume-of-the-strea.patch
@@ -1,0 +1,74 @@
+From fbbdd88d7f862a61216a2c1c62a06f397b9975e6 Mon Sep 17 00:00:00 2001
+From: "Yan, WalterX" <walterx.yan@intel.com>
+Date: Wed, 17 Oct 2018 18:57:47 +0800
+Subject: [PATCH] Correct the seekbar value by min volume of the stream.
+
+For some streams (e.g.Alarm), the min volume is not zero.
+Needs to correct the value of seekbar by min volume.
+
+Change-Id: I97de5f202107433a61ea8da356cf186496bffddc
+Tracked-On: OAM-68651
+Signed-off-by: Yan, WalterX <walterx.yan@intel.com>
+---
+ src/com/android/car/settings/sound/VolumeLineItem.java | 17 ++++++++++++++---
+ 1 file changed, 14 insertions(+), 3 deletions(-)
+
+diff --git a/src/com/android/car/settings/sound/VolumeLineItem.java b/src/com/android/car/settings/sound/VolumeLineItem.java
+index a628ad5..f4d5c24 100644
+--- a/src/com/android/car/settings/sound/VolumeLineItem.java
++++ b/src/com/android/car/settings/sound/VolumeLineItem.java
+@@ -41,6 +41,7 @@ public class VolumeLineItem extends SeekbarListItem implements SeekBar.OnSeekBar
+     private static final Logger LOG = new Logger(VolumeLineItem.class);
+     private static final int AUDIO_FEEDBACK_DURATION_MS = 1000;
+ 
++    private final int mMinVolume;
+     private final Handler mUiHandler;
+     private final Ringtone mRingtone;
+     private final int mVolumeGroupId;
+@@ -59,6 +60,7 @@ public class VolumeLineItem extends SeekbarListItem implements SeekBar.OnSeekBar
+         mRingtone = RingtoneManager.getRingtone(context, getRingtoneUri(usage));
+         mRingtone.setAudioAttributes(new AudioAttributes.Builder().setUsage(usage).build());
+         mVolumeGroupId = volumeGroupId;
++        mMinVolume = getMinVolume();
+         setMax(getMaxSeekbarValue());
+         updateProgress();
+         setOnSeekBarChangeListener(this);
+@@ -91,7 +93,7 @@ public class VolumeLineItem extends SeekbarListItem implements SeekBar.OnSeekBar
+             }
+             // AudioManager.FLAG_PLAY_SOUND does not guarantee play sound, use our own
+             // playback here instead.
+-            mCarAudioManager.setGroupVolume(mVolumeGroupId, progress, 0);
++            mCarAudioManager.setGroupVolume(mVolumeGroupId, progress + mMinVolume, 0);
+             playAudioFeedback();
+         } catch (CarNotConnectedException e) {
+             LOG.e("Car is not connected!", e);
+@@ -141,7 +143,7 @@ public class VolumeLineItem extends SeekbarListItem implements SeekBar.OnSeekBar
+ 
+     private int getSeekbarValue() {
+         try {
+-            return mCarAudioManager.getGroupVolume(mVolumeGroupId);
++            return mCarAudioManager.getGroupVolume(mVolumeGroupId) - mMinVolume;
+         } catch (CarNotConnectedException e) {
+             LOG.e("Car is not connected!", e);
+         }
+@@ -150,7 +152,16 @@ public class VolumeLineItem extends SeekbarListItem implements SeekBar.OnSeekBar
+ 
+     private int getMaxSeekbarValue() {
+         try {
+-            return mCarAudioManager.getGroupMaxVolume(mVolumeGroupId);
++            return mCarAudioManager.getGroupMaxVolume(mVolumeGroupId) - mMinVolume;
++        } catch (CarNotConnectedException e) {
++            LOG.e("Car is not connected!", e);
++        }
++        return 0;
++    }
++
++    private int getMinVolume() {
++        try {
++            return mCarAudioManager.getGroupMinVolume(mVolumeGroupId);
+         } catch (CarNotConnectedException e) {
+             LOG.e("Car is not connected!", e);
+         }
+-- 
+1.9.1
+


### PR DESCRIPTION
For some streams (e.g.Alarm), the min volume is not zero.
Needs to correct the value of seekbar by min volume.

Tracked-On: OAM-68651
Signed-off-by: Yan, WalterX <walterx.yan@intel.com>