### PR TITLE
[Celadon] Fix an issue that video can not be resumed after being paused

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/av/0001-Fix-an-issue-that-video-can-not-be-resumed-after-bei.patch
+++ b/android_p/google_diff/cel_apl/frameworks/av/0001-Fix-an-issue-that-video-can-not-be-resumed-after-bei.patch
@@ -1,0 +1,41 @@
+From 1714552810dca730b8f341d5d7af323c40de77a5 Mon Sep 17 00:00:00 2001
+From: Dan Liang <dan.liang@intel.com>
+Date: Thu, 20 Sep 2018 14:01:14 +0800
+Subject: [PATCH] Fix an issue that video can not be resumed after being paused
+
+Some video clips contain unsupported audio tracks and when the clip
+is paused and resumed, the audio track would trigger a flush and make
+the MediaClock's anchor being cleared.
+
+Change-Id: If31b8ada4bf225af1c1f40ac4b66a4af9fa858fd
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-68892
+Signed-off-by: Dan Liang <dan.liang@intel.com>
+---
+ media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp b/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp
+index 3a28bbd..55e73ca 100644
+--- a/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp
++++ b/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp
+@@ -1639,6 +1639,17 @@ void NuPlayer::Renderer::onFlush(const sp<AMessage> &msg) {
+ 
+     mVideoSampleReceived = false;
+ 
++    if (audio && !mHasAudio) {
++        // Call postDrainVideoQueue() proactively in case audio decoder is
++        // shut down due to the unsupported mime type and video track can
++        // still be resumed after being paused.
++        if (mDrainVideoQueuePending) {
++            // postDrainVideoQueue() may have been called before flush
++            mDrainVideoQueuePending = false;
++            postDrainVideoQueue();
++        }
++    }
++
+     if (notifyComplete) {
+         notifyFlushComplete(audio);
+     }
+-- 
+2.7.4
+

--- a/android_p/google_diff/celadon/frameworks/av/0001-Fix-an-issue-that-video-can-not-be-resumed-after-bei.patch
+++ b/android_p/google_diff/celadon/frameworks/av/0001-Fix-an-issue-that-video-can-not-be-resumed-after-bei.patch
@@ -1,0 +1,41 @@
+From 1714552810dca730b8f341d5d7af323c40de77a5 Mon Sep 17 00:00:00 2001
+From: Dan Liang <dan.liang@intel.com>
+Date: Thu, 20 Sep 2018 14:01:14 +0800
+Subject: [PATCH] Fix an issue that video can not be resumed after being paused
+
+Some video clips contain unsupported audio tracks and when the clip
+is paused and resumed, the audio track would trigger a flush and make
+the MediaClock's anchor being cleared.
+
+Change-Id: If31b8ada4bf225af1c1f40ac4b66a4af9fa858fd
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-68892
+Signed-off-by: Dan Liang <dan.liang@intel.com>
+---
+ media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp b/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp
+index 3a28bbd..55e73ca 100644
+--- a/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp
++++ b/media/libmediaplayerservice/nuplayer/NuPlayerRenderer.cpp
+@@ -1639,6 +1639,17 @@ void NuPlayer::Renderer::onFlush(const sp<AMessage> &msg) {
+ 
+     mVideoSampleReceived = false;
+ 
++    if (audio && !mHasAudio) {
++        // Call postDrainVideoQueue() proactively in case audio decoder is
++        // shut down due to the unsupported mime type and video track can
++        // still be resumed after being paused.
++        if (mDrainVideoQueuePending) {
++            // postDrainVideoQueue() may have been called before flush
++            mDrainVideoQueuePending = false;
++            postDrainVideoQueue();
++        }
++    }
++
+     if (notifyComplete) {
+         notifyFlushComplete(audio);
+     }
+-- 
+2.7.4
+


### PR DESCRIPTION
Some video clips contain unsupported audio tracks and when the clip is paused and resumed,
the audio track would trigger a flush and make the MediaClock's anchor being cleared.

Tracked-On: OAM-71147
Signed-off-by: tianmi.chen <tianmi.chen@intel.com>