### PR TITLE
[REVERT ME] Fallback to legacy(xt_qtaguid) network traffic control

### DIFF
--- a/android_p/google_diff/cel_apl/system/netd/0001-REVERT-ME-Fallback-to-legacy-xt_qtaguid-network-traf.patch
+++ b/android_p/google_diff/cel_apl/system/netd/0001-REVERT-ME-Fallback-to-legacy-xt_qtaguid-network-traf.patch
@@ -1,0 +1,39 @@
+From fbd5a5bfd5bfc6b472fdcd4168106079c336129a Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Mon, 18 Feb 2019 21:21:58 +0530
+Subject: [PATCH] [REVERT ME] Fallback to legacy(xt_qtaguid) network traffic
+ control
+
+eBPF network traffic control is not yet working causing
+many CTS test failures.
+
+As a temporary fix, disable eBPF support. When eBPF support
+is disabled, legacy(xt_qtaguid) network traffic control
+will be used.
+
+Change-Id: I000efe6b9633fcd7d90c0c192a21a69c49502080
+Tracked-On: OAM-76268
+Signed-off-by: Harshita Goswami <harshita.goswami@intel.com>
+Signed-off-by: Amrita Raju <amrita.raju@intel.com>
+Signed-off-by: Nitin Rawat <nitin.rawat@intel.com>
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ libbpf/BpfUtils.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libbpf/BpfUtils.cpp b/libbpf/BpfUtils.cpp
+index 9a587fb..370c693 100644
+--- a/libbpf/BpfUtils.cpp
++++ b/libbpf/BpfUtils.cpp
+@@ -226,7 +226,7 @@ bool hasBpfSupport() {
+     if (ret >= 2 && ((kernel_version_major > 4) ||
+                          (kernel_version_major == 4 && kernel_version_minor >= 9))) {
+         // Check if the device is shipped originally with android P.
+-        return api_level >= MINIMUM_API_REQUIRED;
++        return false; //api_level >= MINIMUM_API_REQUIRED;
+     }
+     return false;
+ }
+-- 
+2.17.1
+

--- a/android_p/google_diff/cel_kbl/system/netd/0001-REVERT-ME-Fallback-to-legacy-xt_qtaguid-network-traf.patch
+++ b/android_p/google_diff/cel_kbl/system/netd/0001-REVERT-ME-Fallback-to-legacy-xt_qtaguid-network-traf.patch
@@ -1,0 +1,39 @@
+From fbd5a5bfd5bfc6b472fdcd4168106079c336129a Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Mon, 18 Feb 2019 21:21:58 +0530
+Subject: [PATCH] [REVERT ME] Fallback to legacy(xt_qtaguid) network traffic
+ control
+
+eBPF network traffic control is not yet working causing
+many CTS test failures.
+
+As a temporary fix, disable eBPF support. When eBPF support
+is disabled, legacy(xt_qtaguid) network traffic control
+will be used.
+
+Change-Id: I000efe6b9633fcd7d90c0c192a21a69c49502080
+Tracked-On: OAM-76268
+Signed-off-by: Harshita Goswami <harshita.goswami@intel.com>
+Signed-off-by: Amrita Raju <amrita.raju@intel.com>
+Signed-off-by: Nitin Rawat <nitin.rawat@intel.com>
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ libbpf/BpfUtils.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libbpf/BpfUtils.cpp b/libbpf/BpfUtils.cpp
+index 9a587fb..370c693 100644
+--- a/libbpf/BpfUtils.cpp
++++ b/libbpf/BpfUtils.cpp
+@@ -226,7 +226,7 @@ bool hasBpfSupport() {
+     if (ret >= 2 && ((kernel_version_major > 4) ||
+                          (kernel_version_major == 4 && kernel_version_minor >= 9))) {
+         // Check if the device is shipped originally with android P.
+-        return api_level >= MINIMUM_API_REQUIRED;
++        return false; //api_level >= MINIMUM_API_REQUIRED;
+     }
+     return false;
+ }
+-- 
+2.17.1
+

--- a/android_p/google_diff/celadon/system/netd/0001-REVERT-ME-Fallback-to-legacy-xt_qtaguid-network-traf.patch
+++ b/android_p/google_diff/celadon/system/netd/0001-REVERT-ME-Fallback-to-legacy-xt_qtaguid-network-traf.patch
@@ -1,0 +1,39 @@
+From fbd5a5bfd5bfc6b472fdcd4168106079c336129a Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Mon, 18 Feb 2019 21:21:58 +0530
+Subject: [PATCH] [REVERT ME] Fallback to legacy(xt_qtaguid) network traffic
+ control
+
+eBPF network traffic control is not yet working causing
+many CTS test failures.
+
+As a temporary fix, disable eBPF support. When eBPF support
+is disabled, legacy(xt_qtaguid) network traffic control
+will be used.
+
+Change-Id: I000efe6b9633fcd7d90c0c192a21a69c49502080
+Tracked-On: OAM-76268
+Signed-off-by: Harshita Goswami <harshita.goswami@intel.com>
+Signed-off-by: Amrita Raju <amrita.raju@intel.com>
+Signed-off-by: Nitin Rawat <nitin.rawat@intel.com>
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ libbpf/BpfUtils.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libbpf/BpfUtils.cpp b/libbpf/BpfUtils.cpp
+index 9a587fb..370c693 100644
+--- a/libbpf/BpfUtils.cpp
++++ b/libbpf/BpfUtils.cpp
+@@ -226,7 +226,7 @@ bool hasBpfSupport() {
+     if (ret >= 2 && ((kernel_version_major > 4) ||
+                          (kernel_version_major == 4 && kernel_version_minor >= 9))) {
+         // Check if the device is shipped originally with android P.
+-        return api_level >= MINIMUM_API_REQUIRED;
++        return false; //api_level >= MINIMUM_API_REQUIRED;
+     }
+     return false;
+ }
+-- 
+2.17.1
+


### PR DESCRIPTION
eBPF network traffic control is not yet working causing
many CTS test failures.

As a temporary fix, disable eBPF support. When eBPF support
is disabled, legacy(xt_qtaguid) network traffic control
will be used.

Tracked-On: OAM-76268
Signed-off-by: Harshita Goswami <harshita.goswami@intel.com>
Signed-off-by: Amrita Raju <amrita.raju@intel.com>
Signed-off-by: Nitin Rawat <nitin.rawat@intel.com>
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>