### PR TITLE
Issue: Fix for Audio not routing to DUT after BT OFF/ON

### DIFF
--- a/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0005-Fix-for-Audio-not-routing-to-DUT-after-BT-OFF-ON.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0005-Fix-for-Audio-not-routing-to-DUT-after-BT-OFF-ON.patch
@@ -1,0 +1,66 @@
+From dcd1974e2b9ab7146f7bfea9e2c274fab4a11ce2 Mon Sep 17 00:00:00 2001
+From: Gaganpreet kaur <gaganpreetx.kaur@intel.com>
+Date: Thu, 27 Dec 2018 15:28:37 +0530
+Subject: [PATCH 5/5] Fix for Audio not routing to DUT after BT OFF/ON
+
+Issue: Reference phone Audio over Bluetooth is not routing
+to IVI speakers after bluetoth turn OFF and ON from DUT car
+settings.
+
+Analysis: the root cause of the issue is as:
+
+1. After BT OFF/ON from the Car Settings, when BT turns on,
+it is initiating the scanning and also at the same time,
+the connection to the already bonded devices starts.
+2. As the controller is performing discovery of devices, so
+when it receives "Create Connection" Command, it rejects the
+command with the status "Command Disallowed- 0x0c".
+3. Due to this, A2DPSink and HEADSET_CLIENT profiles are not
+able to connect.
+
+Fix: Removed StartScanning when BT turns on in Car Settings.
+Scanning will not be initiated automatically on BT ON event
+from Car Sttings App.
+
+Test: BT Pairing, Audio routing after BT OFF/ON working fine.
+
+Tracked-On: OAM-72646
+
+Change-Id: I0b5fa0fee5508540af4b5ce9fef8b9ad3a168071
+Signed-off-by: Gaganpreet kaur <gaganpreetx.kaur@intel.com>
+---
+ src/com/android/car/settings/bluetooth/BluetoothDeviceListAdapter.java | 3 ++-
+ src/com/android/car/settings/bluetooth/BluetoothSettingsFragment.java  | 3 ++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/com/android/car/settings/bluetooth/BluetoothDeviceListAdapter.java b/src/com/android/car/settings/bluetooth/BluetoothDeviceListAdapter.java
+index 74f6bd0..a6e1d8a 100644
+--- a/src/com/android/car/settings/bluetooth/BluetoothDeviceListAdapter.java
++++ b/src/com/android/car/settings/bluetooth/BluetoothDeviceListAdapter.java
+@@ -286,7 +286,8 @@ public class BluetoothDeviceListAdapter
+                 notifyDataSetChanged();
+                 break;
+             case BluetoothAdapter.STATE_ON:
+-                mLocalAdapter.startScanning(true);
++                /* Don't start Scanning here as it will block connection for
++                   already paired devices */
+                 addBondDevices();
+                 addCachedDevices();
+                 break;
+diff --git a/src/com/android/car/settings/bluetooth/BluetoothSettingsFragment.java b/src/com/android/car/settings/bluetooth/BluetoothSettingsFragment.java
+index f0fde8e..900881a 100644
+--- a/src/com/android/car/settings/bluetooth/BluetoothSettingsFragment.java
++++ b/src/com/android/car/settings/bluetooth/BluetoothSettingsFragment.java
+@@ -181,7 +181,8 @@ public class BluetoothSettingsFragment extends BaseFragment implements Bluetooth
+                 break;
+             case BluetoothAdapter.STATE_ON:
+             case BluetoothAdapter.STATE_TURNING_ON:
+-                setProgressBarVisible(true);
++                /* Don't set visibility for progress bar as we are not going to
++                   initiate Scanning on Bluetooth State on event */
+                 mBluetoothSwitch.setChecked(true);
+                 if (mViewSwitcher.getCurrentView() != mSwipeRefreshLayout) {
+                         mViewSwitcher.showPrevious();
+-- 
+2.7.4
+


### PR DESCRIPTION
Reference phone Audio over Bluetooth is not routing
to IVI speakers after bluetoth turn OFF and ON from DUT car
settings.

Analysis: the root cause of the issue is as:

1. After BT OFF/ON from the Car Settings, when BT turns on,
it is initiating the scanning and also at the same time,
the connection to the already bonded devices starts.
2. As the controller is performing discovery of devices, so
when it receives "Create Connection" Command, it rejects the
command with the status "Command Disallowed- 0x0c".
3. Due to this, A2DPSink and HEADSET_CLIENT profiles are not
able to connect.

Fix: Removed StartScanning when BT turns on in Car Settings.
Scanning will not be initiated automatically on BT ON event
from Car Sttings App.

Test: BT Pairing, Audio routing after BT OFF/ON working fine

Tracked-On: OAM-72646