### PR TITLE
seccomp: Allow readlink(2) in x86_64 for UBSan's sake

### DIFF
--- a/android_p/google_diff/cel_apl/bionic/0001-seccomp-Allow-readlink-2-in-x86_64-for-UBSan-s-sake.patch
+++ b/android_p/google_diff/cel_apl/bionic/0001-seccomp-Allow-readlink-2-in-x86_64-for-UBSan-s-sake.patch
@@ -1,0 +1,323 @@
+From 403bff308d7d16f82566c61079b16c7b6af6c8e8 Mon Sep 17 00:00:00 2001
+From: Luis Hector Chavez <lhchavez@google.com>
+Date: Fri, 3 Aug 2018 10:36:02 -0700
+Subject: [PATCH 1/2] seccomp: Allow readlink(2) in x86_64 for UBSan's sake
+
+This patch is cherry-picked from AOSP upstream:
+https://android-review.googlesource.com/c/platform/bionic/+/817533
+
+This change allows the use of readlink(2) so that UBSan can work
+correctly on x86_64.
+
+Bug: 111999822
+Test: CtsWrapWrapDebugTestCases
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-68230
+Change-Id: I7f3013c712e3e41567a0d8e1bbb9d378c04b4433
+(cherry picked from commit ef1a34c85dd3ac4af5de922bdc595a014fe9c14e)
+Signed-off-by: Tong Bo <bo.tong@intel.com>
+Reviewed-on: https://android.intel.com:443/651245
+---
+ libc/SECCOMP_WHITELIST_COMMON.TXT     |   2 +-
+ libc/seccomp/x86_64_app_policy.cpp    | 144 +++++++++++++-------------
+ libc/seccomp/x86_64_global_policy.cpp |  32 +++---
+ libc/seccomp/x86_64_system_policy.cpp |  32 +++---
+ 4 files changed, 108 insertions(+), 102 deletions(-)
+
+diff --git a/libc/SECCOMP_WHITELIST_COMMON.TXT b/libc/SECCOMP_WHITELIST_COMMON.TXT
+index a620b44..5c97e65 100644
+--- a/libc/SECCOMP_WHITELIST_COMMON.TXT
++++ b/libc/SECCOMP_WHITELIST_COMMON.TXT
+@@ -74,7 +74,7 @@ int	epoll_wait:epoll_wait(int epfd, struct epoll_event *events, int maxevents, i
+ # Needed by sanitizers (b/34606909)
+ # 5 (__NR_open) and 195 (__NR_stat64) are also required, but they are
+ # already allowed.
+-ssize_t	readlink:readlink(const char *path, char *buf, size_t bufsiz)	arm,x86,mips
++ssize_t	readlink:readlink(const char *path, char *buf, size_t bufsiz)	arm,x86,x86_64,mips
+ 
+ # b/34908783
+ int	epoll_create:epoll_create(int size)	arm,x86,mips
+diff --git a/libc/seccomp/x86_64_app_policy.cpp b/libc/seccomp/x86_64_app_policy.cpp
+index 26a970f..e6c5388 100644
+--- a/libc/seccomp/x86_64_app_policy.cpp
++++ b/libc/seccomp/x86_64_app_policy.cpp
+@@ -5,90 +5,92 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_app_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 102),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 51, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 25, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 104),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 51, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 25, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 13, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 7, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 95, 94), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 94, 93), //close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 97, 96), //read|write
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 96, 95), //close
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 92, 91), //fstat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 91, 90), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 94, 93), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 93, 92), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 88, 87), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 87, 86), //dup
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 86, 85), //nanosleep|getitimer
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 90, 89), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 89, 88), //dup
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 88, 87), //nanosleep|getitimer
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 82, 81), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 81, 80), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 80, 79), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 84, 83), //setitimer|getpid|sendfile|socket|connect
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 83, 82), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 82, 81), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 77, 76), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 76, 75), //getcwd|chdir|fchdir
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 75, 74), //fchmod
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 120, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 104, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 70, 69), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 79, 78), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 78, 77), //getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 77, 76), //readlink
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 117, 13, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 107, 7, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 72, 71), //fchmod
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 71, 70), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 104, 1, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 103, 69, 68), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 107, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 105, 67, 66), //getgid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 66, 65), //geteuid|getegid|setpgid|getppid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 117, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 114, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 113, 63, 62), //setsid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 116, 62, 61), //setregid|getgroups
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 119, 61, 60), //setresuid|getresuid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 124, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 122, 57, 56), //getresgid|getpgid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 56, 55), //getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 55, 54), //personality
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 52, 51), //statfs|fstatfs
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 51, 50), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 50, 49), //pivot_root
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 25, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 162, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 160, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 159, 44, 43), //prctl|arch_prctl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 105, 68, 67), //getgid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 114, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 65, 64), //geteuid|getegid|setpgid|getppid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 113, 64, 63), //setsid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 116, 63, 62), //setregid|getgroups
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 124, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 120, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 119, 59, 58), //setresuid|getresuid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 122, 58, 57), //getresgid|getpgid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 57, 56), //getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 54, 53), //personality
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 53, 52), //statfs|fstatfs
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 52, 51), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 25, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 13, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 7, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 160, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 46, 45), //pivot_root
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 159, 45, 44), //prctl|arch_prctl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 162, 1, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 161, 43, 42), //setrlimit
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 163, 41, 40), //sync
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 40, 39), //quotactl
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 37, 36), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 36, 35), //futex|sched_setaffinity|sched_getaffinity
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 35, 34), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 228, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 31, 30), //getdents64|set_tid_address|restart_syscall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 227, 30, 29), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 29, 28), //clock_gettime|clock_getres|clock_nanosleep|exit_group
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 26, 25), //epoll_ctl|tgkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 25, 24), //waitid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 24, 23), //ioprio_set|ioprio_get
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 19, 18), //inotify_add_watch|inotify_rm_watch
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 163, 42, 41), //sync
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 39, 38), //quotactl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 38, 37), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 37, 36), //futex|sched_setaffinity|sched_getaffinity
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 228, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 33, 32), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 32, 31), //getdents64|set_tid_address|restart_syscall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 227, 31, 30), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 28, 27), //clock_gettime|clock_getres|clock_nanosleep|exit_group
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 27, 26), //epoll_ctl|tgkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 26, 25), //waitid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 13, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 7, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 21, 20), //ioprio_set|ioprio_get
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 20, 19), //inotify_add_watch|inotify_rm_watch
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 1, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 18, 17), //openat|mkdirat|mknodat|fchownat
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 17, 16), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 3, 0),
+diff --git a/libc/seccomp/x86_64_global_policy.cpp b/libc/seccomp/x86_64_global_policy.cpp
+index 8142ce4..11408f0 100644
+--- a/libc/seccomp/x86_64_global_policy.cpp
++++ b/libc/seccomp/x86_64_global_policy.cpp
+@@ -5,35 +5,37 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_global_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 88),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 43, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 90),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 45, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 23, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 11, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 81, 80), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 80, 79), //close
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 79, 78), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 83, 82), //read|write
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 82, 81), //close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 81, 80), //fstat
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 76, 75), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 75, 74), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 74, 73), //dup
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 78, 77), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 77, 76), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 76, 75), //dup
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 70, 69), //nanosleep|getitimer
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 69, 68), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 68, 67), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 72, 71), //nanosleep|getitimer
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 71, 70), //setitimer|getpid|sendfile|socket|connect
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 70, 69), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 66, 65), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 65, 64), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 67, 66), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 66, 65), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 65, 64), //getcwd|chdir|fchdir
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 11, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 60, 59), //getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 60, 59), //readlink
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 59, 58), //fchmod
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 58, 57), //fchown
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
+diff --git a/libc/seccomp/x86_64_system_policy.cpp b/libc/seccomp/x86_64_system_policy.cpp
+index 67859eb..ad7060c 100644
+--- a/libc/seccomp/x86_64_system_policy.cpp
++++ b/libc/seccomp/x86_64_system_policy.cpp
+@@ -5,35 +5,37 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_system_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 88),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 43, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 90),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 45, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 23, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 11, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 81, 80), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 80, 79), //close
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 79, 78), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 83, 82), //read|write
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 82, 81), //close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 81, 80), //fstat
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 76, 75), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 75, 74), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 74, 73), //dup
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 78, 77), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 77, 76), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 76, 75), //dup
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 70, 69), //nanosleep|getitimer
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 69, 68), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 68, 67), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 72, 71), //nanosleep|getitimer
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 71, 70), //setitimer|getpid|sendfile|socket|connect
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 70, 69), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 66, 65), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 65, 64), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 67, 66), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 66, 65), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 65, 64), //getcwd|chdir|fchdir
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 11, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 60, 59), //getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 60, 59), //readlink
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 59, 58), //fchmod
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 58, 57), //fchown
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
+-- 
+2.20.0
+

--- a/android_p/google_diff/cel_apl/bionic/0002-seccomp-Allow-open-2-and-getdents-2-in-x86_64-for-UB.patch
+++ b/android_p/google_diff/cel_apl/bionic/0002-seccomp-Allow-open-2-and-getdents-2-in-x86_64-for-UB.patch
@@ -1,0 +1,546 @@
+From b199af1e2336d48296ad2d50850051b5e59cd83e Mon Sep 17 00:00:00 2001
+From: Victor Hsieh <victorhsieh@google.com>
+Date: Thu, 15 Nov 2018 10:21:21 -0800
+Subject: [PATCH 2/2] seccomp: Allow open(2) and getdents(2) in x86_64 for
+ UBSan's sake
+
+This patch is cherry-picked from AOSP upstream:
+https://android-review.googlesource.com/c/platform/bionic/+/827522
+
+This change allows the use of open(2) and getdents(2) so that UBSan can
+work correctly on x86_64.
+
+This is a reworked cherry-pick from aosp/master.  See
+https://android-review.googlesource.com/c/platform/bionic/+/728890
+
+Bug: 113991591
+Test: None
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-68230
+Change-Id: I8487ac5adfc4613d2d0b3f5cb166830e573dc15c
+Signed-off-by: Tong Bo <bo.tong@intel.com>
+Reviewed-on: https://android.intel.com:443/652398
+---
+ libc/SECCOMP_WHITELIST_COMMON.TXT     |   4 +-
+ libc/seccomp/x86_64_app_policy.cpp    | 162 +++++++++++++-------------
+ libc/seccomp/x86_64_global_policy.cpp | 148 ++++++++++++-----------
+ libc/seccomp/x86_64_system_policy.cpp | 148 ++++++++++++-----------
+ 4 files changed, 225 insertions(+), 237 deletions(-)
+
+diff --git a/libc/SECCOMP_WHITELIST_COMMON.TXT b/libc/SECCOMP_WHITELIST_COMMON.TXT
+index 5c97e65..854fd74 100644
+--- a/libc/SECCOMP_WHITELIST_COMMON.TXT
++++ b/libc/SECCOMP_WHITELIST_COMMON.TXT
+@@ -62,8 +62,8 @@ int	access:access(const char *pathname, int mode)	arm,x86,mips
+ int	stat64:stat64(const char*, struct stat64*)	arm,x86,mips
+ 
+ # b/34813887
+-int	open:open(const char *path, int oflag, ... ) arm,x86,mips
+-int	getdents:getdents(unsigned int fd, struct linux_dirent *dirp, unsigned int count) arm,x86,mips
++int	open:open(const char *path, int oflag, ... ) arm,x86,x86_64,mips
++int	getdents:getdents(unsigned int fd, struct linux_dirent *dirp, unsigned int count) arm,x86,x86_64,mips
+ 
+ # b/34719286
+ int	eventfd:eventfd(unsigned int initval, int flags)	arm,x86,mips
+diff --git a/libc/seccomp/x86_64_app_policy.cpp b/libc/seccomp/x86_64_app_policy.cpp
+index e6c5388..4356cd4 100644
+--- a/libc/seccomp/x86_64_app_policy.cpp
++++ b/libc/seccomp/x86_64_app_policy.cpp
+@@ -5,92 +5,88 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_app_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 104),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 51, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 25, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 97, 96), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 96, 95), //close
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 94, 93), //fstat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 93, 92), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 90, 89), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 89, 88), //dup
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 88, 87), //nanosleep|getitimer
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 100),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 49, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 25, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 13, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 7, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 93, 92), //read|write|open|close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 92, 91), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 90, 89), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 89, 88), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 86, 85), //dup
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 85, 84), //nanosleep|getitimer
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 84, 83), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 83, 82), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 82, 81), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 79, 78), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 78, 77), //getcwd|chdir|fchdir
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 77, 76), //readlink
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 117, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 107, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 72, 71), //fchmod
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 71, 70), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 80, 79), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 79, 78), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 78, 77), //fcntl|flock|fsync|fdatasync|truncate|ftruncate|getdents|getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 75, 74), //readlink
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 74, 73), //fchmod
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 73, 72), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 120, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 107, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 104, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 103, 69, 68), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 105, 68, 67), //getgid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 114, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 65, 64), //geteuid|getegid|setpgid|getppid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 113, 64, 63), //setsid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 116, 63, 62), //setregid|getgroups
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 124, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 120, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 119, 59, 58), //setresuid|getresuid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 122, 58, 57), //getresgid|getpgid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 57, 56), //getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 54, 53), //personality
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 53, 52), //statfs|fstatfs
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 52, 51), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 25, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 160, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 46, 45), //pivot_root
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 159, 45, 44), //prctl|arch_prctl
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 162, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 103, 68, 67), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 105, 67, 66), //getgid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 66, 65), //geteuid|getegid|setpgid|getppid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 117, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 114, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 113, 63, 62), //setsid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 116, 62, 61), //setregid|getgroups
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 119, 61, 60), //setresuid|getresuid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 124, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 122, 57, 56), //getresgid|getpgid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 56, 55), //getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 55, 54), //personality
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 52, 51), //statfs|fstatfs
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 51, 50), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 50, 49), //pivot_root
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 25, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 13, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 7, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 162, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 160, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 159, 44, 43), //prctl|arch_prctl
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 161, 43, 42), //setrlimit
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 163, 42, 41), //sync
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 39, 38), //quotactl
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 38, 37), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 37, 36), //futex|sched_setaffinity|sched_getaffinity
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 228, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 33, 32), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 32, 31), //getdents64|set_tid_address|restart_syscall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 227, 31, 30), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 28, 27), //clock_gettime|clock_getres|clock_nanosleep|exit_group
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 27, 26), //epoll_ctl|tgkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 26, 25), //waitid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 21, 20), //ioprio_set|ioprio_get
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 20, 19), //inotify_add_watch|inotify_rm_watch
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 163, 41, 40), //sync
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 40, 39), //quotactl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 37, 36), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 36, 35), //futex|sched_setaffinity|sched_getaffinity
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 35, 34), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 228, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 31, 30), //getdents64|set_tid_address|restart_syscall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 227, 30, 29), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 29, 28), //clock_gettime|clock_getres|clock_nanosleep|exit_group
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 26, 25), //epoll_ctl|tgkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 25, 24), //waitid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 24, 23), //ioprio_set|ioprio_get
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 19, 18), //inotify_add_watch|inotify_rm_watch
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 18, 17), //openat|mkdirat|mknodat|fchownat
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 17, 16), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 3, 0),
+diff --git a/libc/seccomp/x86_64_global_policy.cpp b/libc/seccomp/x86_64_global_policy.cpp
+index 11408f0..f69aa6d 100644
+--- a/libc/seccomp/x86_64_global_policy.cpp
++++ b/libc/seccomp/x86_64_global_policy.cpp
+@@ -5,85 +5,81 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_global_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 90),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 45, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 23, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 83, 82), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 82, 81), //close
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 81, 80), //fstat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 78, 77), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 77, 76), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 76, 75), //dup
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 86),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 43, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 79, 78), //read|write|open|close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 78, 77), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 77, 76), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 74, 73), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 73, 72), //dup
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 72, 71), //nanosleep|getitimer
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 71, 70), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 70, 69), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 67, 66), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 66, 65), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 65, 64), //getcwd|chdir|fchdir
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 60, 59), //readlink
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 59, 58), //fchmod
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 58, 57), //fchown
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 55, 54), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid|syslog|getgid|setuid|setgid|geteuid|getegid|setpgid|getppid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 54, 53), //setsid|setreuid|setregid|getgroups|setgroups|setresuid|getresuid|setresgid|getresgid|getpgid|setfsuid|setfsgid|getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 53, 52), //personality
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 49, 48), //statfs|fstatfs
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 48, 47), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 47, 46), //pivot_root
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 169, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 68, 67), //setitimer|getpid|sendfile|socket|connect
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 67, 66), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 66, 65), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 64, 63), //fcntl|flock|fsync|fdatasync|truncate|ftruncate|getdents|getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 63, 62), //readlink
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 58, 57), //fchmod
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 57, 56), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 56, 55), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid|syslog|getgid|setuid|setgid|geteuid|getegid|setpgid|getppid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 53, 52), //setsid|setreuid|setregid|getgroups|setgroups|setresuid|getresuid|setresgid|getresgid|getpgid|setfsuid|setfsgid|getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 52, 51), //personality
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 51, 50), //statfs|fstatfs
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 169, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 47, 46), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 46, 45), //pivot_root
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 168, 45, 44), //prctl|arch_prctl|adjtimex|setrlimit|chroot|sync|acct|settimeofday|mount|umount2|swapon
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 172, 44, 43), //reboot|sethostname|setdomainname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 21, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 177, 38, 37), //init_module|delete_module
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 37, 36), //quotactl
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 36, 35), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 33, 32), //futex|sched_setaffinity|sched_getaffinity
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 32, 31), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 31, 30), //getdents64|set_tid_address|restart_syscall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 250, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 27, 26), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete|clock_settime|clock_gettime|clock_getres|clock_nanosleep|exit_group
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 26, 25), //epoll_ctl|tgkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 249, 25, 24), //waitid|add_key
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 172, 43, 42), //reboot|sethostname|setdomainname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 177, 42, 41), //init_module|delete_module
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 36, 35), //quotactl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 35, 34), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 34, 33), //futex|sched_setaffinity|sched_getaffinity
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 31, 30), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 30, 29), //getdents64|set_tid_address|restart_syscall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 29, 28), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete|clock_settime|clock_gettime|clock_getres|clock_nanosleep|exit_group
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 250, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 25, 24), //epoll_ctl|tgkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 249, 24, 23), //waitid|add_key
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 23, 22), //keyctl|ioprio_set|ioprio_get
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 22, 21), //inotify_add_watch|inotify_rm_watch
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 302, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 280, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 17, 16), //openat|mkdirat|mknodat|fchownat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 16, 15), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 279, 15, 14), //splice|tee|sync_file_range|vmsplice
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 282, 12, 11), //utimensat|epoll_pwait
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 21, 20), //inotify_add_watch|inotify_rm_watch
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 20, 19), //openat|mkdirat|mknodat|fchownat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 302, 9, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 280, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 15, 14), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 279, 14, 13), //splice|tee|sync_file_range|vmsplice
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 282, 13, 12), //utimensat|epoll_pwait
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 1, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 284, 11, 10), //timerfd_create
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 300, 10, 9), //fallocate|timerfd_settime|timerfd_gettime|accept4|signalfd4|eventfd2|epoll_create1|dup3|pipe2|inotify_init1|preadv|pwritev|rt_tgsigqueueinfo|perf_event_open|recvmmsg
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 321, 5, 0),
+diff --git a/libc/seccomp/x86_64_system_policy.cpp b/libc/seccomp/x86_64_system_policy.cpp
+index ad7060c..c471f10 100644
+--- a/libc/seccomp/x86_64_system_policy.cpp
++++ b/libc/seccomp/x86_64_system_policy.cpp
+@@ -5,85 +5,81 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_system_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 90),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 45, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 23, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 83, 82), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 82, 81), //close
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 81, 80), //fstat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 78, 77), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 77, 76), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 76, 75), //dup
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 86),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 43, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 79, 78), //read|write|open|close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 78, 77), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 77, 76), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 74, 73), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 73, 72), //dup
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 72, 71), //nanosleep|getitimer
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 71, 70), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 70, 69), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 67, 66), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 66, 65), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 65, 64), //getcwd|chdir|fchdir
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 60, 59), //readlink
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 59, 58), //fchmod
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 58, 57), //fchown
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 55, 54), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid|syslog|getgid|setuid|setgid|geteuid|getegid|setpgid|getppid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 54, 53), //setsid|setreuid|setregid|getgroups|setgroups|setresuid|getresuid|setresgid|getresgid|getpgid|setfsuid|setfsgid|getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 53, 52), //personality
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 49, 48), //statfs|fstatfs
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 48, 47), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 47, 46), //pivot_root
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 169, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 68, 67), //setitimer|getpid|sendfile|socket|connect
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 67, 66), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 66, 65), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 64, 63), //fcntl|flock|fsync|fdatasync|truncate|ftruncate|getdents|getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 63, 62), //readlink
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 58, 57), //fchmod
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 57, 56), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 56, 55), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid|syslog|getgid|setuid|setgid|geteuid|getegid|setpgid|getppid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 53, 52), //setsid|setreuid|setregid|getgroups|setgroups|setresuid|getresuid|setresgid|getresgid|getpgid|setfsuid|setfsgid|getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 52, 51), //personality
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 51, 50), //statfs|fstatfs
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 169, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 47, 46), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 46, 45), //pivot_root
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 167, 45, 44), //prctl|arch_prctl|adjtimex|setrlimit|chroot|sync|acct|settimeofday|mount|umount2
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 172, 44, 43), //reboot|sethostname|setdomainname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 21, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 177, 38, 37), //init_module|delete_module
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 37, 36), //quotactl
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 36, 35), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 33, 32), //futex|sched_setaffinity|sched_getaffinity
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 32, 31), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 31, 30), //getdents64|set_tid_address|restart_syscall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 27, 26), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete|clock_settime|clock_gettime|clock_getres|clock_nanosleep|exit_group
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 26, 25), //epoll_ctl|tgkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 25, 24), //waitid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 172, 43, 42), //reboot|sethostname|setdomainname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 177, 42, 41), //init_module|delete_module
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 36, 35), //quotactl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 35, 34), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 34, 33), //futex|sched_setaffinity|sched_getaffinity
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 31, 30), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 30, 29), //getdents64|set_tid_address|restart_syscall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 29, 28), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete|clock_settime|clock_gettime|clock_getres|clock_nanosleep|exit_group
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 25, 24), //epoll_ctl|tgkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 24, 23), //waitid
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 23, 22), //ioprio_set|ioprio_get
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 22, 21), //inotify_add_watch|inotify_rm_watch
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 302, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 280, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 17, 16), //openat|mkdirat|mknodat|fchownat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 16, 15), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 279, 15, 14), //splice|tee|sync_file_range|vmsplice
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 282, 12, 11), //utimensat|epoll_pwait
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 21, 20), //inotify_add_watch|inotify_rm_watch
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 20, 19), //openat|mkdirat|mknodat|fchownat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 302, 9, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 280, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 15, 14), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 279, 14, 13), //splice|tee|sync_file_range|vmsplice
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 282, 13, 12), //utimensat|epoll_pwait
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 1, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 284, 11, 10), //timerfd_create
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 300, 10, 9), //fallocate|timerfd_settime|timerfd_gettime|accept4|signalfd4|eventfd2|epoll_create1|dup3|pipe2|inotify_init1|preadv|pwritev|rt_tgsigqueueinfo|perf_event_open|recvmmsg
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 321, 5, 0),
+-- 
+2.20.0
+

--- a/android_p/google_diff/cel_kbl/bionic/0001-seccomp-Allow-readlink-2-in-x86_64-for-UBSan-s-sake.patch
+++ b/android_p/google_diff/cel_kbl/bionic/0001-seccomp-Allow-readlink-2-in-x86_64-for-UBSan-s-sake.patch
@@ -1,0 +1,323 @@
+From 403bff308d7d16f82566c61079b16c7b6af6c8e8 Mon Sep 17 00:00:00 2001
+From: Luis Hector Chavez <lhchavez@google.com>
+Date: Fri, 3 Aug 2018 10:36:02 -0700
+Subject: [PATCH 1/2] seccomp: Allow readlink(2) in x86_64 for UBSan's sake
+
+This patch is cherry-picked from AOSP upstream:
+https://android-review.googlesource.com/c/platform/bionic/+/817533
+
+This change allows the use of readlink(2) so that UBSan can work
+correctly on x86_64.
+
+Bug: 111999822
+Test: CtsWrapWrapDebugTestCases
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-68230
+Change-Id: I7f3013c712e3e41567a0d8e1bbb9d378c04b4433
+(cherry picked from commit ef1a34c85dd3ac4af5de922bdc595a014fe9c14e)
+Signed-off-by: Tong Bo <bo.tong@intel.com>
+Reviewed-on: https://android.intel.com:443/651245
+---
+ libc/SECCOMP_WHITELIST_COMMON.TXT     |   2 +-
+ libc/seccomp/x86_64_app_policy.cpp    | 144 +++++++++++++-------------
+ libc/seccomp/x86_64_global_policy.cpp |  32 +++---
+ libc/seccomp/x86_64_system_policy.cpp |  32 +++---
+ 4 files changed, 108 insertions(+), 102 deletions(-)
+
+diff --git a/libc/SECCOMP_WHITELIST_COMMON.TXT b/libc/SECCOMP_WHITELIST_COMMON.TXT
+index a620b44..5c97e65 100644
+--- a/libc/SECCOMP_WHITELIST_COMMON.TXT
++++ b/libc/SECCOMP_WHITELIST_COMMON.TXT
+@@ -74,7 +74,7 @@ int	epoll_wait:epoll_wait(int epfd, struct epoll_event *events, int maxevents, i
+ # Needed by sanitizers (b/34606909)
+ # 5 (__NR_open) and 195 (__NR_stat64) are also required, but they are
+ # already allowed.
+-ssize_t	readlink:readlink(const char *path, char *buf, size_t bufsiz)	arm,x86,mips
++ssize_t	readlink:readlink(const char *path, char *buf, size_t bufsiz)	arm,x86,x86_64,mips
+ 
+ # b/34908783
+ int	epoll_create:epoll_create(int size)	arm,x86,mips
+diff --git a/libc/seccomp/x86_64_app_policy.cpp b/libc/seccomp/x86_64_app_policy.cpp
+index 26a970f..e6c5388 100644
+--- a/libc/seccomp/x86_64_app_policy.cpp
++++ b/libc/seccomp/x86_64_app_policy.cpp
+@@ -5,90 +5,92 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_app_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 102),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 51, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 25, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 104),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 51, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 25, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 13, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 7, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 95, 94), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 94, 93), //close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 97, 96), //read|write
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 96, 95), //close
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 92, 91), //fstat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 91, 90), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 94, 93), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 93, 92), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 88, 87), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 87, 86), //dup
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 86, 85), //nanosleep|getitimer
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 90, 89), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 89, 88), //dup
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 88, 87), //nanosleep|getitimer
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 82, 81), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 81, 80), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 80, 79), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 84, 83), //setitimer|getpid|sendfile|socket|connect
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 83, 82), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 82, 81), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 77, 76), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 76, 75), //getcwd|chdir|fchdir
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 75, 74), //fchmod
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 120, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 104, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 70, 69), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 79, 78), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 78, 77), //getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 77, 76), //readlink
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 117, 13, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 107, 7, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 72, 71), //fchmod
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 71, 70), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 104, 1, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 103, 69, 68), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 107, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 105, 67, 66), //getgid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 66, 65), //geteuid|getegid|setpgid|getppid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 117, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 114, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 113, 63, 62), //setsid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 116, 62, 61), //setregid|getgroups
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 119, 61, 60), //setresuid|getresuid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 124, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 122, 57, 56), //getresgid|getpgid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 56, 55), //getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 55, 54), //personality
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 52, 51), //statfs|fstatfs
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 51, 50), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 50, 49), //pivot_root
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 25, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 162, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 160, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 159, 44, 43), //prctl|arch_prctl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 105, 68, 67), //getgid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 114, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 65, 64), //geteuid|getegid|setpgid|getppid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 113, 64, 63), //setsid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 116, 63, 62), //setregid|getgroups
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 124, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 120, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 119, 59, 58), //setresuid|getresuid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 122, 58, 57), //getresgid|getpgid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 57, 56), //getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 54, 53), //personality
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 53, 52), //statfs|fstatfs
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 52, 51), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 25, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 13, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 7, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 160, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 46, 45), //pivot_root
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 159, 45, 44), //prctl|arch_prctl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 162, 1, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 161, 43, 42), //setrlimit
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 163, 41, 40), //sync
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 40, 39), //quotactl
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 37, 36), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 36, 35), //futex|sched_setaffinity|sched_getaffinity
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 35, 34), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 228, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 31, 30), //getdents64|set_tid_address|restart_syscall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 227, 30, 29), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 29, 28), //clock_gettime|clock_getres|clock_nanosleep|exit_group
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 26, 25), //epoll_ctl|tgkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 25, 24), //waitid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 24, 23), //ioprio_set|ioprio_get
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 19, 18), //inotify_add_watch|inotify_rm_watch
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 163, 42, 41), //sync
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 39, 38), //quotactl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 38, 37), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 37, 36), //futex|sched_setaffinity|sched_getaffinity
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 228, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 33, 32), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 32, 31), //getdents64|set_tid_address|restart_syscall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 227, 31, 30), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 28, 27), //clock_gettime|clock_getres|clock_nanosleep|exit_group
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 27, 26), //epoll_ctl|tgkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 26, 25), //waitid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 13, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 7, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 21, 20), //ioprio_set|ioprio_get
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 20, 19), //inotify_add_watch|inotify_rm_watch
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 1, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 18, 17), //openat|mkdirat|mknodat|fchownat
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 17, 16), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 3, 0),
+diff --git a/libc/seccomp/x86_64_global_policy.cpp b/libc/seccomp/x86_64_global_policy.cpp
+index 8142ce4..11408f0 100644
+--- a/libc/seccomp/x86_64_global_policy.cpp
++++ b/libc/seccomp/x86_64_global_policy.cpp
+@@ -5,35 +5,37 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_global_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 88),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 43, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 90),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 45, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 23, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 11, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 81, 80), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 80, 79), //close
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 79, 78), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 83, 82), //read|write
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 82, 81), //close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 81, 80), //fstat
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 76, 75), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 75, 74), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 74, 73), //dup
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 78, 77), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 77, 76), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 76, 75), //dup
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 70, 69), //nanosleep|getitimer
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 69, 68), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 68, 67), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 72, 71), //nanosleep|getitimer
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 71, 70), //setitimer|getpid|sendfile|socket|connect
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 70, 69), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 66, 65), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 65, 64), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 67, 66), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 66, 65), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 65, 64), //getcwd|chdir|fchdir
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 11, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 60, 59), //getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 60, 59), //readlink
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 59, 58), //fchmod
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 58, 57), //fchown
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
+diff --git a/libc/seccomp/x86_64_system_policy.cpp b/libc/seccomp/x86_64_system_policy.cpp
+index 67859eb..ad7060c 100644
+--- a/libc/seccomp/x86_64_system_policy.cpp
++++ b/libc/seccomp/x86_64_system_policy.cpp
+@@ -5,35 +5,37 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_system_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 88),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 43, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 90),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 45, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 23, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 11, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 81, 80), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 80, 79), //close
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 79, 78), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 83, 82), //read|write
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 82, 81), //close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 81, 80), //fstat
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 76, 75), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 75, 74), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 74, 73), //dup
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 78, 77), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 77, 76), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 76, 75), //dup
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 70, 69), //nanosleep|getitimer
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 69, 68), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 68, 67), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 72, 71), //nanosleep|getitimer
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 71, 70), //setitimer|getpid|sendfile|socket|connect
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 70, 69), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 66, 65), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 65, 64), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 67, 66), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 66, 65), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 65, 64), //getcwd|chdir|fchdir
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 11, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 60, 59), //getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 60, 59), //readlink
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 59, 58), //fchmod
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 58, 57), //fchown
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
+-- 
+2.20.0
+

--- a/android_p/google_diff/cel_kbl/bionic/0002-seccomp-Allow-open-2-and-getdents-2-in-x86_64-for-UB.patch
+++ b/android_p/google_diff/cel_kbl/bionic/0002-seccomp-Allow-open-2-and-getdents-2-in-x86_64-for-UB.patch
@@ -1,0 +1,546 @@
+From b199af1e2336d48296ad2d50850051b5e59cd83e Mon Sep 17 00:00:00 2001
+From: Victor Hsieh <victorhsieh@google.com>
+Date: Thu, 15 Nov 2018 10:21:21 -0800
+Subject: [PATCH 2/2] seccomp: Allow open(2) and getdents(2) in x86_64 for
+ UBSan's sake
+
+This patch is cherry-picked from AOSP upstream:
+https://android-review.googlesource.com/c/platform/bionic/+/827522
+
+This change allows the use of open(2) and getdents(2) so that UBSan can
+work correctly on x86_64.
+
+This is a reworked cherry-pick from aosp/master.  See
+https://android-review.googlesource.com/c/platform/bionic/+/728890
+
+Bug: 113991591
+Test: None
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-68230
+Change-Id: I8487ac5adfc4613d2d0b3f5cb166830e573dc15c
+Signed-off-by: Tong Bo <bo.tong@intel.com>
+Reviewed-on: https://android.intel.com:443/652398
+---
+ libc/SECCOMP_WHITELIST_COMMON.TXT     |   4 +-
+ libc/seccomp/x86_64_app_policy.cpp    | 162 +++++++++++++-------------
+ libc/seccomp/x86_64_global_policy.cpp | 148 ++++++++++++-----------
+ libc/seccomp/x86_64_system_policy.cpp | 148 ++++++++++++-----------
+ 4 files changed, 225 insertions(+), 237 deletions(-)
+
+diff --git a/libc/SECCOMP_WHITELIST_COMMON.TXT b/libc/SECCOMP_WHITELIST_COMMON.TXT
+index 5c97e65..854fd74 100644
+--- a/libc/SECCOMP_WHITELIST_COMMON.TXT
++++ b/libc/SECCOMP_WHITELIST_COMMON.TXT
+@@ -62,8 +62,8 @@ int	access:access(const char *pathname, int mode)	arm,x86,mips
+ int	stat64:stat64(const char*, struct stat64*)	arm,x86,mips
+ 
+ # b/34813887
+-int	open:open(const char *path, int oflag, ... ) arm,x86,mips
+-int	getdents:getdents(unsigned int fd, struct linux_dirent *dirp, unsigned int count) arm,x86,mips
++int	open:open(const char *path, int oflag, ... ) arm,x86,x86_64,mips
++int	getdents:getdents(unsigned int fd, struct linux_dirent *dirp, unsigned int count) arm,x86,x86_64,mips
+ 
+ # b/34719286
+ int	eventfd:eventfd(unsigned int initval, int flags)	arm,x86,mips
+diff --git a/libc/seccomp/x86_64_app_policy.cpp b/libc/seccomp/x86_64_app_policy.cpp
+index e6c5388..4356cd4 100644
+--- a/libc/seccomp/x86_64_app_policy.cpp
++++ b/libc/seccomp/x86_64_app_policy.cpp
+@@ -5,92 +5,88 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_app_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 104),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 51, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 25, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 97, 96), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 96, 95), //close
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 94, 93), //fstat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 93, 92), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 90, 89), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 89, 88), //dup
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 88, 87), //nanosleep|getitimer
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 100),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 49, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 25, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 13, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 7, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 93, 92), //read|write|open|close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 92, 91), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 90, 89), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 89, 88), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 86, 85), //dup
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 85, 84), //nanosleep|getitimer
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 84, 83), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 83, 82), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 82, 81), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 79, 78), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 78, 77), //getcwd|chdir|fchdir
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 77, 76), //readlink
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 117, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 107, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 72, 71), //fchmod
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 71, 70), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 80, 79), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 79, 78), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 78, 77), //fcntl|flock|fsync|fdatasync|truncate|ftruncate|getdents|getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 75, 74), //readlink
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 74, 73), //fchmod
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 73, 72), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 120, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 107, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 104, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 103, 69, 68), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 105, 68, 67), //getgid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 114, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 65, 64), //geteuid|getegid|setpgid|getppid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 113, 64, 63), //setsid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 116, 63, 62), //setregid|getgroups
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 124, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 120, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 119, 59, 58), //setresuid|getresuid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 122, 58, 57), //getresgid|getpgid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 57, 56), //getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 54, 53), //personality
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 53, 52), //statfs|fstatfs
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 52, 51), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 25, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 160, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 46, 45), //pivot_root
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 159, 45, 44), //prctl|arch_prctl
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 162, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 103, 68, 67), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 105, 67, 66), //getgid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 66, 65), //geteuid|getegid|setpgid|getppid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 117, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 114, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 113, 63, 62), //setsid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 116, 62, 61), //setregid|getgroups
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 119, 61, 60), //setresuid|getresuid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 124, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 122, 57, 56), //getresgid|getpgid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 56, 55), //getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 55, 54), //personality
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 52, 51), //statfs|fstatfs
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 51, 50), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 50, 49), //pivot_root
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 25, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 13, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 7, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 162, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 160, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 159, 44, 43), //prctl|arch_prctl
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 161, 43, 42), //setrlimit
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 163, 42, 41), //sync
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 39, 38), //quotactl
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 38, 37), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 37, 36), //futex|sched_setaffinity|sched_getaffinity
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 228, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 33, 32), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 32, 31), //getdents64|set_tid_address|restart_syscall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 227, 31, 30), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 28, 27), //clock_gettime|clock_getres|clock_nanosleep|exit_group
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 27, 26), //epoll_ctl|tgkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 26, 25), //waitid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 21, 20), //ioprio_set|ioprio_get
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 20, 19), //inotify_add_watch|inotify_rm_watch
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 163, 41, 40), //sync
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 40, 39), //quotactl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 37, 36), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 36, 35), //futex|sched_setaffinity|sched_getaffinity
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 35, 34), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 228, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 31, 30), //getdents64|set_tid_address|restart_syscall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 227, 30, 29), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 29, 28), //clock_gettime|clock_getres|clock_nanosleep|exit_group
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 26, 25), //epoll_ctl|tgkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 25, 24), //waitid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 24, 23), //ioprio_set|ioprio_get
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 19, 18), //inotify_add_watch|inotify_rm_watch
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 18, 17), //openat|mkdirat|mknodat|fchownat
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 17, 16), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 3, 0),
+diff --git a/libc/seccomp/x86_64_global_policy.cpp b/libc/seccomp/x86_64_global_policy.cpp
+index 11408f0..f69aa6d 100644
+--- a/libc/seccomp/x86_64_global_policy.cpp
++++ b/libc/seccomp/x86_64_global_policy.cpp
+@@ -5,85 +5,81 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_global_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 90),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 45, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 23, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 83, 82), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 82, 81), //close
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 81, 80), //fstat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 78, 77), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 77, 76), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 76, 75), //dup
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 86),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 43, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 79, 78), //read|write|open|close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 78, 77), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 77, 76), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 74, 73), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 73, 72), //dup
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 72, 71), //nanosleep|getitimer
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 71, 70), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 70, 69), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 67, 66), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 66, 65), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 65, 64), //getcwd|chdir|fchdir
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 60, 59), //readlink
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 59, 58), //fchmod
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 58, 57), //fchown
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 55, 54), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid|syslog|getgid|setuid|setgid|geteuid|getegid|setpgid|getppid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 54, 53), //setsid|setreuid|setregid|getgroups|setgroups|setresuid|getresuid|setresgid|getresgid|getpgid|setfsuid|setfsgid|getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 53, 52), //personality
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 49, 48), //statfs|fstatfs
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 48, 47), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 47, 46), //pivot_root
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 169, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 68, 67), //setitimer|getpid|sendfile|socket|connect
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 67, 66), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 66, 65), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 64, 63), //fcntl|flock|fsync|fdatasync|truncate|ftruncate|getdents|getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 63, 62), //readlink
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 58, 57), //fchmod
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 57, 56), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 56, 55), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid|syslog|getgid|setuid|setgid|geteuid|getegid|setpgid|getppid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 53, 52), //setsid|setreuid|setregid|getgroups|setgroups|setresuid|getresuid|setresgid|getresgid|getpgid|setfsuid|setfsgid|getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 52, 51), //personality
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 51, 50), //statfs|fstatfs
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 169, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 47, 46), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 46, 45), //pivot_root
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 168, 45, 44), //prctl|arch_prctl|adjtimex|setrlimit|chroot|sync|acct|settimeofday|mount|umount2|swapon
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 172, 44, 43), //reboot|sethostname|setdomainname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 21, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 177, 38, 37), //init_module|delete_module
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 37, 36), //quotactl
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 36, 35), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 33, 32), //futex|sched_setaffinity|sched_getaffinity
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 32, 31), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 31, 30), //getdents64|set_tid_address|restart_syscall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 250, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 27, 26), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete|clock_settime|clock_gettime|clock_getres|clock_nanosleep|exit_group
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 26, 25), //epoll_ctl|tgkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 249, 25, 24), //waitid|add_key
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 172, 43, 42), //reboot|sethostname|setdomainname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 177, 42, 41), //init_module|delete_module
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 36, 35), //quotactl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 35, 34), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 34, 33), //futex|sched_setaffinity|sched_getaffinity
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 31, 30), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 30, 29), //getdents64|set_tid_address|restart_syscall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 29, 28), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete|clock_settime|clock_gettime|clock_getres|clock_nanosleep|exit_group
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 250, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 25, 24), //epoll_ctl|tgkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 249, 24, 23), //waitid|add_key
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 23, 22), //keyctl|ioprio_set|ioprio_get
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 22, 21), //inotify_add_watch|inotify_rm_watch
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 302, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 280, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 17, 16), //openat|mkdirat|mknodat|fchownat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 16, 15), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 279, 15, 14), //splice|tee|sync_file_range|vmsplice
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 282, 12, 11), //utimensat|epoll_pwait
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 21, 20), //inotify_add_watch|inotify_rm_watch
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 20, 19), //openat|mkdirat|mknodat|fchownat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 302, 9, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 280, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 15, 14), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 279, 14, 13), //splice|tee|sync_file_range|vmsplice
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 282, 13, 12), //utimensat|epoll_pwait
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 1, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 284, 11, 10), //timerfd_create
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 300, 10, 9), //fallocate|timerfd_settime|timerfd_gettime|accept4|signalfd4|eventfd2|epoll_create1|dup3|pipe2|inotify_init1|preadv|pwritev|rt_tgsigqueueinfo|perf_event_open|recvmmsg
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 321, 5, 0),
+diff --git a/libc/seccomp/x86_64_system_policy.cpp b/libc/seccomp/x86_64_system_policy.cpp
+index ad7060c..c471f10 100644
+--- a/libc/seccomp/x86_64_system_policy.cpp
++++ b/libc/seccomp/x86_64_system_policy.cpp
+@@ -5,85 +5,81 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_system_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 90),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 45, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 23, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 83, 82), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 82, 81), //close
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 81, 80), //fstat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 78, 77), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 77, 76), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 76, 75), //dup
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 86),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 43, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 79, 78), //read|write|open|close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 78, 77), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 77, 76), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 74, 73), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 73, 72), //dup
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 72, 71), //nanosleep|getitimer
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 71, 70), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 70, 69), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 67, 66), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 66, 65), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 65, 64), //getcwd|chdir|fchdir
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 60, 59), //readlink
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 59, 58), //fchmod
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 58, 57), //fchown
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 55, 54), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid|syslog|getgid|setuid|setgid|geteuid|getegid|setpgid|getppid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 54, 53), //setsid|setreuid|setregid|getgroups|setgroups|setresuid|getresuid|setresgid|getresgid|getpgid|setfsuid|setfsgid|getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 53, 52), //personality
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 49, 48), //statfs|fstatfs
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 48, 47), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 47, 46), //pivot_root
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 169, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 68, 67), //setitimer|getpid|sendfile|socket|connect
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 67, 66), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 66, 65), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 64, 63), //fcntl|flock|fsync|fdatasync|truncate|ftruncate|getdents|getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 63, 62), //readlink
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 58, 57), //fchmod
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 57, 56), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 56, 55), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid|syslog|getgid|setuid|setgid|geteuid|getegid|setpgid|getppid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 53, 52), //setsid|setreuid|setregid|getgroups|setgroups|setresuid|getresuid|setresgid|getresgid|getpgid|setfsuid|setfsgid|getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 52, 51), //personality
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 51, 50), //statfs|fstatfs
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 169, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 47, 46), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 46, 45), //pivot_root
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 167, 45, 44), //prctl|arch_prctl|adjtimex|setrlimit|chroot|sync|acct|settimeofday|mount|umount2
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 172, 44, 43), //reboot|sethostname|setdomainname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 21, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 177, 38, 37), //init_module|delete_module
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 37, 36), //quotactl
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 36, 35), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 33, 32), //futex|sched_setaffinity|sched_getaffinity
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 32, 31), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 31, 30), //getdents64|set_tid_address|restart_syscall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 27, 26), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete|clock_settime|clock_gettime|clock_getres|clock_nanosleep|exit_group
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 26, 25), //epoll_ctl|tgkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 25, 24), //waitid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 172, 43, 42), //reboot|sethostname|setdomainname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 177, 42, 41), //init_module|delete_module
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 36, 35), //quotactl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 35, 34), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 34, 33), //futex|sched_setaffinity|sched_getaffinity
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 31, 30), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 30, 29), //getdents64|set_tid_address|restart_syscall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 29, 28), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete|clock_settime|clock_gettime|clock_getres|clock_nanosleep|exit_group
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 25, 24), //epoll_ctl|tgkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 24, 23), //waitid
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 23, 22), //ioprio_set|ioprio_get
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 22, 21), //inotify_add_watch|inotify_rm_watch
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 302, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 280, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 17, 16), //openat|mkdirat|mknodat|fchownat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 16, 15), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 279, 15, 14), //splice|tee|sync_file_range|vmsplice
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 282, 12, 11), //utimensat|epoll_pwait
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 21, 20), //inotify_add_watch|inotify_rm_watch
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 20, 19), //openat|mkdirat|mknodat|fchownat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 302, 9, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 280, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 15, 14), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 279, 14, 13), //splice|tee|sync_file_range|vmsplice
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 282, 13, 12), //utimensat|epoll_pwait
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 1, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 284, 11, 10), //timerfd_create
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 300, 10, 9), //fallocate|timerfd_settime|timerfd_gettime|accept4|signalfd4|eventfd2|epoll_create1|dup3|pipe2|inotify_init1|preadv|pwritev|rt_tgsigqueueinfo|perf_event_open|recvmmsg
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 321, 5, 0),
+-- 
+2.20.0
+

--- a/android_p/google_diff/celadon/bionic/0001-seccomp-Allow-readlink-2-in-x86_64-for-UBSan-s-sake.patch
+++ b/android_p/google_diff/celadon/bionic/0001-seccomp-Allow-readlink-2-in-x86_64-for-UBSan-s-sake.patch
@@ -1,0 +1,323 @@
+From 403bff308d7d16f82566c61079b16c7b6af6c8e8 Mon Sep 17 00:00:00 2001
+From: Luis Hector Chavez <lhchavez@google.com>
+Date: Fri, 3 Aug 2018 10:36:02 -0700
+Subject: [PATCH 1/2] seccomp: Allow readlink(2) in x86_64 for UBSan's sake
+
+This patch is cherry-picked from AOSP upstream:
+https://android-review.googlesource.com/c/platform/bionic/+/817533
+
+This change allows the use of readlink(2) so that UBSan can work
+correctly on x86_64.
+
+Bug: 111999822
+Test: CtsWrapWrapDebugTestCases
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-68230
+Change-Id: I7f3013c712e3e41567a0d8e1bbb9d378c04b4433
+(cherry picked from commit ef1a34c85dd3ac4af5de922bdc595a014fe9c14e)
+Signed-off-by: Tong Bo <bo.tong@intel.com>
+Reviewed-on: https://android.intel.com:443/651245
+---
+ libc/SECCOMP_WHITELIST_COMMON.TXT     |   2 +-
+ libc/seccomp/x86_64_app_policy.cpp    | 144 +++++++++++++-------------
+ libc/seccomp/x86_64_global_policy.cpp |  32 +++---
+ libc/seccomp/x86_64_system_policy.cpp |  32 +++---
+ 4 files changed, 108 insertions(+), 102 deletions(-)
+
+diff --git a/libc/SECCOMP_WHITELIST_COMMON.TXT b/libc/SECCOMP_WHITELIST_COMMON.TXT
+index a620b44..5c97e65 100644
+--- a/libc/SECCOMP_WHITELIST_COMMON.TXT
++++ b/libc/SECCOMP_WHITELIST_COMMON.TXT
+@@ -74,7 +74,7 @@ int	epoll_wait:epoll_wait(int epfd, struct epoll_event *events, int maxevents, i
+ # Needed by sanitizers (b/34606909)
+ # 5 (__NR_open) and 195 (__NR_stat64) are also required, but they are
+ # already allowed.
+-ssize_t	readlink:readlink(const char *path, char *buf, size_t bufsiz)	arm,x86,mips
++ssize_t	readlink:readlink(const char *path, char *buf, size_t bufsiz)	arm,x86,x86_64,mips
+ 
+ # b/34908783
+ int	epoll_create:epoll_create(int size)	arm,x86,mips
+diff --git a/libc/seccomp/x86_64_app_policy.cpp b/libc/seccomp/x86_64_app_policy.cpp
+index 26a970f..e6c5388 100644
+--- a/libc/seccomp/x86_64_app_policy.cpp
++++ b/libc/seccomp/x86_64_app_policy.cpp
+@@ -5,90 +5,92 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_app_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 102),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 51, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 25, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 104),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 51, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 25, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 13, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 7, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 95, 94), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 94, 93), //close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 97, 96), //read|write
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 96, 95), //close
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 92, 91), //fstat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 91, 90), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 94, 93), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 93, 92), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 88, 87), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 87, 86), //dup
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 86, 85), //nanosleep|getitimer
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 90, 89), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 89, 88), //dup
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 88, 87), //nanosleep|getitimer
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 82, 81), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 81, 80), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 80, 79), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 84, 83), //setitimer|getpid|sendfile|socket|connect
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 83, 82), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 82, 81), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 77, 76), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 76, 75), //getcwd|chdir|fchdir
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 75, 74), //fchmod
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 120, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 104, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 70, 69), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 79, 78), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 78, 77), //getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 77, 76), //readlink
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 117, 13, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 107, 7, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 72, 71), //fchmod
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 71, 70), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 104, 1, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 103, 69, 68), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 107, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 105, 67, 66), //getgid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 66, 65), //geteuid|getegid|setpgid|getppid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 117, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 114, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 113, 63, 62), //setsid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 116, 62, 61), //setregid|getgroups
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 119, 61, 60), //setresuid|getresuid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 124, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 122, 57, 56), //getresgid|getpgid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 56, 55), //getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 55, 54), //personality
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 52, 51), //statfs|fstatfs
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 51, 50), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 50, 49), //pivot_root
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 25, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 162, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 160, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 159, 44, 43), //prctl|arch_prctl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 105, 68, 67), //getgid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 114, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 65, 64), //geteuid|getegid|setpgid|getppid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 113, 64, 63), //setsid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 116, 63, 62), //setregid|getgroups
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 124, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 120, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 119, 59, 58), //setresuid|getresuid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 122, 58, 57), //getresgid|getpgid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 57, 56), //getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 54, 53), //personality
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 53, 52), //statfs|fstatfs
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 52, 51), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 25, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 13, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 7, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 160, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 46, 45), //pivot_root
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 159, 45, 44), //prctl|arch_prctl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 162, 1, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 161, 43, 42), //setrlimit
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 163, 41, 40), //sync
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 40, 39), //quotactl
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 37, 36), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 36, 35), //futex|sched_setaffinity|sched_getaffinity
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 35, 34), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 228, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 31, 30), //getdents64|set_tid_address|restart_syscall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 227, 30, 29), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 29, 28), //clock_gettime|clock_getres|clock_nanosleep|exit_group
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 26, 25), //epoll_ctl|tgkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 25, 24), //waitid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 24, 23), //ioprio_set|ioprio_get
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 19, 18), //inotify_add_watch|inotify_rm_watch
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 163, 42, 41), //sync
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 39, 38), //quotactl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 38, 37), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 37, 36), //futex|sched_setaffinity|sched_getaffinity
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 228, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 33, 32), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 32, 31), //getdents64|set_tid_address|restart_syscall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 227, 31, 30), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 28, 27), //clock_gettime|clock_getres|clock_nanosleep|exit_group
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 27, 26), //epoll_ctl|tgkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 26, 25), //waitid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 13, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 7, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 21, 20), //ioprio_set|ioprio_get
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 20, 19), //inotify_add_watch|inotify_rm_watch
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 1, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 18, 17), //openat|mkdirat|mknodat|fchownat
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 17, 16), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 3, 0),
+diff --git a/libc/seccomp/x86_64_global_policy.cpp b/libc/seccomp/x86_64_global_policy.cpp
+index 8142ce4..11408f0 100644
+--- a/libc/seccomp/x86_64_global_policy.cpp
++++ b/libc/seccomp/x86_64_global_policy.cpp
+@@ -5,35 +5,37 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_global_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 88),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 43, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 90),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 45, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 23, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 11, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 81, 80), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 80, 79), //close
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 79, 78), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 83, 82), //read|write
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 82, 81), //close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 81, 80), //fstat
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 76, 75), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 75, 74), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 74, 73), //dup
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 78, 77), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 77, 76), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 76, 75), //dup
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 70, 69), //nanosleep|getitimer
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 69, 68), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 68, 67), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 72, 71), //nanosleep|getitimer
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 71, 70), //setitimer|getpid|sendfile|socket|connect
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 70, 69), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 66, 65), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 65, 64), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 67, 66), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 66, 65), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 65, 64), //getcwd|chdir|fchdir
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 11, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 60, 59), //getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 60, 59), //readlink
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 59, 58), //fchmod
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 58, 57), //fchown
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
+diff --git a/libc/seccomp/x86_64_system_policy.cpp b/libc/seccomp/x86_64_system_policy.cpp
+index 67859eb..ad7060c 100644
+--- a/libc/seccomp/x86_64_system_policy.cpp
++++ b/libc/seccomp/x86_64_system_policy.cpp
+@@ -5,35 +5,37 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_system_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 88),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 43, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 90),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 45, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 23, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 11, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 81, 80), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 80, 79), //close
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 79, 78), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 83, 82), //read|write
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 82, 81), //close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 81, 80), //fstat
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 76, 75), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 75, 74), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 74, 73), //dup
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 78, 77), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 77, 76), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 76, 75), //dup
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 70, 69), //nanosleep|getitimer
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 69, 68), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 68, 67), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 72, 71), //nanosleep|getitimer
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 71, 70), //setitimer|getpid|sendfile|socket|connect
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 70, 69), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 66, 65), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 65, 64), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 67, 66), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 66, 65), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 65, 64), //getcwd|chdir|fchdir
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 11, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 5, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 60, 59), //getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 60, 59), //readlink
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 59, 58), //fchmod
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 58, 57), //fchown
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
+-- 
+2.20.0
+

--- a/android_p/google_diff/celadon/bionic/0002-seccomp-Allow-open-2-and-getdents-2-in-x86_64-for-UB.patch
+++ b/android_p/google_diff/celadon/bionic/0002-seccomp-Allow-open-2-and-getdents-2-in-x86_64-for-UB.patch
@@ -1,0 +1,546 @@
+From b199af1e2336d48296ad2d50850051b5e59cd83e Mon Sep 17 00:00:00 2001
+From: Victor Hsieh <victorhsieh@google.com>
+Date: Thu, 15 Nov 2018 10:21:21 -0800
+Subject: [PATCH 2/2] seccomp: Allow open(2) and getdents(2) in x86_64 for
+ UBSan's sake
+
+This patch is cherry-picked from AOSP upstream:
+https://android-review.googlesource.com/c/platform/bionic/+/827522
+
+This change allows the use of open(2) and getdents(2) so that UBSan can
+work correctly on x86_64.
+
+This is a reworked cherry-pick from aosp/master.  See
+https://android-review.googlesource.com/c/platform/bionic/+/728890
+
+Bug: 113991591
+Test: None
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-68230
+Change-Id: I8487ac5adfc4613d2d0b3f5cb166830e573dc15c
+Signed-off-by: Tong Bo <bo.tong@intel.com>
+Reviewed-on: https://android.intel.com:443/652398
+---
+ libc/SECCOMP_WHITELIST_COMMON.TXT     |   4 +-
+ libc/seccomp/x86_64_app_policy.cpp    | 162 +++++++++++++-------------
+ libc/seccomp/x86_64_global_policy.cpp | 148 ++++++++++++-----------
+ libc/seccomp/x86_64_system_policy.cpp | 148 ++++++++++++-----------
+ 4 files changed, 225 insertions(+), 237 deletions(-)
+
+diff --git a/libc/SECCOMP_WHITELIST_COMMON.TXT b/libc/SECCOMP_WHITELIST_COMMON.TXT
+index 5c97e65..854fd74 100644
+--- a/libc/SECCOMP_WHITELIST_COMMON.TXT
++++ b/libc/SECCOMP_WHITELIST_COMMON.TXT
+@@ -62,8 +62,8 @@ int	access:access(const char *pathname, int mode)	arm,x86,mips
+ int	stat64:stat64(const char*, struct stat64*)	arm,x86,mips
+ 
+ # b/34813887
+-int	open:open(const char *path, int oflag, ... ) arm,x86,mips
+-int	getdents:getdents(unsigned int fd, struct linux_dirent *dirp, unsigned int count) arm,x86,mips
++int	open:open(const char *path, int oflag, ... ) arm,x86,x86_64,mips
++int	getdents:getdents(unsigned int fd, struct linux_dirent *dirp, unsigned int count) arm,x86,x86_64,mips
+ 
+ # b/34719286
+ int	eventfd:eventfd(unsigned int initval, int flags)	arm,x86,mips
+diff --git a/libc/seccomp/x86_64_app_policy.cpp b/libc/seccomp/x86_64_app_policy.cpp
+index e6c5388..4356cd4 100644
+--- a/libc/seccomp/x86_64_app_policy.cpp
++++ b/libc/seccomp/x86_64_app_policy.cpp
+@@ -5,92 +5,88 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_app_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 104),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 51, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 25, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 97, 96), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 96, 95), //close
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 94, 93), //fstat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 93, 92), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 90, 89), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 89, 88), //dup
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 88, 87), //nanosleep|getitimer
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 100),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 49, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 25, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 13, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 7, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 93, 92), //read|write|open|close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 92, 91), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 90, 89), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 89, 88), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 86, 85), //dup
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 85, 84), //nanosleep|getitimer
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 84, 83), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 83, 82), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 82, 81), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 79, 78), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 78, 77), //getcwd|chdir|fchdir
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 77, 76), //readlink
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 117, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 107, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 72, 71), //fchmod
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 71, 70), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 80, 79), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 79, 78), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 78, 77), //fcntl|flock|fsync|fdatasync|truncate|ftruncate|getdents|getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 75, 74), //readlink
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 74, 73), //fchmod
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 73, 72), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 120, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 107, 3, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 104, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 103, 69, 68), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 105, 68, 67), //getgid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 114, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 65, 64), //geteuid|getegid|setpgid|getppid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 113, 64, 63), //setsid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 116, 63, 62), //setregid|getgroups
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 124, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 120, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 119, 59, 58), //setresuid|getresuid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 122, 58, 57), //getresgid|getpgid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 57, 56), //getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 54, 53), //personality
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 53, 52), //statfs|fstatfs
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 52, 51), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 25, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 160, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 46, 45), //pivot_root
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 159, 45, 44), //prctl|arch_prctl
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 162, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 103, 68, 67), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 105, 67, 66), //getgid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 66, 65), //geteuid|getegid|setpgid|getppid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 117, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 114, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 113, 63, 62), //setsid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 116, 62, 61), //setregid|getgroups
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 119, 61, 60), //setresuid|getresuid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 124, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 122, 57, 56), //getresgid|getpgid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 56, 55), //getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 55, 54), //personality
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 52, 51), //statfs|fstatfs
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 51, 50), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 50, 49), //pivot_root
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 25, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 13, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 7, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 162, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 160, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 159, 44, 43), //prctl|arch_prctl
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 161, 43, 42), //setrlimit
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 163, 42, 41), //sync
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 39, 38), //quotactl
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 38, 37), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 37, 36), //futex|sched_setaffinity|sched_getaffinity
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 228, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 33, 32), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 32, 31), //getdents64|set_tid_address|restart_syscall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 227, 31, 30), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 28, 27), //clock_gettime|clock_getres|clock_nanosleep|exit_group
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 27, 26), //epoll_ctl|tgkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 26, 25), //waitid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 13, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 7, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 21, 20), //ioprio_set|ioprio_get
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 20, 19), //inotify_add_watch|inotify_rm_watch
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 163, 41, 40), //sync
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 40, 39), //quotactl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 37, 36), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 36, 35), //futex|sched_setaffinity|sched_getaffinity
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 35, 34), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 228, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 31, 30), //getdents64|set_tid_address|restart_syscall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 227, 30, 29), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 29, 28), //clock_gettime|clock_getres|clock_nanosleep|exit_group
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 26, 25), //epoll_ctl|tgkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 25, 24), //waitid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 24, 23), //ioprio_set|ioprio_get
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 19, 18), //inotify_add_watch|inotify_rm_watch
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 18, 17), //openat|mkdirat|mknodat|fchownat
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 17, 16), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 3, 0),
+diff --git a/libc/seccomp/x86_64_global_policy.cpp b/libc/seccomp/x86_64_global_policy.cpp
+index 11408f0..f69aa6d 100644
+--- a/libc/seccomp/x86_64_global_policy.cpp
++++ b/libc/seccomp/x86_64_global_policy.cpp
+@@ -5,85 +5,81 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_global_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 90),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 45, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 23, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 83, 82), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 82, 81), //close
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 81, 80), //fstat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 78, 77), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 77, 76), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 76, 75), //dup
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 86),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 43, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 79, 78), //read|write|open|close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 78, 77), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 77, 76), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 74, 73), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 73, 72), //dup
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 72, 71), //nanosleep|getitimer
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 71, 70), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 70, 69), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 67, 66), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 66, 65), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 65, 64), //getcwd|chdir|fchdir
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 60, 59), //readlink
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 59, 58), //fchmod
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 58, 57), //fchown
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 55, 54), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid|syslog|getgid|setuid|setgid|geteuid|getegid|setpgid|getppid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 54, 53), //setsid|setreuid|setregid|getgroups|setgroups|setresuid|getresuid|setresgid|getresgid|getpgid|setfsuid|setfsgid|getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 53, 52), //personality
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 49, 48), //statfs|fstatfs
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 48, 47), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 47, 46), //pivot_root
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 169, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 68, 67), //setitimer|getpid|sendfile|socket|connect
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 67, 66), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 66, 65), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 64, 63), //fcntl|flock|fsync|fdatasync|truncate|ftruncate|getdents|getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 63, 62), //readlink
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 58, 57), //fchmod
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 57, 56), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 56, 55), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid|syslog|getgid|setuid|setgid|geteuid|getegid|setpgid|getppid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 53, 52), //setsid|setreuid|setregid|getgroups|setgroups|setresuid|getresuid|setresgid|getresgid|getpgid|setfsuid|setfsgid|getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 52, 51), //personality
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 51, 50), //statfs|fstatfs
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 169, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 47, 46), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 46, 45), //pivot_root
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 168, 45, 44), //prctl|arch_prctl|adjtimex|setrlimit|chroot|sync|acct|settimeofday|mount|umount2|swapon
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 172, 44, 43), //reboot|sethostname|setdomainname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 21, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 177, 38, 37), //init_module|delete_module
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 37, 36), //quotactl
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 36, 35), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 33, 32), //futex|sched_setaffinity|sched_getaffinity
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 32, 31), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 31, 30), //getdents64|set_tid_address|restart_syscall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 250, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 27, 26), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete|clock_settime|clock_gettime|clock_getres|clock_nanosleep|exit_group
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 26, 25), //epoll_ctl|tgkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 249, 25, 24), //waitid|add_key
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 172, 43, 42), //reboot|sethostname|setdomainname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 177, 42, 41), //init_module|delete_module
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 36, 35), //quotactl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 35, 34), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 34, 33), //futex|sched_setaffinity|sched_getaffinity
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 31, 30), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 30, 29), //getdents64|set_tid_address|restart_syscall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 29, 28), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete|clock_settime|clock_gettime|clock_getres|clock_nanosleep|exit_group
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 250, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 25, 24), //epoll_ctl|tgkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 249, 24, 23), //waitid|add_key
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 23, 22), //keyctl|ioprio_set|ioprio_get
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 22, 21), //inotify_add_watch|inotify_rm_watch
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 302, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 280, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 17, 16), //openat|mkdirat|mknodat|fchownat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 16, 15), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 279, 15, 14), //splice|tee|sync_file_range|vmsplice
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 282, 12, 11), //utimensat|epoll_pwait
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 21, 20), //inotify_add_watch|inotify_rm_watch
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 20, 19), //openat|mkdirat|mknodat|fchownat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 302, 9, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 280, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 15, 14), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 279, 14, 13), //splice|tee|sync_file_range|vmsplice
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 282, 13, 12), //utimensat|epoll_pwait
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 1, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 284, 11, 10), //timerfd_create
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 300, 10, 9), //fallocate|timerfd_settime|timerfd_gettime|accept4|signalfd4|eventfd2|epoll_create1|dup3|pipe2|inotify_init1|preadv|pwritev|rt_tgsigqueueinfo|perf_event_open|recvmmsg
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 321, 5, 0),
+diff --git a/libc/seccomp/x86_64_system_policy.cpp b/libc/seccomp/x86_64_system_policy.cpp
+index ad7060c..c471f10 100644
+--- a/libc/seccomp/x86_64_system_policy.cpp
++++ b/libc/seccomp/x86_64_system_policy.cpp
+@@ -5,85 +5,81 @@
+ 
+ #include "seccomp_bpfs.h"
+ const sock_filter x86_64_system_filter[] = {
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 90),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 45, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 23, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 3, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 2, 83, 82), //read|write
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 82, 81), //close
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 81, 80), //fstat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 78, 77), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 77, 76), //sched_yield|mremap|msync|mincore|madvise
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 76, 75), //dup
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 0, 0, 86),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 43, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 38, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 24, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 8, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 5, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 4, 79, 78), //read|write|open|close
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 6, 78, 77), //fstat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 21, 77, 76), //lseek|mmap|mprotect|munmap|brk|rt_sigaction|rt_sigprocmask|rt_sigreturn|ioctl|pread64|pwrite64|readv|writev
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 35, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 32, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 29, 74, 73), //sched_yield|mremap|msync|mincore|madvise
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 33, 73, 72), //dup
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 37, 72, 71), //nanosleep|getitimer
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 71, 70), //setitimer|getpid|sendfile|socket|connect
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 70, 69), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 79, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 67, 66), //vfork|execve|exit|wait4|kill|uname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 78, 66, 65), //fcntl|flock|fsync|fdatasync|truncate|ftruncate
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 65, 64), //getcwd|chdir|fchdir
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 91, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 60, 59), //readlink
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 59, 58), //fchmod
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 58, 57), //fchown
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 55, 54), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid|syslog|getgid|setuid|setgid|geteuid|getegid|setpgid|getppid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 54, 53), //setsid|setreuid|setregid|getgroups|setgroups|setresuid|getresuid|setresgid|getresgid|getpgid|setfsuid|setfsgid|getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 53, 52), //personality
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 49, 48), //statfs|fstatfs
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 48, 47), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 47, 46), //pivot_root
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 169, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 72, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 58, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 44, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 43, 68, 67), //setitimer|getpid|sendfile|socket|connect
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 57, 67, 66), //sendto|recvfrom|sendmsg|recvmsg|shutdown|bind|listen|getsockname|getpeername|socketpair|setsockopt|getsockopt|clone
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 64, 66, 65), //vfork|execve|exit|wait4|kill|uname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 89, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 82, 64, 63), //fcntl|flock|fsync|fdatasync|truncate|ftruncate|getdents|getcwd|chdir|fchdir
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 90, 63, 62), //readlink
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 140, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 112, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 95, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 93, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 92, 58, 57), //fchmod
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 94, 57, 56), //fchown
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 111, 56, 55), //umask|gettimeofday|getrlimit|getrusage|sysinfo|times|ptrace|getuid|syslog|getgid|setuid|setgid|geteuid|getegid|setpgid|getppid
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 137, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 135, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 132, 53, 52), //setsid|setreuid|setregid|getgroups|setgroups|setresuid|getresuid|setresgid|getresgid|getpgid|setfsuid|setfsgid|getsid|capget|capset|rt_sigpending|rt_sigtimedwait|rt_sigqueueinfo|rt_sigsuspend|sigaltstack
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 136, 52, 51), //personality
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 139, 51, 50), //statfs|fstatfs
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 169, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 157, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 155, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 153, 47, 46), //getpriority|setpriority|sched_setparam|sched_getparam|sched_setscheduler|sched_getscheduler|sched_get_priority_max|sched_get_priority_min|sched_rr_get_interval|mlock|munlock|mlockall|munlockall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 156, 46, 45), //pivot_root
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 167, 45, 44), //prctl|arch_prctl|adjtimex|setrlimit|chroot|sync|acct|settimeofday|mount|umount2
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 172, 44, 43), //reboot|sethostname|setdomainname
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 21, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 179, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 177, 38, 37), //init_module|delete_module
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 37, 36), //quotactl
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 36, 35), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 33, 32), //futex|sched_setaffinity|sched_getaffinity
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 32, 31), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 31, 30), //getdents64|set_tid_address|restart_syscall
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 27, 26), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete|clock_settime|clock_gettime|clock_getres|clock_nanosleep|exit_group
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 26, 25), //epoll_ctl|tgkill
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 25, 24), //waitid
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 175, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 172, 43, 42), //reboot|sethostname|setdomainname
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 177, 42, 41), //init_module|delete_module
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 21, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 233, 11, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 206, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 202, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 186, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 180, 36, 35), //quotactl
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 201, 35, 34), //gettid|readahead|setxattr|lsetxattr|fsetxattr|getxattr|lgetxattr|fgetxattr|listxattr|llistxattr|flistxattr|removexattr|lremovexattr|fremovexattr|tkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 205, 34, 33), //futex|sched_setaffinity|sched_getaffinity
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 221, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 217, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 211, 31, 30), //io_setup|io_destroy|io_getevents|io_submit|io_cancel
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 220, 30, 29), //getdents64|set_tid_address|restart_syscall
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 232, 29, 28), //fadvise64|timer_create|timer_settime|timer_gettime|timer_getoverrun|timer_delete|clock_settime|clock_gettime|clock_getres|clock_nanosleep|exit_group
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 254, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 251, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 247, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 235, 25, 24), //epoll_ctl|tgkill
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 248, 24, 23), //waitid
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 253, 23, 22), //ioprio_set|ioprio_get
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 22, 21), //inotify_add_watch|inotify_rm_watch
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 302, 11, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 280, 5, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 262, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 17, 16), //openat|mkdirat|mknodat|fchownat
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 16, 15), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 279, 15, 14), //splice|tee|sync_file_range|vmsplice
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 3, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 1, 0),
+-BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 282, 12, 11), //utimensat|epoll_pwait
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 257, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 256, 21, 20), //inotify_add_watch|inotify_rm_watch
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 261, 20, 19), //openat|mkdirat|mknodat|fchownat
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 302, 9, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 283, 5, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 280, 3, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 275, 1, 0),
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 273, 15, 14), //newfstatat|unlinkat|renameat|linkat|symlinkat|readlinkat|fchmodat|faccessat|pselect6|ppoll|unshare
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 279, 14, 13), //splice|tee|sync_file_range|vmsplice
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 282, 13, 12), //utimensat|epoll_pwait
++BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 285, 1, 0),
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 284, 11, 10), //timerfd_create
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 300, 10, 9), //fallocate|timerfd_settime|timerfd_gettime|accept4|signalfd4|eventfd2|epoll_create1|dup3|pipe2|inotify_init1|preadv|pwritev|rt_tgsigqueueinfo|perf_event_open|recvmmsg
+ BPF_JUMP(BPF_JMP|BPF_JGE|BPF_K, 321, 5, 0),
+-- 
+2.20.0
+


### PR DESCRIPTION
Fix the CtsWrapWrapDebugMallocDebugTestCases and the
CtsWrapWrapDebugTestCases can not be executed.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-71354
Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>