### PR TITLE
Add TelephonyManager preload class to fix CTS test failure

### DIFF
--- a/android_p/google_diff/cel_apl/packages/services/Car/0009-Add-TelephonyManager-preload-class-to-fix-CTS-test-f.patch
+++ b/android_p/google_diff/cel_apl/packages/services/Car/0009-Add-TelephonyManager-preload-class-to-fix-CTS-test-f.patch
@@ -1,0 +1,27 @@
+From 70cf536ca4c913e36b2885c9fcfffd7f7981fcd5 Mon Sep 17 00:00:00 2001
+From: bxu10x <bingx.xu@intel.com>
+Date: Wed, 7 Mar 2018 17:24:11 +0800
+Subject: [PATCH] Add TelephonyManager preload class to fix CTS test failure.
+
+TelephonyManager class should be preloaded by zygote, com.android.cts.
+webkit.WebViewHostSideStartupTest.testStrictMode in CtsSecurityTestCases
+will use it.
+
+Change-Id: Ie3da657c6723cb3905894ee32621d2caa359566a
+Tracked-On: OAM-76469
+Signed-off-by: Lei,RayX <rayx.lei@intel.com>
+Signed-off-by: bxu10x <bingx.xu@intel.com>
+---
+ car_product/preloaded-classes-car | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/car_product/preloaded-classes-car b/car_product/preloaded-classes-car
+index 962099f..b426a02 100644
+--- a/car_product/preloaded-classes-car
++++ b/car_product/preloaded-classes-car
+@@ -1 +1,2 @@
+ # Classes which are preloaded by com.android.internal.os.ZygoteInit.
++android.telephony.TelephonyManager
+-- 
+1.9.1
+

--- a/android_p/google_diff/cel_kbl/packages/services/Car/0009-Add-TelephonyManager-preload-class-to-fix-CTS-test-f.patch
+++ b/android_p/google_diff/cel_kbl/packages/services/Car/0009-Add-TelephonyManager-preload-class-to-fix-CTS-test-f.patch
@@ -1,0 +1,27 @@
+From 70cf536ca4c913e36b2885c9fcfffd7f7981fcd5 Mon Sep 17 00:00:00 2001
+From: bxu10x <bingx.xu@intel.com>
+Date: Wed, 7 Mar 2018 17:24:11 +0800
+Subject: [PATCH] Add TelephonyManager preload class to fix CTS test failure.
+
+TelephonyManager class should be preloaded by zygote, com.android.cts.
+webkit.WebViewHostSideStartupTest.testStrictMode in CtsSecurityTestCases
+will use it.
+
+Change-Id: Ie3da657c6723cb3905894ee32621d2caa359566a
+Tracked-On: OAM-76469
+Signed-off-by: Lei,RayX <rayx.lei@intel.com>
+Signed-off-by: bxu10x <bingx.xu@intel.com>
+---
+ car_product/preloaded-classes-car | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/car_product/preloaded-classes-car b/car_product/preloaded-classes-car
+index 962099f..b426a02 100644
+--- a/car_product/preloaded-classes-car
++++ b/car_product/preloaded-classes-car
+@@ -1 +1,2 @@
+ # Classes which are preloaded by com.android.internal.os.ZygoteInit.
++android.telephony.TelephonyManager
+-- 
+1.9.1
+


### PR DESCRIPTION
TelephonyManager class should be preloaded by zygote, com.android.cts.
webkit.WebViewHostSideStartupTest.testStrictMode in CtsSecurityTestCases
will use it.

Tracked-On: OAM-76469
Signed-off-by: Lei,RayX <rayx.lei@intel.com>