### PR TITLE
Added Thunderpeak specific product Id.

### DIFF
--- a/android_p/google_diff/cel_kbl/frameworks/base/0029-USB-host-manager-allows-Stone-peak2-and-windstrom-pe.patch
+++ b/android_p/google_diff/cel_kbl/frameworks/base/0029-USB-host-manager-allows-Stone-peak2-and-windstrom-pe.patch
@@ -1,0 +1,26 @@
+From d34cce89b9be54e42faafda2f5f959cdeabc0743 Mon Sep 17 00:00:00 2001
+From: Raveendra Babu Chennakesavulu <raveendra.babu.chennakesavulu@intel.com>
+Date: Thu, 21 Mar 2019 17:19:46 +0530
+Subject: [PATCH] USB host manager allows Stone peak2 and windstrom peak vendor
+ and product ids only, added thunder peak product id to the list of devices
+ allowed to enumarate in Celadon.
+
+Tracked-On:
+Signed-off-by: Babu Chennakesavulu, Raveendra
+			<raveendra.babu.chennakesavulu@intel.com>
+
+diff --git a/services/usb/java/com/android/server/usb/UsbHostManager.java b/services/usb/java/com/android/server/usb/UsbHostManager.java
+index 55f996e1..cfd25c18 100644
+--- a/services/usb/java/com/android/server/usb/UsbHostManager.java
++++ b/services/usb/java/com/android/server/usb/UsbHostManager.java
+@@ -235,6 +235,7 @@ public class UsbHostManager {
+     private VendorIdProductId[] mVidPidBlackList = {
+              new VendorIdProductId(0x8087,0x0a2b),
+              new VendorIdProductId(0x8087,0x0aa7), //dedicated for BT in Celadon
++	     new VendorIdProductId(0x8087,0x0025), // BT with ThP2
+     };
+     /*
+      * UsbHostManager
+-- 
+2.17.1
+


### PR DESCRIPTION
USB host manager allows Stone peak2 and windstrom peak vendor and
product ids only, added thunder peak product id to the list of devices
allowed to enumarate in Celadon.

Tracked-On:
Signed-off-by: Babu Chennakesavulu, Raveendra
			<raveendra.babu.chennakesavulu@intel.com>