### PR TITLE
Handle dummy device as primary

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/av/0007-Allow-virtual-driver-to-be-used-as-primary.patch
+++ b/android_p/google_diff/cel_apl/frameworks/av/0007-Allow-virtual-driver-to-be-used-as-primary.patch
@@ -1,0 +1,47 @@
+From c42734bcb8564ed72ccf1d5a61605e8db4cc676a Mon Sep 17 00:00:00 2001
+From: "M, Kumar K" <kumar.k.m@intel.com>
+Date: Thu, 27 Dec 2018 12:06:49 +0530
+Subject: [PATCH] Allow virtual driver to be used as primary
+
+Revert "Set available device as prmary hardware device"
+
+This reverts commit a1506d062fa75e7cdee46d908d3cc103e5727716.
+
+Change-Id: I662b390ef224b0fcb4542c509f105bd528cd53d6
+Tracked-On: OAM-OAM-73881
+Signed-off-by: M, Kumar K <kumar.k.m@intel.com>
+---
+ services/audioflinger/AudioFlinger.cpp | 10 +---------
+ 1 file changed, 1 insertion(+), 9 deletions(-)
+
+diff --git a/services/audioflinger/AudioFlinger.cpp b/services/audioflinger/AudioFlinger.cpp
+index 2eef169..bdd39c6 100644
+--- a/services/audioflinger/AudioFlinger.cpp
++++ b/services/audioflinger/AudioFlinger.cpp
+@@ -2159,22 +2159,14 @@ status_t AudioFlinger::openOutput(audio_module_handle_t module,
+                 mHardwareStatus = AUDIO_HW_SET_MODE;
+                 mPrimaryHardwareDev->hwDevice()->setMode(mMode);
+                 mHardwareStatus = AUDIO_HW_IDLE;
+-            } else if (mPrimaryHardwareDev == NULL)  {
+-                ALOGV("Using available module %d as the primary audio interface", module);
+-                mPrimaryHardwareDev = playbackThread->getOutput()->audioHwDev;
+-
+-                AutoMutex lock(mHardwareLock);
+-                mHardwareStatus = AUDIO_HW_SET_MODE;
+-                mPrimaryHardwareDev->hwDevice()->setMode(mMode);
+-                mHardwareStatus = AUDIO_HW_IDLE;
+             }
+-
+         } else {
+             MmapThread *mmapThread = (MmapThread *)thread.get();
+             mmapThread->ioConfigChanged(AUDIO_OUTPUT_OPENED);
+         }
+         return NO_ERROR;
+     }
++
+     return NO_INIT;
+ }
+ 
+-- 
+1.9.1
+

--- a/android_p/google_diff/cel_apl/vendor/intel/external/project-celadon/audio/0001-Handle-dummy-sound-card-in-hal.patch
+++ b/android_p/google_diff/cel_apl/vendor/intel/external/project-celadon/audio/0001-Handle-dummy-sound-card-in-hal.patch
@@ -1,0 +1,105 @@
+From f78b7e745a63ef709e0463359abe1a5ae9d510f7 Mon Sep 17 00:00:00 2001
+From: "M, Kumar K" <kumar.k.m@intel.com>
+Date: Thu, 10 Jan 2019 17:00:58 +0530
+Subject: [PATCH] Handle dummy sound card in hal
+
+Tracked-On: OAM-73881
+Signed-off-by: M, Kumar K <kumar.k.m@intel.com>
+---
+ audio_hw.c | 52 +++++++++++++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 49 insertions(+), 3 deletions(-)
+
+diff --git a/audio_hw.c b/audio_hw.c
+index 04846fa..755b660 100644
+--- a/audio_hw.c
++++ b/audio_hw.c
+@@ -42,6 +42,7 @@
+ #include <audio_route/audio_route.h>
+ 
+ #define PCM_CARD 0
++#define PCM_CARD_DEFAULT 0
+ #define PCM_DEVICE 0
+ 
+ #define OUT_PERIOD_SIZE 512
+@@ -80,7 +81,8 @@ struct audio_device {
+     bool standby;
+     bool mic_mute;
+     struct audio_route *ar;
+-
++    
++    int card;
+     struct stream_out *active_out;
+     struct stream_in *active_in;
+ };
+@@ -175,6 +177,26 @@ static void do_in_standby(struct stream_in *in)
+     }
+ }
+ 
++static int get_pcm_card(const char* name)
++{
++        char id_filepath[PATH_MAX] = {0};
++        char number_filepath[PATH_MAX] = {0};
++        ssize_t written;
++
++        snprintf(id_filepath, sizeof(id_filepath), "/proc/asound/%s", name);
++
++        written = readlink(id_filepath, number_filepath, sizeof(number_filepath));
++        if (written < 0) {
++            ALOGE("Sound card %s does not exist - setting default", name);
++                return 0;
++        } else if (written >= (ssize_t)sizeof(id_filepath)) {
++            ALOGE("Sound card %s name is too long - setting default", name);
++            return 0;
++        }
++
++        return atoi(number_filepath + 4);
++}
++
+ /* must be called with hw device and output stream mutexes locked */
+ static int start_output_stream(struct stream_out *out)
+ {
+@@ -187,7 +209,18 @@ static int start_output_stream(struct stream_out *out)
+         return -ENODEV;
+     }
+ 
+-    out->pcm = pcm_open(PCM_CARD, PCM_DEVICE, PCM_OUT | PCM_NORESTART | PCM_MONOTONIC, out->pcm_config);
++
++    ret = system("ls /proc/asound/card0/pcm0p");
++    if(!ret) {
++       adev->card = PCM_CARD_DEFAULT;
++    } else {
++        adev->card = get_pcm_card("Dummy");
++    }
++
++    ALOGE("PCM card selected = %d, \n", adev->card);
++ 
++    out->pcm = pcm_open(adev->card, PCM_DEVICE, PCM_OUT | PCM_NORESTART | PCM_MONOTONIC, out->pcm_config);
++
+     if (!out->pcm) {
+ 	ALOGE("pcm_open(out) failed: device not found");
+         return -ENODEV;
+@@ -624,7 +657,20 @@ static int adev_open_output_stream(struct audio_hw_device *dev,
+     struct stream_out *out;
+     struct pcm_params *params;
+ 
+-    params = pcm_params_get(PCM_CARD, PCM_DEVICE, PCM_OUT);
++   int ret;
++
++    ret = system("ls /proc/asound/card0/pcm0p");
++
++    if(!ret) {
++       adev->card = PCM_CARD_DEFAULT;
++    } else {
++        adev->card = get_pcm_card("Dummy");
++    }
++
++    ALOGE("PCM card selected = %d, \n", adev->card);
++
++    params = pcm_params_get(adev->card, PCM_DEVICE, PCM_OUT);
++
+     if (!params)
+         return -ENOSYS;
+ 
+-- 
+1.9.1
+


### PR DESCRIPTION
Handle dummy sound device as primary device
when no default sound card is present

Tracked-On: OAM-75019
Signed-off-by: M, Kumar K <kumar.k.m@intel.com>