### PR TITLE
[WORKAROUND][CELADON] edit 'make publish_ci'

### DIFF
--- a/android_p/google_diff/cel_apl/device/intel/build/0001-WORKAROUND-CELADON-edit-make-publish_ci.patch
+++ b/android_p/google_diff/cel_apl/device/intel/build/0001-WORKAROUND-CELADON-edit-make-publish_ci.patch
@@ -1,0 +1,41 @@
+From eb61093121a69c3942bacffaead8cbd6f4f114cf Mon Sep 17 00:00:00 2001
+From: sgnanase <sundar.gnanasekaran@intel.com>
+Date: Wed, 16 Jan 2019 18:31:18 +0530
+Subject: [PATCH] [WORKAROUND][CELADON] edit 'make publish_ci'
+
+gpt image is around 14G in size.
+Hence, removing upload of *gpt_image to artifactory
+untic artifactory speed is improved
+
+<To be reverted once we have artifactory issue fixed>
+
+Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>
+---
+ tasks/publish.mk | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tasks/publish.mk b/tasks/publish.mk
+index f7071f5..4ef6cc6 100644
+--- a/tasks/publish.mk
++++ b/tasks/publish.mk
+@@ -185,7 +185,7 @@ endif # PUBLISH_CONF
+ PUBLISH_CI_FILES := $(DIST_DIR)/fastboot $(DIST_DIR)/adb
+ .PHONY: publish_ci
+ ifeq ($(KERNELFLINGER_SUPPORT_NON_EFI_BOOT), false)
+-publish_ci: publish_liveimage publish_ota_flashfile publish_gptimage publish_ifwi publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) $(PUB_CMCC_ZIP) $(PLATFORM_RMA_TOOLS_ZIP)
++publish_ci: publish_liveimage publish_ota_flashfile publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) $(PUB_CMCC_ZIP) $(PLATFORM_RMA_TOOLS_ZIP)
+ 	$(if $(wildcard $(publish_dest)), \
+ 	  $(foreach f,$(PUBLISH_CI_FILES), \
+ 	    $(if $(wildcard $(f)),$(ACP) $(f) $(publish_dest);,)),)
+@@ -198,7 +198,7 @@ publish_windows_tools: $(PLATFORM_RMA_TOOLS_CROSS_ZIP)
+ 	@$(hide) mkdir -p $(publish_tool_destw)
+ 	@$(hide) $(ACP) $(PLATFORM_RMA_TOOLS_CROSS_ZIP) $(publish_tool_destw)
+ else
+-publish_ci: publish_liveimage publish_ota_flashfile publish_gptimage publish_ifwi publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) $(PUB_CMCC_ZIP)
++publish_ci: publish_liveimage publish_ota_flashfile publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) $(PUB_CMCC_ZIP)
+ 	$(if $(wildcard $(publish_dest)), \
+ 	  $(foreach f,$(PUBLISH_CI_FILES), \
+ 	    $(if $(wildcard $(f)),$(ACP) $(f) $(publish_dest);,)),)
+-- 
+2.20.1
+

--- a/android_p/google_diff/cel_kbl/device/intel/build/0001-WORKAROUND-CELADON-edit-make-publish_ci.patch
+++ b/android_p/google_diff/cel_kbl/device/intel/build/0001-WORKAROUND-CELADON-edit-make-publish_ci.patch
@@ -1,0 +1,41 @@
+From eb61093121a69c3942bacffaead8cbd6f4f114cf Mon Sep 17 00:00:00 2001
+From: sgnanase <sundar.gnanasekaran@intel.com>
+Date: Wed, 16 Jan 2019 18:31:18 +0530
+Subject: [PATCH] [WORKAROUND][CELADON] edit 'make publish_ci'
+
+gpt image is around 14G in size.
+Hence, removing upload of *gpt_image to artifactory
+untic artifactory speed is improved
+
+<To be reverted once we have artifactory issue fixed>
+
+Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>
+---
+ tasks/publish.mk | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tasks/publish.mk b/tasks/publish.mk
+index f7071f5..4ef6cc6 100644
+--- a/tasks/publish.mk
++++ b/tasks/publish.mk
+@@ -185,7 +185,7 @@ endif # PUBLISH_CONF
+ PUBLISH_CI_FILES := $(DIST_DIR)/fastboot $(DIST_DIR)/adb
+ .PHONY: publish_ci
+ ifeq ($(KERNELFLINGER_SUPPORT_NON_EFI_BOOT), false)
+-publish_ci: publish_liveimage publish_ota_flashfile publish_gptimage publish_ifwi publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) $(PUB_CMCC_ZIP) $(PLATFORM_RMA_TOOLS_ZIP)
++publish_ci: publish_liveimage publish_ota_flashfile publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) $(PUB_CMCC_ZIP) $(PLATFORM_RMA_TOOLS_ZIP)
+ 	$(if $(wildcard $(publish_dest)), \
+ 	  $(foreach f,$(PUBLISH_CI_FILES), \
+ 	    $(if $(wildcard $(f)),$(ACP) $(f) $(publish_dest);,)),)
+@@ -198,7 +198,7 @@ publish_windows_tools: $(PLATFORM_RMA_TOOLS_CROSS_ZIP)
+ 	@$(hide) mkdir -p $(publish_tool_destw)
+ 	@$(hide) $(ACP) $(PLATFORM_RMA_TOOLS_CROSS_ZIP) $(publish_tool_destw)
+ else
+-publish_ci: publish_liveimage publish_ota_flashfile publish_gptimage publish_ifwi publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) $(PUB_CMCC_ZIP)
++publish_ci: publish_liveimage publish_ota_flashfile publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) $(PUB_CMCC_ZIP)
+ 	$(if $(wildcard $(publish_dest)), \
+ 	  $(foreach f,$(PUBLISH_CI_FILES), \
+ 	    $(if $(wildcard $(f)),$(ACP) $(f) $(publish_dest);,)),)
+-- 
+2.20.1
+

--- a/android_p/google_diff/celadon/device/intel/build/0001-WORKAROUND-CELADON-edit-make-publish_ci.patch
+++ b/android_p/google_diff/celadon/device/intel/build/0001-WORKAROUND-CELADON-edit-make-publish_ci.patch
@@ -1,0 +1,41 @@
+From eb61093121a69c3942bacffaead8cbd6f4f114cf Mon Sep 17 00:00:00 2001
+From: sgnanase <sundar.gnanasekaran@intel.com>
+Date: Wed, 16 Jan 2019 18:31:18 +0530
+Subject: [PATCH] [WORKAROUND][CELADON] edit 'make publish_ci'
+
+gpt image is around 14G in size.
+Hence, removing upload of *gpt_image to artifactory
+untic artifactory speed is improved
+
+<To be reverted once we have artifactory issue fixed>
+
+Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>
+---
+ tasks/publish.mk | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tasks/publish.mk b/tasks/publish.mk
+index f7071f5..4ef6cc6 100644
+--- a/tasks/publish.mk
++++ b/tasks/publish.mk
+@@ -185,7 +185,7 @@ endif # PUBLISH_CONF
+ PUBLISH_CI_FILES := $(DIST_DIR)/fastboot $(DIST_DIR)/adb
+ .PHONY: publish_ci
+ ifeq ($(KERNELFLINGER_SUPPORT_NON_EFI_BOOT), false)
+-publish_ci: publish_liveimage publish_ota_flashfile publish_gptimage publish_ifwi publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) $(PUB_CMCC_ZIP) $(PLATFORM_RMA_TOOLS_ZIP)
++publish_ci: publish_liveimage publish_ota_flashfile publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) $(PUB_CMCC_ZIP) $(PLATFORM_RMA_TOOLS_ZIP)
+ 	$(if $(wildcard $(publish_dest)), \
+ 	  $(foreach f,$(PUBLISH_CI_FILES), \
+ 	    $(if $(wildcard $(f)),$(ACP) $(f) $(publish_dest);,)),)
+@@ -198,7 +198,7 @@ publish_windows_tools: $(PLATFORM_RMA_TOOLS_CROSS_ZIP)
+ 	@$(hide) mkdir -p $(publish_tool_destw)
+ 	@$(hide) $(ACP) $(PLATFORM_RMA_TOOLS_CROSS_ZIP) $(publish_tool_destw)
+ else
+-publish_ci: publish_liveimage publish_ota_flashfile publish_gptimage publish_ifwi publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) $(PUB_CMCC_ZIP)
++publish_ci: publish_liveimage publish_ota_flashfile publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) $(PUB_CMCC_ZIP)
+ 	$(if $(wildcard $(publish_dest)), \
+ 	  $(foreach f,$(PUBLISH_CI_FILES), \
+ 	    $(if $(wildcard $(f)),$(ACP) $(f) $(publish_dest);,)),)
+-- 
+2.20.1
+


### PR DESCRIPTION
gpt image is around 14G in size.
Hence, removing upload of *gpt_image to artifactory
untic artifactory speed is improved

<To be reverted once we have artifactory issue fixed>

Tracked-On: OAM-75233
Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>