### PR TITLE
Add permission whitelist for Car apps.

### DIFF
--- a/android_p/google_diff/cel_apl/packages/services/Car/0007-Add-permission-whitelist-for-Car-apps.patch
+++ b/android_p/google_diff/cel_apl/packages/services/Car/0007-Add-permission-whitelist-for-Car-apps.patch
@@ -1,0 +1,132 @@
+From 75b5f8883e6c95da214b353ceed6cad829335a5c Mon Sep 17 00:00:00 2001
+From: "Yue, VincentX" <vincentx.yue@intel.com>
+Date: Tue, 28 Nov 2017 11:22:32 +0800
+Subject: [PATCH] Add permission whitelist for Car apps.
+
+Test: run cts -m CtsPermission2TestCases \
+           -t android.permission2.cts.PrivappPermissionsTest#testPrivappPermissionsEnforcement
+
+Change-Id: I89d81b37c9edb19c4378372e42047ffe1beb24d7
+Tracked-On: OAM-71342
+Signed-off-by: Yue, VincentX <vincentx.yue@intel.com>
+Signed-off-by: Yan, WalterX <walterx.yan@intel.com>
+---
+ car_product/build/car.mk                    |  4 ++
+ car_product/etc/privapp-permissions-car.xml | 90 +++++++++++++++++++++++++++++
+ 2 files changed, 94 insertions(+)
+ create mode 100644 car_product/etc/privapp-permissions-car.xml
+
+diff --git a/car_product/build/car.mk b/car_product/build/car.mk
+index 669e828..d5afe29 100644
+--- a/car_product/build/car.mk
++++ b/car_product/build/car.mk
+@@ -83,6 +83,10 @@ PRODUCT_PROPERTY_OVERRIDES := \
+ PRODUCT_PROPERTY_OVERRIDES += \
+     keyguard.no_require_sim=true
+ 
++# Add automotive privapp permissions
++PRODUCT_COPY_FILES += \
++    packages/services/Car/car_product/etc/privapp-permissions-car.xml:system/etc/permissions/privapp-permissions-car.xml
++
+ # Automotive specific packages
+ PRODUCT_PACKAGES += \
+     CarService \
+diff --git a/car_product/etc/privapp-permissions-car.xml b/car_product/etc/privapp-permissions-car.xml
+new file mode 100644
+index 0000000..8a07a06
+--- /dev/null
++++ b/car_product/etc/privapp-permissions-car.xml
+@@ -0,0 +1,90 @@
++<?xml version="1.0" encoding="utf-8"?>
++<!--
++  ~ Copyright (C) 2016 The Android Open Source Project
++  ~
++  ~ Licensed under the Apache License, Version 2.0 (the "License");
++  ~ you may not use this file except in compliance with the License.
++  ~ You may obtain a copy of the License at
++  ~
++  ~      http://www.apache.org/licenses/LICENSE-2.0
++  ~
++  ~ Unless required by applicable law or agreed to in writing, software
++  ~ distributed under the License is distributed on an "AS IS" BASIS,
++  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++  ~ See the License for the specific language governing permissions and
++  ~ limitations under the License
++  -->
++
++<!--
++This XML file declares which signature|privileged permissions should be granted to privileged
++applications that come with the platform
++-->
++<permissions>
++    <privapp-permissions package="android.car.cluster.sample">
++        <permission name="android.permission.CONTROL_INCALL_EXPERIENCE"/>
++        <permission name="android.permission.MANAGE_ACTIVITY_STACKS"/>
++        <permission name="android.permission.WRITE_SECURE_SETTINGS"/>
++    </privapp-permissions>
++
++    <privapp-permissions package="com.android.car.media.localmediaplayer">
++        <permission name="android.permission.MANAGE_USERS"/>
++    </privapp-permissions>
++
++    <privapp-permissions package="com.android.car">
++        <permission name="android.permission.LOCATION_HARDWARE" />
++        <permission name="android.permission.MANAGE_ACTIVITY_STACKS" />
++        <permission name="android.permission.MANAGE_USERS" />
++        <permission name="android.permission.MODIFY_AUDIO_ROUTING" />
++        <permission name="android.permission.MODIFY_DAY_NIGHT_MODE" />
++        <permission name="android.permission.MODIFY_PHONE_STATE" />
++        <permission name="android.permission.REAL_GET_TASKS" />
++        <permission name="android.permission.REBOOT" />
++        <permission name="android.permission.WRITE_SECURE_SETTINGS" />
++    </privapp-permissions>
++    <privapp-permissions package="com.android.car.carlauncher">
++        <permission name="android.permission.PACKAGE_USAGE_STATS" />
++    </privapp-permissions>
++    <privapp-permissions package="com.android.car.dialer">
++        <permission name="android.permission.INTERACT_ACROSS_USERS" />
++        <permission name="android.permission.MODIFY_PHONE_STATE" />
++    </privapp-permissions>
++    <privapp-permissions package="com.android.car.hvac">
++        <permission name="android.permission.INTERACT_ACROSS_USERS" />
++    </privapp-permissions>
++    <privapp-permissions package="com.android.car.media">
++        <permission name="android.permission.MEDIA_CONTENT_CONTROL" />
++    </privapp-permissions>
++    <privapp-permissions package="com.android.car.radio">
++        <permission name="android.permission.ACCESS_BROADCAST_RADIO" />
++    </privapp-permissions>
++    <privapp-permissions package="com.android.car.settings">
++        <permission name="android.permission.BACKUP" />
++        <permission name="android.permission.DELETE_CACHE_FILES" />
++        <permission name="android.permission.DUMP" />
++        <permission name="android.permission.FORCE_STOP_PACKAGES" />
++        <permission name="android.permission.GET_ACCOUNTS_PRIVILEGED" />
++        <permission name="android.permission.MANAGE_USERS" />
++        <permission name="android.permission.MASTER_CLEAR" />
++        <permission name="android.permission.OVERRIDE_WIFI_CONFIG" />
++        <permission name="android.permission.REBOOT" />
++        <permission name="android.permission.SET_TIME" />
++        <permission name="android.permission.SET_TIME_ZONE" />
++        <permission name="android.permission.WRITE_MEDIA_STORAGE" />
++        <permission name="android.permission.WRITE_SECURE_SETTINGS" />
++    </privapp-permissions>
++    <privapp-permissions package="com.android.car.trust">
++        <permission name="android.permission.BLUETOOTH" />
++        <permission name="android.permission.BLUETOOTH_ADMIN" />
++        <permission name="android.permission.ACCESS_COARSE_LOCATION"/>
++        <permission name="android.permission.ACCESS_FINE_LOCATION"/>
++        <permission name="android.permission.INTERACT_ACROSS_USERS"/>
++        <permission name="android.permission.INTERACT_ACROSS_USERS_FULL" />
++        <permission name="android.permission.MANAGE_USERS" />
++        <permission name="android.permission.CONTROL_KEYGUARD" />
++        <permission name="android.permission.PROVIDE_TRUST_AGENT" />
++        <permission name="android.permission.RECEIVE_BOOT_COMPLETED" />
++    </privapp-permissions>
++    <privapp-permissions package="android.car.usb.handler">
++        <permission name="android.permission.MANAGE_USB" />
++    </privapp-permissions>
++</permissions>
+-- 
+1.9.1
+


### PR DESCRIPTION
Test: run cts -m CtsPermission2TestCases \
           -t android.permission2.cts.PrivappPermissionsTest#testPrivappPermissionsEnforcement

Tracked-On: OAM-71342
Signed-off-by: Yan, WalterX <walterx.yan@intel.com>