### PR TITLE
Add support for dummy sound card [load at "on boot" instead of "post-fs"]

### DIFF
--- a/android_p/google_diff/cel_apl/device/intel/mixins/0002-Add-support-for-dummy-sound-card.patch
+++ b/android_p/google_diff/cel_apl/device/intel/mixins/0002-Add-support-for-dummy-sound-card.patch
@@ -1,0 +1,26 @@
+From 82a6e3c84ea954762bd35dd3282830caccfaa91e Mon Sep 17 00:00:00 2001
+From: karanpat <karan.patidar@intel.com>
+Date: Thu, 31 Jan 2019 05:22:40 +0530
+Subject: [PATCH] Add support for dummy sound card
+
+Handle dummy sound device as primary device
+when no default sound card is present
+
+Tracked-On: OAM-75019
+Signed-off-by: karanpat <karan.patidar@intel.com>
+---
+ groups/audio/project-celadon/init.rc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/groups/audio/project-celadon/init.rc b/groups/audio/project-celadon/init.rc
+index 3aa9171..406d39a 100644
+--- a/groups/audio/project-celadon/init.rc
++++ b/groups/audio/project-celadon/init.rc
+@@ -1,3 +1,3 @@
+-on post-fs
++on boot
+     insmod /vendor/lib/modules/kernel/sound/drivers/snd-dummy.ko
+ 
+-- 
+2.20.1
+


### PR DESCRIPTION
instead of post-fs execute insmod on boot

Tracked-On: OAM-75019
Signed-off-by: karanpat <karan.patidar@intel.com>