### PR TITLE
[CELADON] Fix LocalMediaPlayer freezed when change the display size

### DIFF
--- a/android_p/google_diff/cel_apl/packages/apps/Car/libs/0001-Fix-LocalMediaPlayer-freezed-when-change-the-display.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Car/libs/0001-Fix-LocalMediaPlayer-freezed-when-change-the-display.patch
@@ -1,0 +1,41 @@
+From ce5f646bc704367c6b097eb105814f9b56eb6261 Mon Sep 17 00:00:00 2001
+From: rleix <rayx.lei@intel.com>
+Date: Tue, 9 Oct 2018 16:39:29 +0800
+Subject: [PATCH] Fix LocalMediaPlayer freezed when change the display size
+
+After the display size changed, LocalMediaPlayer forced to stop
+and restarted. And the media session will be destroyed when the
+app stopped. But the related mediacontroller is still alive even
+the session is invalid.
+
+Set the mediacontroller as null when the session is destroyed.
+
+Change-Id: Ibba89fec11d8f5c6bc5939ac6bacfe7afa4c44c6
+Tracked-On:
+Signed-off-by: Lei,RayX <rayx.lei@intel.com>
+---
+ .../src/com/android/car/media/common/PlaybackModel.java           | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/car-media-common/src/com/android/car/media/common/PlaybackModel.java b/car-media-common/src/com/android/car/media/common/PlaybackModel.java
+index bbddfee..a3642ed 100644
+--- a/car-media-common/src/com/android/car/media/common/PlaybackModel.java
++++ b/car-media-common/src/com/android/car/media/common/PlaybackModel.java
+@@ -97,6 +97,14 @@ public class PlaybackModel {
+             }
+             PlaybackModel.this.notify(PlaybackObserver::onMetadataChanged);
+         }
++
++        @Override
++        public void onSessionDestroyed() {
++            if (mMediaController != null) {
++                mMediaController.unregisterCallback(mCallback);
++            }
++            mMediaController = null;
++        }
+     };
+ 
+     /**
+-- 
+1.9.1
+


### PR DESCRIPTION
After the display size changed, LocalMediaPlayer forced to stop
and restarted. And the media session will be destroyed when the
app stopped. But the related mediacontroller is still alive even
the session is invalid.

Set the mediacontroller as null when the session is destroyed.

Tracked-On: OAM-72299
Signed-off-by: rnaidu <ramya.v.naidu@intel.com>