### PR TITLE
Fix the black screen was observed in the CarSettings

### DIFF
--- a/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0006-Fix-the-black-screen-was-observed-in-the-CarSettings.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0006-Fix-the-black-screen-was-observed-in-the-CarSettings.patch
@@ -1,0 +1,51 @@
+From 92f4c74274e850d046c370d223145691757ed28a Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Fri, 25 Jan 2019 11:12:27 +0800
+Subject: [PATCH] Fix the black screen was observed in the CarSettings
+
+The black screen observed due to the mGridAdapter data
+was cleared on the onStop status. Adding the mGridAdapter
+data in the onStart status to recovery the data.
+
+Test:
+1) Set a pattern/pin lock as an owner
+2) Click on the notification symbol and click "add new user"
+3) Once UI is at new user screen > switch back to owner
+4) When prompted to enter pattern/pin > click on "cancel"
+5) Click on owner from "lock screen" > enter pattern > owner UI comes up
+6) Click on car settings > observe
+
+Change-Id: I2263b47aab3508f77659ef16984d759e089e2836
+Tracked-On: https://jira.devtools.intel.com/browse/OAM-75447
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ .../android/car/settings/quicksettings/QuickSettingFragment.java   | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/car/settings/quicksettings/QuickSettingFragment.java b/src/com/android/car/settings/quicksettings/QuickSettingFragment.java
+index 9e177c6..92d3d9f 100644
+--- a/src/com/android/car/settings/quicksettings/QuickSettingFragment.java
++++ b/src/com/android/car/settings/quicksettings/QuickSettingFragment.java
+@@ -85,13 +85,18 @@ public class QuickSettingFragment extends BaseFragment {
+         View exitBtn = getActivity().findViewById(R.id.exit_button);
+         exitBtn.setOnClickListener(v -> getFragmentController().goBack());
+ 
++        mListView.setAdapter(mGridAdapter);
++    }
++
++    @Override
++    public void onStart() {
++        super.onStart();
+         mGridAdapter
+                 .addTile(new WifiTile(getContext(), mGridAdapter, getFragmentController()))
+                 .addTile(new BluetoothTile(getContext(), mGridAdapter))
+                 .addTile(new DayNightTile(getContext(), mGridAdapter))
+                 .addTile(new CelluarTile(getContext(), mGridAdapter))
+                 .addSeekbarTile(new BrightnessTile(getContext()));
+-        mListView.setAdapter(mGridAdapter);
+     }
+ 
+     @Override
+-- 
+1.9.1
+

--- a/android_p/google_diff/cel_kbl/packages/apps/Car/Settings/0004-Fix-the-black-screen-was-observed-in-the-CarSettings.patch
+++ b/android_p/google_diff/cel_kbl/packages/apps/Car/Settings/0004-Fix-the-black-screen-was-observed-in-the-CarSettings.patch
@@ -1,0 +1,51 @@
+From 92f4c74274e850d046c370d223145691757ed28a Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Fri, 25 Jan 2019 11:12:27 +0800
+Subject: [PATCH] Fix the black screen was observed in the CarSettings
+
+The black screen observed due to the mGridAdapter data
+was cleared on the onStop status. Adding the mGridAdapter
+data in the onStart status to recovery the data.
+
+Test:
+1) Set a pattern/pin lock as an owner
+2) Click on the notification symbol and click "add new user"
+3) Once UI is at new user screen > switch back to owner
+4) When prompted to enter pattern/pin > click on "cancel"
+5) Click on owner from "lock screen" > enter pattern > owner UI comes up
+6) Click on car settings > observe
+
+Change-Id: I2263b47aab3508f77659ef16984d759e089e2836
+Tracked-On: https://jira.devtools.intel.com/browse/OAM-75447
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ .../android/car/settings/quicksettings/QuickSettingFragment.java   | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/car/settings/quicksettings/QuickSettingFragment.java b/src/com/android/car/settings/quicksettings/QuickSettingFragment.java
+index 9e177c6..92d3d9f 100644
+--- a/src/com/android/car/settings/quicksettings/QuickSettingFragment.java
++++ b/src/com/android/car/settings/quicksettings/QuickSettingFragment.java
+@@ -85,13 +85,18 @@ public class QuickSettingFragment extends BaseFragment {
+         View exitBtn = getActivity().findViewById(R.id.exit_button);
+         exitBtn.setOnClickListener(v -> getFragmentController().goBack());
+ 
++        mListView.setAdapter(mGridAdapter);
++    }
++
++    @Override
++    public void onStart() {
++        super.onStart();
+         mGridAdapter
+                 .addTile(new WifiTile(getContext(), mGridAdapter, getFragmentController()))
+                 .addTile(new BluetoothTile(getContext(), mGridAdapter))
+                 .addTile(new DayNightTile(getContext(), mGridAdapter))
+                 .addTile(new CelluarTile(getContext(), mGridAdapter))
+                 .addSeekbarTile(new BrightnessTile(getContext()));
+-        mListView.setAdapter(mGridAdapter);
+     }
+ 
+     @Override
+-- 
+1.9.1
+


### PR DESCRIPTION
The black screen observed due to the mGridAdapter data
was cleared on the onStop status. Adding the mGridAdapter
data in the onStart status to recovery the data.

Test:
1) Set a pattern/pin lock as an owner
2) Click on the notification symbol and click "add new user"
3) Once UI is at new user screen > switch back to owner
4) When prompted to enter pattern/pin > click on "cancel"
5) Click on owner from "lock screen" > enter pattern > owner UI comes up
6) Click on car settings > observe

Tracked-On: https://jira.devtools.intel.com/browse/OAM-75447
Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>