### PR TITLE
celadon: Fix for wifi not working after treble specific changes

### DIFF
--- a/android_p/google_diff/celadon/external/wpa_supplicant_8/0002-Skip-private-commands-causing-vts-failure.patch
+++ b/android_p/google_diff/celadon/external/wpa_supplicant_8/0002-Skip-private-commands-causing-vts-failure.patch
@@ -1,0 +1,51 @@
+From 72cb9a5c31b1f944f90bd1b50289028f354b2dee Mon Sep 17 00:00:00 2001
+From: Amrita Raju <amrita.raju@intel.com>
+Date: Thu, 7 Feb 2019 11:29:37 +0530
+Subject: [PATCH] Skip private commands causing vts failure
+
+As some of the vendor interfaces requires usage of
+vendor specific commands and also some are not applicable or
+handle internally inside firmware, complete the request as
+success.
+
+Change-Id: I71f30416ca83bb9e3b6bfef2e10691f00857368f
+Tracked-On: OAM-75989
+Signed-off-by: Amrita Raju <amrita.raju@intel.com>
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ src/drivers/driver_nl80211.c | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/src/drivers/driver_nl80211.c b/src/drivers/driver_nl80211.c
+index 1d4dbf2..c42b401 100644
+--- a/src/drivers/driver_nl80211.c
++++ b/src/drivers/driver_nl80211.c
+@@ -2409,6 +2409,25 @@ int wpa_driver_nl80211_driver_cmd(void *priv, char *cmd, char *buf, size_t buf_l
+ 		if (!ret) {
+ 			ret = os_snprintf(buf, buf_len,"Macaddr = " MACSTR "\n", MAC2STR(macaddr));
+ 		}
++        } else if ((os_strncasecmp(cmd, "BTCOEXSCAN-", 11) == 0) ||
++                   (os_strncasecmp(cmd, "BTCOEXMODE", 10) == 0) ||
++                   (os_strncasecmp(cmd, "MIRACAST ", 9) == 0) ||
++                   (os_strncasecmp(cmd, "SETSUSPENDMODE", 14) == 0)) {
++                /*
++                * TODO: Above commands are issued by Android framework.
++                * Since this commands depend on vendor and the current
++                * open source driver/firmware not having the support for
++                * vendor commands, implementation is not provided but the
++                * request will be completed successfully to avoid VTS
++                * failures.
++                */
++                wpa_printf(MSG_DEBUG,
++                           "%s: Private commands are not supported %s\n",
++                            __func__, cmd);
++                wpa_printf(MSG_DEBUG,
++                           "%s: Skip this failure in current implementation\n",
++                           __func__);
++                ret = 0;
+ 	} else {
+ 		wpa_printf(MSG_ERROR, "Unsupported command: %s", cmd);
+ 		ret = -1;
+-- 
+2.17.1
+

--- a/android_p/google_diff/celadon/frameworks/opt/net/wifi/0001-libwifi-hal-Add-libwifi-hal-for-intel.patch
+++ b/android_p/google_diff/celadon/frameworks/opt/net/wifi/0001-libwifi-hal-Add-libwifi-hal-for-intel.patch
@@ -1,0 +1,29 @@
+From 4fe52673d4c1b6d5315696e7f058a792a70b164f Mon Sep 17 00:00:00 2001
+From: Amrita Raju <amrita.raju@intel.com>
+Date: Fri, 1 Feb 2019 09:36:26 +0530
+Subject: [PATCH] libwifi-hal: Add libwifi-hal for intel
+
+Change-Id: I7715ef79f211ef46310cdafb1e9405312d465266
+Tracked-On: OAM-75990
+Signed-off-by: Amrita Raju <amrita.raju@intel.com>
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ libwifi_hal/Android.mk | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/libwifi_hal/Android.mk b/libwifi_hal/Android.mk
+index 58e81ff..a57371b 100644
+--- a/libwifi_hal/Android.mk
++++ b/libwifi_hal/Android.mk
+@@ -99,6 +99,8 @@ else ifeq ($(BOARD_WLAN_DEVICE), mrvl)
+ else ifeq ($(BOARD_WLAN_DEVICE), MediaTek)
+   # support MTK WIFI HAL
+   LIB_WIFI_HAL := libwifi-hal-mt66xx
++else ifeq ($(BOARD_WLAN_DEVICE), iwlwifi)
++  LIB_WIFI_HAL := libwifi-hal-intel
+ else ifeq ($(BOARD_WLAN_DEVICE), emulator)
+   LIB_WIFI_HAL := libwifi-hal-emu
+ endif
+-- 
+2.17.1
+

--- a/android_p/google_diff/celadon/hardware/interfaces/0003-wifi-Disable-capabilities-not-yet-supported.patch
+++ b/android_p/google_diff/celadon/hardware/interfaces/0003-wifi-Disable-capabilities-not-yet-supported.patch
@@ -1,0 +1,65 @@
+From 78fd45a343db3b0866df7f04381063d04e6c8c0e Mon Sep 17 00:00:00 2001
+From: Amrita Raju <amrita.raju@intel.com>
+Date: Fri, 8 Feb 2019 09:55:05 +0530
+Subject: [PATCH] wifi: Disable capabilities not yet supported
+
+As E2E support is not yet implemented for following capabilities,
+remove the capabilities.
+DEBUG_RING_BUFFER_VENDOR_DATA, DEBUG_HOST_WAKE_REASON_STATS,
+DEBUG_ERROR_ALERTS and APF.
+
+Change-Id: I3c33a9ad826e36f3765bb57b11e50b9ad92c1221
+Tracked-On: OAM-75990
+Signed-off-by: Amrita Raju <amrita.raju@intel.com>
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ wifi/1.2/default/hidl_struct_util.cpp | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/wifi/1.2/default/hidl_struct_util.cpp b/wifi/1.2/default/hidl_struct_util.cpp
+index 39ac544e6..5555d6a7b 100644
+--- a/wifi/1.2/default/hidl_struct_util.cpp
++++ b/wifi/1.2/default/hidl_struct_util.cpp
+@@ -128,7 +128,7 @@ bool convertLegacyFeaturesToHidlChipCapabilities(
+         return false;
+     }
+     *hidl_caps = {};
+-    using HidlChipCaps = IWifiChip::ChipCapabilityMask;
++    //using HidlChipCaps = IWifiChip::ChipCapabilityMask;
+     for (const auto feature : {legacy_hal::WIFI_LOGGER_MEMORY_DUMP_SUPPORTED,
+                                legacy_hal::WIFI_LOGGER_DRIVER_DUMP_SUPPORTED,
+                                legacy_hal::WIFI_LOGGER_CONNECT_EVENT_SUPPORTED,
+@@ -148,9 +148,9 @@ bool convertLegacyFeaturesToHidlChipCapabilities(
+     }
+     // There are no flags for these 3 in the legacy feature set. Adding them to
+     // the set because all the current devices support it.
+-    *hidl_caps |= HidlChipCaps::DEBUG_RING_BUFFER_VENDOR_DATA;
+-    *hidl_caps |= HidlChipCaps::DEBUG_HOST_WAKE_REASON_STATS;
+-    *hidl_caps |= HidlChipCaps::DEBUG_ERROR_ALERTS;
++    //*hidl_caps |= HidlChipCaps::DEBUG_RING_BUFFER_VENDOR_DATA;
++    //*hidl_caps |= HidlChipCaps::DEBUG_HOST_WAKE_REASON_STATS;
++    //*hidl_caps |= HidlChipCaps::DEBUG_ERROR_ALERTS;
+     return true;
+ }
+ 
+@@ -350,7 +350,7 @@ bool convertLegacyFeaturesToHidlStaCapabilities(
+         return false;
+     }
+     *hidl_caps = {};
+-    using HidlStaIfaceCaps = IWifiStaIface::StaIfaceCapabilityMask;
++    //using HidlStaIfaceCaps = IWifiStaIface::StaIfaceCapabilityMask;
+     for (const auto feature : {legacy_hal::WIFI_LOGGER_PACKET_FATE_SUPPORTED}) {
+         if (feature & legacy_logger_feature_set) {
+             *hidl_caps |=
+@@ -370,7 +370,7 @@ bool convertLegacyFeaturesToHidlStaCapabilities(
+     }
+     // There is no flag for this one in the legacy feature set. Adding it to the
+     // set because all the current devices support it.
+-    *hidl_caps |= HidlStaIfaceCaps::APF;
++    //*hidl_caps |= HidlStaIfaceCaps::APF;
+     return true;
+ }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
Changes include:
- libwifi-hal: Add libwifi-hal for intel
- wifi: Disable capabilities not yet supported
- wpa_supplicant: Skip private commands causing vts failure

Tracked-On: OAM-76167
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>