### PR TITLE
Fix testScreenBrightness failed in CtsStatsdHostTestCases Module

### DIFF
--- a/android_p/google_diff/cel_apl/packages/services/Car/0008-Fix-testScreenBrightness-failed-in-CtsStatsdHostTest.patch
+++ b/android_p/google_diff/cel_apl/packages/services/Car/0008-Fix-testScreenBrightness-failed-in-CtsStatsdHostTest.patch
@@ -1,0 +1,83 @@
+From d4d3d06436580df739dd04825ec17175c9f6115b Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Thu, 13 Dec 2018 15:43:03 +0800
+Subject: [PATCH] Fix testScreenBrightness failed in CtsStatsdHostTestCases
+ Module
+
+Case fail due to update a wrong backlight brightness to the Setting database.
+Due to the display brightness for the vehicle, need a percent brightness.
+but the System screen backlight brightness is a value between 0 and 255, need
+to convert the screen backlight brightness to the percent brightness. If the
+screen backlight brightness had changed from the vehicle, need to convert the
+percent brightness to screen backlight brightness value, So unable to save a
+accurate brightness value to the Setting database.
+
+Test:
+1. adb shell settings put system screen_brightness 100
+2. adb shell settings get system screen_brightness
+
+Change-Id: Ib4f387c123459357220c7bd74a3df7997c6ca231
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-73451
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ .../car/systeminterface/DisplayInterface.java      | 30 +++++++++++++++++-----
+ 1 file changed, 23 insertions(+), 7 deletions(-)
+
+diff --git a/service/src/com/android/car/systeminterface/DisplayInterface.java b/service/src/com/android/car/systeminterface/DisplayInterface.java
+index 015f54d..3a7fc68 100644
+--- a/service/src/com/android/car/systeminterface/DisplayInterface.java
++++ b/service/src/com/android/car/systeminterface/DisplayInterface.java
+@@ -61,18 +61,13 @@ public interface DisplayInterface {
+                     @Override
+                     public void onChange(boolean selfChange) {
+                         int brightness = mMinimumBacklight;
+-                        int range = mMaximumBacklight - mMinimumBacklight;
+-
+                         try {
+                             brightness = System.getInt(mContentResolver, System.SCREEN_BRIGHTNESS);
+                         } catch (SettingNotFoundException e) {
+                             Log.e(CarLog.TAG_POWER, "Could not get SCREEN_BRIGHTNESS:  " + e);
+                         }
+-                        // Convert brightness from 0-255 to 0-100%
+-                        brightness -= mMinimumBacklight;
+-                        brightness *= 100;
+-                        brightness += (range + 1) / 2;
+-                        brightness /= range;
++                        // Convert brightness from minimumBacklight-maximumBacklight to 0-100%
++                        brightness = brightnessToPercent(brightness, mMinimumBacklight, mMaximumBacklight);
+                         mService.sendDisplayBrightness(brightness);
+                     }
+                 };
+@@ -123,8 +118,29 @@ public interface DisplayInterface {
+             return disp.getState() == Display.STATE_ON;
+         }
+ 
++        private static int brightnessToPercent(int brightness, int minimumBacklight, int maximumBacklight) {
++            int range = maximumBacklight - minimumBacklight;
++            // Convert brightness from minimumBacklight-maximumBacklight to 0-100%
++            brightness -= minimumBacklight;
++            brightness *= 100;
++            brightness += (range + 1) / 2;
++            return brightness /= range;
++        }
++
+         @Override
+         public void setDisplayBrightness(int brightness) {
++            try {
++                int old_brightness = System.getInt(mContentResolver, System.SCREEN_BRIGHTNESS);
++                // Convert brightness from minimumBacklight-maximumBacklight to 0-100%
++                old_brightness = brightnessToPercent(old_brightness, mMinimumBacklight, mMaximumBacklight);
++                // If the new brightness is same with old_brightness, ignore this change.
++                if (old_brightness == brightness) {
++                    return;
++                }
++            } catch (SettingNotFoundException e) {
++                Log.e(CarLog.TAG_POWER, "Could not get SCREEN_BRIGHTNESS:  " + e);
++            }
++
+             // Brightness is set in percent.  Need to convert this into 0-255 scale.  The actual
+             //  brightness algorithm should look like this:
+             //
+-- 
+1.9.1
+


### PR DESCRIPTION
Case fail due to update a wrong backlight brightness to the Setting database.
Due to the display brightness for the vehicle, need a percent brightness.
but the System screen backlight brightness is a value between 0 and 255, need
to convert the screen backlight brightness to the percent brightness. If the
screen backlight brightness had changed from the vehicle, need to convert the
percent brightness to screen backlight brightness value, So unable to save a
accurate brightness value to the Setting database.

Test:
1. adb shell settings put system screen_brightness 100
2. adb shell settings get system screen_brightness

Tracked-On: OAM-73451
Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>