### PR TITLE
Intel BT Controller can not handle 2 Commands from the host

### DIFF
--- a/android_p/google_diff/cel_apl/kernel/project-celadon/0004-btusb-Reducing-Command-Credit-from-Controller-to-1(1).patch
+++ b/android_p/google_diff/cel_apl/kernel/project-celadon/0004-btusb-Reducing-Command-Credit-from-Controller-to-1(1).patch
@@ -1,0 +1,52 @@
+From f79cf6911768db9cf877b3a3096498ec69889a17 Mon Sep 17 00:00:00 2001
+From: Mohamed Abbas <mohamed.abbas@intel.com>
+Date: Wed, 15 Mar 2017 23:18:36 +0530
+Subject: [PATCH] btusb: Reducing Command Credit from Controller to 1
+
+Intel BT Controller can not handle 2 Commands from the host
+at the same time resulting in unstatable Bluetooth.
+
+Fix the issue by reducing the command credit in all cases equal
+to 1.
+
+Pairing/Connection/File Transfer/A2DP found to be working.
+
+Change-Id: I16fca67ea158e6ea9e0bef1572e7cd9ffc8c883b
+Tracked-On: PKT-1548
+Signed-off-by: Atul Vaish <atul.vaish@intel.com>
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ drivers/bluetooth/btusb.c | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
+index cd2e5cf14ea5..f6f3ac73ecf9 100644
+--- a/drivers/bluetooth/btusb.c
++++ b/drivers/bluetooth/btusb.c
+@@ -1988,6 +1988,23 @@ static int btusb_recv_event_intel(struct hci_dev *hdev, struct sk_buff *skb)
+ 				break;
+ 			}
+ 		}
++	} else if (skb->len > HCI_EVENT_HDR_SIZE) {
++		struct hci_event_hdr *hdr;
++
++		hdr = (struct hci_event_hdr *) skb->data;
++
++		if (hdr->evt == HCI_EV_CMD_COMPLETE) {
++			struct hci_ev_cmd_complete *cmd_complete;
++
++			cmd_complete =
++				(struct hci_ev_cmd_complete *) (skb->data + HCI_EVENT_HDR_SIZE);
++			cmd_complete->ncmd = 1;
++		} else if (hdr->evt == HCI_EV_CMD_STATUS) {
++			struct hci_ev_cmd_status *cmd_status;
++
++			cmd_status = (struct hci_ev_cmd_status *) (skb->data + HCI_EVENT_HDR_SIZE);
++			cmd_status->ncmd = 1;
++		}
+ 	}
+ 
+ 	return hci_recv_frame(hdev, skb);
+-- 
+2.19.0
+


### PR DESCRIPTION
at the same time resulting in unstatable Bluetooth.

Fix the issue by reducing the command credit in all cases equal
to 1.

Pairing/Connection/File Transfer/A2DP found to be working.

Tracked-On: OAM-71561
Signed-off-by: Atul Vaish <atul.vaish@intel.com>
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>