### PR TITLE
IVI: Set sys.usb.config in suspend/resume

### DIFF
--- a/android_p/google_diff/cel_apl/packages/services/Car/0008-USB-proper-sys-usb-config.patch
+++ b/android_p/google_diff/cel_apl/packages/services/Car/0008-USB-proper-sys-usb-config.patch
@@ -1,0 +1,70 @@
+From 36fa396daabf1e1898a53355dd733530bafd5c19 Mon Sep 17 00:00:00 2001
+From: M Balaji <m.balaji@intel.com>
+Date: Mon, 10 Sep 2018 16:32:32 +0530
+Subject: [PATCH] USB proper sys.usb.config during suspend and resume
+
+During  system suspend kernel disables usb core and sends disconnect
+notification and this wont be able to recive by adb daemon as all user
+process freezed and after resume dwc3 usb core enabled and
+re-enumerated. But adb daemon still waits for old usb packet submitted.
+After sometime it issue close when re-enumaeration happens.bcoz of which
+UDC core goes into  U3 state and hit adb lost.
+This Fix provides clean way of setting usb config to none before suspend
+which properly disconnect usb device and udc core and stopped adb .
+On resume , sets sys.usb.config adb is set.
+
+Change-Id: I19ae618c6015489e18314791aa30d81531c8db5b
+Tracked-On:
+---
+ service/src/com/android/car/SystemStateControllerService.java | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/service/src/com/android/car/SystemStateControllerService.java b/service/src/com/android/car/SystemStateControllerService.java
+index 53d74a3..07a2715 100644
+--- a/service/src/com/android/car/SystemStateControllerService.java
++++ b/service/src/com/android/car/SystemStateControllerService.java
+@@ -23,6 +23,8 @@ import com.android.car.CarPowerManagementService.PowerServiceEventListener;
+ 
+ import java.io.PrintWriter;
+ 
++import android.os.SystemProperties;
++
+ public class SystemStateControllerService implements CarServiceBase,
+     PowerServiceEventListener, PowerEventProcessingHandler {
+ 
+@@ -30,7 +32,8 @@ public class SystemStateControllerService implements CarServiceBase,
+     private final CarAudioService mCarAudioService;
+     private final ICarImpl mICarImpl;
+     private final boolean mLockWhenMuting;
+-
++    private static final String USB_CONFIG_PROPERTY = "sys.usb.config";
++    private static String currUsbConfig;
+     public SystemStateControllerService(Context context,
+             CarPowerManagementService carPowerManagementService,
+             CarAudioService carAudioService, ICarImpl carImpl) {
+@@ -50,6 +53,7 @@ public class SystemStateControllerService implements CarServiceBase,
+     @Override
+     public void onPowerOn(boolean displayOn) {
+         // TODO may consider mute / unmute the system based on displayOn
++        currUsbConfig = SystemProperties.get(USB_CONFIG_PROPERTY, "none");
+     }
+ 
+     @Override
+@@ -65,11 +69,14 @@ public class SystemStateControllerService implements CarServiceBase,
+     @Override
+     public void onSleepEntry() {
+         // TODO bug: 32096079
++        currUsbConfig = SystemProperties.get(USB_CONFIG_PROPERTY, "none");
++        SystemProperties.set(USB_CONFIG_PROPERTY, "none");
+     }
+ 
+     @Override
+     public void onSleepExit() {
+         // TODO bug: 32096079
++        SystemProperties.set(USB_CONFIG_PROPERTY, currUsbConfig);
+     }
+ 
+     @Override
+-- 
+1.9.1
+


### PR DESCRIPTION
This adds a patch to set sys.usb.config
during suspend and resume.

Jira: OAM-71949

Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>