### PR TITLE
[CELADON]Set available device as prmary hardware device

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/av/services/0001-CELADON-Set-available-device-as-prmary-hardware-devi.patch
+++ b/android_p/google_diff/cel_apl/frameworks/av/services/0001-CELADON-Set-available-device-as-prmary-hardware-devi.patch
@@ -1,0 +1,47 @@
+From 4e0bf1ebeb1db363256a30c67000c7a4c7c132ef Mon Sep 17 00:00:00 2001
+From: "M, Kumar K" <kumar.k.m@intel.com>
+Date: Wed, 31 Oct 2018 15:29:12 +0530
+Subject: [PATCH] [CELADON]Set available device as prmary hardware device
+
+set the available device as hardware primary when the on-board
+sound card is not present. This is to fix the USB recording issue
+on commercial NUC.
+
+Change-Id: I2d08b79d5e2bc7b9c2d14b76452ce610d79d60cb
+Tracked-On:OAM-70176
+Signed-off-by: M, Kumar K <kumar.k.m@intel.com>
+---
+ services/audioflinger/AudioFlinger.cpp | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/services/audioflinger/AudioFlinger.cpp b/services/audioflinger/AudioFlinger.cpp
+index bdd39c6..2eef169 100644
+--- a/services/audioflinger/AudioFlinger.cpp
++++ b/services/audioflinger/AudioFlinger.cpp
+@@ -2159,14 +2159,22 @@ status_t AudioFlinger::openOutput(audio_module_handle_t module,
+                 mHardwareStatus = AUDIO_HW_SET_MODE;
+                 mPrimaryHardwareDev->hwDevice()->setMode(mMode);
+                 mHardwareStatus = AUDIO_HW_IDLE;
++            } else if (mPrimaryHardwareDev == NULL)  {
++                ALOGV("Using available module %d as the primary audio interface", module);
++                mPrimaryHardwareDev = playbackThread->getOutput()->audioHwDev;
++
++                AutoMutex lock(mHardwareLock);
++                mHardwareStatus = AUDIO_HW_SET_MODE;
++                mPrimaryHardwareDev->hwDevice()->setMode(mMode);
++                mHardwareStatus = AUDIO_HW_IDLE;
+             }
++
+         } else {
+             MmapThread *mmapThread = (MmapThread *)thread.get();
+             mmapThread->ioConfigChanged(AUDIO_OUTPUT_OPENED);
+         }
+         return NO_ERROR;
+     }
+-
+     return NO_INIT;
+ }
+ 
+-- 
+1.9.1
+


### PR DESCRIPTION
set the available device as hardware primary when the on-board
sound card is not present. This is to fix the USB recording issue
on commercial NUC.

Tracked-On:OAM-70176