### PR TITLE
Rename GFX libdrm to libdrm_pri

### DIFF
--- a/android_p/google_diff/cel_apl/external/minigbm/0001-usb-the-private-drm-name.patch
+++ b/android_p/google_diff/cel_apl/external/minigbm/0001-usb-the-private-drm-name.patch
@@ -1,0 +1,36 @@
+From 5c91b36f347d8aeddf939118201c93ac86ca4bc5 Mon Sep 17 00:00:00 2001
+From: renchenglei <chenglei.ren@intel.com>
+Date: Wed, 2 Jan 2019 14:45:54 +0800
+Subject: [PATCH] usb the private drm name
+
+Change-Id: I88e6ba9e459034ead2e2034a5c5b9ebe5bc6186e
+Signed-off-by: Yong Yao <yong.yao@intel.com>
+---
+ Android.mk | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Android.mk b/Android.mk
+index 2a598c60d662..3757f719497d 100644
+--- a/Android.mk
++++ b/Android.mk
+@@ -14,7 +14,7 @@ SUBDIRS := cros_gralloc
+ LOCAL_SHARED_LIBRARIES := \
+ 	libcutils \
+ 	liblog \
+-	libdrm \
++	libdrm_pri \
+ 	libsync
+ 
+ LOCAL_SRC_FILES := \
+@@ -53,7 +53,7 @@ LOCAL_C_INCLUDES += frameworks/native/libs/nativebase/include \
+ ifneq ($(filter $(intel_drivers), $(BOARD_GPU_DRIVERS)),)
+ LOCAL_CPPFLAGS += -DDRV_I915
+ LOCAL_CFLAGS += -DDRV_I915
+-LOCAL_SHARED_LIBRARIES += libdrm_intel
++LOCAL_SHARED_LIBRARIES += libdrm_intel_pri
+ endif
+ 
+ ifeq ($(shell test $(PLATFORM_SDK_VERSION) -ge 27; echo $$?), 0)
+-- 
+2.15.1
+

--- a/android_p/google_diff/cel_apl/vendor/intel/external/project-celadon/hwcomposer/0001-use-the-private-drm-lib-name.patch
+++ b/android_p/google_diff/cel_apl/vendor/intel/external/project-celadon/hwcomposer/0001-use-the-private-drm-lib-name.patch
@@ -1,0 +1,69 @@
+From 8cc1e1481527b0540d3c179fe1cebe1d0779279b Mon Sep 17 00:00:00 2001
+From: Yong Yao <yong.yao@intel.com>
+Date: Sun, 25 Feb 2018 11:39:12 -0800
+Subject: [PATCH] use the private drm lib name
+
+Change-Id: Ic3ec9229fabd23f6466378f72a3a3b0a3c1520b9
+Signed-off-by: Yong Yao <yong.yao@intel.com>
+---
+ Android.common.mk | 2 +-
+ common/Android.mk | 2 +-
+ tests/Android.mk  | 2 +-
+ wsi/Android.mk    | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Android.common.mk b/Android.common.mk
+index f51499d20989..28812888bf76 100644
+--- a/Android.common.mk
++++ b/Android.common.mk
+@@ -49,7 +49,7 @@ include $(CLEAR_VARS)
+ 
+ LOCAL_SHARED_LIBRARIES := \
+ 	libcutils \
+-	libdrm \
++	libdrm_pri \
+ 	libEGL \
+ 	libGLESv2 \
+ 	libhardware \
+diff --git a/common/Android.mk b/common/Android.mk
+index 8bdf2b495036..496c405159e3 100644
+--- a/common/Android.mk
++++ b/common/Android.mk
+@@ -18,7 +18,7 @@ include $(CLEAR_VARS)
+ 
+ LOCAL_SHARED_LIBRARIES := \
+         libcutils \
+-        libdrm \
++        libdrm_pri \
+         libEGL \
+         libGLESv2 \
+         libhardware \
+diff --git a/tests/Android.mk b/tests/Android.mk
+index 66f70d2d7c6f..f259c5048735 100644
+--- a/tests/Android.mk
++++ b/tests/Android.mk
+@@ -30,7 +30,7 @@ LOCAL_WHOLE_STATIC_LIBRARIES := \
+ 
+ LOCAL_SHARED_LIBRARIES := \
+ 	libcutils \
+-	libdrm \
++	libdrm_pri \
+ 	libEGL \
+ 	libGLESv2 \
+ 	libhardware \
+diff --git a/wsi/Android.mk b/wsi/Android.mk
+index a144f7dcb648..aacb1d38b6c7 100644
+--- a/wsi/Android.mk
++++ b/wsi/Android.mk
+@@ -18,7 +18,7 @@ include $(CLEAR_VARS)
+ 
+ LOCAL_SHARED_LIBRARIES := \
+         libcutils \
+-        libdrm \
++        libdrm_pri \
+         libEGL \
+         libGLESv2 \
+         libhardware \
+-- 
+2.15.1
+

--- a/android_p/google_diff/cel_apl/vendor/intel/external/project-celadon/libdrm/0001-usb-the-private-drm-lib-name.patch
+++ b/android_p/google_diff/cel_apl/vendor/intel/external/project-celadon/libdrm/0001-usb-the-private-drm-lib-name.patch
@@ -1,0 +1,221 @@
+From 337ddfa7fb9cf35963875a96bf552c411d6deb1d Mon Sep 17 00:00:00 2001
+From: renchenglei <chenglei.ren@intel.com>
+Date: Wed, 2 Jan 2019 14:43:11 +0800
+Subject: [PATCH] usb the private drm lib name
+
+Change-Id: I92a2be40d2385edd8bd50e73de9d94567244db09
+Signed-off-by: Yong Yao <yong.yao@intel.com>
+---
+ Android.mk                | 6 +++---
+ amdgpu/Android.mk         | 4 ++--
+ etnaviv/Android.mk        | 4 ++--
+ freedreno/Android.mk      | 4 ++--
+ intel/Android.mk          | 4 ++--
+ libkms/Android.mk         | 4 ++--
+ nouveau/Android.mk        | 4 ++--
+ radeon/Android.mk         | 4 ++--
+ tests/modetest/Android.mk | 6 +++---
+ tests/proptest/Android.mk | 6 +++---
+ tests/util/Android.mk     | 4 ++--
+ 11 files changed, 25 insertions(+), 25 deletions(-)
+
+diff --git a/Android.mk b/Android.mk
+index 6fa4456a47e0..81ec83a2bd28 100644
+--- a/Android.mk
++++ b/Android.mk
+@@ -34,7 +34,7 @@ include $(LOCAL_PATH)/Makefile.sources
+ 
+ #static library for the device (recovery)
+ include $(CLEAR_VARS)
+-LOCAL_MODULE := libdrm
++LOCAL_MODULE := libdrm_pri
+ 
+ LOCAL_SRC_FILES := $(LIBDRM_FILES)
+ LOCAL_EXPORT_C_INCLUDE_DIRS := \
+@@ -50,7 +50,7 @@ include $(BUILD_STATIC_LIBRARY)
+ 
+ # Shared library for the device
+ include $(CLEAR_VARS)
+-LOCAL_MODULE := libdrm
++LOCAL_MODULE := libdrm_pri
+ 
+ LOCAL_SRC_FILES := $(LIBDRM_FILES)
+ LOCAL_EXPORT_C_INCLUDE_DIRS := \
+@@ -73,7 +73,7 @@ LOCAL_COPY_HEADERS :=            \
+        include/drm/i915_drm.h   \
+        intel/intel_bufmgr.h     \
+ 
+-LOCAL_COPY_HEADERS_TO := libdrm
++LOCAL_COPY_HEADERS_TO := libdrm_pri
+ 
+ include $(LIBDRM_COMMON_MK)
+ include $(BUILD_SHARED_LIBRARY)
+diff --git a/amdgpu/Android.mk b/amdgpu/Android.mk
+index 1f028d0b97e9..446e847e0edf 100644
+--- a/amdgpu/Android.mk
++++ b/amdgpu/Android.mk
+@@ -4,9 +4,9 @@ include $(CLEAR_VARS)
+ # Import variables LIBDRM_AMDGPU_FILES, LIBDRM_AMDGPU_H_FILES
+ include $(LOCAL_PATH)/Makefile.sources
+ 
+-LOCAL_MODULE := libdrm_amdgpu
++LOCAL_MODULE := libdrm_amdgpu_pri
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
++LOCAL_SHARED_LIBRARIES := libdrm_pri
+ 
+ LOCAL_SRC_FILES := $(LIBDRM_AMDGPU_FILES)
+ 
+diff --git a/etnaviv/Android.mk b/etnaviv/Android.mk
+index 390f9a98924d..5756ad354c08 100644
+--- a/etnaviv/Android.mk
++++ b/etnaviv/Android.mk
+@@ -4,9 +4,9 @@ include $(CLEAR_VARS)
+ # Import variables LIBDRM_ETNAVIV_FILES, LIBDRM_ETNAVIV_H_FILES
+ include $(LOCAL_PATH)/Makefile.sources
+ 
+-LOCAL_MODULE := libdrm_etnaviv
++LOCAL_MODULE := libdrm_etnaviv_pri
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
++LOCAL_SHARED_LIBRARIES := libdrm_pri
+ 
+ LOCAL_SRC_FILES := $(LIBDRM_ETNAVIV_FILES)
+ 
+diff --git a/freedreno/Android.mk b/freedreno/Android.mk
+index 2b582aeded74..a0af38992eb9 100644
+--- a/freedreno/Android.mk
++++ b/freedreno/Android.mk
+@@ -4,9 +4,9 @@ include $(CLEAR_VARS)
+ # Import variables LIBDRM_FREEDRENO_FILES, LIBDRM_FREEDRENO_H_FILES
+ include $(LOCAL_PATH)/Makefile.sources
+ 
+-LOCAL_MODULE := libdrm_freedreno
++LOCAL_MODULE := libdrm_freedreno_pri
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
++LOCAL_SHARED_LIBRARIES := libdrm_pri
+ 
+ LOCAL_SRC_FILES := $(LIBDRM_FREEDRENO_FILES)
+ 
+diff --git a/intel/Android.mk b/intel/Android.mk
+index f45312dd0237..45d2589cdf50 100644
+--- a/intel/Android.mk
++++ b/intel/Android.mk
+@@ -27,12 +27,12 @@ include $(CLEAR_VARS)
+ # Import variables LIBDRM_INTEL_FILES, LIBDRM_INTEL_H_FILES
+ include $(LOCAL_PATH)/Makefile.sources
+ 
+-LOCAL_MODULE := libdrm_intel
++LOCAL_MODULE := libdrm_intel_pri
+ 
+ LOCAL_SRC_FILES := $(LIBDRM_INTEL_FILES)
+ 
+ LOCAL_SHARED_LIBRARIES := \
+-	libdrm
++	libdrm_pri
+ 
+ include $(LIBDRM_COMMON_MK)
+ include $(BUILD_SHARED_LIBRARY)
+diff --git a/libkms/Android.mk b/libkms/Android.mk
+index 0be72054b3fd..83b96c1b7ee1 100644
+--- a/libkms/Android.mk
++++ b/libkms/Android.mk
+@@ -44,8 +44,8 @@ ifneq ($(filter $(radeon_drivers), $(DRM_GPU_DRIVERS)),)
+ LOCAL_SRC_FILES += $(LIBKMS_RADEON_FILES)
+ endif
+ 
+-LOCAL_MODULE := libkms
+-LOCAL_SHARED_LIBRARIES := libdrm
++LOCAL_MODULE := libkms_pri
++LOCAL_SHARED_LIBRARIES := libdrm_pri
+ 
+ include $(LIBDRM_COMMON_MK)
+ include $(BUILD_SHARED_LIBRARY)
+diff --git a/nouveau/Android.mk b/nouveau/Android.mk
+index b430af4fdd70..b39672241946 100644
+--- a/nouveau/Android.mk
++++ b/nouveau/Android.mk
+@@ -4,9 +4,9 @@ include $(CLEAR_VARS)
+ # Import variables LIBDRM_NOUVEAU_FILES, LIBDRM_NOUVEAU_H_FILES
+ include $(LOCAL_PATH)/Makefile.sources
+ 
+-LOCAL_MODULE := libdrm_nouveau
++LOCAL_MODULE := libdrm_nouveau_pri
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
++LOCAL_SHARED_LIBRARIES := libdrm_pri
+ 
+ LOCAL_SRC_FILES := $(LIBDRM_NOUVEAU_FILES)
+ 
+diff --git a/radeon/Android.mk b/radeon/Android.mk
+index 71040dab79b8..813d61bfa6ec 100644
+--- a/radeon/Android.mk
++++ b/radeon/Android.mk
+@@ -4,9 +4,9 @@ include $(CLEAR_VARS)
+ # Import variables LIBDRM_RADEON_FILES, LIBDRM_RADEON_H_FILES
+ include $(LOCAL_PATH)/Makefile.sources
+ 
+-LOCAL_MODULE := libdrm_radeon
++LOCAL_MODULE := libdrm_radeon_pri
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
++LOCAL_SHARED_LIBRARIES := libdrm_pri
+ 
+ LOCAL_SRC_FILES := $(LIBDRM_RADEON_FILES)
+ 
+diff --git a/tests/modetest/Android.mk b/tests/modetest/Android.mk
+index c1a71fd9702a..b766cf51b70e 100644
+--- a/tests/modetest/Android.mk
++++ b/tests/modetest/Android.mk
+@@ -5,10 +5,10 @@ include $(LOCAL_PATH)/Makefile.sources
+ 
+ LOCAL_SRC_FILES := $(MODETEST_FILES)
+ 
+-LOCAL_MODULE := modetest
++LOCAL_MODULE := modetest_pri
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
+-LOCAL_STATIC_LIBRARIES := libdrm_util
++LOCAL_SHARED_LIBRARIES := libdrm_pri
++LOCAL_STATIC_LIBRARIES := libdrm_util_pri
+ 
+ include $(LIBDRM_COMMON_MK)
+ include $(BUILD_EXECUTABLE)
+diff --git a/tests/proptest/Android.mk b/tests/proptest/Android.mk
+index 91a590fc9fca..36ab0f07d80e 100644
+--- a/tests/proptest/Android.mk
++++ b/tests/proptest/Android.mk
+@@ -5,10 +5,10 @@ include $(LOCAL_PATH)/Makefile.sources
+ 
+ LOCAL_SRC_FILES := $(PROPTEST_FILES)
+ 
+-LOCAL_MODULE := proptest
++LOCAL_MODULE := proptest_pri
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
+-LOCAL_STATIC_LIBRARIES := libdrm_util
++LOCAL_SHARED_LIBRARIES := libdrm_pri
++LOCAL_STATIC_LIBRARIES := libdrm_util_pri
+ 
+ include $(LIBDRM_COMMON_MK)
+ include $(BUILD_EXECUTABLE)
+diff --git a/tests/util/Android.mk b/tests/util/Android.mk
+index 12eccb42add3..8c2d193fc5ae 100644
+--- a/tests/util/Android.mk
++++ b/tests/util/Android.mk
+@@ -26,9 +26,9 @@ LOCAL_PATH := $(call my-dir)
+ include $(CLEAR_VARS)
+ include $(LOCAL_PATH)/Makefile.sources
+ 
+-LOCAL_MODULE := libdrm_util
++LOCAL_MODULE := libdrm_util_pri
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
++LOCAL_SHARED_LIBRARIES := libdrm_pri
+ 
+ LOCAL_SRC_FILES := $(UTIL_FILES)
+ 
+-- 
+2.15.1
+

--- a/android_p/google_diff/cel_apl/vendor/intel/external/project-celadon/mesa/0001-use-the-private-drm-lib-name.patch
+++ b/android_p/google_diff/cel_apl/vendor/intel/external/project-celadon/mesa/0001-use-the-private-drm-lib-name.patch
@@ -1,0 +1,79 @@
+From c2fc6b83fd910834d6d965b2f11ba50dfc974af1 Mon Sep 17 00:00:00 2001
+From: renchenglei <chenglei.ren@intel.com>
+Date: Wed, 2 Jan 2019 14:31:15 +0800
+Subject: [PATCH] use the private drm lib name
+
+Change-Id: I567da1c48e588b1a65c883323e92c2a34822b5d8
+Signed-off-by: Yong Yao <yong.yao@intel.com>
+Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>
+---
+ Android.common.mk                      | 2 +-
+ src/gallium/winsys/i915/drm/Android.mk | 2 +-
+ src/intel/Android.vulkan.mk            | 4 ++--
+ src/mesa/drivers/dri/i915/Android.mk   | 2 +-
+ 4 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/Android.common.mk b/Android.common.mk
+index ddf02b04333c..75f06d56e799 100644
+--- a/Android.common.mk
++++ b/Android.common.mk
+@@ -113,7 +113,7 @@ LOCAL_CFLAGS_arm64 += -DUSE_AARCH64_ASM
+ 
+ ifneq ($(LOCAL_IS_HOST_MODULE),true)
+ LOCAL_CFLAGS += -DHAVE_LIBDRM
+-LOCAL_SHARED_LIBRARIES += libdrm
++LOCAL_SHARED_LIBRARIES += libdrm_pri
+ endif
+ 
+ LOCAL_CFLAGS_32 += -DDEFAULT_DRIVER_DIR=\"/vendor/lib/$(MESA_DRI_MODULE_REL_PATH)\"
+diff --git a/src/gallium/winsys/i915/drm/Android.mk b/src/gallium/winsys/i915/drm/Android.mk
+index bab3e85c5dd0..bc8cd0ebe2ef 100644
+--- a/src/gallium/winsys/i915/drm/Android.mk
++++ b/src/gallium/winsys/i915/drm/Android.mk
+@@ -30,7 +30,7 @@ include $(CLEAR_VARS)
+ 
+ LOCAL_SRC_FILES := $(C_SOURCES)
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm_intel
++LOCAL_SHARED_LIBRARIES := libdrm_intel_pri
+ LOCAL_MODULE := libmesa_winsys_i915
+ 
+ include $(GALLIUM_COMMON_MK)
+diff --git a/src/intel/Android.vulkan.mk b/src/intel/Android.vulkan.mk
+index 8dc201497844..034161e283df 100644
+--- a/src/intel/Android.vulkan.mk
++++ b/src/intel/Android.vulkan.mk
+@@ -75,7 +75,7 @@ $(intermediates)/vulkan/anv_entrypoints.h: $(intermediates)/vulkan/dummy.c
+ LOCAL_EXPORT_C_INCLUDE_DIRS := \
+         $(intermediates)
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
++LOCAL_SHARED_LIBRARIES := libdrm_pri
+ 
+ LOCAL_HEADER_LIBRARIES += libcutils_headers libhardware_headers
+ 
+@@ -89,7 +89,7 @@ ANV_INCLUDES := \
+ 	$(call generated-sources-dir-for,STATIC_LIBRARIES,libmesa_vulkan_common,,)/vulkan \
+ 	$(call generated-sources-dir-for,STATIC_LIBRARIES,libmesa_vulkan_util,,)/util
+ 
+-ANV_SHARED_LIBRARIES := libdrm
++ANV_SHARED_LIBRARIES := libdrm_pri
+ 
+ ifeq ($(filter $(MESA_ANDROID_MAJOR_VERSION), 4 5 6 7),)
+ ANV_SHARED_LIBRARIES += libnativewindow
+diff --git a/src/mesa/drivers/dri/i915/Android.mk b/src/mesa/drivers/dri/i915/Android.mk
+index b1054aa6e285..7c9c8210dffe 100644
+--- a/src/mesa/drivers/dri/i915/Android.mk
++++ b/src/mesa/drivers/dri/i915/Android.mk
+@@ -47,7 +47,7 @@ LOCAL_WHOLE_STATIC_LIBRARIES := \
+ 
+ LOCAL_SHARED_LIBRARIES := \
+ 	$(MESA_DRI_SHARED_LIBRARIES) \
+-	libdrm_intel
++	libdrm_intel_pri
+ 
+ LOCAL_GENERATED_SOURCES := \
+ 	$(MESA_DRI_OPTIONS_H) \
+-- 
+2.15.1
+

--- a/android_p/google_diff/celadon/external/minigbm/0001-usb-the-private-drm-name.patch
+++ b/android_p/google_diff/celadon/external/minigbm/0001-usb-the-private-drm-name.patch
@@ -1,0 +1,36 @@
+From 5c91b36f347d8aeddf939118201c93ac86ca4bc5 Mon Sep 17 00:00:00 2001
+From: renchenglei <chenglei.ren@intel.com>
+Date: Wed, 2 Jan 2019 14:45:54 +0800
+Subject: [PATCH] usb the private drm name
+
+Change-Id: I88e6ba9e459034ead2e2034a5c5b9ebe5bc6186e
+Signed-off-by: Yong Yao <yong.yao@intel.com>
+---
+ Android.mk | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Android.mk b/Android.mk
+index 2a598c60d662..3757f719497d 100644
+--- a/Android.mk
++++ b/Android.mk
+@@ -14,7 +14,7 @@ SUBDIRS := cros_gralloc
+ LOCAL_SHARED_LIBRARIES := \
+ 	libcutils \
+ 	liblog \
+-	libdrm \
++	libdrm_pri \
+ 	libsync
+ 
+ LOCAL_SRC_FILES := \
+@@ -53,7 +53,7 @@ LOCAL_C_INCLUDES += frameworks/native/libs/nativebase/include \
+ ifneq ($(filter $(intel_drivers), $(BOARD_GPU_DRIVERS)),)
+ LOCAL_CPPFLAGS += -DDRV_I915
+ LOCAL_CFLAGS += -DDRV_I915
+-LOCAL_SHARED_LIBRARIES += libdrm_intel
++LOCAL_SHARED_LIBRARIES += libdrm_intel_pri
+ endif
+ 
+ ifeq ($(shell test $(PLATFORM_SDK_VERSION) -ge 27; echo $$?), 0)
+-- 
+2.15.1
+

--- a/android_p/google_diff/celadon/vendor/intel/external/project-celadon/hwcomposer/0001-use-the-private-drm-lib-name.patch
+++ b/android_p/google_diff/celadon/vendor/intel/external/project-celadon/hwcomposer/0001-use-the-private-drm-lib-name.patch
@@ -1,0 +1,69 @@
+From 8cc1e1481527b0540d3c179fe1cebe1d0779279b Mon Sep 17 00:00:00 2001
+From: Yong Yao <yong.yao@intel.com>
+Date: Sun, 25 Feb 2018 11:39:12 -0800
+Subject: [PATCH] use the private drm lib name
+
+Change-Id: Ic3ec9229fabd23f6466378f72a3a3b0a3c1520b9
+Signed-off-by: Yong Yao <yong.yao@intel.com>
+---
+ Android.common.mk | 2 +-
+ common/Android.mk | 2 +-
+ tests/Android.mk  | 2 +-
+ wsi/Android.mk    | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Android.common.mk b/Android.common.mk
+index f51499d20989..28812888bf76 100644
+--- a/Android.common.mk
++++ b/Android.common.mk
+@@ -49,7 +49,7 @@ include $(CLEAR_VARS)
+ 
+ LOCAL_SHARED_LIBRARIES := \
+ 	libcutils \
+-	libdrm \
++	libdrm_pri \
+ 	libEGL \
+ 	libGLESv2 \
+ 	libhardware \
+diff --git a/common/Android.mk b/common/Android.mk
+index 8bdf2b495036..496c405159e3 100644
+--- a/common/Android.mk
++++ b/common/Android.mk
+@@ -18,7 +18,7 @@ include $(CLEAR_VARS)
+ 
+ LOCAL_SHARED_LIBRARIES := \
+         libcutils \
+-        libdrm \
++        libdrm_pri \
+         libEGL \
+         libGLESv2 \
+         libhardware \
+diff --git a/tests/Android.mk b/tests/Android.mk
+index 66f70d2d7c6f..f259c5048735 100644
+--- a/tests/Android.mk
++++ b/tests/Android.mk
+@@ -30,7 +30,7 @@ LOCAL_WHOLE_STATIC_LIBRARIES := \
+ 
+ LOCAL_SHARED_LIBRARIES := \
+ 	libcutils \
+-	libdrm \
++	libdrm_pri \
+ 	libEGL \
+ 	libGLESv2 \
+ 	libhardware \
+diff --git a/wsi/Android.mk b/wsi/Android.mk
+index a144f7dcb648..aacb1d38b6c7 100644
+--- a/wsi/Android.mk
++++ b/wsi/Android.mk
+@@ -18,7 +18,7 @@ include $(CLEAR_VARS)
+ 
+ LOCAL_SHARED_LIBRARIES := \
+         libcutils \
+-        libdrm \
++        libdrm_pri \
+         libEGL \
+         libGLESv2 \
+         libhardware \
+-- 
+2.15.1
+

--- a/android_p/google_diff/celadon/vendor/intel/external/project-celadon/libdrm/0001-usb-the-private-drm-lib-name.patch
+++ b/android_p/google_diff/celadon/vendor/intel/external/project-celadon/libdrm/0001-usb-the-private-drm-lib-name.patch
@@ -1,0 +1,221 @@
+From 337ddfa7fb9cf35963875a96bf552c411d6deb1d Mon Sep 17 00:00:00 2001
+From: renchenglei <chenglei.ren@intel.com>
+Date: Wed, 2 Jan 2019 14:43:11 +0800
+Subject: [PATCH] usb the private drm lib name
+
+Change-Id: I92a2be40d2385edd8bd50e73de9d94567244db09
+Signed-off-by: Yong Yao <yong.yao@intel.com>
+---
+ Android.mk                | 6 +++---
+ amdgpu/Android.mk         | 4 ++--
+ etnaviv/Android.mk        | 4 ++--
+ freedreno/Android.mk      | 4 ++--
+ intel/Android.mk          | 4 ++--
+ libkms/Android.mk         | 4 ++--
+ nouveau/Android.mk        | 4 ++--
+ radeon/Android.mk         | 4 ++--
+ tests/modetest/Android.mk | 6 +++---
+ tests/proptest/Android.mk | 6 +++---
+ tests/util/Android.mk     | 4 ++--
+ 11 files changed, 25 insertions(+), 25 deletions(-)
+
+diff --git a/Android.mk b/Android.mk
+index 6fa4456a47e0..81ec83a2bd28 100644
+--- a/Android.mk
++++ b/Android.mk
+@@ -34,7 +34,7 @@ include $(LOCAL_PATH)/Makefile.sources
+ 
+ #static library for the device (recovery)
+ include $(CLEAR_VARS)
+-LOCAL_MODULE := libdrm
++LOCAL_MODULE := libdrm_pri
+ 
+ LOCAL_SRC_FILES := $(LIBDRM_FILES)
+ LOCAL_EXPORT_C_INCLUDE_DIRS := \
+@@ -50,7 +50,7 @@ include $(BUILD_STATIC_LIBRARY)
+ 
+ # Shared library for the device
+ include $(CLEAR_VARS)
+-LOCAL_MODULE := libdrm
++LOCAL_MODULE := libdrm_pri
+ 
+ LOCAL_SRC_FILES := $(LIBDRM_FILES)
+ LOCAL_EXPORT_C_INCLUDE_DIRS := \
+@@ -73,7 +73,7 @@ LOCAL_COPY_HEADERS :=            \
+        include/drm/i915_drm.h   \
+        intel/intel_bufmgr.h     \
+ 
+-LOCAL_COPY_HEADERS_TO := libdrm
++LOCAL_COPY_HEADERS_TO := libdrm_pri
+ 
+ include $(LIBDRM_COMMON_MK)
+ include $(BUILD_SHARED_LIBRARY)
+diff --git a/amdgpu/Android.mk b/amdgpu/Android.mk
+index 1f028d0b97e9..446e847e0edf 100644
+--- a/amdgpu/Android.mk
++++ b/amdgpu/Android.mk
+@@ -4,9 +4,9 @@ include $(CLEAR_VARS)
+ # Import variables LIBDRM_AMDGPU_FILES, LIBDRM_AMDGPU_H_FILES
+ include $(LOCAL_PATH)/Makefile.sources
+ 
+-LOCAL_MODULE := libdrm_amdgpu
++LOCAL_MODULE := libdrm_amdgpu_pri
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
++LOCAL_SHARED_LIBRARIES := libdrm_pri
+ 
+ LOCAL_SRC_FILES := $(LIBDRM_AMDGPU_FILES)
+ 
+diff --git a/etnaviv/Android.mk b/etnaviv/Android.mk
+index 390f9a98924d..5756ad354c08 100644
+--- a/etnaviv/Android.mk
++++ b/etnaviv/Android.mk
+@@ -4,9 +4,9 @@ include $(CLEAR_VARS)
+ # Import variables LIBDRM_ETNAVIV_FILES, LIBDRM_ETNAVIV_H_FILES
+ include $(LOCAL_PATH)/Makefile.sources
+ 
+-LOCAL_MODULE := libdrm_etnaviv
++LOCAL_MODULE := libdrm_etnaviv_pri
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
++LOCAL_SHARED_LIBRARIES := libdrm_pri
+ 
+ LOCAL_SRC_FILES := $(LIBDRM_ETNAVIV_FILES)
+ 
+diff --git a/freedreno/Android.mk b/freedreno/Android.mk
+index 2b582aeded74..a0af38992eb9 100644
+--- a/freedreno/Android.mk
++++ b/freedreno/Android.mk
+@@ -4,9 +4,9 @@ include $(CLEAR_VARS)
+ # Import variables LIBDRM_FREEDRENO_FILES, LIBDRM_FREEDRENO_H_FILES
+ include $(LOCAL_PATH)/Makefile.sources
+ 
+-LOCAL_MODULE := libdrm_freedreno
++LOCAL_MODULE := libdrm_freedreno_pri
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
++LOCAL_SHARED_LIBRARIES := libdrm_pri
+ 
+ LOCAL_SRC_FILES := $(LIBDRM_FREEDRENO_FILES)
+ 
+diff --git a/intel/Android.mk b/intel/Android.mk
+index f45312dd0237..45d2589cdf50 100644
+--- a/intel/Android.mk
++++ b/intel/Android.mk
+@@ -27,12 +27,12 @@ include $(CLEAR_VARS)
+ # Import variables LIBDRM_INTEL_FILES, LIBDRM_INTEL_H_FILES
+ include $(LOCAL_PATH)/Makefile.sources
+ 
+-LOCAL_MODULE := libdrm_intel
++LOCAL_MODULE := libdrm_intel_pri
+ 
+ LOCAL_SRC_FILES := $(LIBDRM_INTEL_FILES)
+ 
+ LOCAL_SHARED_LIBRARIES := \
+-	libdrm
++	libdrm_pri
+ 
+ include $(LIBDRM_COMMON_MK)
+ include $(BUILD_SHARED_LIBRARY)
+diff --git a/libkms/Android.mk b/libkms/Android.mk
+index 0be72054b3fd..83b96c1b7ee1 100644
+--- a/libkms/Android.mk
++++ b/libkms/Android.mk
+@@ -44,8 +44,8 @@ ifneq ($(filter $(radeon_drivers), $(DRM_GPU_DRIVERS)),)
+ LOCAL_SRC_FILES += $(LIBKMS_RADEON_FILES)
+ endif
+ 
+-LOCAL_MODULE := libkms
+-LOCAL_SHARED_LIBRARIES := libdrm
++LOCAL_MODULE := libkms_pri
++LOCAL_SHARED_LIBRARIES := libdrm_pri
+ 
+ include $(LIBDRM_COMMON_MK)
+ include $(BUILD_SHARED_LIBRARY)
+diff --git a/nouveau/Android.mk b/nouveau/Android.mk
+index b430af4fdd70..b39672241946 100644
+--- a/nouveau/Android.mk
++++ b/nouveau/Android.mk
+@@ -4,9 +4,9 @@ include $(CLEAR_VARS)
+ # Import variables LIBDRM_NOUVEAU_FILES, LIBDRM_NOUVEAU_H_FILES
+ include $(LOCAL_PATH)/Makefile.sources
+ 
+-LOCAL_MODULE := libdrm_nouveau
++LOCAL_MODULE := libdrm_nouveau_pri
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
++LOCAL_SHARED_LIBRARIES := libdrm_pri
+ 
+ LOCAL_SRC_FILES := $(LIBDRM_NOUVEAU_FILES)
+ 
+diff --git a/radeon/Android.mk b/radeon/Android.mk
+index 71040dab79b8..813d61bfa6ec 100644
+--- a/radeon/Android.mk
++++ b/radeon/Android.mk
+@@ -4,9 +4,9 @@ include $(CLEAR_VARS)
+ # Import variables LIBDRM_RADEON_FILES, LIBDRM_RADEON_H_FILES
+ include $(LOCAL_PATH)/Makefile.sources
+ 
+-LOCAL_MODULE := libdrm_radeon
++LOCAL_MODULE := libdrm_radeon_pri
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
++LOCAL_SHARED_LIBRARIES := libdrm_pri
+ 
+ LOCAL_SRC_FILES := $(LIBDRM_RADEON_FILES)
+ 
+diff --git a/tests/modetest/Android.mk b/tests/modetest/Android.mk
+index c1a71fd9702a..b766cf51b70e 100644
+--- a/tests/modetest/Android.mk
++++ b/tests/modetest/Android.mk
+@@ -5,10 +5,10 @@ include $(LOCAL_PATH)/Makefile.sources
+ 
+ LOCAL_SRC_FILES := $(MODETEST_FILES)
+ 
+-LOCAL_MODULE := modetest
++LOCAL_MODULE := modetest_pri
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
+-LOCAL_STATIC_LIBRARIES := libdrm_util
++LOCAL_SHARED_LIBRARIES := libdrm_pri
++LOCAL_STATIC_LIBRARIES := libdrm_util_pri
+ 
+ include $(LIBDRM_COMMON_MK)
+ include $(BUILD_EXECUTABLE)
+diff --git a/tests/proptest/Android.mk b/tests/proptest/Android.mk
+index 91a590fc9fca..36ab0f07d80e 100644
+--- a/tests/proptest/Android.mk
++++ b/tests/proptest/Android.mk
+@@ -5,10 +5,10 @@ include $(LOCAL_PATH)/Makefile.sources
+ 
+ LOCAL_SRC_FILES := $(PROPTEST_FILES)
+ 
+-LOCAL_MODULE := proptest
++LOCAL_MODULE := proptest_pri
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
+-LOCAL_STATIC_LIBRARIES := libdrm_util
++LOCAL_SHARED_LIBRARIES := libdrm_pri
++LOCAL_STATIC_LIBRARIES := libdrm_util_pri
+ 
+ include $(LIBDRM_COMMON_MK)
+ include $(BUILD_EXECUTABLE)
+diff --git a/tests/util/Android.mk b/tests/util/Android.mk
+index 12eccb42add3..8c2d193fc5ae 100644
+--- a/tests/util/Android.mk
++++ b/tests/util/Android.mk
+@@ -26,9 +26,9 @@ LOCAL_PATH := $(call my-dir)
+ include $(CLEAR_VARS)
+ include $(LOCAL_PATH)/Makefile.sources
+ 
+-LOCAL_MODULE := libdrm_util
++LOCAL_MODULE := libdrm_util_pri
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
++LOCAL_SHARED_LIBRARIES := libdrm_pri
+ 
+ LOCAL_SRC_FILES := $(UTIL_FILES)
+ 
+-- 
+2.15.1
+

--- a/android_p/google_diff/celadon/vendor/intel/external/project-celadon/mesa/0001-use-the-private-drm-lib-name.patch
+++ b/android_p/google_diff/celadon/vendor/intel/external/project-celadon/mesa/0001-use-the-private-drm-lib-name.patch
@@ -1,0 +1,79 @@
+From c2fc6b83fd910834d6d965b2f11ba50dfc974af1 Mon Sep 17 00:00:00 2001
+From: renchenglei <chenglei.ren@intel.com>
+Date: Wed, 2 Jan 2019 14:31:15 +0800
+Subject: [PATCH] use the private drm lib name
+
+Change-Id: I567da1c48e588b1a65c883323e92c2a34822b5d8
+Signed-off-by: Yong Yao <yong.yao@intel.com>
+Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>
+---
+ Android.common.mk                      | 2 +-
+ src/gallium/winsys/i915/drm/Android.mk | 2 +-
+ src/intel/Android.vulkan.mk            | 4 ++--
+ src/mesa/drivers/dri/i915/Android.mk   | 2 +-
+ 4 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/Android.common.mk b/Android.common.mk
+index ddf02b04333c..75f06d56e799 100644
+--- a/Android.common.mk
++++ b/Android.common.mk
+@@ -113,7 +113,7 @@ LOCAL_CFLAGS_arm64 += -DUSE_AARCH64_ASM
+ 
+ ifneq ($(LOCAL_IS_HOST_MODULE),true)
+ LOCAL_CFLAGS += -DHAVE_LIBDRM
+-LOCAL_SHARED_LIBRARIES += libdrm
++LOCAL_SHARED_LIBRARIES += libdrm_pri
+ endif
+ 
+ LOCAL_CFLAGS_32 += -DDEFAULT_DRIVER_DIR=\"/vendor/lib/$(MESA_DRI_MODULE_REL_PATH)\"
+diff --git a/src/gallium/winsys/i915/drm/Android.mk b/src/gallium/winsys/i915/drm/Android.mk
+index bab3e85c5dd0..bc8cd0ebe2ef 100644
+--- a/src/gallium/winsys/i915/drm/Android.mk
++++ b/src/gallium/winsys/i915/drm/Android.mk
+@@ -30,7 +30,7 @@ include $(CLEAR_VARS)
+ 
+ LOCAL_SRC_FILES := $(C_SOURCES)
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm_intel
++LOCAL_SHARED_LIBRARIES := libdrm_intel_pri
+ LOCAL_MODULE := libmesa_winsys_i915
+ 
+ include $(GALLIUM_COMMON_MK)
+diff --git a/src/intel/Android.vulkan.mk b/src/intel/Android.vulkan.mk
+index 8dc201497844..034161e283df 100644
+--- a/src/intel/Android.vulkan.mk
++++ b/src/intel/Android.vulkan.mk
+@@ -75,7 +75,7 @@ $(intermediates)/vulkan/anv_entrypoints.h: $(intermediates)/vulkan/dummy.c
+ LOCAL_EXPORT_C_INCLUDE_DIRS := \
+         $(intermediates)
+ 
+-LOCAL_SHARED_LIBRARIES := libdrm
++LOCAL_SHARED_LIBRARIES := libdrm_pri
+ 
+ LOCAL_HEADER_LIBRARIES += libcutils_headers libhardware_headers
+ 
+@@ -89,7 +89,7 @@ ANV_INCLUDES := \
+ 	$(call generated-sources-dir-for,STATIC_LIBRARIES,libmesa_vulkan_common,,)/vulkan \
+ 	$(call generated-sources-dir-for,STATIC_LIBRARIES,libmesa_vulkan_util,,)/util
+ 
+-ANV_SHARED_LIBRARIES := libdrm
++ANV_SHARED_LIBRARIES := libdrm_pri
+ 
+ ifeq ($(filter $(MESA_ANDROID_MAJOR_VERSION), 4 5 6 7),)
+ ANV_SHARED_LIBRARIES += libnativewindow
+diff --git a/src/mesa/drivers/dri/i915/Android.mk b/src/mesa/drivers/dri/i915/Android.mk
+index b1054aa6e285..7c9c8210dffe 100644
+--- a/src/mesa/drivers/dri/i915/Android.mk
++++ b/src/mesa/drivers/dri/i915/Android.mk
+@@ -47,7 +47,7 @@ LOCAL_WHOLE_STATIC_LIBRARIES := \
+ 
+ LOCAL_SHARED_LIBRARIES := \
+ 	$(MESA_DRI_SHARED_LIBRARIES) \
+-	libdrm_intel
++	libdrm_intel_pri
+ 
+ LOCAL_GENERATED_SOURCES := \
+ 	$(MESA_DRI_OPTIONS_H) \
+-- 
+2.15.1
+


### PR DESCRIPTION
To enable Treble, we need add Google's libdrm back and rename GFX libdrm to libdrm_pri