### PR TITLE
Don't use nvme passthru for clk in UEFI platform

### DIFF
--- a/android_p/google_diff/clk/hardware/intel/kernelflinger/0006-Revert-me-Don-t-use-nvme-passthru-when-erase-blocks-.patch
+++ b/android_p/google_diff/clk/hardware/intel/kernelflinger/0006-Revert-me-Don-t-use-nvme-passthru-when-erase-blocks-.patch
@@ -1,0 +1,43 @@
+From 4f02a483455a10b65a189a7a9f2e12821610401a Mon Sep 17 00:00:00 2001
+From: Meng Xianglin <xianglinx.meng@intel.com>
+Date: Thu, 11 Apr 2019 09:52:26 +0800
+Subject: [PATCH] [Revert me]: Don't use nvme passthru when erase blocks in
+ UEFI platform
+
+Since there is not any UEFI platform support the write zerror command
+through passthru of NVMe, this command might cause some platform crash,
+so does not use it at all.
+
+Tracked-On: OAM-79434
+Signed-off-by: Meng Xianglin <xianglinx.meng@intel.com>
+---
+ libkernelflinger/nvme.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/libkernelflinger/nvme.c b/libkernelflinger/nvme.c
+index 81fa594..9360fb0 100644
+--- a/libkernelflinger/nvme.c
++++ b/libkernelflinger/nvme.c
+@@ -189,6 +189,19 @@ static EFI_STATUS nvme_erase_blocks(
+ 	UINT32 num;
+ 	EFI_LBA blk;
+ 
++	/* No UEFI platform can support NVME_CMD_WRITE_ZERROS correctly to erase blocks,
++	 * what's worse, this command can cause some platform crash. It's better to shift
++	 * this work to the following fill_zero
++	 */
++	if (is_UEFI()) {
++		/* workround as comment below */
++		if (end - start > 0x04000000) {
++			error(L"Warning: skip erasing 0x%X blocks this time !!!", end - start + 1);
++			return EFI_SUCCESS;
++		}
++		return EFI_UNSUPPORTED;
++	}
++
+ 	debug(L"nvme_erase_blocks: 0x%X blocks", end - start + 1);
+ 	dp = DevicePathFromHandle(handle);
+ 	if (!dp) {
+-- 
+2.20.1
+


### PR DESCRIPTION
Since there is not any UEFI platform support the write zerror command
through passthru of NVMe, this command might cause some platform crash,
so does not use it at all.

Tracked-On: OAM-79434
Signed-off-by: Meng Xianglin <xianglinx.meng@intel.com>