### PR TITLE
SELinux: cherry-pick some AOSP sepolicy rules related with icmp_socket

### DIFF
--- a/android_p/google_diff/cel_apl/system/sepolicy/0006-Update-socket-ioctl-restrictions.patch
+++ b/android_p/google_diff/cel_apl/system/sepolicy/0006-Update-socket-ioctl-restrictions.patch
@@ -1,0 +1,82 @@
+From c54a88fb5bb245c774200721c701489f08924e2a Mon Sep 17 00:00:00 2001
+From: Jeff Vander Stoep <jeffv@google.com>
+Date: Thu, 21 Jun 2018 16:57:58 -0700
+Subject: [PATCH] Update socket ioctl restrictions
+
+Grant access to icmp_socket to netdomain. This was previously
+labeled as rawip_socket which apps are allowed to use. Neverallow
+all other new socket types for apps.
+
+Kernels versions > 4.9 redefine ICMP sockets from rawip_socket
+to icmp_socket. To pass neverallow tests, we need to define
+which IOCTLs are allowed (and disallowed).
+
+Note that this does not change behavior on devices with
+kernel versions <=4.9. However, it is necessary (although not
+sufficient) to pass CTS on kernel version 4.14.
+
+Bug: 110520616
+Test: Grant icmp_socket in net.te and build.
+Change-Id: I5c7cb6867d1a4cd1554a8da0d55daa8e06daf803
+---
+ private/app_neverallows.te | 8 ++++++--
+ private/net.te             | 3 ++-
+ public/domain.te           | 2 +-
+ 3 files changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/private/app_neverallows.te b/private/app_neverallows.te
+index 8d9ccd6..529508e 100644
+--- a/private/app_neverallows.te
++++ b/private/app_neverallows.te
+@@ -70,7 +70,7 @@ neverallow all_untrusted_apps sysfs:file no_rw_file_perms;
+ 
+ # Restrict socket ioctls. Either 1. disallow privileged ioctls, 2. disallow the
+ # ioctl permission, or 3. disallow the socket class.
+-neverallowxperm all_untrusted_apps domain:{ rawip_socket tcp_socket udp_socket } ioctl priv_sock_ioctls;
++neverallowxperm all_untrusted_apps domain:{ icmp_socket rawip_socket tcp_socket udp_socket } ioctl priv_sock_ioctls;
+ neverallow all_untrusted_apps *:{ netlink_route_socket netlink_selinux_socket } ioctl;
+ neverallow all_untrusted_apps *:{
+   socket netlink_socket packet_socket key_socket appletalk_socket
+@@ -79,7 +79,11 @@ neverallow all_untrusted_apps *:{
+   netlink_dnrt_socket netlink_kobject_uevent_socket tun_socket
+   netlink_iscsi_socket netlink_fib_lookup_socket netlink_connector_socket
+   netlink_netfilter_socket netlink_generic_socket netlink_scsitransport_socket
+-  netlink_rdma_socket netlink_crypto_socket
++  netlink_rdma_socket netlink_crypto_socket sctp_socket
++  ax25_socket ipx_socket netrom_socket atmpvc_socket x25_socket rose_socket decnet_socket
++  atmsvc_socket rds_socket irda_socket pppox_socket llc_socket can_socket tipc_socket
++  bluetooth_socket iucv_socket rxrpc_socket isdn_socket phonet_socket ieee802154_socket caif_socket
++  alg_socket nfc_socket vsock_socket kcm_socket qipcrtr_socket smc_socket
+ } *;
+ 
+ # Do not allow untrusted apps access to /cache
+diff --git a/private/net.te b/private/net.te
+index f16daf9..2e6ced3 100644
+--- a/private/net.te
++++ b/private/net.te
+@@ -4,7 +4,8 @@
+ 
+ # Use network sockets.
+ allow netdomain self:tcp_socket create_stream_socket_perms;
+-allow netdomain self:{ udp_socket rawip_socket } create_socket_perms;
++allow netdomain self:{ icmp_socket udp_socket rawip_socket } create_socket_perms;
++
+ # Connect to ports.
+ allow netdomain port_type:tcp_socket name_connect;
+ # Bind to ports.
+diff --git a/public/domain.te b/public/domain.te
+index e9337b6..ea56d33 100644
+--- a/public/domain.te
++++ b/public/domain.te
+@@ -262,7 +262,7 @@ allow domain fs_type:dir getattr;
+ # defaults for all processes. Note that granting this whitelist to domain does
+ # not grant the ioctl permission on these socket types. That must be granted
+ # separately.
+-allowxperm domain domain:{ rawip_socket tcp_socket udp_socket }
++allowxperm domain domain:{ icmp_socket rawip_socket tcp_socket udp_socket }
+   ioctl { unpriv_sock_ioctls unpriv_tty_ioctls };
+ # default whitelist for unix sockets.
+ allowxperm domain domain:{ unix_dgram_socket unix_stream_socket }
+-- 
+2.7.4
+

--- a/android_p/google_diff/cel_apl/system/sepolicy/0007-public-netd.te-allow-netd-to-operate-icmp_socket-tha.patch
+++ b/android_p/google_diff/cel_apl/system/sepolicy/0007-public-netd.te-allow-netd-to-operate-icmp_socket-tha.patch
@@ -1,0 +1,42 @@
+From a8ac933452dcbe25936e4a40ad4a7e9e19769533 Mon Sep 17 00:00:00 2001
+From: Yongqin Liu <yongqin.liu@linaro.org>
+Date: Mon, 2 Jul 2018 18:34:18 +0800
+Subject: [PATCH] public/netd.te: allow netd to operate icmp_socket that passed
+ to it
+
+This should be supplement for the change here:
+https://android-review.googlesource.com/c/platform/system/sepolicy/+/708638
+
+When test the cts libcore.libcore.io.OsTest#test_socketPing test case, it will fail
+with avc denial message like following:
+
+[ 1906.617027] type=1400 audit(1530527518.195:10496): avc: denied { read write } for comm="netd" path="socket:[32066]" dev="sockfs" ino=32066 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1906.617189] type=1400 audit(1530527518.195:10496): avc: denied { read write } for comm="netd" path="socket:[32066]" dev="sockfs" ino=32066 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1906.617206] type=1400 audit(1530527518.195:10497): avc: denied { getopt } for comm="netd" lport=2 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1906.617313] type=1400 audit(1530527518.195:10497): avc: denied { getopt } for comm="netd" lport=2 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1906.617330] type=1400 audit(1530527518.195:10498): avc: denied { setopt } for comm="netd" lport=2 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1907.832425] type=1400 audit(1530527518.195:10498): avc: denied { setopt } for comm="netd" lport=2 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+
+Test: run cts -m CtsLibcoreTestCases -t libcore.libcore.io.OsTest#test_socketPing
+
+Change-Id: If41cb804292834b8994333f170d1f7f837bcd7df
+Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>
+---
+ public/netd.te | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/public/netd.te b/public/netd.te
+index 18113e7..d280756 100644
+--- a/public/netd.te
++++ b/public/netd.te
+@@ -94,6 +94,7 @@ allow netd netd_listener_service:service_manager find;
+ 
+ # Allow netd to operate on sockets that are passed to it.
+ allow netd netdomain:{
++  icmp_socket
+   tcp_socket
+   udp_socket
+   rawip_socket
+-- 
+2.7.4
+

--- a/android_p/google_diff/cel_kbl/system/sepolicy/0006-Update-socket-ioctl-restrictions.patch
+++ b/android_p/google_diff/cel_kbl/system/sepolicy/0006-Update-socket-ioctl-restrictions.patch
@@ -1,0 +1,82 @@
+From c54a88fb5bb245c774200721c701489f08924e2a Mon Sep 17 00:00:00 2001
+From: Jeff Vander Stoep <jeffv@google.com>
+Date: Thu, 21 Jun 2018 16:57:58 -0700
+Subject: [PATCH] Update socket ioctl restrictions
+
+Grant access to icmp_socket to netdomain. This was previously
+labeled as rawip_socket which apps are allowed to use. Neverallow
+all other new socket types for apps.
+
+Kernels versions > 4.9 redefine ICMP sockets from rawip_socket
+to icmp_socket. To pass neverallow tests, we need to define
+which IOCTLs are allowed (and disallowed).
+
+Note that this does not change behavior on devices with
+kernel versions <=4.9. However, it is necessary (although not
+sufficient) to pass CTS on kernel version 4.14.
+
+Bug: 110520616
+Test: Grant icmp_socket in net.te and build.
+Change-Id: I5c7cb6867d1a4cd1554a8da0d55daa8e06daf803
+---
+ private/app_neverallows.te | 8 ++++++--
+ private/net.te             | 3 ++-
+ public/domain.te           | 2 +-
+ 3 files changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/private/app_neverallows.te b/private/app_neverallows.te
+index 8d9ccd6..529508e 100644
+--- a/private/app_neverallows.te
++++ b/private/app_neverallows.te
+@@ -70,7 +70,7 @@ neverallow all_untrusted_apps sysfs:file no_rw_file_perms;
+ 
+ # Restrict socket ioctls. Either 1. disallow privileged ioctls, 2. disallow the
+ # ioctl permission, or 3. disallow the socket class.
+-neverallowxperm all_untrusted_apps domain:{ rawip_socket tcp_socket udp_socket } ioctl priv_sock_ioctls;
++neverallowxperm all_untrusted_apps domain:{ icmp_socket rawip_socket tcp_socket udp_socket } ioctl priv_sock_ioctls;
+ neverallow all_untrusted_apps *:{ netlink_route_socket netlink_selinux_socket } ioctl;
+ neverallow all_untrusted_apps *:{
+   socket netlink_socket packet_socket key_socket appletalk_socket
+@@ -79,7 +79,11 @@ neverallow all_untrusted_apps *:{
+   netlink_dnrt_socket netlink_kobject_uevent_socket tun_socket
+   netlink_iscsi_socket netlink_fib_lookup_socket netlink_connector_socket
+   netlink_netfilter_socket netlink_generic_socket netlink_scsitransport_socket
+-  netlink_rdma_socket netlink_crypto_socket
++  netlink_rdma_socket netlink_crypto_socket sctp_socket
++  ax25_socket ipx_socket netrom_socket atmpvc_socket x25_socket rose_socket decnet_socket
++  atmsvc_socket rds_socket irda_socket pppox_socket llc_socket can_socket tipc_socket
++  bluetooth_socket iucv_socket rxrpc_socket isdn_socket phonet_socket ieee802154_socket caif_socket
++  alg_socket nfc_socket vsock_socket kcm_socket qipcrtr_socket smc_socket
+ } *;
+ 
+ # Do not allow untrusted apps access to /cache
+diff --git a/private/net.te b/private/net.te
+index f16daf9..2e6ced3 100644
+--- a/private/net.te
++++ b/private/net.te
+@@ -4,7 +4,8 @@
+ 
+ # Use network sockets.
+ allow netdomain self:tcp_socket create_stream_socket_perms;
+-allow netdomain self:{ udp_socket rawip_socket } create_socket_perms;
++allow netdomain self:{ icmp_socket udp_socket rawip_socket } create_socket_perms;
++
+ # Connect to ports.
+ allow netdomain port_type:tcp_socket name_connect;
+ # Bind to ports.
+diff --git a/public/domain.te b/public/domain.te
+index e9337b6..ea56d33 100644
+--- a/public/domain.te
++++ b/public/domain.te
+@@ -262,7 +262,7 @@ allow domain fs_type:dir getattr;
+ # defaults for all processes. Note that granting this whitelist to domain does
+ # not grant the ioctl permission on these socket types. That must be granted
+ # separately.
+-allowxperm domain domain:{ rawip_socket tcp_socket udp_socket }
++allowxperm domain domain:{ icmp_socket rawip_socket tcp_socket udp_socket }
+   ioctl { unpriv_sock_ioctls unpriv_tty_ioctls };
+ # default whitelist for unix sockets.
+ allowxperm domain domain:{ unix_dgram_socket unix_stream_socket }
+-- 
+2.7.4
+

--- a/android_p/google_diff/cel_kbl/system/sepolicy/0007-public-netd.te-allow-netd-to-operate-icmp_socket-tha.patch
+++ b/android_p/google_diff/cel_kbl/system/sepolicy/0007-public-netd.te-allow-netd-to-operate-icmp_socket-tha.patch
@@ -1,0 +1,42 @@
+From a8ac933452dcbe25936e4a40ad4a7e9e19769533 Mon Sep 17 00:00:00 2001
+From: Yongqin Liu <yongqin.liu@linaro.org>
+Date: Mon, 2 Jul 2018 18:34:18 +0800
+Subject: [PATCH] public/netd.te: allow netd to operate icmp_socket that passed
+ to it
+
+This should be supplement for the change here:
+https://android-review.googlesource.com/c/platform/system/sepolicy/+/708638
+
+When test the cts libcore.libcore.io.OsTest#test_socketPing test case, it will fail
+with avc denial message like following:
+
+[ 1906.617027] type=1400 audit(1530527518.195:10496): avc: denied { read write } for comm="netd" path="socket:[32066]" dev="sockfs" ino=32066 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1906.617189] type=1400 audit(1530527518.195:10496): avc: denied { read write } for comm="netd" path="socket:[32066]" dev="sockfs" ino=32066 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1906.617206] type=1400 audit(1530527518.195:10497): avc: denied { getopt } for comm="netd" lport=2 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1906.617313] type=1400 audit(1530527518.195:10497): avc: denied { getopt } for comm="netd" lport=2 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1906.617330] type=1400 audit(1530527518.195:10498): avc: denied { setopt } for comm="netd" lport=2 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1907.832425] type=1400 audit(1530527518.195:10498): avc: denied { setopt } for comm="netd" lport=2 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+
+Test: run cts -m CtsLibcoreTestCases -t libcore.libcore.io.OsTest#test_socketPing
+
+Change-Id: If41cb804292834b8994333f170d1f7f837bcd7df
+Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>
+---
+ public/netd.te | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/public/netd.te b/public/netd.te
+index 18113e7..d280756 100644
+--- a/public/netd.te
++++ b/public/netd.te
+@@ -94,6 +94,7 @@ allow netd netd_listener_service:service_manager find;
+ 
+ # Allow netd to operate on sockets that are passed to it.
+ allow netd netdomain:{
++  icmp_socket
+   tcp_socket
+   udp_socket
+   rawip_socket
+-- 
+2.7.4
+

--- a/android_p/google_diff/celadon/system/sepolicy/0006-Update-socket-ioctl-restrictions.patch
+++ b/android_p/google_diff/celadon/system/sepolicy/0006-Update-socket-ioctl-restrictions.patch
@@ -1,0 +1,82 @@
+From c54a88fb5bb245c774200721c701489f08924e2a Mon Sep 17 00:00:00 2001
+From: Jeff Vander Stoep <jeffv@google.com>
+Date: Thu, 21 Jun 2018 16:57:58 -0700
+Subject: [PATCH] Update socket ioctl restrictions
+
+Grant access to icmp_socket to netdomain. This was previously
+labeled as rawip_socket which apps are allowed to use. Neverallow
+all other new socket types for apps.
+
+Kernels versions > 4.9 redefine ICMP sockets from rawip_socket
+to icmp_socket. To pass neverallow tests, we need to define
+which IOCTLs are allowed (and disallowed).
+
+Note that this does not change behavior on devices with
+kernel versions <=4.9. However, it is necessary (although not
+sufficient) to pass CTS on kernel version 4.14.
+
+Bug: 110520616
+Test: Grant icmp_socket in net.te and build.
+Change-Id: I5c7cb6867d1a4cd1554a8da0d55daa8e06daf803
+---
+ private/app_neverallows.te | 8 ++++++--
+ private/net.te             | 3 ++-
+ public/domain.te           | 2 +-
+ 3 files changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/private/app_neverallows.te b/private/app_neverallows.te
+index 8d9ccd6..529508e 100644
+--- a/private/app_neverallows.te
++++ b/private/app_neverallows.te
+@@ -70,7 +70,7 @@ neverallow all_untrusted_apps sysfs:file no_rw_file_perms;
+ 
+ # Restrict socket ioctls. Either 1. disallow privileged ioctls, 2. disallow the
+ # ioctl permission, or 3. disallow the socket class.
+-neverallowxperm all_untrusted_apps domain:{ rawip_socket tcp_socket udp_socket } ioctl priv_sock_ioctls;
++neverallowxperm all_untrusted_apps domain:{ icmp_socket rawip_socket tcp_socket udp_socket } ioctl priv_sock_ioctls;
+ neverallow all_untrusted_apps *:{ netlink_route_socket netlink_selinux_socket } ioctl;
+ neverallow all_untrusted_apps *:{
+   socket netlink_socket packet_socket key_socket appletalk_socket
+@@ -79,7 +79,11 @@ neverallow all_untrusted_apps *:{
+   netlink_dnrt_socket netlink_kobject_uevent_socket tun_socket
+   netlink_iscsi_socket netlink_fib_lookup_socket netlink_connector_socket
+   netlink_netfilter_socket netlink_generic_socket netlink_scsitransport_socket
+-  netlink_rdma_socket netlink_crypto_socket
++  netlink_rdma_socket netlink_crypto_socket sctp_socket
++  ax25_socket ipx_socket netrom_socket atmpvc_socket x25_socket rose_socket decnet_socket
++  atmsvc_socket rds_socket irda_socket pppox_socket llc_socket can_socket tipc_socket
++  bluetooth_socket iucv_socket rxrpc_socket isdn_socket phonet_socket ieee802154_socket caif_socket
++  alg_socket nfc_socket vsock_socket kcm_socket qipcrtr_socket smc_socket
+ } *;
+ 
+ # Do not allow untrusted apps access to /cache
+diff --git a/private/net.te b/private/net.te
+index f16daf9..2e6ced3 100644
+--- a/private/net.te
++++ b/private/net.te
+@@ -4,7 +4,8 @@
+ 
+ # Use network sockets.
+ allow netdomain self:tcp_socket create_stream_socket_perms;
+-allow netdomain self:{ udp_socket rawip_socket } create_socket_perms;
++allow netdomain self:{ icmp_socket udp_socket rawip_socket } create_socket_perms;
++
+ # Connect to ports.
+ allow netdomain port_type:tcp_socket name_connect;
+ # Bind to ports.
+diff --git a/public/domain.te b/public/domain.te
+index e9337b6..ea56d33 100644
+--- a/public/domain.te
++++ b/public/domain.te
+@@ -262,7 +262,7 @@ allow domain fs_type:dir getattr;
+ # defaults for all processes. Note that granting this whitelist to domain does
+ # not grant the ioctl permission on these socket types. That must be granted
+ # separately.
+-allowxperm domain domain:{ rawip_socket tcp_socket udp_socket }
++allowxperm domain domain:{ icmp_socket rawip_socket tcp_socket udp_socket }
+   ioctl { unpriv_sock_ioctls unpriv_tty_ioctls };
+ # default whitelist for unix sockets.
+ allowxperm domain domain:{ unix_dgram_socket unix_stream_socket }
+-- 
+2.7.4
+

--- a/android_p/google_diff/celadon/system/sepolicy/0007-public-netd.te-allow-netd-to-operate-icmp_socket-tha.patch
+++ b/android_p/google_diff/celadon/system/sepolicy/0007-public-netd.te-allow-netd-to-operate-icmp_socket-tha.patch
@@ -1,0 +1,42 @@
+From a8ac933452dcbe25936e4a40ad4a7e9e19769533 Mon Sep 17 00:00:00 2001
+From: Yongqin Liu <yongqin.liu@linaro.org>
+Date: Mon, 2 Jul 2018 18:34:18 +0800
+Subject: [PATCH] public/netd.te: allow netd to operate icmp_socket that passed
+ to it
+
+This should be supplement for the change here:
+https://android-review.googlesource.com/c/platform/system/sepolicy/+/708638
+
+When test the cts libcore.libcore.io.OsTest#test_socketPing test case, it will fail
+with avc denial message like following:
+
+[ 1906.617027] type=1400 audit(1530527518.195:10496): avc: denied { read write } for comm="netd" path="socket:[32066]" dev="sockfs" ino=32066 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1906.617189] type=1400 audit(1530527518.195:10496): avc: denied { read write } for comm="netd" path="socket:[32066]" dev="sockfs" ino=32066 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1906.617206] type=1400 audit(1530527518.195:10497): avc: denied { getopt } for comm="netd" lport=2 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1906.617313] type=1400 audit(1530527518.195:10497): avc: denied { getopt } for comm="netd" lport=2 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1906.617330] type=1400 audit(1530527518.195:10498): avc: denied { setopt } for comm="netd" lport=2 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1907.832425] type=1400 audit(1530527518.195:10498): avc: denied { setopt } for comm="netd" lport=2 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+
+Test: run cts -m CtsLibcoreTestCases -t libcore.libcore.io.OsTest#test_socketPing
+
+Change-Id: If41cb804292834b8994333f170d1f7f837bcd7df
+Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>
+---
+ public/netd.te | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/public/netd.te b/public/netd.te
+index 18113e7..d280756 100644
+--- a/public/netd.te
++++ b/public/netd.te
+@@ -94,6 +94,7 @@ allow netd netd_listener_service:service_manager find;
+ 
+ # Allow netd to operate on sockets that are passed to it.
+ allow netd netdomain:{
++  icmp_socket
+   tcp_socket
+   udp_socket
+   rawip_socket
+-- 
+2.7.4
+

--- a/android_p/google_diff/clk/system/sepolicy/0006-Update-socket-ioctl-restrictions.patch
+++ b/android_p/google_diff/clk/system/sepolicy/0006-Update-socket-ioctl-restrictions.patch
@@ -1,0 +1,82 @@
+From c54a88fb5bb245c774200721c701489f08924e2a Mon Sep 17 00:00:00 2001
+From: Jeff Vander Stoep <jeffv@google.com>
+Date: Thu, 21 Jun 2018 16:57:58 -0700
+Subject: [PATCH] Update socket ioctl restrictions
+
+Grant access to icmp_socket to netdomain. This was previously
+labeled as rawip_socket which apps are allowed to use. Neverallow
+all other new socket types for apps.
+
+Kernels versions > 4.9 redefine ICMP sockets from rawip_socket
+to icmp_socket. To pass neverallow tests, we need to define
+which IOCTLs are allowed (and disallowed).
+
+Note that this does not change behavior on devices with
+kernel versions <=4.9. However, it is necessary (although not
+sufficient) to pass CTS on kernel version 4.14.
+
+Bug: 110520616
+Test: Grant icmp_socket in net.te and build.
+Change-Id: I5c7cb6867d1a4cd1554a8da0d55daa8e06daf803
+---
+ private/app_neverallows.te | 8 ++++++--
+ private/net.te             | 3 ++-
+ public/domain.te           | 2 +-
+ 3 files changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/private/app_neverallows.te b/private/app_neverallows.te
+index 8d9ccd6..529508e 100644
+--- a/private/app_neverallows.te
++++ b/private/app_neverallows.te
+@@ -70,7 +70,7 @@ neverallow all_untrusted_apps sysfs:file no_rw_file_perms;
+ 
+ # Restrict socket ioctls. Either 1. disallow privileged ioctls, 2. disallow the
+ # ioctl permission, or 3. disallow the socket class.
+-neverallowxperm all_untrusted_apps domain:{ rawip_socket tcp_socket udp_socket } ioctl priv_sock_ioctls;
++neverallowxperm all_untrusted_apps domain:{ icmp_socket rawip_socket tcp_socket udp_socket } ioctl priv_sock_ioctls;
+ neverallow all_untrusted_apps *:{ netlink_route_socket netlink_selinux_socket } ioctl;
+ neverallow all_untrusted_apps *:{
+   socket netlink_socket packet_socket key_socket appletalk_socket
+@@ -79,7 +79,11 @@ neverallow all_untrusted_apps *:{
+   netlink_dnrt_socket netlink_kobject_uevent_socket tun_socket
+   netlink_iscsi_socket netlink_fib_lookup_socket netlink_connector_socket
+   netlink_netfilter_socket netlink_generic_socket netlink_scsitransport_socket
+-  netlink_rdma_socket netlink_crypto_socket
++  netlink_rdma_socket netlink_crypto_socket sctp_socket
++  ax25_socket ipx_socket netrom_socket atmpvc_socket x25_socket rose_socket decnet_socket
++  atmsvc_socket rds_socket irda_socket pppox_socket llc_socket can_socket tipc_socket
++  bluetooth_socket iucv_socket rxrpc_socket isdn_socket phonet_socket ieee802154_socket caif_socket
++  alg_socket nfc_socket vsock_socket kcm_socket qipcrtr_socket smc_socket
+ } *;
+ 
+ # Do not allow untrusted apps access to /cache
+diff --git a/private/net.te b/private/net.te
+index f16daf9..2e6ced3 100644
+--- a/private/net.te
++++ b/private/net.te
+@@ -4,7 +4,8 @@
+ 
+ # Use network sockets.
+ allow netdomain self:tcp_socket create_stream_socket_perms;
+-allow netdomain self:{ udp_socket rawip_socket } create_socket_perms;
++allow netdomain self:{ icmp_socket udp_socket rawip_socket } create_socket_perms;
++
+ # Connect to ports.
+ allow netdomain port_type:tcp_socket name_connect;
+ # Bind to ports.
+diff --git a/public/domain.te b/public/domain.te
+index e9337b6..ea56d33 100644
+--- a/public/domain.te
++++ b/public/domain.te
+@@ -262,7 +262,7 @@ allow domain fs_type:dir getattr;
+ # defaults for all processes. Note that granting this whitelist to domain does
+ # not grant the ioctl permission on these socket types. That must be granted
+ # separately.
+-allowxperm domain domain:{ rawip_socket tcp_socket udp_socket }
++allowxperm domain domain:{ icmp_socket rawip_socket tcp_socket udp_socket }
+   ioctl { unpriv_sock_ioctls unpriv_tty_ioctls };
+ # default whitelist for unix sockets.
+ allowxperm domain domain:{ unix_dgram_socket unix_stream_socket }
+-- 
+2.7.4
+

--- a/android_p/google_diff/clk/system/sepolicy/0007-public-netd.te-allow-netd-to-operate-icmp_socket-tha.patch
+++ b/android_p/google_diff/clk/system/sepolicy/0007-public-netd.te-allow-netd-to-operate-icmp_socket-tha.patch
@@ -1,0 +1,42 @@
+From a8ac933452dcbe25936e4a40ad4a7e9e19769533 Mon Sep 17 00:00:00 2001
+From: Yongqin Liu <yongqin.liu@linaro.org>
+Date: Mon, 2 Jul 2018 18:34:18 +0800
+Subject: [PATCH] public/netd.te: allow netd to operate icmp_socket that passed
+ to it
+
+This should be supplement for the change here:
+https://android-review.googlesource.com/c/platform/system/sepolicy/+/708638
+
+When test the cts libcore.libcore.io.OsTest#test_socketPing test case, it will fail
+with avc denial message like following:
+
+[ 1906.617027] type=1400 audit(1530527518.195:10496): avc: denied { read write } for comm="netd" path="socket:[32066]" dev="sockfs" ino=32066 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1906.617189] type=1400 audit(1530527518.195:10496): avc: denied { read write } for comm="netd" path="socket:[32066]" dev="sockfs" ino=32066 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1906.617206] type=1400 audit(1530527518.195:10497): avc: denied { getopt } for comm="netd" lport=2 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1906.617313] type=1400 audit(1530527518.195:10497): avc: denied { getopt } for comm="netd" lport=2 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1906.617330] type=1400 audit(1530527518.195:10498): avc: denied { setopt } for comm="netd" lport=2 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+[ 1907.832425] type=1400 audit(1530527518.195:10498): avc: denied { setopt } for comm="netd" lport=2 scontext=u:r:netd:s0 tcontext=u:r:untrusted_app:s0:c512,c768 tclass=icmp_socket permissive=1
+
+Test: run cts -m CtsLibcoreTestCases -t libcore.libcore.io.OsTest#test_socketPing
+
+Change-Id: If41cb804292834b8994333f170d1f7f837bcd7df
+Signed-off-by: Yongqin Liu <yongqin.liu@linaro.org>
+---
+ public/netd.te | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/public/netd.te b/public/netd.te
+index 18113e7..d280756 100644
+--- a/public/netd.te
++++ b/public/netd.te
+@@ -94,6 +94,7 @@ allow netd netd_listener_service:service_manager find;
+ 
+ # Allow netd to operate on sockets that are passed to it.
+ allow netd netdomain:{
++  icmp_socket
+   tcp_socket
+   udp_socket
+   rawip_socket
+-- 
+2.7.4
+


### PR DESCRIPTION
Tracked-On: OAM-79592
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>