### PR TITLE
[WA]Decrease the duration of screen-off animation to get CTS pass.

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0024-WA-Decrease-the-duration-of-screen-off-animation-to-.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0024-WA-Decrease-the-duration-of-screen-off-animation-to-.patch
@@ -1,0 +1,34 @@
+From 837c3862ea8e90d18a5cf0061105f0f5141245dd Mon Sep 17 00:00:00 2001
+From: "Yan, WalterX" <walterx.yan@intel.com>
+Date: Tue, 18 Dec 2018 11:23:54 +0800
+Subject: [PATCH] [WA]Decrease the duration of screen-off animation to get CTS
+ pass.
+
+testWakelockState requires screen off before it's running.
+But the current source code of case testPartialWakelock does not
+guarantee that. This workaround will get screen off faster to
+get the case pass.
+
+Change-Id: Ic7ff7fc9734b192ecd5b285c3f849594c8445530
+Tracked-On: OAM-72680
+Signed-off-by: Yan, WalterX <walterx.yan@intel.com>
+---
+ .../core/java/com/android/server/display/DisplayPowerController.java    | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/services/core/java/com/android/server/display/DisplayPowerController.java b/services/core/java/com/android/server/display/DisplayPowerController.java
+index 99412c5..6e5f4e4 100644
+--- a/services/core/java/com/android/server/display/DisplayPowerController.java
++++ b/services/core/java/com/android/server/display/DisplayPowerController.java
+@@ -96,7 +96,7 @@ final class DisplayPowerController implements AutomaticBrightnessController.Call
+     private static final int SCREEN_DIM_MINIMUM_REDUCTION = 10;
+ 
+     private static final int COLOR_FADE_ON_ANIMATION_DURATION_MILLIS = 250;
+-    private static final int COLOR_FADE_OFF_ANIMATION_DURATION_MILLIS = 400;
++    private static final int COLOR_FADE_OFF_ANIMATION_DURATION_MILLIS = 200;
+ 
+     private static final int MSG_UPDATE_POWER_STATE = 1;
+     private static final int MSG_PROXIMITY_SENSOR_DEBOUNCED = 2;
+-- 
+1.9.1
+

--- a/android_p/google_diff/celadon/frameworks/base/0024-WA-Decrease-the-duration-of-screen-off-animation-to-.patch
+++ b/android_p/google_diff/celadon/frameworks/base/0024-WA-Decrease-the-duration-of-screen-off-animation-to-.patch
@@ -1,0 +1,34 @@
+From 837c3862ea8e90d18a5cf0061105f0f5141245dd Mon Sep 17 00:00:00 2001
+From: "Yan, WalterX" <walterx.yan@intel.com>
+Date: Tue, 18 Dec 2018 11:23:54 +0800
+Subject: [PATCH] [WA]Decrease the duration of screen-off animation to get CTS
+ pass.
+
+testWakelockState requires screen off before it's running.
+But the current source code of case testPartialWakelock does not
+guarantee that. This workaround will get screen off faster to
+get the case pass.
+
+Change-Id: Ic7ff7fc9734b192ecd5b285c3f849594c8445530
+Tracked-On: OAM-72680
+Signed-off-by: Yan, WalterX <walterx.yan@intel.com>
+---
+ .../core/java/com/android/server/display/DisplayPowerController.java    | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/services/core/java/com/android/server/display/DisplayPowerController.java b/services/core/java/com/android/server/display/DisplayPowerController.java
+index 99412c5..6e5f4e4 100644
+--- a/services/core/java/com/android/server/display/DisplayPowerController.java
++++ b/services/core/java/com/android/server/display/DisplayPowerController.java
+@@ -96,7 +96,7 @@ final class DisplayPowerController implements AutomaticBrightnessController.Call
+     private static final int SCREEN_DIM_MINIMUM_REDUCTION = 10;
+ 
+     private static final int COLOR_FADE_ON_ANIMATION_DURATION_MILLIS = 250;
+-    private static final int COLOR_FADE_OFF_ANIMATION_DURATION_MILLIS = 400;
++    private static final int COLOR_FADE_OFF_ANIMATION_DURATION_MILLIS = 200;
+ 
+     private static final int MSG_UPDATE_POWER_STATE = 1;
+     private static final int MSG_PROXIMITY_SENSOR_DEBOUNCED = 2;
+-- 
+1.9.1
+


### PR DESCRIPTION
testWakelockState requires screen off before it's running.
But the current source code of case testPartialWakelock does not
guarantee that. This workaround will get screen off faster to
get the case pass.

Tracked-On: OAM-72680
Signed-off-by: Yan, WalterX <walterx.yan@intel.com>