### PR TITLE
Not to save and dump the empty approved list.

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0025-Not-to-save-and-dump-the-empty-approved-list.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0025-Not-to-save-and-dump-the-empty-approved-list.patch
@@ -1,0 +1,60 @@
+From a347c1c8a09a34d2ae1251c0bce35dc4478ed50d Mon Sep 17 00:00:00 2001
+From: "Yan, WalterX" <walterx.yan@intel.com>
+Date: Thu, 24 Jan 2019 11:24:08 +0800
+Subject: [PATCH] Not to save and dump the empty approved list.
+
+To dump a empty approved list will cause cts cases fail,
+and also no need to save the empty ones.
+
+Change-Id: I39663ddc4f69b37663b9f2d71308107b9e22d15b
+Tracked-On: OAM-75159
+Signed-off-by: Yan, WalterX <walterx.yan@intel.com>
+---
+ .../java/com/android/server/notification/ManagedServices.java  | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/services/core/java/com/android/server/notification/ManagedServices.java b/services/core/java/com/android/server/notification/ManagedServices.java
+index f7becd5..0bec37e 100644
+--- a/services/core/java/com/android/server/notification/ManagedServices.java
++++ b/services/core/java/com/android/server/notification/ManagedServices.java
+@@ -197,7 +197,7 @@ abstract public class ManagedServices {
+                 for (int j = 0; j < M; j++) {
+                     final boolean isPrimary = approvedByType.keyAt(j);
+                     final ArraySet<String> approved = approvedByType.valueAt(j);
+-                    if (approvedByType != null && approvedByType.size() > 0) {
++                    if (approved.size() > 0) {
+                         pw.println("      " + String.join(ENABLED_SERVICES_SEPARATOR, approved)
+                                 + " (user: " + userId + " isPrimary: " + isPrimary + ")");
+                     }
+@@ -239,7 +239,7 @@ abstract public class ManagedServices {
+                 for (int j = 0; j < M; j++) {
+                     final boolean isPrimary = approvedByType.keyAt(j);
+                     final ArraySet<String> approved = approvedByType.valueAt(j);
+-                    if (approvedByType != null && approvedByType.size() > 0) {
++                    if (approved.size() > 0) {
+                         final long sToken = proto.start(ManagedServicesProto.APPROVED);
+                         for (String s : approved) {
+                             proto.write(ServiceProto.NAME, s);
+@@ -311,8 +311,8 @@ abstract public class ManagedServices {
+                 final int M = approvedByType.size();
+                 for (int j = 0; j < M; j++) {
+                     final boolean isPrimary = approvedByType.keyAt(j);
+-                    final Set<String> approved = approvedByType.valueAt(j);
+-                    if (approved != null) {
++                    final ArraySet<String> approved = approvedByType.valueAt(j);
++                    if (approved.size() > 0) {
+                         String allowedItems = String.join(ENABLED_SERVICES_SEPARATOR, approved);
+                         out.startTag(null, TAG_MANAGED_SERVICES);
+                         out.attribute(null, ATT_APPROVED_LIST, allowedItems);
+@@ -415,7 +415,7 @@ abstract public class ManagedServices {
+         String[] approvedArray = approved.split(ENABLED_SERVICES_SEPARATOR);
+         for (String pkgOrComponent : approvedArray) {
+             String approvedItem = getApprovedValue(pkgOrComponent);
+-            if (approvedItem != null) {
++            if (!TextUtils.isEmpty(approvedItem)) {
+                 approvedList.add(approvedItem);
+             }
+         }
+-- 
+1.9.1
+

--- a/android_p/google_diff/cel_kbl/frameworks/base/0025-Not-to-save-and-dump-the-empty-approved-list.patch
+++ b/android_p/google_diff/cel_kbl/frameworks/base/0025-Not-to-save-and-dump-the-empty-approved-list.patch
@@ -1,0 +1,60 @@
+From a347c1c8a09a34d2ae1251c0bce35dc4478ed50d Mon Sep 17 00:00:00 2001
+From: "Yan, WalterX" <walterx.yan@intel.com>
+Date: Thu, 24 Jan 2019 11:24:08 +0800
+Subject: [PATCH] Not to save and dump the empty approved list.
+
+To dump a empty approved list will cause cts cases fail,
+and also no need to save the empty ones.
+
+Change-Id: I39663ddc4f69b37663b9f2d71308107b9e22d15b
+Tracked-On: OAM-75159
+Signed-off-by: Yan, WalterX <walterx.yan@intel.com>
+---
+ .../java/com/android/server/notification/ManagedServices.java  | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/services/core/java/com/android/server/notification/ManagedServices.java b/services/core/java/com/android/server/notification/ManagedServices.java
+index f7becd5..0bec37e 100644
+--- a/services/core/java/com/android/server/notification/ManagedServices.java
++++ b/services/core/java/com/android/server/notification/ManagedServices.java
+@@ -197,7 +197,7 @@ abstract public class ManagedServices {
+                 for (int j = 0; j < M; j++) {
+                     final boolean isPrimary = approvedByType.keyAt(j);
+                     final ArraySet<String> approved = approvedByType.valueAt(j);
+-                    if (approvedByType != null && approvedByType.size() > 0) {
++                    if (approved.size() > 0) {
+                         pw.println("      " + String.join(ENABLED_SERVICES_SEPARATOR, approved)
+                                 + " (user: " + userId + " isPrimary: " + isPrimary + ")");
+                     }
+@@ -239,7 +239,7 @@ abstract public class ManagedServices {
+                 for (int j = 0; j < M; j++) {
+                     final boolean isPrimary = approvedByType.keyAt(j);
+                     final ArraySet<String> approved = approvedByType.valueAt(j);
+-                    if (approvedByType != null && approvedByType.size() > 0) {
++                    if (approved.size() > 0) {
+                         final long sToken = proto.start(ManagedServicesProto.APPROVED);
+                         for (String s : approved) {
+                             proto.write(ServiceProto.NAME, s);
+@@ -311,8 +311,8 @@ abstract public class ManagedServices {
+                 final int M = approvedByType.size();
+                 for (int j = 0; j < M; j++) {
+                     final boolean isPrimary = approvedByType.keyAt(j);
+-                    final Set<String> approved = approvedByType.valueAt(j);
+-                    if (approved != null) {
++                    final ArraySet<String> approved = approvedByType.valueAt(j);
++                    if (approved.size() > 0) {
+                         String allowedItems = String.join(ENABLED_SERVICES_SEPARATOR, approved);
+                         out.startTag(null, TAG_MANAGED_SERVICES);
+                         out.attribute(null, ATT_APPROVED_LIST, allowedItems);
+@@ -415,7 +415,7 @@ abstract public class ManagedServices {
+         String[] approvedArray = approved.split(ENABLED_SERVICES_SEPARATOR);
+         for (String pkgOrComponent : approvedArray) {
+             String approvedItem = getApprovedValue(pkgOrComponent);
+-            if (approvedItem != null) {
++            if (!TextUtils.isEmpty(approvedItem)) {
+                 approvedList.add(approvedItem);
+             }
+         }
+-- 
+1.9.1
+

--- a/android_p/google_diff/celadon/frameworks/base/0025-Not-to-save-and-dump-the-empty-approved-list.patch
+++ b/android_p/google_diff/celadon/frameworks/base/0025-Not-to-save-and-dump-the-empty-approved-list.patch
@@ -1,0 +1,60 @@
+From a347c1c8a09a34d2ae1251c0bce35dc4478ed50d Mon Sep 17 00:00:00 2001
+From: "Yan, WalterX" <walterx.yan@intel.com>
+Date: Thu, 24 Jan 2019 11:24:08 +0800
+Subject: [PATCH] Not to save and dump the empty approved list.
+
+To dump a empty approved list will cause cts cases fail,
+and also no need to save the empty ones.
+
+Change-Id: I39663ddc4f69b37663b9f2d71308107b9e22d15b
+Tracked-On: OAM-75159
+Signed-off-by: Yan, WalterX <walterx.yan@intel.com>
+---
+ .../java/com/android/server/notification/ManagedServices.java  | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/services/core/java/com/android/server/notification/ManagedServices.java b/services/core/java/com/android/server/notification/ManagedServices.java
+index f7becd5..0bec37e 100644
+--- a/services/core/java/com/android/server/notification/ManagedServices.java
++++ b/services/core/java/com/android/server/notification/ManagedServices.java
+@@ -197,7 +197,7 @@ abstract public class ManagedServices {
+                 for (int j = 0; j < M; j++) {
+                     final boolean isPrimary = approvedByType.keyAt(j);
+                     final ArraySet<String> approved = approvedByType.valueAt(j);
+-                    if (approvedByType != null && approvedByType.size() > 0) {
++                    if (approved.size() > 0) {
+                         pw.println("      " + String.join(ENABLED_SERVICES_SEPARATOR, approved)
+                                 + " (user: " + userId + " isPrimary: " + isPrimary + ")");
+                     }
+@@ -239,7 +239,7 @@ abstract public class ManagedServices {
+                 for (int j = 0; j < M; j++) {
+                     final boolean isPrimary = approvedByType.keyAt(j);
+                     final ArraySet<String> approved = approvedByType.valueAt(j);
+-                    if (approvedByType != null && approvedByType.size() > 0) {
++                    if (approved.size() > 0) {
+                         final long sToken = proto.start(ManagedServicesProto.APPROVED);
+                         for (String s : approved) {
+                             proto.write(ServiceProto.NAME, s);
+@@ -311,8 +311,8 @@ abstract public class ManagedServices {
+                 final int M = approvedByType.size();
+                 for (int j = 0; j < M; j++) {
+                     final boolean isPrimary = approvedByType.keyAt(j);
+-                    final Set<String> approved = approvedByType.valueAt(j);
+-                    if (approved != null) {
++                    final ArraySet<String> approved = approvedByType.valueAt(j);
++                    if (approved.size() > 0) {
+                         String allowedItems = String.join(ENABLED_SERVICES_SEPARATOR, approved);
+                         out.startTag(null, TAG_MANAGED_SERVICES);
+                         out.attribute(null, ATT_APPROVED_LIST, allowedItems);
+@@ -415,7 +415,7 @@ abstract public class ManagedServices {
+         String[] approvedArray = approved.split(ENABLED_SERVICES_SEPARATOR);
+         for (String pkgOrComponent : approvedArray) {
+             String approvedItem = getApprovedValue(pkgOrComponent);
+-            if (approvedItem != null) {
++            if (!TextUtils.isEmpty(approvedItem)) {
+                 approvedList.add(approvedItem);
+             }
+         }
+-- 
+1.9.1
+


### PR DESCRIPTION
To dump a empty approved list will cause cts cases fail,
and also no need to save the empty ones.

Tracked-On: OAM-75159
Signed-off-by: Yan, WalterX <walterx.yan@intel.com>