### PR TITLE
Setting the bump pointer space to 48m for Celadon IVI

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/native/0005-Set-heapsize-to-704M-for-EpsilonGC-configuration.patch
+++ b/android_p/google_diff/cel_apl/frameworks/native/0005-Set-heapsize-to-704M-for-EpsilonGC-configuration.patch
@@ -1,0 +1,30 @@
+From 9c77949c0927ff7adc7b2be2c454f493ecd3458f Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Sat, 9 Feb 2019 16:59:38 +0530
+Subject: [PATCH] Set heapsize to 704M for EpsilonGC configuration
+
+Tracked-On: OAM-76070
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ build/tablet-10in-xhdpi-2048-dalvik-heap.mk | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/build/tablet-10in-xhdpi-2048-dalvik-heap.mk b/build/tablet-10in-xhdpi-2048-dalvik-heap.mk
+index 1721fcc..1269f16 100644
+--- a/build/tablet-10in-xhdpi-2048-dalvik-heap.mk
++++ b/build/tablet-10in-xhdpi-2048-dalvik-heap.mk
+@@ -16,6 +16,11 @@
+ 
+ # Provides overrides to configure the Dalvik heap for a standard tablet device.
+ 
++ART_ENABLE_EPSILON_GC?=false
++ifeq ($(ART_ENABLE_EPSILON_GC),true)
++   PRODUCT_PROPERTY_OVERRIDES += dalvik.vm.heapsize=704m
++endif
++
+ PRODUCT_PROPERTY_OVERRIDES += \
+     dalvik.vm.heapstartsize=16m \
+     dalvik.vm.heapgrowthlimit=192m \
+-- 
+1.9.1
+

--- a/android_p/google_diff/cel_kbl/frameworks/native/0005-Set-heapsize-to-704M-for-EpsilonGC-configuration.patch
+++ b/android_p/google_diff/cel_kbl/frameworks/native/0005-Set-heapsize-to-704M-for-EpsilonGC-configuration.patch
@@ -1,0 +1,30 @@
+From 9c77949c0927ff7adc7b2be2c454f493ecd3458f Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Sat, 9 Feb 2019 16:59:38 +0530
+Subject: [PATCH] Set heapsize to 704M for EpsilonGC configuration
+
+Tracked-On: OAM-76070
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ build/tablet-10in-xhdpi-2048-dalvik-heap.mk | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/build/tablet-10in-xhdpi-2048-dalvik-heap.mk b/build/tablet-10in-xhdpi-2048-dalvik-heap.mk
+index 1721fcc..1269f16 100644
+--- a/build/tablet-10in-xhdpi-2048-dalvik-heap.mk
++++ b/build/tablet-10in-xhdpi-2048-dalvik-heap.mk
+@@ -16,6 +16,11 @@
+ 
+ # Provides overrides to configure the Dalvik heap for a standard tablet device.
+ 
++ART_ENABLE_EPSILON_GC?=false
++ifeq ($(ART_ENABLE_EPSILON_GC),true)
++   PRODUCT_PROPERTY_OVERRIDES += dalvik.vm.heapsize=704m
++endif
++
+ PRODUCT_PROPERTY_OVERRIDES += \
+     dalvik.vm.heapstartsize=16m \
+     dalvik.vm.heapgrowthlimit=192m \
+-- 
+1.9.1
+

--- a/android_p/google_diff/celadon/frameworks/native/0004-Set-heapsize-to-704M-for-EpsilonGC-configuration.patch
+++ b/android_p/google_diff/celadon/frameworks/native/0004-Set-heapsize-to-704M-for-EpsilonGC-configuration.patch
@@ -1,0 +1,30 @@
+From 9c77949c0927ff7adc7b2be2c454f493ecd3458f Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Sat, 9 Feb 2019 16:59:38 +0530
+Subject: [PATCH] Set heapsize to 704M for EpsilonGC configuration
+
+Tracked-On: OAM-76070
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ build/tablet-10in-xhdpi-2048-dalvik-heap.mk | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/build/tablet-10in-xhdpi-2048-dalvik-heap.mk b/build/tablet-10in-xhdpi-2048-dalvik-heap.mk
+index 1721fcc..1269f16 100644
+--- a/build/tablet-10in-xhdpi-2048-dalvik-heap.mk
++++ b/build/tablet-10in-xhdpi-2048-dalvik-heap.mk
+@@ -16,6 +16,11 @@
+ 
+ # Provides overrides to configure the Dalvik heap for a standard tablet device.
+ 
++ART_ENABLE_EPSILON_GC?=false
++ifeq ($(ART_ENABLE_EPSILON_GC),true)
++   PRODUCT_PROPERTY_OVERRIDES += dalvik.vm.heapsize=704m
++endif
++
+ PRODUCT_PROPERTY_OVERRIDES += \
+     dalvik.vm.heapstartsize=16m \
+     dalvik.vm.heapgrowthlimit=192m \
+-- 
+1.9.1
+


### PR DESCRIPTION
Tracked-On: OAM-76016
Signed-off-by: Amrita H S <amrita.h.s@intel.com>