### PR TITLE
set CONFIG_F2FS_FS_ENCRYPTION to support fbe on f2fs

### DIFF
--- a/android_p/google_diff/cel_apl/device/intel/project-celadon/0005-SET-F2FS_FS_ENCRYPTION-to-support-fbe-on-adoptable-s.patch
+++ b/android_p/google_diff/cel_apl/device/intel/project-celadon/0005-SET-F2FS_FS_ENCRYPTION-to-support-fbe-on-adoptable-s.patch
@@ -1,0 +1,26 @@
+From 8e524347d406df9ea42e10d0d8339b7d5b2002a0 Mon Sep 17 00:00:00 2001
+From: Zhiwei Li <zhiwei.li@intel.com>
+Date: Mon, 22 Oct 2018 15:35:58 +0800
+Subject: [PATCH] SET F2FS_FS_ENCRYPTION to support fbe on adoptable storage
+
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-70236
+Signed-off-by: Zhiwei Li zhiwei.li@intel.com
+---
+ kernel_config/kernel_64_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel_config/kernel_64_defconfig b/kernel_config/kernel_64_defconfig
+index b890a1a..c73745c 100644
+--- a/kernel_config/kernel_64_defconfig
++++ b/kernel_config/kernel_64_defconfig
+@@ -6891,6 +6891,7 @@ CONFIG_F2FS_STAT_FS=y
+ CONFIG_F2FS_FS_XATTR=y
+ CONFIG_F2FS_FS_POSIX_ACL=y
+ CONFIG_F2FS_FS_SECURITY=y
++CONFIG_F2FS_FS_ENCRYPTION=y
+ # CONFIG_FS_DAX is not set
+ CONFIG_FS_POSIX_ACL=y
+ CONFIG_EXPORTFS=m
+-- 
+2.7.4
+

--- a/android_p/google_diff/celadon/device/intel/project-celadon/0002-SET-F2FS_FS_ENCRYPTION-to-support-fbe-on-adoptable-s.patch
+++ b/android_p/google_diff/celadon/device/intel/project-celadon/0002-SET-F2FS_FS_ENCRYPTION-to-support-fbe-on-adoptable-s.patch
@@ -1,0 +1,26 @@
+From 8e524347d406df9ea42e10d0d8339b7d5b2002a0 Mon Sep 17 00:00:00 2001
+From: Zhiwei Li <zhiwei.li@intel.com>
+Date: Mon, 22 Oct 2018 15:35:58 +0800
+Subject: [PATCH] SET F2FS_FS_ENCRYPTION to support fbe on adoptable storage
+
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-70236
+Signed-off-by: Zhiwei Li zhiwei.li@intel.com
+---
+ kernel_config/kernel_64_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel_config/kernel_64_defconfig b/kernel_config/kernel_64_defconfig
+index b890a1a..c73745c 100644
+--- a/kernel_config/kernel_64_defconfig
++++ b/kernel_config/kernel_64_defconfig
+@@ -6891,6 +6891,7 @@ CONFIG_F2FS_STAT_FS=y
+ CONFIG_F2FS_FS_XATTR=y
+ CONFIG_F2FS_FS_POSIX_ACL=y
+ CONFIG_F2FS_FS_SECURITY=y
++CONFIG_F2FS_FS_ENCRYPTION=y
+ # CONFIG_FS_DAX is not set
+ CONFIG_FS_POSIX_ACL=y
+ CONFIG_EXPORTFS=m
+-- 
+2.7.4
+


### PR DESCRIPTION
set CONFIG_F2FS_FS_ENCRYPTION to support fbe on f2fs

Tracked-On: https://jira01.devtools.intel.com/browse/OAM-70236
Signed-off-by: Zhiwei Li zhiwei.li@intel.com