### PR TITLE
Disable feature "android.software.app_widgets" on the automotive device.

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/native/0004-Disable-feature-android.software.app_widgets-on-the-.patch
+++ b/android_p/google_diff/cel_apl/frameworks/native/0004-Disable-feature-android.software.app_widgets-on-the-.patch
@@ -1,0 +1,31 @@
+From 9f13d12698ab730eaa8580f1abd5b5f6a2085dbd Mon Sep 17 00:00:00 2001
+From: fanzha3x <fanx.zhang@intel.com>
+Date: Thu, 8 Nov 2018 16:12:20 +0800
+Subject: [PATCH] Disable feature "android.software.app_widgets" on the
+ automotive device.
+
+Car launcher doesn't implement AppWidgetHost to support "android.software.app_widgets".
+
+Change-Id: I39b4f0379a2613e9a19ce7bb32440558cc025f8a
+Tracked-On: https://jira.devtools.intel.com/browse/OAM-75541
+Signed-off-by: fanzha3x <fanx.zhang@intel.com>
+---
+ data/etc/car_core_hardware.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/etc/car_core_hardware.xml b/data/etc/car_core_hardware.xml
+index 561f5ba..21c4e0a 100644
+--- a/data/etc/car_core_hardware.xml
++++ b/data/etc/car_core_hardware.xml
+@@ -36,7 +36,7 @@
+     <feature name="android.hardware.type.automotive" />
+ 
+     <!-- basic system services -->
+-    <feature name="android.software.app_widgets" />
++    <!-- <feature name="android.software.app_widgets" /> -->
+     <feature name="android.software.connectionservice" />
+     <feature name="android.software.voice_recognizers" notLowRam="true" />
+     <feature name="android.software.backup" />
+-- 
+1.9.1
+

--- a/android_p/google_diff/cel_kbl/frameworks/native/0004-Disable-feature-android.software.app_widgets-on-the-.patch
+++ b/android_p/google_diff/cel_kbl/frameworks/native/0004-Disable-feature-android.software.app_widgets-on-the-.patch
@@ -1,0 +1,31 @@
+From 9f13d12698ab730eaa8580f1abd5b5f6a2085dbd Mon Sep 17 00:00:00 2001
+From: fanzha3x <fanx.zhang@intel.com>
+Date: Thu, 8 Nov 2018 16:12:20 +0800
+Subject: [PATCH] Disable feature "android.software.app_widgets" on the
+ automotive device.
+
+Car launcher doesn't implement AppWidgetHost to support "android.software.app_widgets".
+
+Change-Id: I39b4f0379a2613e9a19ce7bb32440558cc025f8a
+Tracked-On: https://jira.devtools.intel.com/browse/OAM-75541
+Signed-off-by: fanzha3x <fanx.zhang@intel.com>
+---
+ data/etc/car_core_hardware.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/etc/car_core_hardware.xml b/data/etc/car_core_hardware.xml
+index 561f5ba..21c4e0a 100644
+--- a/data/etc/car_core_hardware.xml
++++ b/data/etc/car_core_hardware.xml
+@@ -36,7 +36,7 @@
+     <feature name="android.hardware.type.automotive" />
+ 
+     <!-- basic system services -->
+-    <feature name="android.software.app_widgets" />
++    <!-- <feature name="android.software.app_widgets" /> -->
+     <feature name="android.software.connectionservice" />
+     <feature name="android.software.voice_recognizers" notLowRam="true" />
+     <feature name="android.software.backup" />
+-- 
+1.9.1
+


### PR DESCRIPTION
Car launcher doesn't implement AppWidgetHost to support "android.software.app_widgets".

Change-Id: I39b4f0379a2613e9a19ce7bb32440558cc025f8a
Tracked-On: https://jira.devtools.intel.com/browse/OAM-75541
Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>