### PR TITLE
Backport Prevent shortcut info package name spoofing

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0017-Backport-Prevent-shortcut-info-package-name-spoofing.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0017-Backport-Prevent-shortcut-info-package-name-spoofing.patch
@@ -1,0 +1,96 @@
+From ac4b6d7c1f63d771801826f706954b4f709cdf68 Mon Sep 17 00:00:00 2001
+From: Po-Chien Hsueh <pchsueh@google.com>
+Date: Mon, 12 Nov 2018 17:15:51 +0530
+Subject: [PATCH] Backport Prevent shortcut info package name spoofing
+
+Test: cts-tradefed run cts -m CtsShortcutManagerTestCases -t android.content.pm.cts.shortcutmanager.ShortcutManagerFakingPublisherTest
+Bug: 109824443
+
+Change-Id: I90443973aaef157d357b98b739572866125b2bbc
+Merged-In: I78948446a63b428ae750464194558fd44a658493
+(cherry picked from commit 9e21579a11219581a0c08ff5dd6ac4dc22e988a4)
+Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>
+---
+ .../com/android/server/pm/ShortcutService.java     | 24 ++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/services/core/java/com/android/server/pm/ShortcutService.java b/services/core/java/com/android/server/pm/ShortcutService.java
+index 599e5a5..b9c3048 100644
+--- a/services/core/java/com/android/server/pm/ShortcutService.java
++++ b/services/core/java/com/android/server/pm/ShortcutService.java
+@@ -132,6 +132,7 @@ import java.nio.charset.StandardCharsets;
+ import java.util.ArrayList;
+ import java.util.Collections;
+ import java.util.List;
++import java.util.Objects;
+ import java.util.concurrent.atomic.AtomicBoolean;
+ import java.util.function.Consumer;
+ import java.util.function.Predicate;
+@@ -1573,6 +1574,24 @@ public class ShortcutService extends IShortcutService.Stub {
+                 "Ephemeral apps can't use ShortcutManager");
+     }
+ 
++    private void verifyShortcutInfoPackage(String callerPackage, ShortcutInfo si) {
++        if (si == null) {
++            return;
++        }
++        if (!Objects.equals(callerPackage, si.getPackage())) {
++            android.util.EventLog.writeEvent(0x534e4554, "109824443", -1, "");
++            throw new SecurityException("Shortcut package name mismatch");
++        }
++    }
++
++    private void verifyShortcutInfoPackages(
++            String callerPackage, List<ShortcutInfo> list) {
++        final int size = list.size();
++        for (int i = 0; i < size; i++) {
++            verifyShortcutInfoPackage(callerPackage, list.get(i));
++        }
++    }
++
+     // Overridden in unit tests to execute r synchronously.
+     void injectPostToHandler(Runnable r) {
+         mHandler.post(r);
+@@ -1720,6 +1739,7 @@ public class ShortcutService extends IShortcutService.Stub {
+         verifyCaller(packageName, userId);
+ 
+         final List<ShortcutInfo> newShortcuts = (List<ShortcutInfo>) shortcutInfoList.getList();
++        verifyShortcutInfoPackages(packageName, newShortcuts);
+         final int size = newShortcuts.size();
+ 
+         final boolean unlimited = injectHasUnlimitedShortcutsApiCallsPermission(
+@@ -1774,6 +1794,7 @@ public class ShortcutService extends IShortcutService.Stub {
+         verifyCaller(packageName, userId);
+ 
+         final List<ShortcutInfo> newShortcuts = (List<ShortcutInfo>) shortcutInfoList.getList();
++        verifyShortcutInfoPackages(packageName, newShortcuts);
+         final int size = newShortcuts.size();
+ 
+         final boolean unlimited = injectHasUnlimitedShortcutsApiCallsPermission(
+@@ -1859,6 +1880,7 @@ public class ShortcutService extends IShortcutService.Stub {
+         verifyCaller(packageName, userId);
+ 
+         final List<ShortcutInfo> newShortcuts = (List<ShortcutInfo>) shortcutInfoList.getList();
++        verifyShortcutInfoPackages(packageName, newShortcuts);
+         final int size = newShortcuts.size();
+ 
+         final boolean unlimited = injectHasUnlimitedShortcutsApiCallsPermission(
+@@ -1921,6 +1943,7 @@ public class ShortcutService extends IShortcutService.Stub {
+         Preconditions.checkNotNull(shortcut);
+         Preconditions.checkArgument(shortcut.isEnabled(), "Shortcut must be enabled");
+         verifyCaller(packageName, userId);
++        verifyShortcutInfoPackage(packageName, shortcut);
+ 
+         final Intent ret;
+         synchronized (mLock) {
+@@ -1942,6 +1965,7 @@ public class ShortcutService extends IShortcutService.Stub {
+     private boolean requestPinItem(String packageName, int userId, ShortcutInfo shortcut,
+             AppWidgetProviderInfo appWidget, Bundle extras, IntentSender resultIntent) {
+         verifyCaller(packageName, userId);
++        verifyShortcutInfoPackage(packageName, shortcut);
+ 
+         final boolean ret;
+         synchronized (mLock) {
+-- 
+1.9.1
+

--- a/android_p/google_diff/celadon/frameworks/base/0010-Backport-Prevent-shortcut-info-package-name-spoofing.patch
+++ b/android_p/google_diff/celadon/frameworks/base/0010-Backport-Prevent-shortcut-info-package-name-spoofing.patch
@@ -1,0 +1,96 @@
+From ac4b6d7c1f63d771801826f706954b4f709cdf68 Mon Sep 17 00:00:00 2001
+From: Po-Chien Hsueh <pchsueh@google.com>
+Date: Mon, 12 Nov 2018 17:15:51 +0530
+Subject: [PATCH] Backport Prevent shortcut info package name spoofing
+
+Test: cts-tradefed run cts -m CtsShortcutManagerTestCases -t android.content.pm.cts.shortcutmanager.ShortcutManagerFakingPublisherTest
+Bug: 109824443
+
+Change-Id: I90443973aaef157d357b98b739572866125b2bbc
+Merged-In: I78948446a63b428ae750464194558fd44a658493
+(cherry picked from commit 9e21579a11219581a0c08ff5dd6ac4dc22e988a4)
+Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>
+---
+ .../com/android/server/pm/ShortcutService.java     | 24 ++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/services/core/java/com/android/server/pm/ShortcutService.java b/services/core/java/com/android/server/pm/ShortcutService.java
+index 599e5a5..b9c3048 100644
+--- a/services/core/java/com/android/server/pm/ShortcutService.java
++++ b/services/core/java/com/android/server/pm/ShortcutService.java
+@@ -132,6 +132,7 @@ import java.nio.charset.StandardCharsets;
+ import java.util.ArrayList;
+ import java.util.Collections;
+ import java.util.List;
++import java.util.Objects;
+ import java.util.concurrent.atomic.AtomicBoolean;
+ import java.util.function.Consumer;
+ import java.util.function.Predicate;
+@@ -1573,6 +1574,24 @@ public class ShortcutService extends IShortcutService.Stub {
+                 "Ephemeral apps can't use ShortcutManager");
+     }
+ 
++    private void verifyShortcutInfoPackage(String callerPackage, ShortcutInfo si) {
++        if (si == null) {
++            return;
++        }
++        if (!Objects.equals(callerPackage, si.getPackage())) {
++            android.util.EventLog.writeEvent(0x534e4554, "109824443", -1, "");
++            throw new SecurityException("Shortcut package name mismatch");
++        }
++    }
++
++    private void verifyShortcutInfoPackages(
++            String callerPackage, List<ShortcutInfo> list) {
++        final int size = list.size();
++        for (int i = 0; i < size; i++) {
++            verifyShortcutInfoPackage(callerPackage, list.get(i));
++        }
++    }
++
+     // Overridden in unit tests to execute r synchronously.
+     void injectPostToHandler(Runnable r) {
+         mHandler.post(r);
+@@ -1720,6 +1739,7 @@ public class ShortcutService extends IShortcutService.Stub {
+         verifyCaller(packageName, userId);
+ 
+         final List<ShortcutInfo> newShortcuts = (List<ShortcutInfo>) shortcutInfoList.getList();
++        verifyShortcutInfoPackages(packageName, newShortcuts);
+         final int size = newShortcuts.size();
+ 
+         final boolean unlimited = injectHasUnlimitedShortcutsApiCallsPermission(
+@@ -1774,6 +1794,7 @@ public class ShortcutService extends IShortcutService.Stub {
+         verifyCaller(packageName, userId);
+ 
+         final List<ShortcutInfo> newShortcuts = (List<ShortcutInfo>) shortcutInfoList.getList();
++        verifyShortcutInfoPackages(packageName, newShortcuts);
+         final int size = newShortcuts.size();
+ 
+         final boolean unlimited = injectHasUnlimitedShortcutsApiCallsPermission(
+@@ -1859,6 +1880,7 @@ public class ShortcutService extends IShortcutService.Stub {
+         verifyCaller(packageName, userId);
+ 
+         final List<ShortcutInfo> newShortcuts = (List<ShortcutInfo>) shortcutInfoList.getList();
++        verifyShortcutInfoPackages(packageName, newShortcuts);
+         final int size = newShortcuts.size();
+ 
+         final boolean unlimited = injectHasUnlimitedShortcutsApiCallsPermission(
+@@ -1921,6 +1943,7 @@ public class ShortcutService extends IShortcutService.Stub {
+         Preconditions.checkNotNull(shortcut);
+         Preconditions.checkArgument(shortcut.isEnabled(), "Shortcut must be enabled");
+         verifyCaller(packageName, userId);
++        verifyShortcutInfoPackage(packageName, shortcut);
+ 
+         final Intent ret;
+         synchronized (mLock) {
+@@ -1942,6 +1965,7 @@ public class ShortcutService extends IShortcutService.Stub {
+     private boolean requestPinItem(String packageName, int userId, ShortcutInfo shortcut,
+             AppWidgetProviderInfo appWidget, Bundle extras, IntentSender resultIntent) {
+         verifyCaller(packageName, userId);
++        verifyShortcutInfoPackage(packageName, shortcut);
+ 
+         final boolean ret;
+         synchronized (mLock) {
+-- 
+1.9.1
+


### PR DESCRIPTION
Test: cts-tradefed run cts -m CtsShortcutManagerTestCases -t android.content.pm.cts.shortcutmanager.ShortcutManagerFakingPublisherTest
Bug: 109824443

Change-Id: I90443973aaef157d357b98b739572866125b2bbc
Merged-In: I78948446a63b428ae750464194558fd44a658493
(cherry picked from commit 9e21579a11219581a0c08ff5dd6ac4dc22e988a4)
Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>