### PR TITLE
Add primary text color to the CarSettingTheme

### DIFF
--- a/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0007-Add-primary-text-color-to-the-CarSettingTheme.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0007-Add-primary-text-color-to-the-CarSettingTheme.patch
@@ -1,0 +1,60 @@
+From 088bfd75bdcba5fc8d149b6793a5c53229fe8824 Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Sat, 2 Feb 2019 16:38:18 +0800
+Subject: [PATCH] Add primary text color to the CarSettingTheme
+
+The base style from the "Theme.Car.Light", the primary
+ text color needs to be declared.
+
+Change-Id: Ie3a1a8f3adedf0cc1c45857e6aa9c84df5c6a7d3
+Tracked-On: https://jira.devtools.intel.com/browse/OAM-69588
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ res/values/styles.xml                                         |  5 +++++
+ src/com/android/car/settings/datetime/DatePickerFragment.java | 11 +++++++++++
+ 2 files changed, 16 insertions(+)
+
+diff --git a/res/values/styles.xml b/res/values/styles.xml
+index 5ef139c..c4c1f46 100644
+--- a/res/values/styles.xml
++++ b/res/values/styles.xml
+@@ -88,4 +88,9 @@
+     <style name="SettingList">
+         <item name="gutter">both</item>
+     </style>
++
++    <style name="DatePicker" parent="CarSettingTheme">
++        <item name="android:textColorPrimary">@color/car_title</item>
++        <item name="android:textColorSecondary">@color/car_headline1</item>
++    </style>
+ </resources>
+diff --git a/src/com/android/car/settings/datetime/DatePickerFragment.java b/src/com/android/car/settings/datetime/DatePickerFragment.java
+index 4a2af00..71f2ba1 100644
+--- a/src/com/android/car/settings/datetime/DatePickerFragment.java
++++ b/src/com/android/car/settings/datetime/DatePickerFragment.java
+@@ -19,6 +19,10 @@ import android.app.AlarmManager;
+ import android.content.Context;
+ import android.content.Intent;
+ import android.os.Bundle;
++import android.view.ContextThemeWrapper;
++import android.view.LayoutInflater;
++import android.view.View;
++import android.view.ViewGroup;
+ import android.widget.Button;
+ import android.widget.DatePicker;
+ 
+@@ -67,4 +71,11 @@ public class DatePickerFragment extends BaseFragment {
+             getFragmentController().goBack();
+         });
+     }
++
++    @Override
++    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
++        final Context contextThemeWrapper = new ContextThemeWrapper(getActivity(), R.style.DatePicker);
++        inflater = inflater.cloneInContext(contextThemeWrapper);
++        return super.onCreateView(inflater, container, savedInstanceState);
++    }
+ }
+-- 
+1.9.1
+

--- a/android_p/google_diff/cel_kbl/packages/apps/Car/Settings/0005-Add-primary-text-color-to-the-CarSettingTheme.patch
+++ b/android_p/google_diff/cel_kbl/packages/apps/Car/Settings/0005-Add-primary-text-color-to-the-CarSettingTheme.patch
@@ -1,0 +1,60 @@
+From 088bfd75bdcba5fc8d149b6793a5c53229fe8824 Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Sat, 2 Feb 2019 16:38:18 +0800
+Subject: [PATCH] Add primary text color to the CarSettingTheme
+
+The base style from the "Theme.Car.Light", the primary
+ text color needs to be declared.
+
+Change-Id: Ie3a1a8f3adedf0cc1c45857e6aa9c84df5c6a7d3
+Tracked-On: https://jira.devtools.intel.com/browse/OAM-69588
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ res/values/styles.xml                                         |  5 +++++
+ src/com/android/car/settings/datetime/DatePickerFragment.java | 11 +++++++++++
+ 2 files changed, 16 insertions(+)
+
+diff --git a/res/values/styles.xml b/res/values/styles.xml
+index 5ef139c..c4c1f46 100644
+--- a/res/values/styles.xml
++++ b/res/values/styles.xml
+@@ -88,4 +88,9 @@
+     <style name="SettingList">
+         <item name="gutter">both</item>
+     </style>
++
++    <style name="DatePicker" parent="CarSettingTheme">
++        <item name="android:textColorPrimary">@color/car_title</item>
++        <item name="android:textColorSecondary">@color/car_headline1</item>
++    </style>
+ </resources>
+diff --git a/src/com/android/car/settings/datetime/DatePickerFragment.java b/src/com/android/car/settings/datetime/DatePickerFragment.java
+index 4a2af00..71f2ba1 100644
+--- a/src/com/android/car/settings/datetime/DatePickerFragment.java
++++ b/src/com/android/car/settings/datetime/DatePickerFragment.java
+@@ -19,6 +19,10 @@ import android.app.AlarmManager;
+ import android.content.Context;
+ import android.content.Intent;
+ import android.os.Bundle;
++import android.view.ContextThemeWrapper;
++import android.view.LayoutInflater;
++import android.view.View;
++import android.view.ViewGroup;
+ import android.widget.Button;
+ import android.widget.DatePicker;
+ 
+@@ -67,4 +71,11 @@ public class DatePickerFragment extends BaseFragment {
+             getFragmentController().goBack();
+         });
+     }
++
++    @Override
++    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
++        final Context contextThemeWrapper = new ContextThemeWrapper(getActivity(), R.style.DatePicker);
++        inflater = inflater.cloneInContext(contextThemeWrapper);
++        return super.onCreateView(inflater, container, savedInstanceState);
++    }
+ }
+-- 
+1.9.1
+


### PR DESCRIPTION
The base style from the "Theme.Car.Light", the primary
text color needs to be declared.

Tracked-On: https://jira.devtools.intel.com/browse/OAM-69588
Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>