### PR TITLE
[CELADON] Enabling suspend on IVI after clicking sleep from

### DIFF
--- a/android_p/google_diff/cel_apl/device/intel/project-celadon/0004-CELADON-SELinux-Remove-dedicated-sepolicy-configurat.patch
+++ b/android_p/google_diff/cel_apl/device/intel/project-celadon/0004-CELADON-SELinux-Remove-dedicated-sepolicy-configurat.patch
@@ -1,0 +1,56 @@
+From 6839db34278e5be2a35b052fcefe639a088814cd Mon Sep 17 00:00:00 2001
+From: Madhusudhan S <madhusudhan.s@intel.com>
+Date: Wed, 31 Oct 2018 15:21:12 +0530
+Subject: [PATCH 1/2] [CELADON] SELinux: Remove dedicated sepolicy
+ configuration for /sys/power/state
+
+We do not need the sepolicy changes for sys/power/state in "P" since
+it is already handled by the core.
+
+Tracked-on: OAM-56502
+Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>
+---
+ sepolicy/car/file.te          | 1 -
+ sepolicy/car/file_contexts    | 1 -
+ sepolicy/car/system_app.te    | 2 --
+ sepolicy/car/system_server.te | 1 -
+ 4 files changed, 5 deletions(-)
+ delete mode 100644 sepolicy/car/system_app.te
+
+diff --git a/sepolicy/car/file.te b/sepolicy/car/file.te
+index 1e3ef6f..0399da3 100644
+--- a/sepolicy/car/file.te
++++ b/sepolicy/car/file.te
+@@ -3,5 +3,4 @@
+ # when system is going to suspend, by press ignition button, Carservice needs to write
+ # /sys/power/state to put system to suspend
+ #
+-type sysfs_power_state, fs_type, sysfs_type;
+ type sysfs_early_evs, fs_type, sysfs_type;
+diff --git a/sepolicy/car/file_contexts b/sepolicy/car/file_contexts
+index 66fd766..589ff44 100644
+--- a/sepolicy/car/file_contexts
++++ b/sepolicy/car/file_contexts
+@@ -1,5 +1,4 @@
+ /(vendor|system/vendor)/bin/hw/android\.hardware\.automotive\.vehicle\.intel@2\.0-service  u:object_r:hal_vehicle_default_exec:s0
+ /(vendor|system/vendor)/bin/hw/android\.hardware\.automotive\.vehicle\.intel@2\.1-service  u:object_r:hal_vehicle_default_exec:s0
+-/sys/power/state u:object_r:sysfs_power_state:s0
+ 
+ /vendor/bin/hw/android.hardware.broadcastradio@intel-service u:object_r:hal_broadcastradio_default_exec:s0
+diff --git a/sepolicy/car/system_app.te b/sepolicy/car/system_app.te
+deleted file mode 100644
+index 9a4a4f3..0000000
+--- a/sepolicy/car/system_app.te
++++ /dev/null
+@@ -1,2 +0,0 @@
+-# allow CarService to write /sys/power/state to enter deep sleep.
+-allow system_app sysfs_power_state:file rw_file_perms;
+diff --git a/sepolicy/car/system_server.te b/sepolicy/car/system_server.te
+index 2ad5fe2..e69de29 100644
+--- a/sepolicy/car/system_server.te
++++ b/sepolicy/car/system_server.te
+@@ -1 +0,0 @@
+-allow system_server sysfs_power_state:file rw_file_perms;
+-- 
+2.7.4
+

--- a/android_p/google_diff/cel_apl/device/intel/project-celadon/0005-CELADON-Enabling-CONFIG_ANDROID_AUTO_SUSPEND_BEHAVIO.patch
+++ b/android_p/google_diff/cel_apl/device/intel/project-celadon/0005-CELADON-Enabling-CONFIG_ANDROID_AUTO_SUSPEND_BEHAVIO.patch
@@ -1,0 +1,26 @@
+From d516b4a8000d1d54b532bee3e8391517d37adef1 Mon Sep 17 00:00:00 2001
+From: Madhusudhan S <madhusudhan.s@intel.com>
+Date: Tue, 6 Nov 2018 10:56:46 +0530
+Subject: [PATCH 2/2] [CELADON] Enabling CONFIG_ANDROID_AUTO_SUSPEND_BEHAVIOR
+
+Enabling CONFIG_ANDROID_AUTO_SUSPEND_BEHAVIOR
+to bypass the alarmtimer during suspend flow.
+
+Tracked-On: OAM-56502
+Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>
+---
+ kernel_config/kernel_64_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel_config/kernel_64_defconfig b/kernel_config/kernel_64_defconfig
+index 705b9f2..3561166 100644
+--- a/kernel_config/kernel_64_defconfig
++++ b/kernel_config/kernel_64_defconfig
+@@ -6705,3 +6705,4 @@ CONFIG_UNWINDER_ORC=y
+ # CONFIG_UNWINDER_GUESS is not set
+ 
+ CONFIG_TYPEC_TCPM=y
++CONFIG_ANDROID_AUTO_SUSPEND_BEHAVIOR=y
+-- 
+2.7.4
+

--- a/android_p/google_diff/cel_apl/frameworks/base/0017-CELADON-GlobalActions-Handle-sleep-action.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0017-CELADON-GlobalActions-Handle-sleep-action.patch
@@ -1,0 +1,94 @@
+From 04e9c4bd2ebc77e458bb2b1ff448538e224e1c2a Mon Sep 17 00:00:00 2001
+From: saranya <saranya.gopal@intel.com>
+Date: Tue, 17 Apr 2018 15:52:08 +0530
+Subject: [PATCH] [CELADON] GlobalActions: Handle 'sleep' action
+
+Some Intel platforms do not provide separate
+events for power key press and release. This
+makes it impossible to detect long press of
+power button. So, the solution is to handle
+only short press and add 'sleep' also as an
+option in GlobalActions menu. This patch
+handles 'sleep' option.
+
+Change-Id: Iaae59b324e5ba6eaed9e507fdaa8e5006535716c
+Tracked-On: OAM-56502
+Signed-off-by: saranya <saranya.gopal@intel.com>
+Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>
+---
+ .../globalactions/GlobalActionsDialog.java         | 35 ++++++++++++++++++++++
+ 1 file changed, 35 insertions(+)
+
+diff --git a/packages/SystemUI/src/com/android/systemui/globalactions/GlobalActionsDialog.java b/packages/SystemUI/src/com/android/systemui/globalactions/GlobalActionsDialog.java
+index d232108..4aad11b 100644
+--- a/packages/SystemUI/src/com/android/systemui/globalactions/GlobalActionsDialog.java
++++ b/packages/SystemUI/src/com/android/systemui/globalactions/GlobalActionsDialog.java
+@@ -44,9 +44,11 @@ import android.os.Build;
+ import android.os.Handler;
+ import android.os.IBinder;
+ import android.os.Message;
++import android.os.PowerManager;
+ import android.os.Messenger;
+ import android.os.RemoteException;
+ import android.os.ServiceManager;
++import android.os.SystemClock;
+ import android.os.SystemProperties;
+ import android.os.UserHandle;
+ import android.os.UserManager;
+@@ -126,6 +128,7 @@ class GlobalActionsDialog implements DialogInterface.OnDismissListener,
+     private static final String GLOBAL_ACTION_KEY_VOICEASSIST = "voiceassist";
+     private static final String GLOBAL_ACTION_KEY_ASSIST = "assist";
+     private static final String GLOBAL_ACTION_KEY_RESTART = "restart";
++    private static final String GLOBAL_ACTION_KEY_SLEEP = "sleep";
+     private static final String GLOBAL_ACTION_KEY_LOGOUT = "logout";
+     private static final String GLOBAL_ACTION_KEY_SCREENSHOT = "screenshot";
+ 
+@@ -357,6 +360,8 @@ class GlobalActionsDialog implements DialogInterface.OnDismissListener,
+                 mItems.add(getAssistAction());
+             } else if (GLOBAL_ACTION_KEY_RESTART.equals(actionKey)) {
+                 mItems.add(new RestartAction());
++            } else if (GLOBAL_ACTION_KEY_SLEEP.equals(actionKey)) {
++                mItems.add(new SleepAction());
+             } else if (GLOBAL_ACTION_KEY_SCREENSHOT.equals(actionKey)) {
+                 mItems.add(new ScreenshotAction());
+             } else if (GLOBAL_ACTION_KEY_LOGOUT.equals(actionKey)) {
+@@ -472,6 +477,36 @@ class GlobalActionsDialog implements DialogInterface.OnDismissListener,
+         }
+     }
+ 
++    private final class SleepAction extends SinglePressAction implements LongPressAction {
++        private SleepAction() {
++            super(R.drawable.ic_restart, R.string.global_action_sleep);
++        }
++
++        @Override
++        public boolean onLongPress() {
++            PowerManager mPowerManager = (PowerManager)
++                   mContext.getSystemService(Context.POWER_SERVICE);
++            mPowerManager.goToSleep(SystemClock.uptimeMillis());
++            return true;
++        }
++
++        @Override
++        public boolean showDuringKeyguard() {
++            return true;
++        }
++
++        @Override
++        public boolean showBeforeProvisioning() {
++            return true;
++        }
++
++        @Override
++        public void onPress() {
++            PowerManager mPowerManager = (PowerManager)
++                   mContext.getSystemService(Context.POWER_SERVICE);
++            mPowerManager.goToSleep(SystemClock.uptimeMillis());
++        }
++    }
+ 
+     private class ScreenshotAction extends SinglePressAction {
+         public ScreenshotAction() {
+-- 
+2.7.4
+

--- a/android_p/google_diff/cel_apl/frameworks/base/0018-CELADON-Enabling-suspend-on-IVI-after-clicking.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0018-CELADON-Enabling-suspend-on-IVI-after-clicking.patch
@@ -1,0 +1,44 @@
+From 5db57924ee277f923beacefbe7edb924713cb4e3 Mon Sep 17 00:00:00 2001
+From: Madhusudhan S <madhusudhan.s@intel.com>
+Date: Mon, 12 Nov 2018 13:18:34 +0530
+Subject: [PATCH] [CELADON] Enabling suspend on IVI after clicking sleep from
+ the power button menu.
+
+Tracked-on: OAM-56502
+
+Change-Id: Ib8e5f351815474d8e99739938ac5845227f711ff
+Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>
+---
+ .../core/java/com/android/server/power/PowerManagerService.java  | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/services/core/java/com/android/server/power/PowerManagerService.java b/services/core/java/com/android/server/power/PowerManagerService.java
+index 697801f..44cda43 100644
+--- a/services/core/java/com/android/server/power/PowerManagerService.java
++++ b/services/core/java/com/android/server/power/PowerManagerService.java
+@@ -108,6 +108,8 @@ import java.lang.annotation.RetentionPolicy;
+ import java.util.ArrayList;
+ import java.util.Arrays;
+ import java.util.Objects;
++import java.io.IOException;
++import android.os.FileUtils;
+ 
+ /**
+  * The power manager service is responsible for coordinating power management
+@@ -1429,6 +1431,13 @@ public final class PowerManagerService extends SystemService
+                 default:
+                     Slog.i(TAG, "Going to sleep by application request (uid " + uid +")...");
+                     reason = PowerManager.GO_TO_SLEEP_REASON_APPLICATION;
++		    // Adding force suspend code to enable IVI to enter S3 after pressing sleep button
++                    try {
++                        FileUtils.stringToFile("/sys/power/state", "mem");
++                    }
++                    catch (IOException e) {
++                        Slog.v(TAG, "IOException: " + e);
++                    }
+                     break;
+             }
+ 
+-- 
+2.7.4
+

--- a/android_p/google_diff/cel_apl/packages/services/Car/0006-CELADON-Enabling-display-timeout-on-IVI.patch
+++ b/android_p/google_diff/cel_apl/packages/services/Car/0006-CELADON-Enabling-display-timeout-on-IVI.patch
@@ -1,0 +1,32 @@
+From ca658f1bdfd2ad40b3f9cdaf9491dda7f780b541 Mon Sep 17 00:00:00 2001
+From: Madhusudhan S <madhusudhan.s@intel.com>
+Date: Wed, 14 Nov 2018 16:28:15 +0530
+Subject: [PATCH] [CELADON]Enabling display timeout on IVI.
+
+Changing SCREEN_DIM_WAKE_LOCK to PARTIAL_WAKE_LOCK
+since SCREEN_DIM_WAKE_LOCK never allows to timeout
+display.
+
+Change-Id: Ia8312fcefe70902f185e4ad7423073bc1d529ad9
+Tracked-on: OAM-69117
+Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>
+---
+ service/src/com/android/car/systeminterface/WakeLockInterface.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/service/src/com/android/car/systeminterface/WakeLockInterface.java b/service/src/com/android/car/systeminterface/WakeLockInterface.java
+index cde6e5b..771d625 100644
+--- a/service/src/com/android/car/systeminterface/WakeLockInterface.java
++++ b/service/src/com/android/car/systeminterface/WakeLockInterface.java
+@@ -36,7 +36,7 @@ public interface WakeLockInterface {
+         DefaultImpl(Context context) {
+             PowerManager powerManager =
+                     (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+-            mFullWakeLock = powerManager.newWakeLock(PowerManager.SCREEN_DIM_WAKE_LOCK,
++            mFullWakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK,
+                 CarLog.TAG_POWER);
+             mPartialWakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK,
+                 CarLog.TAG_POWER);
+-- 
+2.7.4
+


### PR DESCRIPTION
 the power button menu.

Enabled S3 and modified dedicated sepolicy configurations.

Tracked-on: OAM-56502
Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>