### PR TITLE
[CELADON] Enabling S3 on IVI.

### DIFF
--- a/android_p/google_diff/cel_apl/device/intel/project-celadon/0004-CELADON-SELinux-remove-dedicated-sepolicy-configurat.patch
+++ b/android_p/google_diff/cel_apl/device/intel/project-celadon/0004-CELADON-SELinux-remove-dedicated-sepolicy-configurat.patch
@@ -1,0 +1,57 @@
+From 177b926492f429ac271e9a7be302353d767278f9 Mon Sep 17 00:00:00 2001
+From: Madhusudhan S <madhusudhan.s@intel.com>
+Date: Wed, 31 Oct 2018 15:21:12 +0530
+Subject: [PATCH] [CELADON]SELinux:remove dedicated sepolicy configuration for
+ /sys/power/state
+
+Adding car service to access /sys/power/state to enable IVI to go for
+suspend.
+
+Tracked-on: OAM-56502
+Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>
+---
+ sepolicy/car/file.te          | 2 +-
+ sepolicy/car/file_contexts    | 1 -
+ sepolicy/car/system_app.te    | 3 ++-
+ sepolicy/car/system_server.te | 1 -
+ 4 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/sepolicy/car/file.te b/sepolicy/car/file.te
+index 1e3ef6f..02eb9ed 100644
+--- a/sepolicy/car/file.te
++++ b/sepolicy/car/file.te
+@@ -3,5 +3,5 @@
+ # when system is going to suspend, by press ignition button, Carservice needs to write
+ # /sys/power/state to put system to suspend
+ #
+-type sysfs_power_state, fs_type, sysfs_type;
++#type sysfs_power_state, fs_type, sysfs_type;
+ type sysfs_early_evs, fs_type, sysfs_type;
+diff --git a/sepolicy/car/file_contexts b/sepolicy/car/file_contexts
+index 66fd766..589ff44 100644
+--- a/sepolicy/car/file_contexts
++++ b/sepolicy/car/file_contexts
+@@ -1,5 +1,4 @@
+ /(vendor|system/vendor)/bin/hw/android\.hardware\.automotive\.vehicle\.intel@2\.0-service  u:object_r:hal_vehicle_default_exec:s0
+ /(vendor|system/vendor)/bin/hw/android\.hardware\.automotive\.vehicle\.intel@2\.1-service  u:object_r:hal_vehicle_default_exec:s0
+-/sys/power/state u:object_r:sysfs_power_state:s0
+ 
+ /vendor/bin/hw/android.hardware.broadcastradio@intel-service u:object_r:hal_broadcastradio_default_exec:s0
+diff --git a/sepolicy/car/system_app.te b/sepolicy/car/system_app.te
+index 9a4a4f3..267e3d2 100644
+--- a/sepolicy/car/system_app.te
++++ b/sepolicy/car/system_app.te
+@@ -1,2 +1,3 @@
+ # allow CarService to write /sys/power/state to enter deep sleep.
+-allow system_app sysfs_power_state:file rw_file_perms;
++allow carservice_app sysfs_power:file rw_file_perms;
++
+diff --git a/sepolicy/car/system_server.te b/sepolicy/car/system_server.te
+index 2ad5fe2..e69de29 100644
+--- a/sepolicy/car/system_server.te
++++ b/sepolicy/car/system_server.te
+@@ -1 +0,0 @@
+-allow system_server sysfs_power_state:file rw_file_perms;
+-- 
+2.7.4
+


### PR DESCRIPTION
Implemented: This patch enables APL to enter into S3 
when user clicks 'sleep' from the power button menu.

Tracked-on: OAM-56502 
Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>