### PR TITLE
[CEALDON]AudioPolicyManager: Avoid invalid volume setting in APM

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/av/0005-AudioPolicyManager-Avoid-invalid-volume-setting-in-A.patch
+++ b/android_p/google_diff/cel_apl/frameworks/av/0005-AudioPolicyManager-Avoid-invalid-volume-setting-in-A.patch
@@ -1,0 +1,35 @@
+From a244fed20f0fe393682fa7d4620989af7d093f54 Mon Sep 17 00:00:00 2001
+From: Aravind Siddappaji <aravindx.siddappaji@intel.com>
+Date: Wed, 7 Nov 2018 12:45:12 +0530
+Subject: [PATCH] AudioPolicyManager: Avoid invalid volume setting in APM
+
+Do skip volume setting when invalid device id is sent as
+argument to checkAndSetVolume().  If this setting is not skipped,
+the audio volume index sent to checkAndSetVolume() may not match
+with the actual audio device associated with outputDesc sent as
+another argument, causing invalid volume set to actual audio device.
+
+Change-Id: If2a38473480feea3fa14792de850d88a9a0fd835
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-71124
+Signed-off-by: Aravind Siddappaji <aravindx.siddappaji@intel.com>
+---
+ services/audiopolicy/managerdefault/AudioPolicyManager.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/services/audiopolicy/managerdefault/AudioPolicyManager.cpp b/services/audiopolicy/managerdefault/AudioPolicyManager.cpp
+index 3775551..cac8cfd 100644
+--- a/services/audiopolicy/managerdefault/AudioPolicyManager.cpp
++++ b/services/audiopolicy/managerdefault/AudioPolicyManager.cpp
+@@ -5636,6 +5636,9 @@ status_t AudioPolicyManager::checkAndSetVolume(audio_stream_type_t stream,
+ 
+     if (device == AUDIO_DEVICE_NONE) {
+         device = outputDesc->device();
++        ALOGW("checkAndSetVolume() skip setVolume : target device = %d, actual device = %d",
++             AUDIO_DEVICE_NONE, device);
++        return NO_ERROR;
+     }
+ 
+     float volumeDb = computeVolume(stream, index, device);
+-- 
+1.9.1
+


### PR DESCRIPTION
Do skip volume setting when invalid device id is sent as
argument to checkAndSetVolume().  If this setting is not skipped,
the audio volume index sent to checkAndSetVolume() may not match
with the actual audio device associated with outputDesc sent as
another argument, causing invalid volume set to actual audio device.

Tracked-On: https://jira01.devtools.intel.com/browse/OAM-71124
Signed-off-by: Aravind Siddappaji <aravindx.siddappaji@intel.com>