### PR TITLE
Fix for request audio focus when play audio by A2DP.

### DIFF
--- a/android_p/google_diff/cel_apl/packages/apps/Bluetooth/0005-Fix-for-request-audio-focus-when-play-audio-by-A2DP.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Bluetooth/0005-Fix-for-request-audio-focus-when-play-audio-by-A2DP.patch
@@ -1,0 +1,47 @@
+From 968a44bb8fbacf9d1ba426861e36f94769844269 Mon Sep 17 00:00:00 2001
+From: anitha3x <anithax.h.chandrasekar@intel.com>
+Date: Mon, 29 Oct 2018 16:53:10 +0530
+Subject: [PATCH 5/5] Fix for request audio focus when play audio by A2DP
+
+Reason: When audio stream was started, the audio was
+paused
+
+Fix: Removed the audio pause and requested for audio focus
+
+Tracked-On: OAM-70162
+
+Signed-off-by: huguobiX <guobingx.hu@intel.com>
+Signed-off-by: anitha3x <anithax.h.chandrasekar@intel.com>
+---
+ src/com/android/bluetooth/a2dpsink/A2dpSinkStreamHandler.java | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/src/com/android/bluetooth/a2dpsink/A2dpSinkStreamHandler.java b/src/com/android/bluetooth/a2dpsink/A2dpSinkStreamHandler.java
+index a44cf47..9b4b6e1 100644
+--- a/src/com/android/bluetooth/a2dpsink/A2dpSinkStreamHandler.java
++++ b/src/com/android/bluetooth/a2dpsink/A2dpSinkStreamHandler.java
+@@ -117,10 +117,8 @@ public class A2dpSinkStreamHandler extends Handler {
+                         requestAudioFocus();
+                     }
+                 }
+-                // Audio stream has started, stop it if we don't have focus.
+-                if (mAudioFocus == AudioManager.AUDIOFOCUS_NONE) {
+-                    sendAvrcpPause();
+-                } else {
++                // Audio stream has started.
++                if (mAudioFocus != AudioManager.AUDIOFOCUS_NONE) {
+                     startAvrcpUpdates();
+                 }
+                 break;
+@@ -149,7 +147,7 @@ public class A2dpSinkStreamHandler extends Handler {
+                 mStreamAvailable = true;
+                 // Remote play command.
+                 // If is an iot device gain focus and start avrcp updates.
+-                if (isIotDevice() || isTvDevice()) {
++                if (isIotDevice() || isTvDevice() || isAutomotiveDevice()) {
+                     if (mAudioFocus == AudioManager.AUDIOFOCUS_NONE) {
+                         requestAudioFocus();
+                     }
+-- 
+2.7.4
+


### PR DESCRIPTION
Reason: During DUT BT ON/OFF or Reboot, the ongoing audio
stream was paused.

Fix: Removed the audio pause and requested for audio focus

Tracked-On: OAM-70162

Signed-off-by: huguobiX <guobingx.hu@intel.com>
Signed-off-by: anitha3x <anithax.h.chandrasekar@intel.com>