### PR TITLE
Fix "Guest" user option seen when logged in as "New User"

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0022-Fix-Guest-user-option-seen-when-logged-in-as-New-Use.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0022-Fix-Guest-user-option-seen-when-logged-in-as-New-Use.patch
@@ -1,0 +1,33 @@
+From 25dc1c7cde85a319ec3cdf4b634683f2e5b5f7ca Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Thu, 6 Dec 2018 18:16:18 +0800
+Subject: [PATCH] Fix "Guest" user option seen when logged in as "New User"
+
+if the foreground user is the device owner, add the guest
+user record.
+
+Change-Id: Ie636ff43c14b6b62ac27caa3fe0500d714da5d88
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-70634
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ .../src/com/android/systemui/statusbar/car/UserGridRecyclerView.java  | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/packages/SystemUI/src/com/android/systemui/statusbar/car/UserGridRecyclerView.java b/packages/SystemUI/src/com/android/systemui/statusbar/car/UserGridRecyclerView.java
+index 35575d2..1fdd4b7 100644
+--- a/packages/SystemUI/src/com/android/systemui/statusbar/car/UserGridRecyclerView.java
++++ b/packages/SystemUI/src/com/android/systemui/statusbar/car/UserGridRecyclerView.java
+@@ -109,8 +109,8 @@ public class UserGridRecyclerView extends PagedListView implements
+             userRecords.add(record);
+         }
+ 
+-        // Add guest user record if the foreground user is not a guest
+-        if (!mUserManagerHelper.foregroundUserIsGuestUser()) {
++        // Add guest user record if the foreground user is the device owner
++        if (mUserManagerHelper.getForegroundUserInfo().isAdmin()) {
+             userRecords.add(addGuestUserRecord());
+         }
+ 
+-- 
+1.9.1
+

--- a/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0003-Fix-Guest-user-option-seen-when-logged-in-as-New-Use.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0003-Fix-Guest-user-option-seen-when-logged-in-as-New-Use.patch
@@ -1,0 +1,47 @@
+From 56b87dbfb3761a90a2a70758b2ca6bd1e655ba1c Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Mon, 10 Dec 2018 15:38:04 +0800
+Subject: [PATCH] Fix "Guest" user option seen when logged in as "New User"
+
+if the foreground user is the device owner, add the guest
+user record.
+
+Change-Id: I6dc10503d9761b57df396e0343fd9a099653eaa5
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-70634
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ src/com/android/car/settings/users/UserGridRecyclerView.java | 4 ++--
+ src/com/android/car/settings/users/UsersItemProvider.java    | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/com/android/car/settings/users/UserGridRecyclerView.java b/src/com/android/car/settings/users/UserGridRecyclerView.java
+index b6d73fa..5b58f96 100644
+--- a/src/com/android/car/settings/users/UserGridRecyclerView.java
++++ b/src/com/android/car/settings/users/UserGridRecyclerView.java
+@@ -108,8 +108,8 @@ public class UserGridRecyclerView extends PagedListView implements
+             userRecords.add(record);
+         }
+ 
+-        // Add guest user record if the foreground user is not a guest
+-        if (!mCarUserManagerHelper.isForegroundUserGuest()) {
++        // Add guest user record if the foreground user is the device owner
++        if (mCarUserManagerHelper.getCurrentProcessUserInfo().isAdmin()) {
+             userRecords.add(addGuestUserRecord());
+         }
+ 
+diff --git a/src/com/android/car/settings/users/UsersItemProvider.java b/src/com/android/car/settings/users/UsersItemProvider.java
+index 9a678e3..8154ffe 100644
+--- a/src/com/android/car/settings/users/UsersItemProvider.java
++++ b/src/com/android/car/settings/users/UsersItemProvider.java
+@@ -86,7 +86,7 @@ class UsersItemProvider extends ListItemProvider {
+         }
+ 
+         // Display guest session option.
+-        if (!currUserInfo.isGuest()) {
++        if (currUserInfo.isAdmin()) {
+             mItems.add(createGuestItem());
+         }
+     }
+-- 
+1.9.1
+


### PR DESCRIPTION
if the foreground user is the device owner, add the guest
user record.

Tracked-On: OAM-70634
Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>