### PR TITLE
[workaround] set default ro.crypto.volume.filenames_mode = aes-256-cts

### DIFF
--- a/android_p/google_diff/cel_apl/system/vold/0002-workaround-set-default-ro.crypto.volume.filenames_mo.patch
+++ b/android_p/google_diff/cel_apl/system/vold/0002-workaround-set-default-ro.crypto.volume.filenames_mo.patch
@@ -1,0 +1,32 @@
+From e1fb7eef232f35f3d28bbbf41b5e8f355aa39158 Mon Sep 17 00:00:00 2001
+From: Zhiwei Li <zhiwei.li@intel.com>
+Date: Thu, 21 Feb 2019 16:01:50 +0800
+Subject: [PATCH] [workaround] set default ro.crypto.volume.filenames_mode =
+ aes-256-cts
+
+    after tremble enabled, we can not set ro.crypto.volume.filenames_mode in device.mk
+    so use this patch to workaround
+
+Change-Id: Ied8c3fc84b92c0b5ce22ec7173d91690fae646f8
+Tracked-On: https://jira.devtools.intel.com/browse/OAM-76267
+Signed-off-by: Zhiwei Li <zhiwei.li@intel.com>
+---
+ Ext4Crypt.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Ext4Crypt.cpp b/Ext4Crypt.cpp
+index 67b7e90..1829cc8 100644
+--- a/Ext4Crypt.cpp
++++ b/Ext4Crypt.cpp
+@@ -537,7 +537,7 @@ static bool read_or_create_volkey(const std::string& misc_path, const std::strin
+     key_ref->contents_mode =
+         android::base::GetProperty("ro.crypto.volume.contents_mode", "aes-256-xts");
+     key_ref->filenames_mode =
+-        android::base::GetProperty("ro.crypto.volume.filenames_mode", "aes-256-heh");
++        android::base::GetProperty("ro.crypto.volume.filenames_mode", "aes-256-cts");
+     return true;
+ }
+ 
+-- 
+2.20.1.2.gb21ebb6
+

--- a/android_p/google_diff/cel_kbl/system/vold/0002-workaround-set-default-ro.crypto.volume.filenames_mo.patch
+++ b/android_p/google_diff/cel_kbl/system/vold/0002-workaround-set-default-ro.crypto.volume.filenames_mo.patch
@@ -1,0 +1,32 @@
+From e1fb7eef232f35f3d28bbbf41b5e8f355aa39158 Mon Sep 17 00:00:00 2001
+From: Zhiwei Li <zhiwei.li@intel.com>
+Date: Thu, 21 Feb 2019 16:01:50 +0800
+Subject: [PATCH] [workaround] set default ro.crypto.volume.filenames_mode =
+ aes-256-cts
+
+    after tremble enabled, we can not set ro.crypto.volume.filenames_mode in device.mk
+    so use this patch to workaround
+
+Change-Id: Ied8c3fc84b92c0b5ce22ec7173d91690fae646f8
+Tracked-On: https://jira.devtools.intel.com/browse/OAM-76267
+Signed-off-by: Zhiwei Li <zhiwei.li@intel.com>
+---
+ Ext4Crypt.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Ext4Crypt.cpp b/Ext4Crypt.cpp
+index 67b7e90..1829cc8 100644
+--- a/Ext4Crypt.cpp
++++ b/Ext4Crypt.cpp
+@@ -537,7 +537,7 @@ static bool read_or_create_volkey(const std::string& misc_path, const std::strin
+     key_ref->contents_mode =
+         android::base::GetProperty("ro.crypto.volume.contents_mode", "aes-256-xts");
+     key_ref->filenames_mode =
+-        android::base::GetProperty("ro.crypto.volume.filenames_mode", "aes-256-heh");
++        android::base::GetProperty("ro.crypto.volume.filenames_mode", "aes-256-cts");
+     return true;
+ }
+ 
+-- 
+2.20.1.2.gb21ebb6
+

--- a/android_p/google_diff/celadon/system/vold/0002-workaround-set-default-ro.crypto.volume.filenames_mo.patch
+++ b/android_p/google_diff/celadon/system/vold/0002-workaround-set-default-ro.crypto.volume.filenames_mo.patch
@@ -1,0 +1,32 @@
+From e1fb7eef232f35f3d28bbbf41b5e8f355aa39158 Mon Sep 17 00:00:00 2001
+From: Zhiwei Li <zhiwei.li@intel.com>
+Date: Thu, 21 Feb 2019 16:01:50 +0800
+Subject: [PATCH] [workaround] set default ro.crypto.volume.filenames_mode =
+ aes-256-cts
+
+    after tremble enabled, we can not set ro.crypto.volume.filenames_mode in device.mk
+    so use this patch to workaround
+
+Change-Id: Ied8c3fc84b92c0b5ce22ec7173d91690fae646f8
+Tracked-On: https://jira.devtools.intel.com/browse/OAM-76267
+Signed-off-by: Zhiwei Li <zhiwei.li@intel.com>
+---
+ Ext4Crypt.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Ext4Crypt.cpp b/Ext4Crypt.cpp
+index 67b7e90..1829cc8 100644
+--- a/Ext4Crypt.cpp
++++ b/Ext4Crypt.cpp
+@@ -537,7 +537,7 @@ static bool read_or_create_volkey(const std::string& misc_path, const std::strin
+     key_ref->contents_mode =
+         android::base::GetProperty("ro.crypto.volume.contents_mode", "aes-256-xts");
+     key_ref->filenames_mode =
+-        android::base::GetProperty("ro.crypto.volume.filenames_mode", "aes-256-heh");
++        android::base::GetProperty("ro.crypto.volume.filenames_mode", "aes-256-cts");
+     return true;
+ }
+ 
+-- 
+2.20.1.2.gb21ebb6
+


### PR DESCRIPTION
    after tremble enabled, we can not set ro.crypto.volume.filenames_mode in device.mk
    so use this patch to workaround

Tracked-On: https://jira.devtools.intel.com/browse/OAM-76267
Signed-off-by: Zhiwei Li <zhiwei.li@intel.com>