### PR TITLE
Add default values for system locales

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0016-Add-default-values-for-system-locales.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0016-Add-default-values-for-system-locales.patch
@@ -1,0 +1,70 @@
+From 156300bd38f535555f67f98ccc4e09f16dc71c20 Mon Sep 17 00:00:00 2001
+From: robinz1x <robinx.zhang@intel.com>
+Date: Fri, 2 Nov 2018 14:24:18 +0800
+Subject: [PATCH] Add default values for system locales
+
+Now when first time log in, the system user's system locales is not
+stored in settings_system database. So the value will be written by
+the new user's change language action. And after switch back to system
+user, the system locales value will remain the same as new user.
+
+So the solution is add default values for system locales when system
+user first time log in, and the default values is coming from device
+configuration.
+
+Change-Id: I08c51a98e8739e137389cf591cf0fcc03d4307af
+Tracked-On: OAM-70885
+Signed-off-by: robinz1x <robinx.zhang@intel.com>
+---
+ .../providers/settings/SettingsProvider.java        | 21 ++++++++++++++++++++-
+ 1 file changed, 20 insertions(+), 1 deletion(-)
+
+diff --git a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
+index 960d305..bc1f1a7 100644
+--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
++++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProvider.java
+@@ -77,6 +77,7 @@ import android.util.SparseBooleanArray;
+ import android.util.proto.ProtoOutputStream;
+ 
+ import com.android.internal.annotations.GuardedBy;
++import com.android.internal.app.LocalePicker;
+ import com.android.internal.content.PackageMonitor;
+ import com.android.internal.os.BackgroundThread;
+ import com.android.providers.settings.SettingsState.Setting;
+@@ -2935,7 +2936,7 @@ public class SettingsProvider extends ContentProvider {
+         }
+ 
+         private final class UpgradeController {
+-            private static final int SETTINGS_VERSION = 169;
++            private static final int SETTINGS_VERSION = 170;
+ 
+             private final int mUserId;
+ 
+@@ -3820,6 +3821,24 @@ public class SettingsProvider extends ContentProvider {
+                     currentVersion = 169;
+                 }
+ 
++                if (currentVersion == 169) {
++                    // Version 169: add default value for system locales
++                    if (userId == UserHandle.USER_SYSTEM) {
++                        final SettingsState systemSettings = getSystemSettingsLocked(userId);
++                        final Setting currentSetting = systemSettings.getSettingLocked(
++                                Settings.System.SYSTEM_LOCALES);
++                        if (currentSetting.isNull()) {
++                            Locale locale = LocalePicker.getLocales().get(0);
++                            final String defaultValue = locale.toLanguageTag();
++                            systemSettings.insertSettingLocked(
++                                    Settings.System.SYSTEM_LOCALES,
++                                    defaultValue,
++                                    null, true, SettingsState.SYSTEM_PACKAGE_NAME);
++                        }
++                    }
++                    currentVersion = 170;
++                }
++
+                 // vXXX: Add new settings above this point.
+ 
+                 if (currentVersion != newVersion) {
+-- 
+1.9.1
+


### PR DESCRIPTION
Now when first time log in, the system user's system locales is not
stored in settings_system database. So the value will be written by
the new user's change language action. And after switch back to system
user, the system locales value will remain the same as new user.

So the solution is add default values for system locales when system
user first time log in, and the default values is coming from device
configuration.

Tracked-On: OAM-70885
Signed-off-by: robinz1x <robinx.zhang@intel.com>