### PR TITLE
Make DisplayInfo struct packed

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/native/0003-Make-DisplayInfo-struct-packed.patch
+++ b/android_p/google_diff/cel_apl/frameworks/native/0003-Make-DisplayInfo-struct-packed.patch
@@ -1,0 +1,33 @@
+From 7ce7aa1d743f04300bb03e1c6ea0739bfdc9779f Mon Sep 17 00:00:00 2001
+From: Tong Bo <bo.tong@intel.com>
+Date: Wed, 29 Aug 2018 17:12:30 +0800
+Subject: [PATCH] Make DisplayInfo struct packed
+
+When DisplayInfo is handled through binder transaction, especially
+between a 32-bit client and 64-bit service, it may have different
+size and client will receive incorrect values. Make this struct packed
+and so it will keep the same size.
+
+Change-Id: Ia0a9afb28ba2c9a2fc581f3ae544e3ea2b3fe419
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-67302
+Signed-off-by: Tong Bo <bo.tong@intel.com>
+---
+ libs/ui/include/ui/DisplayInfo.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libs/ui/include/ui/DisplayInfo.h b/libs/ui/include/ui/DisplayInfo.h
+index 94caf6b..e7f16be 100644
+--- a/libs/ui/include/ui/DisplayInfo.h
++++ b/libs/ui/include/ui/DisplayInfo.h
+@@ -24,7 +24,7 @@
+ 
+ namespace android {
+ 
+-struct DisplayInfo {
++struct __attribute__ ((__packed__)) DisplayInfo {
+     uint32_t w{0};
+     uint32_t h{0};
+     float xdpi{0};
+-- 
+2.7.4
+

--- a/android_p/google_diff/celadon/frameworks/native/0003-Make-DisplayInfo-struct-packed.patch
+++ b/android_p/google_diff/celadon/frameworks/native/0003-Make-DisplayInfo-struct-packed.patch
@@ -1,0 +1,33 @@
+From 7ce7aa1d743f04300bb03e1c6ea0739bfdc9779f Mon Sep 17 00:00:00 2001
+From: Tong Bo <bo.tong@intel.com>
+Date: Wed, 29 Aug 2018 17:12:30 +0800
+Subject: [PATCH] Make DisplayInfo struct packed
+
+When DisplayInfo is handled through binder transaction, especially
+between a 32-bit client and 64-bit service, it may have different
+size and client will receive incorrect values. Make this struct packed
+and so it will keep the same size.
+
+Change-Id: Ia0a9afb28ba2c9a2fc581f3ae544e3ea2b3fe419
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-67302
+Signed-off-by: Tong Bo <bo.tong@intel.com>
+---
+ libs/ui/include/ui/DisplayInfo.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libs/ui/include/ui/DisplayInfo.h b/libs/ui/include/ui/DisplayInfo.h
+index 94caf6b..e7f16be 100644
+--- a/libs/ui/include/ui/DisplayInfo.h
++++ b/libs/ui/include/ui/DisplayInfo.h
+@@ -24,7 +24,7 @@
+ 
+ namespace android {
+ 
+-struct DisplayInfo {
++struct __attribute__ ((__packed__)) DisplayInfo {
+     uint32_t w{0};
+     uint32_t h{0};
+     float xdpi{0};
+-- 
+2.7.4
+


### PR DESCRIPTION
When DisplayInfo is handled through binder transaction, especially
between a 32-bit client and 64-bit service, it may have different
size and client will receive incorrect values. Make this struct packed
and so it will keep the same size.

Tracked-On: OAM-71847
Signed-off-by: Hongcheng Xie <hongcheng.xie@intel.com>