### PR TITLE
[CELADON] Adding finally block to enable adb if S3 fails

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0020-CELADON-Adding-finally-block-to-enable-adb-if-S3-fai.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0020-CELADON-Adding-finally-block-to-enable-adb-if-S3-fai.patch
@@ -1,0 +1,31 @@
+From d42eb5f8a10d064186496c6d73301dab37a49856 Mon Sep 17 00:00:00 2001
+From: Madhusudhan S <madhusudhan.s@intel.com>
+Date: Wed, 28 Nov 2018 17:09:59 +0530
+Subject: [PATCH] [CELADON] Adding finally block to enable adb if S3 fails
+
+If suspend fails due to some reason, we are setting the
+usb config to adb again to restore adb functionality.
+
+Tracked-on: OAM-71949
+Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>
+---
+ services/core/java/com/android/server/power/PowerManagerService.java | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/services/core/java/com/android/server/power/PowerManagerService.java b/services/core/java/com/android/server/power/PowerManagerService.java
+index a29a2c9..1f9b926 100644
+--- a/services/core/java/com/android/server/power/PowerManagerService.java
++++ b/services/core/java/com/android/server/power/PowerManagerService.java
+@@ -1441,6 +1441,9 @@ public final class PowerManagerService extends SystemService
+                     catch (IOException e) {
+                         Slog.v(TAG, "IOException: " + e);
+                     }
++		    finally {
++			SystemProperties.set(USB_CONFIG_PROPERTY, "adb");
++		    }
+                     break;
+             }
+ 
+-- 
+2.7.4
+


### PR DESCRIPTION
If suspend fails due to some reason, we are setting the
usb config to adb again to restore adb functionality.

Tracked-on: OAM-71949
Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>