### PR TITLE
Fix for Audio not routing to DUT after BT OFF/ON

### DIFF
--- a/android_p/google_diff/cel_kbl/packages/apps/Car/Settings/0005-Fix-for-Audio-not-routing-to-DUT-after-BT-OFF-ON.patch
+++ b/android_p/google_diff/cel_kbl/packages/apps/Car/Settings/0005-Fix-for-Audio-not-routing-to-DUT-after-BT-OFF-ON.patch
@@ -1,0 +1,81 @@
+From 86d11f259e3cd131b618164f323b8fb9d2249444 Mon Sep 17 00:00:00 2001
+From: Gaganpreet kaur <gaganpreetx.kaur@intel.com>
+Date: Fri, 1 Feb 2019 15:55:31 +0530
+Subject: [PATCH 5/5] Fix for Audio not routing to DUT after BT OFF/ON
+
+Issue: Reference phone Audio over Bluetooth is not routing
+to IVI speakers after bluetooth turn OFF and ON from DUT car
+settings.
+
+Analysis: the root cause of the issue is as:
+
+1. After BT OFF/ON from the Car Settings, when BT turns on,
+it is initiating the scanning and also at the same time,
+the connection to the already bonded devices starts.
+2. As the controller is performing discovery of devices, so
+when it receives "Create Connection" Command, it rejects the
+command with the status "Command Disallowed- 0x0c".
+3. Due to this, A2DPSink and HEADSET_CLIENT profiles are not
+able to connect.
+
+Fix: Removed StartScanning when BT turns on in Car Settings.
+Scanning will not be initiated automatically on BT ON event
+from Car Sttings App.
+
+Test: BT Pairing, Audio routing after BT OFF/ON working fine.
+
+Tracked-On: OAM-75966
+
+Change-Id: I2a8e42354d5377b9ce3922d5d3fe8a487a0d6e40
+Signed-off-by: Gaganpreet kaur <gaganpreetx.kaur@intel.com>
+---
+ .../android/car/settings/bluetooth/BluetoothDeviceListAdapter.java    | 4 +++-
+ src/com/android/car/settings/bluetooth/BluetoothSettingsFragment.java | 3 ++-
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/com/android/car/settings/bluetooth/BluetoothDeviceListAdapter.java b/src/com/android/car/settings/bluetooth/BluetoothDeviceListAdapter.java
+index 74f6bd0..aa2194a 100644
+--- a/src/com/android/car/settings/bluetooth/BluetoothDeviceListAdapter.java
++++ b/src/com/android/car/settings/bluetooth/BluetoothDeviceListAdapter.java
+@@ -140,6 +140,7 @@ public class BluetoothDeviceListAdapter
+     public void start() {
+         mLocalManager.getEventManager().registerCallback(this);
+         if (mLocalAdapter.isEnabled()) {
++            LOG.d("starting forced scanning");
+             mLocalAdapter.startScanning(true);
+             addBondDevices();
+             addCachedDevices();
+@@ -286,7 +287,7 @@ public class BluetoothDeviceListAdapter
+                 notifyDataSetChanged();
+                 break;
+             case BluetoothAdapter.STATE_ON:
+-                mLocalAdapter.startScanning(true);
++                LOG.d("starting forced Scanning");
+                 addBondDevices();
+                 addCachedDevices();
+                 break;
+@@ -299,6 +300,7 @@ public class BluetoothDeviceListAdapter
+         mBondedDevicesSorted.clear();
+         mAvailableDevices.clear();
+         mAvailableDevicesSorted.clear();
++        LOG.d("starting Forced Scanning");
+         mLocalAdapter.startScanning(true);
+         addBondDevices();
+         addCachedDevices();
+diff --git a/src/com/android/car/settings/bluetooth/BluetoothSettingsFragment.java b/src/com/android/car/settings/bluetooth/BluetoothSettingsFragment.java
+index f0fde8e..900881a 100644
+--- a/src/com/android/car/settings/bluetooth/BluetoothSettingsFragment.java
++++ b/src/com/android/car/settings/bluetooth/BluetoothSettingsFragment.java
+@@ -181,7 +181,8 @@ public class BluetoothSettingsFragment extends BaseFragment implements Bluetooth
+                 break;
+             case BluetoothAdapter.STATE_ON:
+             case BluetoothAdapter.STATE_TURNING_ON:
+-                setProgressBarVisible(true);
++                /* Don't set visibility for progress bar as we are not going to
++                   initiate Scanning on Bluetooth State on event */
+                 mBluetoothSwitch.setChecked(true);
+                 if (mViewSwitcher.getCurrentView() != mSwipeRefreshLayout) {
+                         mViewSwitcher.showPrevious();
+-- 
+2.7.4
+

--- a/android_p/google_diff/cel_kbl/packages/apps/Settings/0002-Adding-only-one-pbap-profile-client-or-server-to-the.patch
+++ b/android_p/google_diff/cel_kbl/packages/apps/Settings/0002-Adding-only-one-pbap-profile-client-or-server-to-the.patch
@@ -1,0 +1,55 @@
+From 80ffbcaafc54ad1d4f653d04e35fc982528d6e28 Mon Sep 17 00:00:00 2001
+From: anitha3x <anithax.h.chandrasekar@intel.com>
+Date: Mon, 4 Feb 2019 16:03:20 +0530
+Subject: [PATCH 2/2] Adding only one pbap profile client or server to the list
+
+Issue : - We see that even when the pbab client profile
+was present in the list, the pbab server profile was
+added again in device details list. Therefore
+contact sharing option for two pbap profiles server
+and client appeared on UI.
+
+Fix: - Keeping a check to not to add the pbap server
+profile if pbab client was present in the device details
+list.
+
+Change-Id: Ifa96d9d454ec3ce8502b83cf7d74484ff31e07da
+Tracked-On: OAM-75968
+Signed-off-by: Gaganpreet kaur <gaganpreetx.kaur@intel.com>
+---
+ .../settings/bluetooth/BluetoothDetailsProfilesController.java | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/settings/bluetooth/BluetoothDetailsProfilesController.java b/src/com/android/settings/bluetooth/BluetoothDetailsProfilesController.java
+index b0ed056..e7a12b3 100644
+--- a/src/com/android/settings/bluetooth/BluetoothDetailsProfilesController.java
++++ b/src/com/android/settings/bluetooth/BluetoothDetailsProfilesController.java
+@@ -54,6 +54,7 @@ public class BluetoothDetailsProfilesController extends BluetoothDetailsControll
+     private LocalBluetoothProfileManager mProfileManager;
+     private CachedBluetoothDevice mCachedDevice;
+     private PreferenceCategory mProfilesContainer;
++    private boolean mPbapClientAdded = false;
+ 
+     public BluetoothDetailsProfilesController(Context context, PreferenceFragment fragment,
+             LocalBluetoothManager manager, CachedBluetoothDevice device, Lifecycle lifecycle) {
+@@ -194,9 +195,16 @@ public class BluetoothDetailsProfilesController extends BluetoothDetailsControll
+     private List<LocalBluetoothProfile> getProfiles() {
+         List<LocalBluetoothProfile> result = mCachedDevice.getConnectableProfiles();
+ 
++        for (LocalBluetoothProfile profile : result) {
++            if (profile.getProfileId() ==  BluetoothProfile.PBAP_CLIENT) {
++                mPbapClientAdded = true;
++                break;
++            }
++        }
++
+         final int pbapPermission = mCachedDevice.getPhonebookPermissionChoice();
+         // Only provide PBAP cabability if the client device has requested PBAP.
+-        if (pbapPermission != CachedBluetoothDevice.ACCESS_UNKNOWN) {
++        if  (!mPbapClientAdded && (pbapPermission != CachedBluetoothDevice.ACCESS_UNKNOWN)) {
+             final PbapServerProfile psp = mManager.getProfileManager().getPbapProfile();
+             result.add(psp);
+         }
+-- 
+2.7.4
+


### PR DESCRIPTION
Issue: Reference phone Audio over Bluetooth is not routing
to IVI speakers after bluetooth turn OFF and ON from DUT car
settings.

Analysis: the root cause of the issue is as:

1. After BT OFF/ON from the Car Settings, when BT turns on,
it is initiating the scanning and also at the same time,
the connection to the already bonded devices starts.
2. As the controller is performing discovery of devices, so
when it receives "Create Connection" Command, it rejects the
command with the status "Command Disallowed- 0x0c".
3. Due to this, A2DPSink and HEADSET_CLIENT profiles are not
able to connect.

Fix: Removed StartScanning when BT turns on in Car Settings.
Scanning will not be initiated automatically on BT ON event
from Car Sttings App.

Test: BT Pairing, Audio routing after BT OFF/ON working fine.

Tracked-On: OAM-75966

Signed-off-by: Gaganpreet kaur <gaganpreetx.kaur@intel.com>