### PR TITLE
Fix "disallow user switch" from "Device owner Test" failed

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0027-Fix-disallow-user-switch-from-Device-owner-Test-fail.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0027-Fix-disallow-user-switch-from-Device-owner-Test-fail.patch
@@ -1,0 +1,152 @@
+From 52f5b72fea6b63374008ef6a9d15804148946920 Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Thu, 23 Aug 2018 17:55:44 +0800
+Subject: [PATCH] Fix disallow user switch from Device owner Test failed
+
+if devices are managed by admin, the current user doesn't allow
+to manage the user.
+
+Change-Id: I8f0d8de61e1ffbf4fc0d9294679c3813b8e8a428
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-67336
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ .../android/systemui/qs/car/CarQSFooter.java  | 79 ++++++++++++++++++-
+ 1 file changed, 78 insertions(+), 1 deletion(-)
+
+diff --git a/packages/SystemUI/src/com/android/systemui/qs/car/CarQSFooter.java b/packages/SystemUI/src/com/android/systemui/qs/car/CarQSFooter.java
+index 2ea21c66..6635c4af 100644
+--- a/packages/SystemUI/src/com/android/systemui/qs/car/CarQSFooter.java
++++ b/packages/SystemUI/src/com/android/systemui/qs/car/CarQSFooter.java
+@@ -13,13 +13,20 @@
+  */
+ package com.android.systemui.qs.car;
+ 
++import android.app.AlertDialog;
+ import android.content.Context;
++import android.content.DialogInterface;
+ import android.content.Intent;
+ import android.graphics.drawable.Drawable;
++import android.provider.Settings;
+ import android.support.annotation.Nullable;
+ import android.util.AttributeSet;
+ import android.util.Log;
++import android.view.ContextThemeWrapper;
++import android.view.LayoutInflater;
+ import android.view.View;
++import android.view.ViewGroup;
++import android.view.Window;
+ import android.widget.ImageView;
+ import android.widget.RelativeLayout;
+ import android.widget.TextView;
+@@ -30,15 +37,18 @@ import com.android.systemui.plugins.ActivityStarter;
+ import com.android.systemui.qs.QSFooter;
+ import com.android.systemui.qs.QSPanel;
+ import com.android.systemui.statusbar.phone.MultiUserSwitch;
++import com.android.systemui.statusbar.phone.SystemUIDialog;
+ import com.android.systemui.statusbar.policy.DeviceProvisionedController;
++import com.android.systemui.statusbar.policy.SecurityController;
+ import com.android.systemui.statusbar.policy.UserInfoController;
++import android.content.DialogInterface;
+ 
+ /**
+  * The footer view that displays below the status bar in the auto use-case. This view shows the
+  * user switcher and access to settings.
+  */
+ public class CarQSFooter extends RelativeLayout implements QSFooter,
+-        UserInfoController.OnUserInfoChangedListener {
++        UserInfoController.OnUserInfoChangedListener, DialogInterface.OnClickListener {
+     private static final String TAG = "CarQSFooter";
+ 
+     private UserInfoController mUserInfoController;
+@@ -47,9 +57,14 @@ public class CarQSFooter extends RelativeLayout implements QSFooter,
+     private TextView mUserName;
+     private ImageView mMultiUserAvatar;
+     private CarQSFragment.UserSwitchCallback mUserSwitchCallback;
++    private final SecurityController mSecurityController;
++    private AlertDialog mDialog;
++    private final ActivityStarter mActivityStarter;
+ 
+     public CarQSFooter(Context context, AttributeSet attrs) {
+         super(context, attrs);
++        mSecurityController = Dependency.get(SecurityController.class);
++        mActivityStarter = Dependency.get(ActivityStarter.class);
+     }
+ 
+     @Override
+@@ -62,6 +77,10 @@ public class CarQSFooter extends RelativeLayout implements QSFooter,
+         mUserInfoController = Dependency.get(UserInfoController.class);
+ 
+         mMultiUserSwitch.setOnClickListener(v -> {
++            if (mSecurityController.isDeviceManaged()) {
++                createDialog();
++                return;
++            }
+             if (mUserSwitchCallback == null) {
+                 Log.e(TAG, "CarQSFooter not properly set up; cannot display user switcher.");
+                 return;
+@@ -133,4 +152,62 @@ public class CarQSFooter extends RelativeLayout implements QSFooter,
+     public void setKeyguardShowing(boolean keyguardShowing) {
+         // Do nothing because the footer will not be shown when the keyguard is up.
+     }
++
++    private String getSettingsButton() {
++        return mContext.getString(R.string.monitoring_button_view_policies);
++    }
++
++    private String getPositiveButton() {
++        return mContext.getString(R.string.ok);
++    }
++
++    @Override
++    public void onClick(DialogInterface dialog, int which) {
++        if (which == DialogInterface.BUTTON_NEGATIVE) {
++            final Intent intent = new Intent(Settings.ACTION_ENTERPRISE_PRIVACY_SETTINGS);
++            mDialog.dismiss();
++            mActivityStarter.postStartActivityDismissingKeyguard(intent, 0);
++        }
++    }
++
++    protected CharSequence getManagementMessage(boolean isDeviceManaged,
++                                                CharSequence organizationName) {
++        if (!isDeviceManaged) return null;
++        if (organizationName != null)
++            return mContext.getString(
++                    R.string.monitoring_description_named_management, organizationName);
++        return mContext.getString(R.string.monitoring_description_management);
++    }
++
++    private void createDialog() {
++        final boolean isDeviceManaged = mSecurityController.isDeviceManaged();
++        final CharSequence deviceOwnerOrganization =
++                mSecurityController.getDeviceOwnerOrganizationName();
++        mDialog = new SystemUIDialog(mContext);
++        mDialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
++        View dialogView = LayoutInflater.from(
++                new ContextThemeWrapper(mContext, R.style.Theme_SystemUI_Dialog))
++                .inflate(R.layout.quick_settings_footer_dialog, null, false);
++        mDialog.setView(dialogView);
++        mDialog.setButton(DialogInterface.BUTTON_POSITIVE, getPositiveButton(), this);
++
++        // device management section
++        CharSequence managementMessage = getManagementMessage(isDeviceManaged,
++                deviceOwnerOrganization);
++        if (managementMessage == null) {
++            dialogView.findViewById(R.id.device_management_disclosures).setVisibility(View.GONE);
++        } else {
++            dialogView.findViewById(R.id.device_management_disclosures).setVisibility(View.VISIBLE);
++            TextView deviceManagementWarning =
++                    (TextView) dialogView.findViewById(R.id.device_management_warning);
++            deviceManagementWarning.setText(managementMessage);
++            mDialog.setButton(DialogInterface.BUTTON_NEGATIVE, getSettingsButton(), this);
++        }
++        dialogView.findViewById(R.id.ca_certs_disclosures).setVisibility(View.GONE);
++        dialogView.findViewById(R.id.network_logging_disclosures).setVisibility(View.GONE);
++        dialogView.findViewById(R.id.vpn_disclosures).setVisibility(View.GONE);
++        mDialog.show();
++        mDialog.getWindow().setLayout(ViewGroup.LayoutParams.MATCH_PARENT,
++                ViewGroup.LayoutParams.WRAP_CONTENT);
++    }
+ }
+-- 
+2.20.0
+

--- a/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0008-Fix-disallow-user-switch-for-CTS-Device-owner-Test.patch
+++ b/android_p/google_diff/cel_apl/packages/apps/Car/Settings/0008-Fix-disallow-user-switch-for-CTS-Device-owner-Test.patch
@@ -1,0 +1,62 @@
+From e8fa0f8f97cfb3fa0c717d5ab37d4ab371ee1c50 Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Tue, 15 Jan 2019 17:18:51 +0800
+Subject: [PATCH] Fix disallow user switch for CTS Device owner Test
+
+if devices are managed by admin, the current user doesn't allow
+to manage the user.
+
+bug: 120237874
+Test: Launch CTS-VERIFIER, follow the instruction to start the
+      Device owner Test ->Disallow user switch
+
+Change-Id: I0cf8d1e9f701cc49ff7e400e325294480803422d
+Tracked-On: https://jira.devtools.intel.com/browse/OAM-71178
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+Signed-off-by: Yong Yao <yong.yao@intel.com>
+Reviewed-on: https://android.intel.com:443/642677
+---
+ .../quicksettings/QuickSettingFragment.java         | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/src/com/android/car/settings/quicksettings/QuickSettingFragment.java b/src/com/android/car/settings/quicksettings/QuickSettingFragment.java
+index 92d3d9f..aaddef8 100644
+--- a/src/com/android/car/settings/quicksettings/QuickSettingFragment.java
++++ b/src/com/android/car/settings/quicksettings/QuickSettingFragment.java
+@@ -19,6 +19,7 @@ import android.car.drivingstate.CarUxRestrictions;
+ import android.car.user.CarUserManagerHelper;
+ import android.content.pm.UserInfo;
+ import android.os.Bundle;
++import android.os.UserManager;
+ import android.view.View;
+ import android.view.View.OnClickListener;
+ import android.widget.ImageView;
+@@ -97,6 +98,7 @@ public class QuickSettingFragment extends BaseFragment {
+                 .addTile(new DayNightTile(getContext(), mGridAdapter))
+                 .addTile(new CelluarTile(getContext(), mGridAdapter))
+                 .addSeekbarTile(new BrightnessTile(getContext()));
++        mUserSwitcherBtn.setVisibility(showUserSwitcher() ? View.VISIBLE : View.INVISIBLE);
+     }
+ 
+     @Override
+@@ -115,6 +117,17 @@ public class QuickSettingFragment extends BaseFragment {
+         userSwitcherText.setText(currentUserInfo.name);
+     }
+ 
++    private boolean showUserSwitcher() {
++        UserManager userManager = UserManager.get(getContext());
++        if (userManager.isDeviceInDemoMode(getContext()) || !userManager.supportsMultipleUsers()) {
++            return false;
++        }
++        if (userManager.hasUserRestriction(UserManager.DISALLOW_USER_SWITCH)) {
++            return false;
++        }
++        return true;
++    }
++
+     /**
+      * Quick setting fragment is distraction optimized, so is allowed at all times.
+      */
+-- 
+2.20.0
+

--- a/android_p/google_diff/cel_kbl/frameworks/base/0027-Fix-disallow-user-switch-from-Device-owner-Test-fail.patch
+++ b/android_p/google_diff/cel_kbl/frameworks/base/0027-Fix-disallow-user-switch-from-Device-owner-Test-fail.patch
@@ -1,0 +1,152 @@
+From 52f5b72fea6b63374008ef6a9d15804148946920 Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Thu, 23 Aug 2018 17:55:44 +0800
+Subject: [PATCH] Fix disallow user switch from Device owner Test failed
+
+if devices are managed by admin, the current user doesn't allow
+to manage the user.
+
+Change-Id: I8f0d8de61e1ffbf4fc0d9294679c3813b8e8a428
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-67336
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ .../android/systemui/qs/car/CarQSFooter.java  | 79 ++++++++++++++++++-
+ 1 file changed, 78 insertions(+), 1 deletion(-)
+
+diff --git a/packages/SystemUI/src/com/android/systemui/qs/car/CarQSFooter.java b/packages/SystemUI/src/com/android/systemui/qs/car/CarQSFooter.java
+index 2ea21c66..6635c4af 100644
+--- a/packages/SystemUI/src/com/android/systemui/qs/car/CarQSFooter.java
++++ b/packages/SystemUI/src/com/android/systemui/qs/car/CarQSFooter.java
+@@ -13,13 +13,20 @@
+  */
+ package com.android.systemui.qs.car;
+ 
++import android.app.AlertDialog;
+ import android.content.Context;
++import android.content.DialogInterface;
+ import android.content.Intent;
+ import android.graphics.drawable.Drawable;
++import android.provider.Settings;
+ import android.support.annotation.Nullable;
+ import android.util.AttributeSet;
+ import android.util.Log;
++import android.view.ContextThemeWrapper;
++import android.view.LayoutInflater;
+ import android.view.View;
++import android.view.ViewGroup;
++import android.view.Window;
+ import android.widget.ImageView;
+ import android.widget.RelativeLayout;
+ import android.widget.TextView;
+@@ -30,15 +37,18 @@ import com.android.systemui.plugins.ActivityStarter;
+ import com.android.systemui.qs.QSFooter;
+ import com.android.systemui.qs.QSPanel;
+ import com.android.systemui.statusbar.phone.MultiUserSwitch;
++import com.android.systemui.statusbar.phone.SystemUIDialog;
+ import com.android.systemui.statusbar.policy.DeviceProvisionedController;
++import com.android.systemui.statusbar.policy.SecurityController;
+ import com.android.systemui.statusbar.policy.UserInfoController;
++import android.content.DialogInterface;
+ 
+ /**
+  * The footer view that displays below the status bar in the auto use-case. This view shows the
+  * user switcher and access to settings.
+  */
+ public class CarQSFooter extends RelativeLayout implements QSFooter,
+-        UserInfoController.OnUserInfoChangedListener {
++        UserInfoController.OnUserInfoChangedListener, DialogInterface.OnClickListener {
+     private static final String TAG = "CarQSFooter";
+ 
+     private UserInfoController mUserInfoController;
+@@ -47,9 +57,14 @@ public class CarQSFooter extends RelativeLayout implements QSFooter,
+     private TextView mUserName;
+     private ImageView mMultiUserAvatar;
+     private CarQSFragment.UserSwitchCallback mUserSwitchCallback;
++    private final SecurityController mSecurityController;
++    private AlertDialog mDialog;
++    private final ActivityStarter mActivityStarter;
+ 
+     public CarQSFooter(Context context, AttributeSet attrs) {
+         super(context, attrs);
++        mSecurityController = Dependency.get(SecurityController.class);
++        mActivityStarter = Dependency.get(ActivityStarter.class);
+     }
+ 
+     @Override
+@@ -62,6 +77,10 @@ public class CarQSFooter extends RelativeLayout implements QSFooter,
+         mUserInfoController = Dependency.get(UserInfoController.class);
+ 
+         mMultiUserSwitch.setOnClickListener(v -> {
++            if (mSecurityController.isDeviceManaged()) {
++                createDialog();
++                return;
++            }
+             if (mUserSwitchCallback == null) {
+                 Log.e(TAG, "CarQSFooter not properly set up; cannot display user switcher.");
+                 return;
+@@ -133,4 +152,62 @@ public class CarQSFooter extends RelativeLayout implements QSFooter,
+     public void setKeyguardShowing(boolean keyguardShowing) {
+         // Do nothing because the footer will not be shown when the keyguard is up.
+     }
++
++    private String getSettingsButton() {
++        return mContext.getString(R.string.monitoring_button_view_policies);
++    }
++
++    private String getPositiveButton() {
++        return mContext.getString(R.string.ok);
++    }
++
++    @Override
++    public void onClick(DialogInterface dialog, int which) {
++        if (which == DialogInterface.BUTTON_NEGATIVE) {
++            final Intent intent = new Intent(Settings.ACTION_ENTERPRISE_PRIVACY_SETTINGS);
++            mDialog.dismiss();
++            mActivityStarter.postStartActivityDismissingKeyguard(intent, 0);
++        }
++    }
++
++    protected CharSequence getManagementMessage(boolean isDeviceManaged,
++                                                CharSequence organizationName) {
++        if (!isDeviceManaged) return null;
++        if (organizationName != null)
++            return mContext.getString(
++                    R.string.monitoring_description_named_management, organizationName);
++        return mContext.getString(R.string.monitoring_description_management);
++    }
++
++    private void createDialog() {
++        final boolean isDeviceManaged = mSecurityController.isDeviceManaged();
++        final CharSequence deviceOwnerOrganization =
++                mSecurityController.getDeviceOwnerOrganizationName();
++        mDialog = new SystemUIDialog(mContext);
++        mDialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
++        View dialogView = LayoutInflater.from(
++                new ContextThemeWrapper(mContext, R.style.Theme_SystemUI_Dialog))
++                .inflate(R.layout.quick_settings_footer_dialog, null, false);
++        mDialog.setView(dialogView);
++        mDialog.setButton(DialogInterface.BUTTON_POSITIVE, getPositiveButton(), this);
++
++        // device management section
++        CharSequence managementMessage = getManagementMessage(isDeviceManaged,
++                deviceOwnerOrganization);
++        if (managementMessage == null) {
++            dialogView.findViewById(R.id.device_management_disclosures).setVisibility(View.GONE);
++        } else {
++            dialogView.findViewById(R.id.device_management_disclosures).setVisibility(View.VISIBLE);
++            TextView deviceManagementWarning =
++                    (TextView) dialogView.findViewById(R.id.device_management_warning);
++            deviceManagementWarning.setText(managementMessage);
++            mDialog.setButton(DialogInterface.BUTTON_NEGATIVE, getSettingsButton(), this);
++        }
++        dialogView.findViewById(R.id.ca_certs_disclosures).setVisibility(View.GONE);
++        dialogView.findViewById(R.id.network_logging_disclosures).setVisibility(View.GONE);
++        dialogView.findViewById(R.id.vpn_disclosures).setVisibility(View.GONE);
++        mDialog.show();
++        mDialog.getWindow().setLayout(ViewGroup.LayoutParams.MATCH_PARENT,
++                ViewGroup.LayoutParams.WRAP_CONTENT);
++    }
+ }
+-- 
+2.20.0
+

--- a/android_p/google_diff/cel_kbl/packages/apps/Car/Settings/0006-Fix-disallow-user-switch-for-CTS-Device-owner-Test.patch
+++ b/android_p/google_diff/cel_kbl/packages/apps/Car/Settings/0006-Fix-disallow-user-switch-for-CTS-Device-owner-Test.patch
@@ -1,0 +1,62 @@
+From e8fa0f8f97cfb3fa0c717d5ab37d4ab371ee1c50 Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Tue, 15 Jan 2019 17:18:51 +0800
+Subject: [PATCH] Fix disallow user switch for CTS Device owner Test
+
+if devices are managed by admin, the current user doesn't allow
+to manage the user.
+
+bug: 120237874
+Test: Launch CTS-VERIFIER, follow the instruction to start the
+      Device owner Test ->Disallow user switch
+
+Change-Id: I0cf8d1e9f701cc49ff7e400e325294480803422d
+Tracked-On: https://jira.devtools.intel.com/browse/OAM-71178
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+Signed-off-by: Yong Yao <yong.yao@intel.com>
+Reviewed-on: https://android.intel.com:443/642677
+---
+ .../quicksettings/QuickSettingFragment.java         | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/src/com/android/car/settings/quicksettings/QuickSettingFragment.java b/src/com/android/car/settings/quicksettings/QuickSettingFragment.java
+index 92d3d9f..aaddef8 100644
+--- a/src/com/android/car/settings/quicksettings/QuickSettingFragment.java
++++ b/src/com/android/car/settings/quicksettings/QuickSettingFragment.java
+@@ -19,6 +19,7 @@ import android.car.drivingstate.CarUxRestrictions;
+ import android.car.user.CarUserManagerHelper;
+ import android.content.pm.UserInfo;
+ import android.os.Bundle;
++import android.os.UserManager;
+ import android.view.View;
+ import android.view.View.OnClickListener;
+ import android.widget.ImageView;
+@@ -97,6 +98,7 @@ public class QuickSettingFragment extends BaseFragment {
+                 .addTile(new DayNightTile(getContext(), mGridAdapter))
+                 .addTile(new CelluarTile(getContext(), mGridAdapter))
+                 .addSeekbarTile(new BrightnessTile(getContext()));
++        mUserSwitcherBtn.setVisibility(showUserSwitcher() ? View.VISIBLE : View.INVISIBLE);
+     }
+ 
+     @Override
+@@ -115,6 +117,17 @@ public class QuickSettingFragment extends BaseFragment {
+         userSwitcherText.setText(currentUserInfo.name);
+     }
+ 
++    private boolean showUserSwitcher() {
++        UserManager userManager = UserManager.get(getContext());
++        if (userManager.isDeviceInDemoMode(getContext()) || !userManager.supportsMultipleUsers()) {
++            return false;
++        }
++        if (userManager.hasUserRestriction(UserManager.DISALLOW_USER_SWITCH)) {
++            return false;
++        }
++        return true;
++    }
++
+     /**
+      * Quick setting fragment is distraction optimized, so is allowed at all times.
+      */
+-- 
+2.20.0
+


### PR DESCRIPTION
If devices are managed by the admin, the current user doesn't allow
to manage USER.

Tracked-On: OAM-76693
Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>