### PR TITLE
Sepolicy : Enable /sys/class/thermal access permission

### DIFF
--- a/android_p/google_diff/cel_apl/device/intel/project-celadon/0001-Sepolicy-Enable-sys-class-thermal-access-permission.patch
+++ b/android_p/google_diff/cel_apl/device/intel/project-celadon/0001-Sepolicy-Enable-sys-class-thermal-access-permission.patch
@@ -1,0 +1,39 @@
+From cc0266d1bd74a1f218508640cb14ef416baec799 Mon Sep 17 00:00:00 2001
+From: "Yanhongx.Zhou" <yanhongx.zhou@intel.com>
+Date: Tue, 12 Mar 2019 12:37:34 +0800
+Subject: [PATCH] Sepolicy : Enable /sys/class/thermal access permission
+
+When do adb sideload in recovery mode, there is an error "E: Failed to
+scandir /sys/class/thermal/: Permission denied". There is enable the
+file access permission with SElinux sepolicy.
+
+Tracked-On: OAM-76587
+Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>
+---
+ sepolicy/file_contexts | 2 ++
+ sepolicy/shell.te      | 3 +++
+ 2 files changed, 5 insertions(+)
+ create mode 100644 sepolicy/file_contexts
+
+diff --git a/sepolicy/file_contexts b/sepolicy/file_contexts
+new file mode 100644
+index 0000000..c0fe488
+--- /dev/null
++++ b/sepolicy/file_contexts
+@@ -0,0 +1,2 @@
++/sys/class/thermal(/.*)?                             u:object_r:sysfs_thermal:s0
++/sys/module/thermal(/.*)?                            u:object_r:sysfs_thermal:s0
+diff --git a/sepolicy/shell.te b/sepolicy/shell.te
+index 62ae1bd..3846a06 100644
+--- a/sepolicy/shell.te
++++ b/sepolicy/shell.te
+@@ -2,3 +2,6 @@ allow shell efs_file:dir search;
+ allow shell efs_file:file r_file_perms;
+ allow shell bluetooth_efs_file:dir search;
+ allow shell bluetooth_efs_file:file r_file_perms;
++
++#allow shell read access to sysfs_thermal
++r_dir_file(shell, sysfs_thermal);
+-- 
+2.20.1
+

--- a/android_p/google_diff/cel_kbl/device/intel/project-celadon/0001-Sepolicy-Enable-sys-class-thermal-access-permission.patch
+++ b/android_p/google_diff/cel_kbl/device/intel/project-celadon/0001-Sepolicy-Enable-sys-class-thermal-access-permission.patch
@@ -1,0 +1,39 @@
+From cc0266d1bd74a1f218508640cb14ef416baec799 Mon Sep 17 00:00:00 2001
+From: "Yanhongx.Zhou" <yanhongx.zhou@intel.com>
+Date: Tue, 12 Mar 2019 12:37:34 +0800
+Subject: [PATCH] Sepolicy : Enable /sys/class/thermal access permission
+
+When do adb sideload in recovery mode, there is an error "E: Failed to
+scandir /sys/class/thermal/: Permission denied". There is enable the
+file access permission with SElinux sepolicy.
+
+Tracked-On: OAM-76587
+Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>
+---
+ sepolicy/file_contexts | 2 ++
+ sepolicy/shell.te      | 3 +++
+ 2 files changed, 5 insertions(+)
+ create mode 100644 sepolicy/file_contexts
+
+diff --git a/sepolicy/file_contexts b/sepolicy/file_contexts
+new file mode 100644
+index 0000000..c0fe488
+--- /dev/null
++++ b/sepolicy/file_contexts
+@@ -0,0 +1,2 @@
++/sys/class/thermal(/.*)?                             u:object_r:sysfs_thermal:s0
++/sys/module/thermal(/.*)?                            u:object_r:sysfs_thermal:s0
+diff --git a/sepolicy/shell.te b/sepolicy/shell.te
+index 62ae1bd..3846a06 100644
+--- a/sepolicy/shell.te
++++ b/sepolicy/shell.te
+@@ -2,3 +2,6 @@ allow shell efs_file:dir search;
+ allow shell efs_file:file r_file_perms;
+ allow shell bluetooth_efs_file:dir search;
+ allow shell bluetooth_efs_file:file r_file_perms;
++
++#allow shell read access to sysfs_thermal
++r_dir_file(shell, sysfs_thermal);
+-- 
+2.20.1
+

--- a/android_p/google_diff/celadon/device/intel/project-celadon/0001-Sepolicy-Enable-sys-class-thermal-access-permission.patch
+++ b/android_p/google_diff/celadon/device/intel/project-celadon/0001-Sepolicy-Enable-sys-class-thermal-access-permission.patch
@@ -1,0 +1,39 @@
+From cc0266d1bd74a1f218508640cb14ef416baec799 Mon Sep 17 00:00:00 2001
+From: "Yanhongx.Zhou" <yanhongx.zhou@intel.com>
+Date: Tue, 12 Mar 2019 12:37:34 +0800
+Subject: [PATCH] Sepolicy : Enable /sys/class/thermal access permission
+
+When do adb sideload in recovery mode, there is an error "E: Failed to
+scandir /sys/class/thermal/: Permission denied". There is enable the
+file access permission with SElinux sepolicy.
+
+Tracked-On: OAM-76587
+Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>
+---
+ sepolicy/file_contexts | 2 ++
+ sepolicy/shell.te      | 3 +++
+ 2 files changed, 5 insertions(+)
+ create mode 100644 sepolicy/file_contexts
+
+diff --git a/sepolicy/file_contexts b/sepolicy/file_contexts
+new file mode 100644
+index 0000000..c0fe488
+--- /dev/null
++++ b/sepolicy/file_contexts
+@@ -0,0 +1,2 @@
++/sys/class/thermal(/.*)?                             u:object_r:sysfs_thermal:s0
++/sys/module/thermal(/.*)?                            u:object_r:sysfs_thermal:s0
+diff --git a/sepolicy/shell.te b/sepolicy/shell.te
+index 62ae1bd..3846a06 100644
+--- a/sepolicy/shell.te
++++ b/sepolicy/shell.te
+@@ -2,3 +2,6 @@ allow shell efs_file:dir search;
+ allow shell efs_file:file r_file_perms;
+ allow shell bluetooth_efs_file:dir search;
+ allow shell bluetooth_efs_file:file r_file_perms;
++
++#allow shell read access to sysfs_thermal
++r_dir_file(shell, sysfs_thermal);
+-- 
+2.20.1
+

--- a/android_p/google_diff/clk/device/intel/project-celadon/0001-Sepolicy-Enable-sys-class-thermal-access-permission.patch
+++ b/android_p/google_diff/clk/device/intel/project-celadon/0001-Sepolicy-Enable-sys-class-thermal-access-permission.patch
@@ -1,0 +1,39 @@
+From cc0266d1bd74a1f218508640cb14ef416baec799 Mon Sep 17 00:00:00 2001
+From: "Yanhongx.Zhou" <yanhongx.zhou@intel.com>
+Date: Tue, 12 Mar 2019 12:37:34 +0800
+Subject: [PATCH] Sepolicy : Enable /sys/class/thermal access permission
+
+When do adb sideload in recovery mode, there is an error "E: Failed to
+scandir /sys/class/thermal/: Permission denied". There is enable the
+file access permission with SElinux sepolicy.
+
+Tracked-On: OAM-76587
+Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>
+---
+ sepolicy/file_contexts | 2 ++
+ sepolicy/shell.te      | 3 +++
+ 2 files changed, 5 insertions(+)
+ create mode 100644 sepolicy/file_contexts
+
+diff --git a/sepolicy/file_contexts b/sepolicy/file_contexts
+new file mode 100644
+index 0000000..c0fe488
+--- /dev/null
++++ b/sepolicy/file_contexts
+@@ -0,0 +1,2 @@
++/sys/class/thermal(/.*)?                             u:object_r:sysfs_thermal:s0
++/sys/module/thermal(/.*)?                            u:object_r:sysfs_thermal:s0
+diff --git a/sepolicy/shell.te b/sepolicy/shell.te
+index 62ae1bd..3846a06 100644
+--- a/sepolicy/shell.te
++++ b/sepolicy/shell.te
+@@ -2,3 +2,6 @@ allow shell efs_file:dir search;
+ allow shell efs_file:file r_file_perms;
+ allow shell bluetooth_efs_file:dir search;
+ allow shell bluetooth_efs_file:file r_file_perms;
++
++#allow shell read access to sysfs_thermal
++r_dir_file(shell, sysfs_thermal);
+-- 
+2.20.1
+


### PR DESCRIPTION
When do adb sideload in recovery mode, there is an error "E: Failed to
scandir /sys/class/thermal/: Permission denied". There is enable the
file access permission with SElinux sepolicy.

Tracked-On: OAM-76587
Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>