### PR TITLE
MMC: SDHCI-Host-controller-enabling-for-4.19.x-kernel

### DIFF
--- a/android_p/google_diff/cel_apl/device/intel/project-celadon/0004-MMC-SDHCI-Host-controller-enabling-for-4.19.x-kernel.patch
+++ b/android_p/google_diff/cel_apl/device/intel/project-celadon/0004-MMC-SDHCI-Host-controller-enabling-for-4.19.x-kernel.patch
@@ -1,0 +1,35 @@
+From b3803cf43de84f8d3c492f3c8410c01557b9bde5 Mon Sep 17 00:00:00 2001
+From: shyjumon <shyjumon.n@intel.com>
+Date: Tue, 27 Nov 2018 07:41:25 +0530
+Subject: [PATCH] MMC: SDHCI Host controller enabling for 4.19.x kernel
+
+Tracked-On: OAM-71946
+Signed-off-by: shyjumon <shyjumon.n@intel.com>
+---
+ kernel_config/kernel_64_defconfig | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/kernel_config/kernel_64_defconfig b/kernel_config/kernel_64_defconfig
+index 14d6a25..2e0162b 100644
+--- a/kernel_config/kernel_64_defconfig
++++ b/kernel_config/kernel_64_defconfig
+@@ -1616,7 +1616,7 @@ CONFIG_INTEL_MEI_TXE=y
+ #
+ # CONFIG_GENWQE is not set
+ # CONFIG_ECHO is not set
+-# CONFIG_MISC_RTSX_PCI is not set
++CONFIG_MISC_RTSX_PCI=y
+ # CONFIG_MISC_RTSX_USB is not set
+ CONFIG_HAVE_IDE=y
+ # CONFIG_IDE is not set
+@@ -4801,6 +4801,7 @@ CONFIG_MMC_SDHCI_ACPI=y
+ # CONFIG_MMC_VUB300 is not set
+ # CONFIG_MMC_USHC is not set
+ # CONFIG_MMC_USDHI6ROL0 is not set
++CONFIG_MMC_REALTEK_PCI=y
+ CONFIG_MMC_CQHCI=y
+ # CONFIG_MMC_TOSHIBA_PCI is not set
+ # CONFIG_MMC_MTK is not set
+-- 
+2.7.4
+


### PR DESCRIPTION
Tracked-On: OAM-71946
Signed-off-by: shyjumon <shyjumon.n@intel.com>