### PR TITLE
[CELADON] Changing usb config during suspend and resume

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0019-Changing-usb-config-during-suspend-and-resume.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0019-Changing-usb-config-during-suspend-and-resume.patch
@@ -1,0 +1,51 @@
+From 58a84024213c9e3cc9bb51c2fffd9b95ad34b2c0 Mon Sep 17 00:00:00 2001
+From: Madhusudhan S <madhusudhan.s@intel.com>
+Date: Mon, 26 Nov 2018 13:36:32 +0530
+Subject: [PATCH] Changing usb config during suspend and resume
+
+Changing the usb config to "none" during S3 and enabling
+the usb config to "adb" to resume adb.
+
+Change-Id: Ic445c1df5fbefb55f7d9505fed3a3375931a1cbd
+Tracked-on: OAM-71949
+Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>
+---
+ .../core/java/com/android/server/power/PowerManagerService.java   | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/services/core/java/com/android/server/power/PowerManagerService.java b/services/core/java/com/android/server/power/PowerManagerService.java
+index 44cda43..a29a2c9 100644
+--- a/services/core/java/com/android/server/power/PowerManagerService.java
++++ b/services/core/java/com/android/server/power/PowerManagerService.java
+@@ -118,6 +118,7 @@ import android.os.FileUtils;
+ public final class PowerManagerService extends SystemService
+         implements Watchdog.Monitor {
+     private static final String TAG = "PowerManagerService";
++    private static final String USB_CONFIG_PROPERTY = "sys.usb.config";
+ 
+     private static final boolean DEBUG = false;
+     private static final boolean DEBUG_SPEW = DEBUG && true;
+@@ -1431,6 +1432,8 @@ public final class PowerManagerService extends SystemService
+                 default:
+                     Slog.i(TAG, "Going to sleep by application request (uid " + uid +")...");
+                     reason = PowerManager.GO_TO_SLEEP_REASON_APPLICATION;
++		    SystemProperties.set(USB_CONFIG_PROPERTY, "none");
++
+ 		    // Adding force suspend code to enable IVI to enter S3 after pressing sleep button
+                     try {
+                         FileUtils.stringToFile("/sys/power/state", "mem");
+@@ -4289,6 +4292,11 @@ public final class PowerManagerService extends SystemService
+             final int uid = Binder.getCallingUid();
+             final long ident = Binder.clearCallingIdentity();
+             try {
++		// Setting usbconfig to "adb" to enable ADB after wakeup from S3
++		String currUsbConfig = new String(SystemProperties.get(USB_CONFIG_PROPERTY, "none"));
++		if(currUsbConfig.equals("none"))
++			SystemProperties.set(USB_CONFIG_PROPERTY, "adb");
++
+                 wakeUpInternal(eventTime, reason, uid, opPackageName, uid);
+             } finally {
+                 Binder.restoreCallingIdentity(ident);
+-- 
+2.7.4
+


### PR DESCRIPTION
Changing the usb config to "none" during S3 and enabling
the usb config to "adb" to resume adb.

Tracked-on: OAM-71949
Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>