### PR TITLE
[CELADON] Screen will not display “Power/Restart/Sleep”

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0024-CELADON-Bugfix-Screen-will-not-display-Power.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0024-CELADON-Bugfix-Screen-will-not-display-Power.patch
@@ -1,0 +1,53 @@
+From c60286f623193de61627ca5f188cdcef7c5d50e7 Mon Sep 17 00:00:00 2001
+From: Madhusudhan S <madhusudhan.s@intel.com>
+Date: Wed, 12 Dec 2018 11:53:34 +0530
+Subject: [PATCH] [CELADON] Bugfix: Screen will not display Power/
+ Restart/Sleep after S3.
+
+Screen will not display “Power/Restart/Sleep”
+options after resume from S3. However this issue
+was specific to APL.
+
+Change-Id: I4e51763ac7df7eec075577b01305530f0cb62d11
+Tracked-On:OAM-72731
+Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>
+---
+ .../android/server/power/PowerManagerService.java   | 21 +++++++++++----------
+ 1 file changed, 11 insertions(+), 10 deletions(-)
+
+diff --git a/services/core/java/com/android/server/power/PowerManagerService.java b/services/core/java/com/android/server/power/PowerManagerService.java
+index ab138e3..e07d63b 100644
+--- a/services/core/java/com/android/server/power/PowerManagerService.java
++++ b/services/core/java/com/android/server/power/PowerManagerService.java
+@@ -1953,17 +1953,18 @@ public final class PowerManagerService extends SystemService
+      */
+     private void updateUserActivitySummaryLocked(long now, int dirty) {
+ 
+-        String currUsbConfig = new String(SystemProperties.get(USB_CONFIG_PROPERTY, "none"));
+-        PowerManager mPowerManager = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
+-
+-        if(currUsbConfig.equals("none") && (!mPowerManager.isInteractive())) {
+-                SystemProperties.set(USB_CONFIG_PROPERTY, "adb");
+-
+-                //Acquiring wakelock to resume from S3 since some devices won't capture power button events
+-                PowerManager.WakeLock mWakeLock = mPowerManager.newWakeLock(PowerManager.ACQUIRE_CAUSES_WAKEUP | PowerManager.FULL_WAKE_LOCK, "TurnDisplayStateOn");
+-                mWakeLock.acquire(5000);
+-        }
++	String bootloaderString = SystemProperties.get("ro.bootloader");
++	if ((bootloaderString != null) && (bootloaderString.contains("dnkbl"))){ 
++		String currUsbConfig = new String(SystemProperties.get(USB_CONFIG_PROPERTY, "none"));
++		PowerManager mPowerManager = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
++		if(currUsbConfig.equals("none") && (!mPowerManager.isInteractive())) {
++			SystemProperties.set(USB_CONFIG_PROPERTY, "adb");
+ 
++			//Acquiring wakelock to resume from S3 since some devices won't capture power button events
++	                PowerManager.WakeLock mWakeLock = mPowerManager.newWakeLock(PowerManager.ACQUIRE_CAUSES_WAKEUP | PowerManager.FULL_WAKE_LOCK, "TurnDisplayStateOn");
++	                mWakeLock.acquire(5000);
++		}
++	}
+         // Update the status of the user activity timeout timer.
+         if ((dirty & (DIRTY_WAKE_LOCKS | DIRTY_USER_ACTIVITY
+                 | DIRTY_WAKEFULNESS | DIRTY_SETTINGS)) != 0) {
+-- 
+2.7.4
+


### PR DESCRIPTION
Screen will not display “Power/Restart/Sleep”
options after resume from S3. However this issue
was specific to APL.

Tracked-On: OAM-72731
Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>