### PR TITLE
Allow SystemUpdater&update_engine to access removable storage

### DIFF
--- a/android_p/google_diff/cel_apl/packages/apps/Car/SystemUpdater/0001-systemupdater-access-removable-storage.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Car/SystemUpdater/0001-systemupdater-access-removable-storage.patch
@@ -1,0 +1,40 @@
+From 64093965168dfc55dad938db36ed487d9e72a32f Mon Sep 17 00:00:00 2001
+From: hengluo <heng.luo@intel.com>
+Date: Wed, 17 Oct 2018 13:34:56 +0800
+Subject: [PATCH] SystemUpdater: allow to access removable storage
+
+Add WRITE_MEDIA_STORAGE permission in SystemUpdater,
+allow it to select OTA package in removable storage,
+such as USB stick or SD card.
+
+Change-Id: I33902661e728ea5763d2b601ac2109e7370acb10
+Tracked-On:
+Signed-off-by: hengluo <heng.luo@intel.com>
+---
+
+diff --git a/AndroidManifest.xml b/AndroidManifest.xml
+index 1a77c05..3dbe8dc 100644
+--- a/AndroidManifest.xml
++++ b/AndroidManifest.xml
+@@ -19,6 +19,7 @@
+         xmlns:android="http://schemas.android.com/apk/res/android"
+         package="com.android.car.systemupdater">
+ 
++    <uses-permission android:name="android.permission.WRITE_MEDIA_STORAGE" />
+     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+     <uses-permission android:name="android.permission.REBOOT" />
+diff --git a/src/com/android/car/systemupdater/SystemUpdaterActivity.java b/src/com/android/car/systemupdater/SystemUpdaterActivity.java
+index c53ea18..ee1c1c8 100644
+--- a/src/com/android/car/systemupdater/SystemUpdaterActivity.java
++++ b/src/com/android/car/systemupdater/SystemUpdaterActivity.java
+@@ -39,7 +39,8 @@
+     private static final int STORAGE_PERMISSIONS_REQUEST_CODE = 0;
+     private static final String[] REQUIRED_STORAGE_PERMISSIONS = new String[]{
+             Manifest.permission.READ_EXTERNAL_STORAGE,
+-            Manifest.permission.WRITE_EXTERNAL_STORAGE
++            Manifest.permission.WRITE_EXTERNAL_STORAGE,
++            Manifest.permission.WRITE_MEDIA_STORAGE
+     };
+ 
+     @Override

--- a/android_p/google_diff/cel_apl/system/update_engine/0002-update_engine-to-media_rw.patch
+++ b/android_p/google_diff/cel_apl/system/update_engine/0002-update_engine-to-media_rw.patch
@@ -1,0 +1,25 @@
+From 541b1f49b6b2c09b386e3f8292894e4fcecca6af Mon Sep 17 00:00:00 2001
+From: hengluo <heng.luo@intel.com>
+Date: Mon, 22 Oct 2018 13:47:23 +0800
+Subject: [PATCH] Add update_engine to media_rw group
+
+Allow update_engine to access the OTA file in removable storage.
+
+Change-Id: I501485f174a0bf01ea36a9f8d22e0cfd218883f1
+Tracked-On:
+Signed-off-by: hengluo <heng.luo@intel.com>
+---
+
+diff --git a/update_engine.rc b/update_engine.rc
+index a7d6235..90ca4c6 100644
+--- a/update_engine.rc
++++ b/update_engine.rc
+@@ -1,7 +1,7 @@
+ service update_engine /system/bin/update_engine --logtostderr --logtofile --foreground
+     class late_start
+     user root
+-    group root system wakelock inet cache
++    group root system wakelock inet cache media_rw
+     writepid /dev/cpuset/system-background/tasks
+     disabled
+ 


### PR DESCRIPTION
1. Add update_engine to media_rw group, allow update_engine
to access the OTA file in removable storage.
2. Add WRITE_MEDIA_STORAGE permission in SystemUpdater,
allow it to select OTA package in removable storage,
such as USB stick or SD card.

Change-Id: Ibcb1c15acec151d6ffaa3957cd05580a0f338dfb
Tracked-On: OAM-73479
Signed-off-by: hengluo <heng.luo@intel.com>
Signed-off-by: phireg <philippe.regnier@intel.com>
Reviewed-on: https://android.intel.com:443/649670