### PR TITLE
Remove the interface state change done after softap setup

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/opt/net/wifi/0002-Remove-the-interface-state-change-done-after-softap-.patch
+++ b/android_p/google_diff/cel_apl/frameworks/opt/net/wifi/0002-Remove-the-interface-state-change-done-after-softap-.patch
@@ -1,0 +1,44 @@
+From 37322ae29e18e42c5a50225ba53de4e5963876a7 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Wed, 27 Feb 2019 19:44:03 +0530
+Subject: [PATCH] Remove the interface state change done after softap setup
+
+Wi-Fi hotspot is getting deactivated after few seconds
+of activation.
+
+After setting up the interface in AP mode, interface state
+changed is triggered from setupInterfaceForSoftApMode function
+to avoid any race conditions. As the interface state changed
+received properly whenever link state is changed, updating
+interface state changed after setup call results in hotspot
+getting deactivated after few seconds of activation.
+
+Remove the interface state changed done on setup interface.
+Interface state change on link state changed event is enough to
+properly update the SoftAp state machine.
+
+Change-Id: Icbe97629878dee739e752985845ae216823761c7
+Tracked-On: OAM-76271
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Signed-off-by: Harshita Goswami <harshita.goswami@intel.com>
+---
+ service/java/com/android/server/wifi/WifiNative.java | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/service/java/com/android/server/wifi/WifiNative.java b/service/java/com/android/server/wifi/WifiNative.java
+index 0f78587..69b547b 100644
+--- a/service/java/com/android/server/wifi/WifiNative.java
++++ b/service/java/com/android/server/wifi/WifiNative.java
+@@ -939,9 +939,6 @@ public class WifiNative {
+                 teardownInterface(iface.name);
+                 return null;
+             }
+-            // Just to avoid any race conditions with interface state change callbacks,
+-            // update the interface state before we exit.
+-            onInterfaceStateChanged(iface, isInterfaceUp(iface.name));
+             Log.i(TAG, "Successfully setup " + iface);
+             return iface.name;
+         }
+-- 
+2.17.1
+

--- a/android_p/google_diff/cel_kbl/frameworks/opt/net/wifi/0002-Remove-the-interface-state-change-done-after-softap-.patch
+++ b/android_p/google_diff/cel_kbl/frameworks/opt/net/wifi/0002-Remove-the-interface-state-change-done-after-softap-.patch
@@ -1,0 +1,44 @@
+From 37322ae29e18e42c5a50225ba53de4e5963876a7 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Wed, 27 Feb 2019 19:44:03 +0530
+Subject: [PATCH] Remove the interface state change done after softap setup
+
+Wi-Fi hotspot is getting deactivated after few seconds
+of activation.
+
+After setting up the interface in AP mode, interface state
+changed is triggered from setupInterfaceForSoftApMode function
+to avoid any race conditions. As the interface state changed
+received properly whenever link state is changed, updating
+interface state changed after setup call results in hotspot
+getting deactivated after few seconds of activation.
+
+Remove the interface state changed done on setup interface.
+Interface state change on link state changed event is enough to
+properly update the SoftAp state machine.
+
+Change-Id: Icbe97629878dee739e752985845ae216823761c7
+Tracked-On: OAM-76271
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Signed-off-by: Harshita Goswami <harshita.goswami@intel.com>
+---
+ service/java/com/android/server/wifi/WifiNative.java | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/service/java/com/android/server/wifi/WifiNative.java b/service/java/com/android/server/wifi/WifiNative.java
+index 0f78587..69b547b 100644
+--- a/service/java/com/android/server/wifi/WifiNative.java
++++ b/service/java/com/android/server/wifi/WifiNative.java
+@@ -939,9 +939,6 @@ public class WifiNative {
+                 teardownInterface(iface.name);
+                 return null;
+             }
+-            // Just to avoid any race conditions with interface state change callbacks,
+-            // update the interface state before we exit.
+-            onInterfaceStateChanged(iface, isInterfaceUp(iface.name));
+             Log.i(TAG, "Successfully setup " + iface);
+             return iface.name;
+         }
+-- 
+2.17.1
+

--- a/android_p/google_diff/celadon/frameworks/opt/net/wifi/0002-Remove-the-interface-state-change-done-after-softap-.patch
+++ b/android_p/google_diff/celadon/frameworks/opt/net/wifi/0002-Remove-the-interface-state-change-done-after-softap-.patch
@@ -1,0 +1,44 @@
+From 37322ae29e18e42c5a50225ba53de4e5963876a7 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Wed, 27 Feb 2019 19:44:03 +0530
+Subject: [PATCH] Remove the interface state change done after softap setup
+
+Wi-Fi hotspot is getting deactivated after few seconds
+of activation.
+
+After setting up the interface in AP mode, interface state
+changed is triggered from setupInterfaceForSoftApMode function
+to avoid any race conditions. As the interface state changed
+received properly whenever link state is changed, updating
+interface state changed after setup call results in hotspot
+getting deactivated after few seconds of activation.
+
+Remove the interface state changed done on setup interface.
+Interface state change on link state changed event is enough to
+properly update the SoftAp state machine.
+
+Change-Id: Icbe97629878dee739e752985845ae216823761c7
+Tracked-On: OAM-76271
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Signed-off-by: Harshita Goswami <harshita.goswami@intel.com>
+---
+ service/java/com/android/server/wifi/WifiNative.java | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/service/java/com/android/server/wifi/WifiNative.java b/service/java/com/android/server/wifi/WifiNative.java
+index 0f78587..69b547b 100644
+--- a/service/java/com/android/server/wifi/WifiNative.java
++++ b/service/java/com/android/server/wifi/WifiNative.java
+@@ -939,9 +939,6 @@ public class WifiNative {
+                 teardownInterface(iface.name);
+                 return null;
+             }
+-            // Just to avoid any race conditions with interface state change callbacks,
+-            // update the interface state before we exit.
+-            onInterfaceStateChanged(iface, isInterfaceUp(iface.name));
+             Log.i(TAG, "Successfully setup " + iface);
+             return iface.name;
+         }
+-- 
+2.17.1
+


### PR DESCRIPTION
Wi-Fi hotspot is getting deactivated after few seconds
of activation.

After setting up the interface in AP mode, interface state
changed is triggered from setupInterfaceForSoftApMode function
to avoid any race conditions. As the interface state changed
received properly whenever link state is changed, updating
interface state changed after setup call results in hotspot
getting deactivated after few seconds of activation.

Remove the interface state changed done on setup interface.
Interface state change on link state changed event is enough to
properly update the SoftAp state machine.

Tracked-On: OAM-76271
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
Signed-off-by: Harshita Goswami <harshita.goswami@intel.com>