### PR TITLE
Fix for failing CTS test BluetoothLeScanTest#testBatchScan

### DIFF
--- a/android_p/google_diff/cel_apl/packages/apps/Bluetooth/0006-Fix-for-failing-CTS-test-BluetoothLeScanTest-testBat.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Bluetooth/0006-Fix-for-failing-CTS-test-BluetoothLeScanTest-testBat.patch
@@ -1,0 +1,66 @@
+From c887ffbf8cfee863925013ec96bebc4fcea5118b Mon Sep 17 00:00:00 2001
+From: anitha3x <anithax.h.chandrasekar@intel.com>
+Date: Wed, 30 Aug 2017 10:21:26 +0530
+Subject: [PATCH 6/6] Fix for failing CTS test
+ BluetoothLeScanTest#testBatchScan
+
+Reason: While running testBatchScan assertion happened for
+invalid advertisePacketLen and timestamp.
+
+Fix: Added condition checks to prevent erroneous array
+operations
+
+Tracked-on: OAM-71309
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Signed-off-by: anitha3x <anithax.h.chandrasekar@intel.com>
+---
+ src/com/android/bluetooth/gatt/GattService.java | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/src/com/android/bluetooth/gatt/GattService.java b/src/com/android/bluetooth/gatt/GattService.java
+index fd8551a..dae89c2 100644
+--- a/src/com/android/bluetooth/gatt/GattService.java
++++ b/src/com/android/bluetooth/gatt/GattService.java
+@@ -1650,6 +1650,8 @@ public class GattService extends ProfileService {
+         int position = 0;
+         long now = SystemClock.elapsedRealtimeNanos();
+         while (position < batchRecord.length) {
++            if (position + 6 >= batchRecord.length)
++                break;
+             byte[] address = extractBytes(batchRecord, position, 6);
+             // TODO: remove temp hack.
+             reverse(address);
+@@ -1659,15 +1661,30 @@ public class GattService extends ProfileService {
+             position++;
+             // Skip tx power level.
+             position++;
++            if (position >= batchRecord.length)
++                break;
+             int rssi = batchRecord[position++];
++            if ((position + 2) >= batchRecord.length)
++                break;
+             long timestampNanos = now - parseTimestampNanos(extractBytes(batchRecord, position, 2));
++            if (timestampNanos < 0)
++                break;
+             position += 2;
+ 
+             // Combine advertise packet and scan response packet.
++            if (position >= batchRecord.length)
++                break;
+             int advertisePacketLen = batchRecord[position++];
++            if ((advertisePacketLen < 0) || ((position + advertisePacketLen) >= batchRecord.length))
++                break;
+             byte[] advertiseBytes = extractBytes(batchRecord, position, advertisePacketLen);
+             position += advertisePacketLen;
++            if (position >= batchRecord.length)
++                break;
+             int scanResponsePacketLen = batchRecord[position++];
++            if ((scanResponsePacketLen < 0) ||
++               ((position + scanResponsePacketLen) >= batchRecord.length))
++                break;
+             byte[] scanResponseBytes = extractBytes(batchRecord, position, scanResponsePacketLen);
+             position += scanResponsePacketLen;
+             byte[] scanRecord = new byte[advertisePacketLen + scanResponsePacketLen];
+-- 
+2.7.4
+


### PR DESCRIPTION
Reason: While running testBatchScan assertion happened for
invalid advertisePacketLen and timestamp .Fix Added condition checks to prevent erroneous array
operations

Tracked-On: OAM-71309
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
Signed-off-by: anitha3x <anithax.h.chandrasekar@intel.com>