### PR TITLE
Resuming display after S3

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0021-CELADON-Resuming-display-after-S3.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0021-CELADON-Resuming-display-after-S3.patch
@@ -1,0 +1,44 @@
+From fd1b7865640fcc4d14993b3187390e250e4adf6e Mon Sep 17 00:00:00 2001
+From: Madhusudhan S <madhusudhan.s@intel.com>
+Date: Wed, 5 Dec 2018 17:27:02 +0530
+Subject: [PATCH] [CELADON] Resuming display after S3
+
+On platforms like KBL, the display was never resuming
+on single power button press. This work-around will fix
+issues where single power button press is not detected
+during wakeup.
+
+Tracked-on: OAM-72346
+
+Change-Id: I697deaa42c527e2d283cc6432616f89442aa5822
+Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>
+---
+ .../java/com/android/server/power/PowerManagerService.java   | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/services/core/java/com/android/server/power/PowerManagerService.java b/services/core/java/com/android/server/power/PowerManagerService.java
+index a29a2c9..ab138e3 100644
+--- a/services/core/java/com/android/server/power/PowerManagerService.java
++++ b/services/core/java/com/android/server/power/PowerManagerService.java
+@@ -1952,6 +1952,18 @@ public final class PowerManagerService extends SystemService
+      * This function must have no other side-effects.
+      */
+     private void updateUserActivitySummaryLocked(long now, int dirty) {
++
++        String currUsbConfig = new String(SystemProperties.get(USB_CONFIG_PROPERTY, "none"));
++        PowerManager mPowerManager = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
++
++        if(currUsbConfig.equals("none") && (!mPowerManager.isInteractive())) {
++                SystemProperties.set(USB_CONFIG_PROPERTY, "adb");
++
++                //Acquiring wakelock to resume from S3 since some devices won't capture power button events
++                PowerManager.WakeLock mWakeLock = mPowerManager.newWakeLock(PowerManager.ACQUIRE_CAUSES_WAKEUP | PowerManager.FULL_WAKE_LOCK, "TurnDisplayStateOn");
++                mWakeLock.acquire(5000);
++        }
++
+         // Update the status of the user activity timeout timer.
+         if ((dirty & (DIRTY_WAKE_LOCKS | DIRTY_USER_ACTIVITY
+                 | DIRTY_WAKEFULNESS | DIRTY_SETTINGS)) != 0) {
+-- 
+2.7.4
+


### PR DESCRIPTION
On platforms like KBL, the display was never resuming
on single power button press. This work-around will fix
issues where single power button press is not detected
during wakeup.

Tracked-on: OAM-72346

Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>