### PR TITLE
Added Thunderpeak specific product Id.

### DIFF
--- a/android_p/google_diff/cel_kbl/frameworks/base/0027-Added-Thunderpeak-specific-product-Id.patch
+++ b/android_p/google_diff/cel_kbl/frameworks/base/0027-Added-Thunderpeak-specific-product-Id.patch
@@ -1,0 +1,28 @@
+From 65b1382c89db21017838f854fd712671aa118624 Mon Sep 17 00:00:00 2001
+From: Raveendra Babu Chennakesavulu <raveendra.babu.chennakesavulu@intel.com>
+Date: Tue, 5 Feb 2019 17:55:57 +0530
+Subject: [PATCH] Added Thunderpeak specific product Id.
+
+USB host manager allows Stone peak2 and windstrom peak vendor and
+product ids only, added thunder peak product id to the list of devices
+allowed to enumarate in Celadon.
+
+Tracked-On:
+Signed-off-by: Babu Chennakesavulu, Raveendra
+			<raveendra.babu.chennakesavulu@intel.com>
+
+diff --git a/services/usb/java/com/android/server/usb/UsbHostManager.java b/services/usb/java/com/android/server/usb/UsbHostManager.java
+index 55f996e1..27ae7024 100644
+--- a/services/usb/java/com/android/server/usb/UsbHostManager.java
++++ b/services/usb/java/com/android/server/usb/UsbHostManager.java
+@@ -235,6 +235,7 @@ public class UsbHostManager {
+     private VendorIdProductId[] mVidPidBlackList = {
+              new VendorIdProductId(0x8087,0x0a2b),
+              new VendorIdProductId(0x8087,0x0aa7), //dedicated for BT in Celadon
++             new VendorIdProductId(0x8087,0x0025), //dedicated for BT in Celadon
+     };
+     /*
+      * UsbHostManager
+-- 
+2.17.1
+


### PR DESCRIPTION
USB host manager allows Stone peak2 and windstrom peak vendor and
product ids only, added thunder peak product id to the list of devices
allowed to enumarate in Celadon.

Tracked-On:
Signed-off-by: Babu Chennakesavulu, Raveendra
                        <raveendra.babu.chennakesavulu@intel.com>