### PR TITLE
usb: xhci: dbc: Add a dbc raw driver to provide a raw interface on DbC

### DIFF
--- a/android_p/google_diff/cel_kbl/kernel/project-celadon/0006-usb-xhci-dbc-Add-a-dbc-raw-driver-to-provide-a-raw-i.patch
+++ b/android_p/google_diff/cel_kbl/kernel/project-celadon/0006-usb-xhci-dbc-Add-a-dbc-raw-driver-to-provide-a-raw-i.patch
@@ -1,0 +1,1703 @@
+From 873f678291458d7a69c57d49c7746be3a6b2edeb Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Tue, 23 Apr 2019 15:29:58 +0530
+Subject: [PATCH] usb: xhci: dbc: Add a dbc raw driver to provide a raw
+ interface on DbC
+
+This patch provides a raw device interface on xhci Debug capability.
+This abstracts dbc functionality to user space inorder to facilitate
+various frameworks to utilize xhci debug capability.
+
+It helps to render the target as an usb debug class device on host and
+establish an usb connection by providing two bulk endpoints.
+
+Added the DbC RAW doc.
+
+[ Fix mutex in file operation open function -Mathias]
+[ Remove extra memory allocation failure message -Mathias]
+Signed-off-by: Rajaram Regupathy <rajaram.regupathy@intel.com>
+Signed-off-by: Abhilash K V <abhilash.k.v@intel.com>
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Reviewed-by: Mathias Nyman <mathias.nyman@linux.intel.com>
+---
+ .../testing/sysfs-bus-pci-drivers-xhci_hcd    | 112 ++++
+ Documentation/usb/dbc_raw.rst                 | 132 +++++
+ Documentation/usb/index.rst                   |  14 +
+ drivers/usb/host/Kconfig                      |  24 +-
+ drivers/usb/host/Makefile                     |   5 +-
+ drivers/usb/host/xhci-dbgcap.c                | 493 ++++++++++++++++--
+ drivers/usb/host/xhci-dbgcap.h                |  36 +-
+ drivers/usb/host/xhci-dbgraw.c                | 365 +++++++++++++
+ drivers/usb/host/xhci-dbgtty.c                |  81 ++-
+ 9 files changed, 1191 insertions(+), 71 deletions(-)
+ create mode 100644 Documentation/usb/dbc_raw.rst
+ create mode 100644 Documentation/usb/index.rst
+ create mode 100644 drivers/usb/host/xhci-dbgraw.c
+
+diff --git a/Documentation/ABI/testing/sysfs-bus-pci-drivers-xhci_hcd b/Documentation/ABI/testing/sysfs-bus-pci-drivers-xhci_hcd
+index 0088aba4caa8..b46b6afc6c4a 100644
+--- a/Documentation/ABI/testing/sysfs-bus-pci-drivers-xhci_hcd
++++ b/Documentation/ABI/testing/sysfs-bus-pci-drivers-xhci_hcd
+@@ -23,3 +23,115 @@ Description:
+		Reading this attribute gives the state of the DbC. It
+		can be one of the following states: disabled, enabled,
+		initialized, connected, configured and stalled.
++
++What:		/sys/bus/pci/drivers/xhci_hcd/.../dbc_function
++Date:		June 2018
++Contact:	Rajaram Regupathy <rajaram.regupathy@intel.com>
++Description:
++		xHCI USB host controllers provide Debug Capability (Dbc)
++		as an extended feature. When configured Dbc presents a
++		debug device which is fully compliant with the USB
++		framework.
++
++		This framework can be utilized to provide various interfaces.
++		By Default, it is configured to provide a serial Interface.
++
++		This attribute lets us configure the interface provided
++		by Dbc functionality. By Default, this attribute value
++		is "TTY" corresponding to the the serial interface. Other
++		values can be supported in future to provide a varied
++		interface to use DbC.
++
++		Reading this attribute gives the interface which is
++		currently configured with DbC. If it is "TTY" then serial
++		interface is configured.
++
++What:		/sys/bus/pci/drivers/xhci_hcd/.../dbc_manufacturer
++Date:		June 2018
++Contact:	Rajaram Regupathy <rajaram.regupathy@intel.com>
++Description:
++		xHCI USB host controllers provide Debug Capability (Dbc)
++		as an extended feature. When configured Dbc presents a
++		debug device which is fully compliant with the USB
++		framework.
++		This attribute lets us change the manufacturer name as
++		presented by the debug device in the USB Manufacturer String
++		descriptor. The default value is "Linux Foundation".
++
++What:		/sys/bus/pci/drivers/xhci_hcd/.../dbc_product
++Date:		June 2018
++Contact:	Rajaram Regupathy <rajaram.regupathy@intel.com>
++Description:
++		xHCI USB host controllers provide Debug Capability (Dbc)
++		as an extended feature. When configured Dbc presents a
++		debug device which is fully compliant with the USB
++		framework.
++		This attribute lets us change the product name as
++		presented by the debug device in the USB Product String
++		descriptor. The default value is "Linux USB Debug Target".
++
++What:		/sys/bus/pci/drivers/xhci_hcd/.../dbc_serial
++Date:		June 2018
++Contact:	Rajaram Regupathy <rajaram.regupathy@intel.com>
++Description:
++		xHCI USB host controllers provide Debug Capability (Dbc)
++		as an extended feature. When configured Dbc presents a
++		debug device which is fully compliant with the USB
++		framework.
++		This attribute lets us change the serial number as
++		presented by the debug device in the USB Serial Number String
++		descriptor. The default value is "0001".
++
++What:		/sys/bus/pci/drivers/xhci_hcd/.../dbc_protocol
++Date:		June 2018
++Contact:	Rajaram Regupathy <rajaram.regupathy@intel.com>
++Description:
++		xHCI USB host controllers provide Debug Capability (Dbc)
++		as an extended feature. When configured Dbc presents a
++		debug device which is fully compliant with the USB
++		framework.
++		This attribute lets us change the bInterfaceProtocol field as
++		presented by the debug device in the USB Interface descriptor.
++
++		The default value is  1  (GNU Remote Debug command).
++		Other permissible value is 0 which is for vendor defined debug
++		target.
++
++What:		/sys/bus/pci/drivers/xhci_hcd/.../dbc_vid
++Date:		June 2018
++Contact:	Rajaram Regupathy <rajaram.regupathy@intel.com>
++Description:
++		xHCI USB host controllers provide Debug Capability (Dbc)
++		as an extended feature. When configured Dbc presents a
++		debug device which is fully compliant with the USB
++		framework.
++		This attribute lets us change the idVendor field as
++		presented by the debug device in the USB Device descriptor.
++		The default value is 0x1d6b (Linux Foundation).
++		It can be any 16-bit integer.
++
++
++What:		/sys/bus/pci/drivers/xhci_hcd/.../dbc_pid
++Date:		June 2018
++Contact:	Rajaram Regupathy <rajaram.regupathy@intel.com>
++Description:
++		xHCI USB host controllers provide Debug Capability (Dbc)
++		as an extended feature. When configured Dbc presents a
++		debug device which is fully compliant with the USB
++		framework.
++		This attribute lets us change the idProduct field as
++		presented by the debug device in the USB Device descriptor.
++		The default value is 0x0010. It can be any 16-bit integer.
++
++What:		/sys/bus/pci/drivers/xhci_hcd/.../dbc_device_rev
++Date:		June 2018
++Contact:	Rajaram Regupathy <rajaram.regupathy@intel.com>
++Description:
++		xHCI USB host controllers provide Debug Capability (Dbc)
++		as an extended feature. When configured Dbc presents a
++		debug device which is fully compliant with the USB
++		framework.
++		This attribute lets us change the bcdDevice field as
++		presented by the debug device in the USB Device descriptor.
++		The default value is 0x0010 (device rev 0.10).
++		It can be any 16-bit integer.
+diff --git a/Documentation/usb/dbc_raw.rst b/Documentation/usb/dbc_raw.rst
+new file mode 100644
+index 000000000000..d7bf9023d9a7
+--- /dev/null
++++ b/Documentation/usb/dbc_raw.rst
+@@ -0,0 +1,132 @@
++======================================
++This described about DBC RAW Interface
++======================================
++
++Content
++========
++
++- DBC Overview
++- Motivation
++- DBC RAW Capabilities
++- Target Build Setup
++- Target Test Setup
++- Host Target Connection
++- Experiment Test Result
++- DBC TTY Use Cases
++- DBC RAW Use Cases
++- Conclusion
++
++DBC Overview
++-------------
++xDBC stands for the USB Debug capability provided extensible Host Controller
++Interface. Universal Serial Bus is a host controlled Bus. Host Controller is
++a hardware whose functionality is to manage usb bus and usb host ports. It is
++responsible for initiating and managing all usb transfers. Extensible Host
++Controller Interface (xHCI) is a register-level interface which provides a
++mechanism by which the host controller (xHC) can communicate with the Operating
++System of the host computer. In addition to exposing register interfaces
++essential for proper functioning of the xHC it also supports many extended
++capabilities which can optionally be implemented by xHC.
++
++It includes Extended Power Management Capability, I/O Virtualization capability
++USB Legacy support capability among many others. USB Debug Capability is one of
++the main extended capabilities supported by xHCI.
++
++This functionality enables low-level system debug over USB. The xHCI debug
++capabilities (xDBC) provides a means of connecting two systems where the system
++is a Debug Host and the other is a Debug target. This is achieved through
++emulating a debug device by using xDBC on the debug target. The debug device
++presented by the debug target can be used by debug host for low level system
++debugging of target.
++
++Motivation
++-----------
++In this patch-set we learn the requirement of new DBC interface called DBC RAW,
++which can be used for platform debugging, large data transfer with comparatively
++10x faster data rate than DBC TTY and it have all the USB specific error handling
++mechanism enabled which DBC TTY doesn't have.
++
++DBC RAW Capabilities
++---------------------
++* Current transfer rate of up to 25.4 MB/s from host to target (using Blocking APIs).
++* Current transfer rate of up to 28.8 MB/s from target to host (using Blocking APIs).
++* Have further scope of improvement in transfer rate of up to USB 3.x speed.
++* This interface can bind with multiple target xHCI (i.e. /dev/dbc_raw0, raw1 etc).
++* It helps to render the target as an usb debug class device on host and establish
++  an usb connection by providing two bulk endpoints.
++* It has support to handle halt bit and send STALL packet.
++
++Target Build Setup
++-------------------
++* Make sure to use Kernel of version >= 4.13.
++* Enable USB_XHCI_DBGCAP in Kernel menuconfig.
++	Device Drivers  ---> USB support  ---> xHCI support for debug capability [Y]
++* Enable DBC RAW in kernel menuconfig.
++	Device Drivers  ---> USB support  ---> Select function for debug capability
++							(xHCI DbC raw driver support)
++* Build Image.
++
++Target Test Setup
++------------------
++* Flash binary with above changes in the target board.
++* Cross check the current DBC function interface, it should be RAW in this case
++  otherwise TTY, below is the sysfs entry for the dbc_function (it's a read only file,
++  switching b/w RAW and TTY is only possible at build time):
++	root@target:/ # cat /sys/bus/pci/devices/0000\:00\:14.0/dbc_function
++	RWA
++* Enable DBC with the following command:
++	root@target:/ # echo enable > /sys/bus/pci/devices/0000\:00\:14.0/dbc
++
++Host Target Connection
++-----------------------
++* Connect Type A to Type A cable between Target and Host.
++* Make sure it is an usb 3.0 cable.
++* At this point debug device should be enumerated on Host side.
++* On Target side dbc sysfs attribute should change to configured state and
++  dbc_raw0 character device should appear under dev directory.
++
++	On Target-:
++		root@target:/ # cat /sys/bus/pci/devices/0000\:00\:14.0/dbc
++		configured
++
++	Target dmesg-:
++		[   32.420018] xhci_hcd 0000:00:14.0: DbC connected
++		[   32.676014] xhci_hcd 0000:00:14.0: DbC configured
++
++	Host dmesg-:
++		[3613626.064257] usb 2-1: new SuperSpeed USB device number 46 using xhci_hcd
++		[3613626.084391] usb 2-1: LPM exit latency is zeroed, disabling LPM.
++		[3613626.084642] usb 2-1: New USB device found, idVendor=1d6b, idProduct=0010
++		[3613626.084647] usb 2-1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
++		[3613626.084651] usb 2-1: Product: Linux USB Debug Target
++		[3613626.084655] usb 2-1: Manufacturer: Linux Foundation
++		[3613626.084658] usb 2-1: SerialNumber: 0001
++
++Experiment Test Result
++-----------------------
++* Transferred 32MB data from host to target with packet size 16KB using blocking
++  APIs and achieved 25.4 MB/s with no data loss.
++* Transferred 32MB data from target to host with packet size 16KB using blocking
++  APIs and achieved 28.8 MB/s with no data loss.
++
++DBC TTY Use Cases
++------------------
++* Used for platform debugging via USB interface, in the absence of serial port.
++* It replace the need of using external serial-to-USB device for console access
++  or for low level debugging.
++* Used to send/receive data between platforms with the limited bandwidth.
++
++DBC RAW Use Cases
++------------------
++* Used at different platform (i.e. Linux, Android, Chrome etc.) for debugging
++  via USB interface.
++* It replace the need of using external serial-to-USB device for console access
++  or for low level debugging.
++* Transfer data with high data rate between platforms via DBC RAW without using
++  USB device controller.
++
++Conclusion
++-----------
++DBC RAW interface transfer data with 10x time faster than DBC TTY. And handle
++all the USB specific error like STALL packet, when the endpoint has had an error
++and its halt bit has been set.
+diff --git a/Documentation/usb/index.rst b/Documentation/usb/index.rst
+new file mode 100644
+index 000000000000..2e3b76a105af
+--- /dev/null
++++ b/Documentation/usb/index.rst
+@@ -0,0 +1,14 @@
++===============================
++Welcome to USB's documentation!
++===============================
++
++.. toctree::
++
++   dbc_raw
++
++.. only::  subproject and html
++
++   Indices
++   =======
++
++   * :ref:`genindex`
+diff --git a/drivers/usb/host/Kconfig b/drivers/usb/host/Kconfig
+index 1a4ea98cac2a..1d3518767c49 100644
+--- a/drivers/usb/host/Kconfig
++++ b/drivers/usb/host/Kconfig
+@@ -29,13 +29,35 @@ config USB_XHCI_HCD
+ if USB_XHCI_HCD
+ config USB_XHCI_DBGCAP
+	bool "xHCI support for debug capability"
+-	depends on TTY
+	---help---
+	  Say 'Y' to enable the support for the xHCI debug capability. Make
+	  sure that your xHCI host supports the extended debug capability and
+	  you want a TTY serial device based on the xHCI debug capability
+	  before enabling this option. If unsure, say 'N'.
+
++choice
++	prompt "Select function for debug capability"
++	depends on USB_XHCI_DBGCAP
++
++config USB_XHCI_DBGCAP_TTY
++	tristate "xHCI DbC tty driver support"
++	depends on USB_XHCI_HCD && USB_XHCI_DBGCAP && TTY
++	help
++	  Say 'Y' to enable the support for the tty driver interface to xHCI
++	  debug capability. This will expose a /dev/ttyDBC* device node on device
++	  which may be used by the usb-debug driver on the debug host.
++	  If unsure, say 'N'.
++
++config USB_XHCI_DBGCAP_RAW
++       tristate "xHCI DbC raw driver support"
++       depends on USB_XHCI_HCD && USB_XHCI_DBGCAP
++       help
++         Say 'Y' to enable the support for the raw driver interface to xHCI
++         debug capability. This will expose a device node corresponding to
++         1 bulk IN and 1 bulk OUT endpoints to be presented to debug host.
++         If unsure, say 'N'.
++endchoice
++
+ config USB_XHCI_PCI
+        tristate
+        depends on USB_PCI
+diff --git a/drivers/usb/host/Makefile b/drivers/usb/host/Makefile
+index e6235269c151..fd79b25e253b 100644
+--- a/drivers/usb/host/Makefile
++++ b/drivers/usb/host/Makefile
+@@ -16,9 +16,12 @@ xhci-hcd-y += xhci-ring.o xhci-hub.o xhci-dbg.o
+ xhci-hcd-y += xhci-trace.o
+
+ ifneq ($(CONFIG_USB_XHCI_DBGCAP), )
+-	xhci-hcd-y += xhci-dbgcap.o xhci-dbgtty.o
++	xhci-hcd-y += xhci-dbgcap.o
+ endif
+
++obj-$(CONFIG_USB_XHCI_DBGCAP_TTY) += xhci-dbgtty.o
++obj-$(CONFIG_USB_XHCI_DBGCAP_RAW) += xhci-dbgraw.o
++
+ ifneq ($(CONFIG_USB_XHCI_MTK), )
+	xhci-hcd-y += xhci-mtk-sch.o
+ endif
+diff --git a/drivers/usb/host/xhci-dbgcap.c b/drivers/usb/host/xhci-dbgcap.c
+index 86cff5c28eff..cc3eab096b5f 100644
+--- a/drivers/usb/host/xhci-dbgcap.c
++++ b/drivers/usb/host/xhci-dbgcap.c
+@@ -9,11 +9,14 @@
+ #include <linux/dma-mapping.h>
+ #include <linux/slab.h>
+ #include <linux/nls.h>
++#include <linux/module.h>
+
+ #include "xhci.h"
+ #include "xhci-trace.h"
+ #include "xhci-dbgcap.h"
+
++static struct dbc_function *dbc_registered_func;
++
+ static inline void *
+ dbc_dma_alloc_coherent(struct xhci_hcd *xhci, size_t size,
+		       dma_addr_t *dma_handle, gfp_t flags)
+@@ -35,41 +38,42 @@ dbc_dma_free_coherent(struct xhci_hcd *xhci, size_t size,
+				  size, cpu_addr, dma_handle);
+ }
+
+-static u32 xhci_dbc_populate_strings(struct dbc_str_descs *strings)
++static u32 xhci_dbc_populate_strings(struct dbc_str_descs *strings,
++					struct dbc_function *func)
+ {
+	struct usb_string_descriptor	*s_desc;
+	u32				string_length;
+
+	/* Serial string: */
+	s_desc = (struct usb_string_descriptor *)strings->serial;
+-	utf8s_to_utf16s(DBC_STRING_SERIAL, strlen(DBC_STRING_SERIAL),
++	utf8s_to_utf16s(func->string.serial, strlen(func->string.serial),
+			UTF16_LITTLE_ENDIAN, (wchar_t *)s_desc->wData,
+			DBC_MAX_STRING_LENGTH);
+
+-	s_desc->bLength		= (strlen(DBC_STRING_SERIAL) + 1) * 2;
++	s_desc->bLength		= (strlen(func->string.serial) + 1) * 2;
+	s_desc->bDescriptorType	= USB_DT_STRING;
+	string_length		= s_desc->bLength;
+	string_length		<<= 8;
+
+	/* Product string: */
+	s_desc = (struct usb_string_descriptor *)strings->product;
+-	utf8s_to_utf16s(DBC_STRING_PRODUCT, strlen(DBC_STRING_PRODUCT),
++	utf8s_to_utf16s(func->string.product, strlen(func->string.product),
+			UTF16_LITTLE_ENDIAN, (wchar_t *)s_desc->wData,
+			DBC_MAX_STRING_LENGTH);
+
+-	s_desc->bLength		= (strlen(DBC_STRING_PRODUCT) + 1) * 2;
++	s_desc->bLength		= (strlen(func->string.product) + 1) * 2;
+	s_desc->bDescriptorType	= USB_DT_STRING;
+	string_length		+= s_desc->bLength;
+	string_length		<<= 8;
+
+	/* Manufacture string: */
+	s_desc = (struct usb_string_descriptor *)strings->manufacturer;
+-	utf8s_to_utf16s(DBC_STRING_MANUFACTURER,
+-			strlen(DBC_STRING_MANUFACTURER),
++	utf8s_to_utf16s(func->string.manufacturer,
++			strlen(func->string.manufacturer),
+			UTF16_LITTLE_ENDIAN, (wchar_t *)s_desc->wData,
+			DBC_MAX_STRING_LENGTH);
+
+-	s_desc->bLength		= (strlen(DBC_STRING_MANUFACTURER) + 1) * 2;
++	s_desc->bLength		= (strlen(func->string.manufacturer) + 1) * 2;
+	s_desc->bDescriptorType	= USB_DT_STRING;
+	string_length		+= s_desc->bLength;
+	string_length		<<= 8;
+@@ -84,7 +88,9 @@ static u32 xhci_dbc_populate_strings(struct dbc_str_descs *strings)
+	return string_length;
+ }
+
+-static void xhci_dbc_init_contexts(struct xhci_hcd *xhci, u32 string_length)
++static void xhci_dbc_init_contexts(struct xhci_hcd *xhci,
++					struct dbc_function *func,
++					u32 string_length)
+ {
+	struct xhci_dbc		*dbc;
+	struct dbc_info_context	*info;
+@@ -124,10 +130,10 @@ static void xhci_dbc_init_contexts(struct xhci_hcd *xhci, u32 string_length)
+	/* Set DbC context and info registers: */
+	xhci_write_64(xhci, dbc->ctx->dma, &dbc->regs->dccp);
+
+-	dev_info = cpu_to_le32((DBC_VENDOR_ID << 16) | DBC_PROTOCOL);
++	dev_info = cpu_to_le32((func->vid << 16) | func->protocol);
+	writel(dev_info, &dbc->regs->devinfo1);
+
+-	dev_info = cpu_to_le32((DBC_DEVICE_REV << 16) | DBC_PRODUCT_ID);
++	dev_info = cpu_to_le32((func->device_rev << 16) | func->pid);
+	writel(dev_info, &dbc->regs->devinfo2);
+ }
+
+@@ -181,11 +187,13 @@ static void xhci_dbc_flush_endpoint_requests(struct dbc_ep *dep)
+		xhci_dbc_flush_single_request(req);
+ }
+
+-static void xhci_dbc_flush_reqests(struct xhci_dbc *dbc)
++
++void xhci_dbc_flush_requests(struct xhci_dbc *dbc)
+ {
+	xhci_dbc_flush_endpoint_requests(&dbc->eps[BULK_OUT]);
+	xhci_dbc_flush_endpoint_requests(&dbc->eps[BULK_IN]);
+ }
++EXPORT_SYMBOL_GPL(xhci_dbc_flush_requests);
+
+ struct dbc_request *
+ dbc_alloc_request(struct dbc_ep *dep, gfp_t gfp_flags)
+@@ -205,6 +213,7 @@ dbc_alloc_request(struct dbc_ep *dep, gfp_t gfp_flags)
+
+	return req;
+ }
++EXPORT_SYMBOL_GPL(dbc_alloc_request);
+
+ void
+ dbc_free_request(struct dbc_ep *dep, struct dbc_request *req)
+@@ -213,6 +222,7 @@ dbc_free_request(struct dbc_ep *dep, struct dbc_request *req)
+
+	kfree(req);
+ }
++EXPORT_SYMBOL_GPL(dbc_free_request);
+
+ static void
+ xhci_dbc_queue_trb(struct xhci_ring *ring, u32 field1,
+@@ -344,6 +354,7 @@ int dbc_ep_queue(struct dbc_ep *dep, struct dbc_request *req,
+
+	return ret;
+ }
++EXPORT_SYMBOL_GPL(dbc_ep_queue);
+
+ static inline void xhci_dbc_do_eps_init(struct xhci_hcd *xhci, bool direction)
+ {
+@@ -371,7 +382,9 @@ static void xhci_dbc_eps_exit(struct xhci_hcd *xhci)
+	memset(dbc->eps, 0, sizeof(struct dbc_ep) * ARRAY_SIZE(dbc->eps));
+ }
+
+-static int xhci_dbc_mem_init(struct xhci_hcd *xhci, gfp_t flags)
++static int xhci_dbc_mem_init(struct xhci_hcd *xhci,
++				struct dbc_function *func,
++				gfp_t flags)
+ {
+	int			ret;
+	dma_addr_t		deq;
+@@ -418,9 +431,9 @@ static int xhci_dbc_mem_init(struct xhci_hcd *xhci, gfp_t flags)
+	xhci_write_64(xhci, deq, &dbc->regs->erdp);
+
+	/* Setup strings and contexts: */
+-	string_length = xhci_dbc_populate_strings(dbc->string);
+-	xhci_dbc_init_contexts(xhci, string_length);
+
++	string_length = xhci_dbc_populate_strings(dbc->string, func);
++	xhci_dbc_init_contexts(xhci, func, string_length);
+	mmiowb();
+
+	xhci_dbc_eps_init(xhci);
+@@ -480,20 +493,9 @@ static int xhci_do_dbc_start(struct xhci_hcd *xhci)
+	u32			ctrl;
+	struct xhci_dbc		*dbc = xhci->dbc;
+
+-	if (dbc->state != DS_DISABLED)
++	if (dbc->state != DS_INITIALIZED)
+		return -EINVAL;
+
+-	writel(0, &dbc->regs->control);
+-	ret = xhci_handshake(&dbc->regs->control,
+-			     DBC_CTRL_DBC_ENABLE,
+-			     0, 1000);
+-	if (ret)
+-		return ret;
+-
+-	ret = xhci_dbc_mem_init(xhci, GFP_ATOMIC);
+-	if (ret)
+-		return ret;
+-
+	ctrl = readl(&dbc->regs->control);
+	writel(ctrl | DBC_CTRL_DBC_ENABLE | DBC_CTRL_PORT_ENABLE,
+	       &dbc->regs->control);
+@@ -516,7 +518,6 @@ static int xhci_do_dbc_stop(struct xhci_hcd *xhci)
+		return -1;
+
+	writel(0, &dbc->regs->control);
+-	xhci_dbc_mem_cleanup(xhci);
+	dbc->state = DS_DISABLED;
+
+	return 0;
+@@ -546,7 +547,7 @@ static int xhci_dbc_start(struct xhci_hcd *xhci)
+
+ static void xhci_dbc_stop(struct xhci_hcd *xhci)
+ {
+-	int ret;
++	int			ret;
+	unsigned long		flags;
+	struct xhci_dbc		*dbc = xhci->dbc;
+	struct dbc_port		*port = &dbc->port;
+@@ -555,15 +556,19 @@ static void xhci_dbc_stop(struct xhci_hcd *xhci)
+
+	cancel_delayed_work_sync(&dbc->event_work);
+
+-	if (port->registered)
+-		xhci_dbc_tty_unregister_device(xhci);
++	if (port->registered
++		&& dbc_registered_func
++		&& dbc_registered_func->post_disconnect)
++		ret = dbc_registered_func->post_disconnect(dbc);
+
+	spin_lock_irqsave(&dbc->lock, flags);
+	ret = xhci_do_dbc_stop(xhci);
+	spin_unlock_irqrestore(&dbc->lock, flags);
+
+-	if (!ret)
++	if (!ret) {
++		xhci_dbc_mem_cleanup(xhci);
+		pm_runtime_put_sync(xhci_to_hcd(xhci)->self.controller);
++	}
+ }
+
+ static void
+@@ -687,7 +692,7 @@ static enum evtreturn xhci_dbc_do_handle_events(struct xhci_dbc *dbc)
+		    !(portsc & DBC_PORTSC_CONN_STATUS)) {
+			xhci_info(xhci, "DbC cable unplugged\n");
+			dbc->state = DS_ENABLED;
+-			xhci_dbc_flush_reqests(dbc);
++			xhci_dbc_flush_requests(dbc);
+
+			return EVT_DISC;
+		}
+@@ -697,7 +702,7 @@ static enum evtreturn xhci_dbc_do_handle_events(struct xhci_dbc *dbc)
+			xhci_info(xhci, "DbC port reset\n");
+			writel(portsc, &dbc->regs->portsc);
+			dbc->state = DS_ENABLED;
+-			xhci_dbc_flush_reqests(dbc);
++			xhci_dbc_flush_requests(dbc);
+
+			return EVT_DISC;
+		}
+@@ -799,16 +804,12 @@ static void xhci_dbc_handle_events(struct work_struct *work)
+
+	switch (evtr) {
+	case EVT_GSER:
+-		ret = xhci_dbc_tty_register_device(xhci);
+-		if (ret) {
+-			xhci_err(xhci, "failed to alloc tty device\n");
+-			break;
+-		}
+-
+-		xhci_info(xhci, "DbC now attached to /dev/ttyDBC0\n");
++		if (dbc_registered_func->post_config)
++			dbc_registered_func->post_config(dbc);
+		break;
+	case EVT_DISC:
+-		xhci_dbc_tty_unregister_device(xhci);
++		if (dbc_registered_func->post_disconnect)
++			ret = dbc_registered_func->post_disconnect(dbc);
+		break;
+	case EVT_DONE:
+		break;
+@@ -872,6 +873,316 @@ static int xhci_do_dbc_init(struct xhci_hcd *xhci)
+	return 0;
+ }
+
++static ssize_t dbc_function_show(struct device *dev,
++			struct device_attribute *attr,
++			char *buf)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	int    count = 0;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (!dbc)
++		return -ENODEV;
++	if (!dbc_registered_func)
++		count += sprintf(buf, "%s\n", "none");
++	else
++		count += sprintf(buf, "%s\n", dbc_registered_func->func_name);
++
++	return count;
++}
++
++static ssize_t dbc_manufacturer_show(struct device *dev,
++			struct device_attribute *attr,
++			char *buf)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	struct usb_string_descriptor    *s_desc;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (!dbc || !dbc->string)
++		return -ENODEV;
++	s_desc = (struct usb_string_descriptor *) dbc->string->manufacturer;
++	return utf16s_to_utf8s((wchar_t *) s_desc->wData, s_desc->bLength / 2,
++			UTF16_LITTLE_ENDIAN, buf, DBC_MAX_STRING_LENGTH);
++}
++
++static ssize_t dbc_manufacturer_store(struct device *dev,
++			 struct device_attribute *attr,
++			 const char *buf, size_t size)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	struct usb_string_descriptor    *s_desc;
++	int ret;
++	struct dbc_info_context	*info;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (dbc->state != DS_DISABLED)
++		return -EBUSY;
++	s_desc = (struct usb_string_descriptor *) dbc->string->manufacturer;
++	ret =  utf8s_to_utf16s(buf, strlen(buf),
++				UTF16_LITTLE_ENDIAN, (wchar_t *)s_desc->wData,
++				DBC_MAX_STRING_LENGTH);
++	if (ret < 0)
++		return ret;
++	s_desc->bLength         = (strlen(buf) + 1) * 2;
++	info			= (struct dbc_info_context *)dbc->ctx->bytes;
++	info->length		= (info->length & ~(0xffu << 8))
++					|  (s_desc->bLength) << 8;
++	return size;
++}
++
++static ssize_t dbc_product_show(struct device *dev,
++			struct device_attribute *attr,
++			char *buf)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	struct usb_string_descriptor    *s_desc;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (!dbc || !dbc->string)
++		return -ENODEV;
++	s_desc = (struct usb_string_descriptor *) dbc->string->product;
++	return utf16s_to_utf8s((wchar_t *) s_desc->wData, s_desc->bLength / 2,
++			UTF16_LITTLE_ENDIAN, buf, DBC_MAX_STRING_LENGTH);
++}
++
++static ssize_t dbc_product_store(struct device *dev,
++			 struct device_attribute *attr,
++			 const char *buf, size_t size)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	struct usb_string_descriptor    *s_desc;
++	int ret;
++	struct dbc_info_context	*info;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (dbc->state != DS_DISABLED)
++		return -EBUSY;
++	s_desc = (struct usb_string_descriptor *) dbc->string->serial;
++	ret = utf8s_to_utf16s(buf, strlen(buf),
++				UTF16_LITTLE_ENDIAN, (wchar_t *)s_desc->wData,
++				DBC_MAX_STRING_LENGTH);
++	if (ret < 0)
++		return ret;
++	s_desc->bLength         = (strlen(buf) + 1) * 2;
++	info			= (struct dbc_info_context *)dbc->ctx->bytes;
++	info->length		= (info->length & ~(0xffu << 16))
++					 |  (s_desc->bLength) << 16;
++	return size;
++}
++
++static ssize_t dbc_serial_show(struct device *dev,
++			struct device_attribute *attr,
++			char *buf)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	struct usb_string_descriptor    *s_desc;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (!dbc || !dbc->string)
++		return -ENODEV;
++	s_desc = (struct usb_string_descriptor *) dbc->string->serial;
++	return utf16s_to_utf8s((wchar_t *) s_desc->wData, s_desc->bLength / 2,
++			UTF16_LITTLE_ENDIAN, buf, DBC_MAX_STRING_LENGTH);
++}
++
++static ssize_t dbc_serial_store(struct device *dev,
++			 struct device_attribute *attr,
++			 const char *buf, size_t size)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	struct usb_string_descriptor    *s_desc;
++	int ret;
++	struct dbc_info_context	*info;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (dbc->state != DS_DISABLED)
++		return -EBUSY;
++	s_desc = (struct usb_string_descriptor *) dbc->string->serial;
++	ret = utf8s_to_utf16s(buf, strlen(buf),
++				UTF16_LITTLE_ENDIAN, (wchar_t *)s_desc->wData,
++				DBC_MAX_STRING_LENGTH);
++	if (ret < 0)
++		return ret;
++	s_desc->bLength         = (strlen(buf) + 1) * 2;
++	info			= (struct dbc_info_context *)dbc->ctx->bytes;
++	info->length		= (info->length & ~(0xffu << 24))
++					 |  (s_desc->bLength) << 24;
++	return size;
++}
++
++static ssize_t dbc_protocol_show(struct device *dev,
++			struct device_attribute *attr,
++			char *buf)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	void __iomem *ptr;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	ptr = &dbc->regs->devinfo1;
++	return sprintf(buf, "%02x\n", le32_to_cpu(readl(ptr)) & 0xff);
++}
++
++static ssize_t dbc_protocol_store(struct device *dev,
++			 struct device_attribute *attr,
++			 const char *buf, size_t size)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	int value;
++	int ret;
++	void __iomem *ptr;
++	u32 dev_info;
++
++	ret = kstrtoint(buf, 0, &value);
++	if (ret || value < 0 || value > 0xff)
++		return -EINVAL;
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (dbc->state != DS_DISABLED)
++		return -EBUSY;
++	ptr = &dbc->regs->devinfo1;
++	dev_info = le32_to_cpu(readl(ptr));
++	dev_info = cpu_to_le32((dev_info & ~(0xffu)) | value);
++	writel(dev_info, ptr);
++	return size;
++}
++
++static ssize_t dbc_vid_show(struct device *dev,
++			struct device_attribute *attr,
++			char *buf)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	void __iomem *ptr;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	ptr = &dbc->regs->devinfo1;
++	return sprintf(buf, "%04x\n", ((u32)le32_to_cpu(readl(ptr))) >> 16);
++}
++
++static ssize_t dbc_vid_store(struct device *dev,
++			 struct device_attribute *attr,
++			 const char *buf, size_t size)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	int value;
++	int ret;
++	void __iomem *ptr;
++	u32 dev_info;
++
++	ret = kstrtoint(buf, 0, &value);
++	if (ret || value < 0 || value > 0xffff)
++		return -EINVAL;
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (dbc->state != DS_DISABLED)
++		return -EBUSY;
++	ptr = &dbc->regs->devinfo1;
++	dev_info = le32_to_cpu(readl(ptr));
++	dev_info = cpu_to_le32((dev_info & ~(0xffffu << 16)) | (value << 16));
++	writel(dev_info, ptr);
++	return size;
++}
++
++
++static ssize_t dbc_pid_show(struct device *dev,
++			struct device_attribute *attr,
++			char *buf)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	void __iomem *ptr;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	ptr = &dbc->regs->devinfo2;
++	return sprintf(buf, "%04x\n", le32_to_cpu(readl(ptr)) & 0xffff);
++}
++
++static ssize_t dbc_pid_store(struct device *dev,
++			 struct device_attribute *attr,
++			 const char *buf, size_t size)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	int value;
++	int ret;
++	void __iomem *ptr;
++	u32 dev_info;
++
++	ret = kstrtoint(buf, 0, &value);
++	if (ret || value < 0 || value > 0xffff)
++		return -EINVAL;
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (dbc->state != DS_DISABLED)
++		return -EBUSY;
++	ptr = &dbc->regs->devinfo2;
++	dev_info = le32_to_cpu(readl(ptr));
++	dev_info = cpu_to_le32((dev_info & ~(0xffffu)) | value);
++	writel(dev_info, ptr);
++	return size;
++}
++
++static ssize_t dbc_device_rev_show(struct device *dev,
++			struct device_attribute *attr,
++			char *buf)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	void __iomem *ptr;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	ptr = &dbc->regs->devinfo2;
++	return sprintf(buf, "%04x\n",  ((u32)le32_to_cpu(readl(ptr))) >> 16);
++}
++
++static ssize_t dbc_device_rev_store(struct device *dev,
++			 struct device_attribute *attr,
++			 const char *buf, size_t size)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	int value;
++	int ret;
++	void __iomem *ptr;
++	u32 dev_info;
++
++	ret = kstrtoint(buf, 0, &value);
++	if (ret || value < 0 || value > 0xffff)
++		return -EINVAL;
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (dbc->state != DS_DISABLED)
++		return -EBUSY;
++	ptr = &dbc->regs->devinfo2;
++	dev_info = le32_to_cpu(readl(ptr));
++	dev_info = cpu_to_le32((dev_info & ~(0xffffu << 16)) | (value << 16));
++	writel(dev_info, ptr);
++	return size;
++}
++
++
+ static ssize_t dbc_show(struct device *dev,
+			struct device_attribute *attr,
+			char *buf)
+@@ -913,21 +1224,74 @@ static ssize_t dbc_store(struct device *dev,
+			 struct device_attribute *attr,
+			 const char *buf, size_t count)
+ {
++	struct xhci_dbc		*dbc;
+	struct xhci_hcd		*xhci;
++	int			ret = 0;
+
+	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
+
+-	if (!strncmp(buf, "enable", 6))
++	if (!strncmp(buf, "enable", 6)) {
++		if (!dbc_registered_func)
++			return -EINVAL;
++		if (!try_module_get(dbc_registered_func->owner))
++			return -ENODEV;
++		ret = xhci_dbc_mem_init(dbc->xhci, dbc_registered_func,
++						GFP_ATOMIC);
++		if (ret)
++			goto err;
++		if (dbc_registered_func->run)
++			ret = dbc_registered_func->run(dbc);
++		if (ret) {
++			xhci_dbc_mem_cleanup(xhci);
++			dbc->state = DS_DISABLED;
++			goto err;
++		}
+		xhci_dbc_start(xhci);
+-	else if (!strncmp(buf, "disable", 7))
++	} else if (!strncmp(buf, "disable", 7)) {
++		if (!dbc_registered_func)
++			return -EINVAL;
+		xhci_dbc_stop(xhci);
+-	else
++		if (dbc_registered_func->stop)
++			dbc_registered_func->stop(dbc);
++		module_put(dbc_registered_func->owner);
++	} else
+		return -EINVAL;
+
+	return count;
++err:
++	module_put(dbc_registered_func->owner);
++	return ret;
+ }
+
+ static DEVICE_ATTR_RW(dbc);
++static DEVICE_ATTR_RO(dbc_function);
++static DEVICE_ATTR_RW(dbc_manufacturer);
++static DEVICE_ATTR_RW(dbc_product);
++static DEVICE_ATTR_RW(dbc_serial);
++
++static DEVICE_ATTR_RW(dbc_protocol);
++static DEVICE_ATTR_RW(dbc_vid);
++static DEVICE_ATTR_RW(dbc_pid);
++static DEVICE_ATTR_RW(dbc_device_rev);
++
++static struct attribute *dbc_dev_attributes[] = {
++	&dev_attr_dbc.attr,
++	&dev_attr_dbc_function.attr,
++	&dev_attr_dbc_manufacturer.attr,
++	&dev_attr_dbc_product.attr,
++	&dev_attr_dbc_serial.attr,
++	&dev_attr_dbc_protocol.attr,
++	&dev_attr_dbc_vid.attr,
++	&dev_attr_dbc_pid.attr,
++	&dev_attr_dbc_device_rev.attr,
++	NULL
++};
++
++static const struct attribute_group dbc_dev_attrib_grp = {
++	.attrs = dbc_dev_attributes,
++};
++
+
+ int xhci_dbc_init(struct xhci_hcd *xhci)
+ {
+@@ -935,24 +1299,18 @@ int xhci_dbc_init(struct xhci_hcd *xhci)
+	struct device		*dev = xhci_to_hcd(xhci)->self.controller;
+
+	ret = xhci_do_dbc_init(xhci);
+-	if (ret)
+-		goto init_err3;
+-
+-	ret = xhci_dbc_tty_register_driver(xhci);
+	if (ret)
+		goto init_err2;
+
+-	ret = device_create_file(dev, &dev_attr_dbc);
++	ret = sysfs_create_group(&dev->kobj, &dbc_dev_attrib_grp);
+	if (ret)
+		goto init_err1;
+
+	return 0;
+
+ init_err1:
+-	xhci_dbc_tty_unregister_driver();
+-init_err2:
+	xhci_do_dbc_exit(xhci);
+-init_err3:
++init_err2:
+	return ret;
+ }
+
+@@ -964,11 +1322,38 @@ void xhci_dbc_exit(struct xhci_hcd *xhci)
+		return;
+
+	device_remove_file(dev, &dev_attr_dbc);
+-	xhci_dbc_tty_unregister_driver();
+	xhci_dbc_stop(xhci);
+	xhci_do_dbc_exit(xhci);
+ }
+
++static inline int is_invalid(int val)
++{
++	return (val <  0 || val > 0xffff);
++}
++
++int xhci_dbc_register_function(struct dbc_function *func)
++{
++	if (dbc_registered_func)
++		return -EBUSY;
++
++	if (is_invalid(func->protocol) ||
++		is_invalid(func->vid) ||
++		is_invalid(func->pid) ||
++		is_invalid(func->device_rev))
++		return -EINVAL;
++	if (!func->run || !func->stop)
++		return -EINVAL;
++	dbc_registered_func = func;
++	return 0;
++}
++EXPORT_SYMBOL_GPL(xhci_dbc_register_function);
++
++void xhci_dbc_unregister_function(void)
++{
++	dbc_registered_func = NULL;
++}
++EXPORT_SYMBOL_GPL(xhci_dbc_unregister_function);
++
+ #ifdef CONFIG_PM
+ int xhci_dbc_suspend(struct xhci_hcd *xhci)
+ {
+diff --git a/drivers/usb/host/xhci-dbgcap.h b/drivers/usb/host/xhci-dbgcap.h
+index ce0c6072bd48..302e6ca72370 100644
+--- a/drivers/usb/host/xhci-dbgcap.h
++++ b/drivers/usb/host/xhci-dbgcap.h
+@@ -11,6 +11,7 @@
+
+ #include <linux/tty.h>
+ #include <linux/kfifo.h>
++#include <linux/kernel.h>
+
+ struct dbc_regs {
+	__le32	capability;
+@@ -48,9 +49,9 @@ struct dbc_info_context {
+
+ #define DBC_MAX_PACKET			1024
+ #define DBC_MAX_STRING_LENGTH		64
+-#define DBC_STRING_MANUFACTURER		"Linux Foundation"
+-#define DBC_STRING_PRODUCT		"Linux USB Debug Target"
+-#define DBC_STRING_SERIAL		"0001"
++#define DBC_STR_MANUFACTURER		"Linux Foundation"
++#define DBC_STR_PRODUCT		"Linux USB Debug Target"
++#define DBC_STR_SERIAL			"0001"
+ #define	DBC_CONTEXT_SIZE		64
+
+ /*
+@@ -75,6 +76,7 @@ struct dbc_str_descs {
+ #define DBC_PRODUCT_ID			0x0010	/* device 0010 */
+ #define DBC_DEVICE_REV			0x0010	/* 0.10 */
+
++
+ enum dbc_state {
+	DS_DISABLED = 0,
+	DS_INITIALIZED,
+@@ -108,6 +110,25 @@ struct dbc_ep {
+	unsigned			direction:1;
+ };
+
++struct dbc_function {
++	char				func_name[32];
++	/* string descriptors */
++	struct dbc_str_descs            string;
++	/* other device or interface descriptors */
++	u16				protocol;
++	u16				vid;
++	u16				pid;
++	u16				device_rev;
++
++	/* callbacks */
++	int (*run)(struct xhci_dbc *dbc);
++	int (*post_config)(struct xhci_dbc *dbc);
++	int (*post_disconnect)(struct xhci_dbc *dbc);
++	int (*stop)(struct xhci_dbc *dbc);
++
++	/* module owner */
++	struct module			*owner;
++};
+ #define DBC_QUEUE_SIZE			16
+ #define DBC_WRITE_BUF_SIZE		8192
+
+@@ -151,6 +172,8 @@ struct xhci_dbc {
+	struct dbc_ep			eps[2];
+
+	struct dbc_port			port;
++	/* priv pointer for a function */
++	void                            *func_priv;
+ };
+
+ #define dbc_bulkout_ctx(d)		\
+@@ -195,13 +218,12 @@ static inline struct dbc_ep *get_out_ep(struct xhci_hcd *xhci)
+ #ifdef CONFIG_USB_XHCI_DBGCAP
+ int xhci_dbc_init(struct xhci_hcd *xhci);
+ void xhci_dbc_exit(struct xhci_hcd *xhci);
+-int xhci_dbc_tty_register_driver(struct xhci_hcd *xhci);
+-void xhci_dbc_tty_unregister_driver(void);
+-int xhci_dbc_tty_register_device(struct xhci_hcd *xhci);
+-void xhci_dbc_tty_unregister_device(struct xhci_hcd *xhci);
+ struct dbc_request *dbc_alloc_request(struct dbc_ep *dep, gfp_t gfp_flags);
++void xhci_dbc_flush_reqests(struct xhci_dbc *dbc);
+ void dbc_free_request(struct dbc_ep *dep, struct dbc_request *req);
+ int dbc_ep_queue(struct dbc_ep *dep, struct dbc_request *req, gfp_t gfp_flags);
++int xhci_dbc_register_function(struct dbc_function *func);
++void xhci_dbc_unregister_function(void);
+ #ifdef CONFIG_PM
+ int xhci_dbc_suspend(struct xhci_hcd *xhci);
+ int xhci_dbc_resume(struct xhci_hcd *xhci);
+diff --git a/drivers/usb/host/xhci-dbgraw.c b/drivers/usb/host/xhci-dbgraw.c
+new file mode 100644
+index 000000000000..a55c4d7a2040
+--- /dev/null
++++ b/drivers/usb/host/xhci-dbgraw.c
+@@ -0,0 +1,365 @@
++// SPDX-License-Identifier: GPL-2.0+
++/**
++ * xhci-dbcraw.c - Raw DbC for xHCI debug capability
++ *
++ * Copyright (C) 2019 Intel Corporation
++ *
++ * Author: Rajaram Regupathy <rajaram.regupathy@intel.com>
++ */
++
++#include <linux/module.h>
++#include <linux/miscdevice.h>
++#include <linux/slab.h>
++#include <linux/idr.h>
++
++#include "xhci.h"
++#include "xhci-dbgcap.h"
++
++#define DBC_XHCI_MINORS     8
++#define DBC_STR_FUNC_RAW    "RAW"
++#define DBC_RAW_BULK_BUFFER_SIZE    (64 * 1024)
++
++static DEFINE_IDR(dbc_minors);
++
++struct dbc_dev {
++	struct mutex dev_excl;
++	struct mutex read_excl;
++	struct mutex write_excl;
++
++	wait_queue_head_t read_wq;
++	wait_queue_head_t write_wq;
++
++	int error;
++	bool in_use;
++	char name[16];
++	struct xhci_dbc *dbc;
++	struct miscdevice misc_dev;
++};
++
++static void xhci_dbc_free_req(struct dbc_ep *dep, struct dbc_request *req)
++{
++	kfree(req->buf);
++	dbc_free_request(dep, req);
++}
++
++struct dbc_request *xhci_dbc_alloc_requests(struct dbc_ep *dep,
++		void (*fn)(struct xhci_hcd *, struct dbc_request *))
++{
++	struct dbc_request *req;
++
++	req = dbc_alloc_request(dep, GFP_KERNEL);
++	if (!req)
++		return req;
++
++	req->length = DBC_RAW_BULK_BUFFER_SIZE;
++	req->buf = kmalloc(req->length, GFP_KERNEL);
++	if (!req->buf)
++		xhci_dbc_free_req(dep, req);
++
++	req->complete = fn;
++
++	return req;
++}
++
++static void dbc_complete_in(struct xhci_hcd *xhci,
++				struct dbc_request *req)
++{
++	struct xhci_dbc *dbc = (struct xhci_dbc *) xhci->dbc;
++	struct dbc_dev *dev = (struct dbc_dev *) dbc->func_priv;
++
++	if (req->status)
++		dev->error = req->status;
++
++	wake_up(&dev->write_wq);
++}
++
++static void dbc_complete_out(struct xhci_hcd *xhci,
++				struct dbc_request *req)
++{
++	struct xhci_dbc *dbc = (struct xhci_dbc *) xhci->dbc;
++	struct dbc_dev *dev = (struct dbc_dev *) dbc->func_priv;
++
++	if (req->status)
++		dev->error = req->status;
++
++	wake_up(&dev->read_wq);
++}
++
++static ssize_t dbc_read(struct file *fp, char __user *buf,
++				size_t count, loff_t *pos)
++{
++	int status = 0;
++	struct dbc_dev *dev = (struct dbc_dev *) fp->private_data;
++	struct xhci_dbc   *dbc = dev->dbc;
++	struct dbc_request *req;
++	struct dbc_port   *port = &dbc->port;
++	int r = count, xfer;
++	int ret;
++
++	if (!dev)
++		return -ENODEV;
++	if (dbc->state != DS_CONFIGURED)
++		return -EAGAIN;
++
++	port->in = get_in_ep(dbc->xhci);
++
++	mutex_lock(&dev->read_excl);
++
++	req = xhci_dbc_alloc_requests(port->in, dbc_complete_out);
++	if (!req) {
++		r = -ENOMEM;
++		goto alloc_fail;
++	}
++
++	req->actual = 0;
++
++	xfer = min_t(size_t, count, DBC_RAW_BULK_BUFFER_SIZE);
++	req->length = xfer;
++
++	status = dbc_ep_queue(port->in, req, GFP_ATOMIC);
++	if (status) {
++		dev->error = status;
++		r = status;
++		goto request_fail;
++	}
++
++	ret = wait_event_interruptible(dev->read_wq,
++			(req->status != -EINPROGRESS));
++
++	if (ret < 0) {
++		r = ret;
++		goto request_fail;
++	}
++
++	if (dev->error) {
++		r = dev->error;
++		goto request_fail;
++	}
++
++	xfer = (req->actual < count) ? req->actual : count;
++	if (!req->actual) {
++		r = 0;
++	} else {
++		r = copy_to_user(buf, req->buf, xfer);
++		if (!r)
++			r = xfer;
++	}
++
++request_fail:
++	xhci_dbc_free_req(port->in, req);
++alloc_fail:
++	mutex_unlock(&dev->read_excl);
++
++	return r;
++}
++
++static ssize_t dbc_write(struct file *fp, const char __user *buf,
++				size_t count, loff_t *pos)
++{
++	int status = 0;
++	struct dbc_dev *dev = (struct dbc_dev *) fp->private_data;
++	struct xhci_dbc *dbc = dev->dbc;
++	struct dbc_request *req = 0;
++	struct dbc_port   *port = &dbc->port;
++	int r = count, xfer;
++	int ret;
++
++	if (!dev)
++		return -ENODEV;
++	if (dbc->state != DS_CONFIGURED)
++		return -EAGAIN;
++
++	port->out = get_out_ep(dbc->xhci);
++
++	mutex_lock(&dev->write_excl);
++
++	/* get an idle tx request to use */
++	req = xhci_dbc_alloc_requests(port->out, dbc_complete_in);
++	if (!req) {
++		r = -ENOMEM;
++		goto alloc_fail;
++	}
++
++	req->actual = 0;
++	xfer = min_t(size_t, count, DBC_RAW_BULK_BUFFER_SIZE);
++
++	ret = copy_from_user(req->buf, buf, xfer);
++	if (ret) {
++		r = ret;
++		goto request_fail;
++	}
++	r = xfer;
++	req->length = xfer;
++	status = dbc_ep_queue(port->out, req, GFP_ATOMIC);
++	if (status) {
++		dev->error = status;
++		r = status;
++		goto request_fail;
++	}
++
++	ret = wait_event_interruptible(dev->write_wq,
++			(req->status != -EINPROGRESS));
++	if (ret < 0)
++		r = ret;
++
++request_fail:
++	xhci_dbc_free_req(port->out, req);
++alloc_fail:
++	mutex_unlock(&dev->write_excl);
++
++	return r;
++}
++
++static int dbc_open(struct inode *ip, struct file *fp)
++{
++	struct dbc_dev *dbc_dev;
++	struct xhci_dbc *dbc;
++
++	dbc_dev = container_of(fp->private_data, struct dbc_dev, misc_dev);
++	if (!dbc_dev || !dbc_dev->dbc)
++		return -ENODEV;
++	dbc = dbc_dev->dbc;
++
++	mutex_lock(&dbc_dev->dev_excl);
++
++	if (dbc_dev->in_use) {
++		mutex_unlock(&dbc_dev->dev_excl);
++		return -EBUSY;
++	}
++	dbc_dev->in_use = true;
++	fp->private_data = dbc_dev;
++
++	/* clear the error latch */
++	dbc_dev->error = 0;
++	mutex_unlock(&dbc_dev->dev_excl);
++
++	return 0;
++}
++
++static int dbc_release(struct inode *ip, struct file *fp)
++{
++	struct dbc_dev *dbc_dev = (struct dbc_dev *) fp->private_data;
++
++	if (!dbc_dev)
++		return -ENODEV;
++
++	mutex_lock(&dbc_dev->dev_excl);
++	dbc_dev->in_use = false;
++	fp->private_data = NULL;
++	mutex_unlock(&dbc_dev->dev_excl);
++
++	return 0;
++}
++
++static const struct file_operations dbc_fops = {
++	.owner = THIS_MODULE,
++	.read = dbc_read,
++	.write = dbc_write,
++	.open = dbc_open,
++	.release = dbc_release,
++};
++
++static int dbc_raw_register_device(struct xhci_hcd *xhci)
++{
++	struct device *devm = xhci->main_hcd->self.controller;
++	struct xhci_dbc *dbc = xhci->dbc;
++	struct dbc_dev *dev;
++	int ret = 0;
++	int id;
++
++	dev = devm_kzalloc(devm, sizeof(*dev), GFP_KERNEL);
++	if (!dev)
++		return -ENOMEM;
++
++	mutex_init(&dev->dev_excl);
++	mutex_init(&dev->read_excl);
++	mutex_init(&dev->write_excl);
++
++	init_waitqueue_head(&dev->read_wq);
++	init_waitqueue_head(&dev->write_wq);
++
++	id = idr_alloc(&dbc_minors, dbc, 0, DBC_XHCI_MINORS,
++			GFP_KERNEL);
++
++	if (id < 0)
++		return id;
++
++	snprintf(dev->name, sizeof(dev->name), "dbc_raw%d", id);
++
++	dev->misc_dev.name = dev->name;
++	dev->misc_dev.minor = MISC_DYNAMIC_MINOR;
++	dev->misc_dev.fops = &dbc_fops;
++
++	ret = misc_register(&dev->misc_dev);
++	if (ret) {
++		kfree(dev->misc_dev.name);
++		pr_err("failed to register misc dev: %d\n", ret);
++		goto error;
++	}
++
++	dev->dbc = dbc;
++	dbc->func_priv = (void *) dev;
++	return ret;
++
++error:
++	idr_remove(&dbc_minors, id);
++
++	return ret;
++}
++
++static void dbc_raw_unregister_device(struct xhci_hcd *xhci)
++{
++	struct xhci_dbc *dbc = xhci->dbc;
++	struct dbc_dev *dbc_dev = (struct dbc_dev *) dbc->func_priv;
++
++	if (dbc_dev) {
++		idr_remove(&dbc_minors, dbc_dev->misc_dev.minor);
++		misc_deregister(&dbc_dev->misc_dev);
++	}
++	idr_destroy(&dbc_minors);
++}
++
++static int dbc_raw_run(struct xhci_dbc *dbc)
++{
++	return dbc_raw_register_device(dbc->xhci);
++}
++
++static int dbc_raw_stop(struct xhci_dbc *dbc)
++{
++	dbc_raw_unregister_device(dbc->xhci);
++	return 0;
++}
++
++static struct dbc_function raw_func = {
++	.owner = THIS_MODULE,
++	.string = {
++		.manufacturer = DBC_STR_MANUFACTURER,
++		.product = DBC_STR_PRODUCT,
++		.serial = DBC_STR_SERIAL,
++	},
++	.protocol = DBC_PROTOCOL,
++	.vid = DBC_VENDOR_ID,
++	.pid = DBC_PRODUCT_ID,
++	.device_rev = DBC_DEVICE_REV,
++	.func_name = DBC_STR_FUNC_RAW,
++
++	.run = dbc_raw_run,
++	.stop = dbc_raw_stop,
++};
++
++static int __init xhci_dbc_raw_init(void)
++{
++	return xhci_dbc_register_function(&raw_func);
++}
++
++static void __exit xhci_dbc_raw_fini(void)
++{
++	xhci_dbc_unregister_function();
++}
++
++late_initcall(xhci_dbc_raw_init);
++module_exit(xhci_dbc_raw_fini);
++
++MODULE_DESCRIPTION("xHCI DbC raw driver");
++MODULE_AUTHOR("Rajaram Regupathy");
++MODULE_LICENSE("GPL v2");
+diff --git a/drivers/usb/host/xhci-dbgtty.c b/drivers/usb/host/xhci-dbgtty.c
+index aff79ff5aba4..f75a95006c51 100644
+--- a/drivers/usb/host/xhci-dbgtty.c
++++ b/drivers/usb/host/xhci-dbgtty.c
+@@ -7,13 +7,15 @@
+  * Author: Lu Baolu <baolu.lu@linux.intel.com>
+  */
+
++#include <linux/module.h>
+ #include <linux/slab.h>
+ #include <linux/tty.h>
+ #include <linux/tty_flip.h>
+-
+ #include "xhci.h"
+ #include "xhci-dbgcap.h"
+
++#define DBC_STR_FUNC_TTY    "TTY"
++
+ static unsigned int
+ dbc_send_packet(struct dbc_port *port, char *packet, unsigned int size)
+ {
+@@ -279,12 +281,11 @@ static const struct tty_operations dbc_tty_ops = {
+	.unthrottle		= dbc_tty_unthrottle,
+ };
+
+-static struct tty_driver *dbc_tty_driver;
+-
+-int xhci_dbc_tty_register_driver(struct xhci_hcd *xhci)
++static int xhci_dbc_tty_register_driver(struct xhci_hcd *xhci)
+ {
+	int			status;
+	struct xhci_dbc		*dbc = xhci->dbc;
++	struct tty_driver	*dbc_tty_driver;
+
+	dbc_tty_driver = tty_alloc_driver(1, TTY_DRIVER_REAL_RAW |
+					  TTY_DRIVER_DYNAMIC_DEV);
+@@ -296,7 +297,6 @@ int xhci_dbc_tty_register_driver(struct xhci_hcd *xhci)
+
+	dbc_tty_driver->driver_name = "dbc_serial";
+	dbc_tty_driver->name = "ttyDBC";
+-
+	dbc_tty_driver->type = TTY_DRIVER_TYPE_SERIAL;
+	dbc_tty_driver->subtype = SERIAL_TYPE_NORMAL;
+	dbc_tty_driver->init_termios = tty_std_termios;
+@@ -315,16 +315,19 @@ int xhci_dbc_tty_register_driver(struct xhci_hcd *xhci)
+		put_tty_driver(dbc_tty_driver);
+		dbc_tty_driver = NULL;
+	}
++	dbc->func_priv = dbc_tty_driver;
+
+	return status;
+ }
+
+-void xhci_dbc_tty_unregister_driver(void)
++static void xhci_dbc_tty_unregister_driver(struct xhci_dbc *dbc)
+ {
++	struct tty_driver	*dbc_tty_driver =
++					(struct tty_driver *) dbc->func_priv;
+	if (dbc_tty_driver) {
+		tty_unregister_driver(dbc_tty_driver);
+		put_tty_driver(dbc_tty_driver);
+-		dbc_tty_driver = NULL;
++		dbc->func_priv = NULL;
+	}
+ }
+
+@@ -440,12 +443,14 @@ xhci_dbc_tty_exit_port(struct dbc_port *port)
+	tty_port_destroy(&port->port);
+ }
+
+-int xhci_dbc_tty_register_device(struct xhci_hcd *xhci)
++static int xhci_dbc_tty_register_device(struct xhci_hcd *xhci)
+ {
+	int			ret;
+	struct device		*tty_dev;
+	struct xhci_dbc		*dbc = xhci->dbc;
+	struct dbc_port		*port = &dbc->port;
++	struct tty_driver	*dbc_tty_driver =
++					(struct tty_driver *) dbc->func_priv;
+
+	xhci_dbc_tty_init_port(xhci, port);
+	tty_dev = tty_port_register_device(&port->port,
+@@ -493,6 +498,8 @@ void xhci_dbc_tty_unregister_device(struct xhci_hcd *xhci)
+ {
+	struct xhci_dbc		*dbc = xhci->dbc;
+	struct dbc_port		*port = &dbc->port;
++	struct tty_driver	*dbc_tty_driver =
++					(struct tty_driver *) dbc->func_priv;
+
+	tty_unregister_device(dbc_tty_driver, 0);
+	xhci_dbc_tty_exit_port(port);
+@@ -503,3 +510,61 @@ void xhci_dbc_tty_unregister_device(struct xhci_hcd *xhci)
+	xhci_dbc_free_requests(get_out_ep(xhci), &port->read_queue);
+	xhci_dbc_free_requests(get_in_ep(xhci), &port->write_pool);
+ }
++
++static int dbc_tty_post_config(struct xhci_dbc *dbc)
++{
++	return xhci_dbc_tty_register_device(dbc->xhci);
++}
++
++static int dbc_tty_post_disconnect(struct xhci_dbc *dbc)
++{
++	xhci_dbc_tty_unregister_device(dbc->xhci);
++	return 0;
++}
++
++static int dbc_tty_run(struct xhci_dbc *dbc)
++{
++	return  xhci_dbc_tty_register_driver(dbc->xhci);
++}
++
++static int dbc_tty_stop(struct xhci_dbc *dbc)
++{
++	xhci_dbc_tty_unregister_driver(dbc);
++	return 0;
++}
++
++static struct dbc_function tty_func = {
++	.owner = THIS_MODULE,
++	.string = {
++		.manufacturer = DBC_STR_MANUFACTURER,
++		.product = DBC_STR_PRODUCT,
++		.serial = DBC_STR_SERIAL,
++	},
++	.protocol = DBC_PROTOCOL,
++	.vid =     DBC_VENDOR_ID,
++	.pid =     DBC_PRODUCT_ID,
++	.device_rev = DBC_DEVICE_REV,
++	.func_name = DBC_STR_FUNC_TTY,
++
++	.post_config = dbc_tty_post_config,
++	.post_disconnect = dbc_tty_post_disconnect,
++	.run = dbc_tty_run,
++	.stop = dbc_tty_stop,
++};
++
++static int __init xhci_dbc_tty_init(void)
++{
++	return xhci_dbc_register_function(&tty_func);
++}
++
++static void __exit xhci_dbc_tty_fini(void)
++{
++	xhci_dbc_unregister_function();
++}
++
++late_initcall(xhci_dbc_tty_init);
++module_exit(xhci_dbc_tty_fini);
++
++MODULE_DESCRIPTION("xHCI DbC tty driver");
++MODULE_AUTHOR("Baoulu Lu");
++MODULE_LICENSE("GPL");
+--
+2.21.0

--- a/android_p/google_diff/cel_kbl/system/core/0025-System-Core-ADB-Adding-DBC-support-in-ADB-Daemon.patch
+++ b/android_p/google_diff/cel_kbl/system/core/0025-System-Core-ADB-Adding-DBC-support-in-ADB-Daemon.patch
@@ -1,0 +1,367 @@
+From 7b58a190961a8433f3eeaeca8491d968be03bf8e Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Mon, 1 Apr 2019 14:53:49 +0530
+Subject: [PATCH] System : Core : ADB : Adding DBC support in ADB Daemon
+
+Added all the adb operation for adb over DBC.
+
+Change-Id: I8b4120d5d88fe1e4348f1f5a2512f0695bb1aa41
+Tracked-On:
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+---
+ adb/adb.h                |   5 ++
+ adb/client/usb_linux.cpp |  45 ++++++++++++++
+ adb/commandline.cpp      |  12 ++--
+ adb/daemon/main.cpp      |   3 +-
+ adb/daemon/usb.cpp       | 131 ++++++++++++++++++++++++++++++++++++++-
+ adb/daemon/usb.h         |   1 +
+ adb/transport_usb.cpp    |  11 +++-
+ 7 files changed, 199 insertions(+), 9 deletions(-)
+
+diff --git a/adb/adb.h b/adb/adb.h
+index 65b5fc00d..5c8cd78bc 100644
+--- a/adb/adb.h
++++ b/adb/adb.h
+@@ -187,6 +187,10 @@ void put_apacket(apacket* p);
+ #define ADB_SUBCLASS 0x42
+ #define ADB_PROTOCOL 0x1
+
++#define ADB_DBC_CLASS 0xDC
++#define ADB_DBC_SUBCLASS 0x2
++#define ADB_DBC_PROTOCOL 0x1
++
+ void local_init(int port);
+ bool local_connect(int port);
+ int local_connect_arbitrary_ports(int console_port, int adb_port, std::string* error);
+@@ -204,6 +208,7 @@ extern const char* adb_device_banner;
+ #define USB_FFS_ADB_EP0 USB_FFS_ADB_EP(ep0)
+ #define USB_FFS_ADB_OUT USB_FFS_ADB_EP(ep1)
+ #define USB_FFS_ADB_IN USB_FFS_ADB_EP(ep2)
++#define USB_DBC_ADB_PATH  "/dev/dbc_raw0"
+ #endif
+
+ int handle_host_request(const char* service, TransportType type, const char* serial,
+diff --git a/adb/client/usb_linux.cpp b/adb/client/usb_linux.cpp
+index 1f376a4c9..d5a47070d 100644
+--- a/adb/client/usb_linux.cpp
++++ b/adb/client/usb_linux.cpp
+@@ -350,6 +350,9 @@ static int usb_bulk_read(usb_handle* h, void* data, int len) {
+     urb->buffer = data;
+     urb->buffer_length = len;
+
++    usbdevfs_ctrltransfer ufs;
++    unsigned short int ufsdata;
++
+     if (h->dead) {
+         errno = EINVAL;
+         return -1;
+@@ -364,13 +367,55 @@ static int usb_bulk_read(usb_handle* h, void* data, int len) {
+         D("[ reap urb - wait ]");
+         h->reaper_thread = pthread_self();
+         int fd = h->fd;
++
++        ufsdata = 0;
++        ufs.bRequestType = 0x82;
++        ufs.bRequest = USB_REQ_GET_STATUS;
++        ufs.wValue = 0x0000;
++        ufs.wIndex = h->ep_in;
++        ufs.wLength = 0x0002;
++        ufs.data = &ufsdata;
++
++        if(TEMP_FAILURE_RETRY(ioctl(h->fd,USBDEVFS_CONTROL,&ufs))== -1)
++        {
++            D("clear_halt read failed");}
++        else
++        {
++            D("clear_halt read successful %d",ufsdata);
++        }
++
++        if(ufsdata)
++        {
++            ufs.bRequestType = 0x02;
++            ufs.bRequest = USB_REQ_CLEAR_FEATURE;
++            ufs.wValue = 0x0000;
++            ufs.wIndex = h->ep_out;
++            ufs.wLength = 0x0000;
++            ufs.data = NULL;
++
++            if(TEMP_FAILURE_RETRY(ioctl(h->fd,USBDEVFS_CONTROL,&ufs))== -1)
++            {
++                D("clear_halt read2 failed");
++            }
++            else
++            {
++                D("clear_halt read2 successful ");
++            }
++        errno = ETIMEDOUT;
++        return -1;
++        }
++
+         lock.unlock();
+
+         // This ioctl must not have TEMP_FAILURE_RETRY because we send SIGALRM to break out.
++
+         usbdevfs_urb* out = nullptr;
++        D("before reap urb");
++
+         int res = ioctl(fd, USBDEVFS_REAPURB, &out);
+         int saved_errno = errno;
+
++        D("after reap urb");
+         lock.lock();
+         h->reaper_thread = 0;
+         if (h->dead) {
+diff --git a/adb/commandline.cpp b/adb/commandline.cpp
+index 6981ff25c..f12a47b0c 100644
+--- a/adb/commandline.cpp
++++ b/adb/commandline.cpp
+@@ -68,6 +68,7 @@ static int install_multiple_app(int argc, const char** argv);
+ static int uninstall_app(int argc, const char** argv);
+ static int install_app_legacy(int argc, const char** argv);
+ static int uninstall_app_legacy(int argc, const char** argv);
++static int adb_query_command(const std::string& command);
+
+ extern int gListenAll;
+
+@@ -1041,7 +1042,12 @@ static bool adb_root(const char* command) {
+         return false;
+     }
+
++    // Give adbd some time to kill itself and come back up.
++    // We can't use wait-for-device because devices (e.g. adb over network) might not come back.
++    std::this_thread::sleep_for(1s);
++
+     // Figure out whether we actually did anything.
++/*
+     char buf[256];
+     char* cur = buf;
+     ssize_t bytes_left = sizeof(buf);
+@@ -1067,10 +1073,8 @@ static bool adb_root(const char* command) {
+     if (cur != buf && strstr(buf, "restarting") == nullptr) {
+         return true;
+     }
++*/
+
+-    // Give adbd some time to kill itself and come back up.
+-    // We can't use wait-for-device because devices (e.g. adb over network) might not come back.
+-    std::this_thread::sleep_for(3s);
+     return true;
+ }
+
+@@ -1613,7 +1617,7 @@ int adb_commandline(int argc, const char** argv) {
+         }
+         return adb_connect_command(command);
+     } else if (!strcmp(argv[0], "root") || !strcmp(argv[0], "unroot")) {
+-        return adb_root(argv[0]) ? 0 : 1;
++        return adb_root(argv[0]) ? adb_query_command(format_host_command("reconnect")) : 1;
+     } else if (!strcmp(argv[0], "bugreport")) {
+         Bugreport bugreport;
+         return bugreport.DoIt(argc, argv);
+diff --git a/adb/daemon/main.cpp b/adb/daemon/main.cpp
+index 5adeb4446..7805bdbe3 100644
+--- a/adb/daemon/main.cpp
++++ b/adb/daemon/main.cpp
+@@ -26,6 +26,7 @@
+ #include <sys/capability.h>
+ #include <sys/prctl.h>
+
++#include <stdio.h>
+ #include <memory>
+
+ #include <android-base/logging.h>
+@@ -202,7 +203,7 @@ int adbd_main(int server_port) {
+     drop_privileges(server_port);
+
+     bool is_usb = false;
+-    if (access(USB_FFS_ADB_EP0, F_OK) == 0) {
++    if ( (access(USB_FFS_ADB_EP0, F_OK) == 0) || (access(USB_DBC_ADB_PATH,F_OK) == 0) ) {
+         // Listen on USB.
+         usb_init();
+         is_usb = true;
+diff --git a/adb/daemon/usb.cpp b/adb/daemon/usb.cpp
+index 78693248d..60e05a849 100644
+--- a/adb/daemon/usb.cpp
++++ b/adb/daemon/usb.cpp
+@@ -50,7 +50,16 @@ using namespace std::chrono_literals;
+ #define MAX_PACKET_SIZE_HS 512
+ #define MAX_PACKET_SIZE_SS 1024
+
+-#define USB_FFS_BULK_SIZE 16384
++// Kernels before 3.3 have a 16KiB transfer limit  That limit was replaced
++// with a 16MiB global limit in 3.3, but each URB submitted required a
++// contiguous kernel allocation, so you would get ENOMEM if you tried to
++// send something larger than the biggest available contiguous kernel
++// memory region. Large contiguous allocations could be unreliable
++// on a device kernel that has been running for a while fragmenting its
++// memory so we start with a larger allocation, and shrink the amount if
++// necessary.
++#define USB_FFS_BULK_SIZE (64*1024)
++#define USB_DBC_BULK_SIZE (64*1024)
+
+ // Number of buffers needed to fit MAX_PAYLOAD, with an extra for ZLPs.
+ #define USB_FFS_NUM_BUFS ((MAX_PAYLOAD / USB_FFS_BULK_SIZE) + 1)
+@@ -531,10 +540,128 @@ static void usb_ffs_init() {
+     std::thread(usb_ffs_open_thread, h).detach();
+ }
+
++bool init_dbc_raw(struct usb_handle* h) {
++    D("init_dbc_raw called\n");
++    h->max_rw = USB_DBC_BULK_SIZE;
++
++    h->bulk_out = adb_open(USB_DBC_ADB_PATH, O_RDWR);
++    if (h->bulk_out < 0) {
++        D("[ %s: cannot open bulk-out ep: errno=%d ]", USB_DBC_ADB_PATH, errno);
++        goto err;
++    }
++
++    h->bulk_in = h->bulk_out;
++    h->control = h->bulk_out;
++
++    return true;
++
++err:
++    h->bulk_out = -1;
++    h->bulk_in = -1;
++    h->control = -1;
++    return false;
++}
++
++static void usb_dbc_open_thread(void* x) {
++    struct usb_handle* usb = (struct usb_handle*)x;
++
++    adb_thread_setname("usb dbc open");
++    D("dbc_open_thread called\n");
++    while (true) {
++        // wait until the USB device needs opening
++        std::unique_lock<std::mutex> lock(usb->lock);
++        while (!usb->open_new_connection) {
++            usb->notify.wait(lock);
++        }
++        usb->open_new_connection = false;
++        lock.unlock();
++
++        while (true) {
++            if (init_dbc_raw(usb)) {
++                break;
++            }
++            std::this_thread::sleep_for(1s);
++        }
++
++        D("register usb transport\n");
++        register_usb_transport(usb, 0, 0, 1);
++    }
++
++    // never gets here
++    abort();
++}
++
++static int usb_dbc_write(usb_handle* h, const void* data, int len) {
++    D("about to write (fd=%d, len=%d)", h->bulk_in, len);
++
++    const char* buf = static_cast<const char*>(data);
++    while (len > 0) {
++        int write_len = std::min(h->max_rw, len);
++        int n = adb_write(h->bulk_in, buf, write_len);
++        if (n < 0) {
++            D("ERROR: fd = %d, n = %d: %s", h->bulk_in, n, strerror(errno));
++            return -1;
++        }
++        buf += n;
++        len -= n;
++    }
++
++    D("[ done fd=%d ]", h->bulk_in);
++    return 0;
++}
++
++static int usb_dbc_read(usb_handle* h, void* data, int len) {
++    D("about to read (fd=%d, len=%d)", h->bulk_out, len);
++
++    char* buf = static_cast<char*>(data);
++    while (len > 0) {
++        int read_len = std::min(h->max_rw, len);
++        int n = adb_read(h->bulk_out, buf, read_len);
++        if (n < 0) {
++            D("ERROR: fd = %d, n = %d: %s", h->bulk_out, n, strerror(errno));
++            return -1;
++        }
++        buf += n;
++        len -= n;
++    }
++    D("[ done fd=%d ]", h->bulk_out);
++    return 0;
++}
++
++static void usb_dbc_close(usb_handle* h) {
++    h->kicked = false;
++		D("usb_dbc_close called\n");
++    adb_close(h->bulk_out);
++    // Notify usb_adb_open_thread to open a new connection.
++    h->lock.lock();
++    h->open_new_connection = true;
++    h->lock.unlock();
++    h->notify.notify_one();
++}
++
++static void usb_dbc_init() {
++    D("[ usb_init - using dbc ]");
++
++    usb_handle* h = new usb_handle();
++
++    h->write = usb_dbc_write;
++    h->read = usb_dbc_read;
++    h->close = usb_dbc_close;
++
++    D("[ usb_init - starting thread ]");
++    std::thread(usb_dbc_open_thread, h).detach();
++}
++
++
+ void usb_init() {
+     dummy_fd = adb_open("/dev/null", O_WRONLY);
+     CHECK_NE(dummy_fd, -1);
+-    usb_ffs_init();
++
++    if (access(USB_DBC_ADB_PATH,F_OK) == 0)
++        usb_dbc_init();
++    else
++        usb_ffs_init();
++
+ }
+
+ int usb_write(usb_handle* h, const void* data, int len) {
+diff --git a/adb/daemon/usb.h b/adb/daemon/usb.h
+index 15a7f6539..5ca9919a7 100644
+--- a/adb/daemon/usb.h
++++ b/adb/daemon/usb.h
+@@ -54,5 +54,6 @@ struct usb_handle {
+     // read and write threads.
+     struct aio_block read_aiob;
+     struct aio_block write_aiob;
++    int max_rw;
+ };
+
+diff --git a/adb/transport_usb.cpp b/adb/transport_usb.cpp
+index d7565f63d..1427476ad 100644
+--- a/adb/transport_usb.cpp
++++ b/adb/transport_usb.cpp
+@@ -179,8 +179,15 @@ void init_usb_transport(atransport* t, usb_handle* h) {
+     t->type = kTransportUsb;
+ }
+
+-int is_adb_interface(int usb_class, int usb_subclass, int usb_protocol) {
+-    return (usb_class == ADB_CLASS && usb_subclass == ADB_SUBCLASS && usb_protocol == ADB_PROTOCOL);
++int is_adb_interface(int usb_class, int usb_subclass, int usb_protocol)
++{
++
++    if ( (usb_class == ADB_CLASS && usb_subclass == ADB_SUBCLASS && usb_protocol == ADB_PROTOCOL) ||
++     (usb_class == ADB_DBC_CLASS && usb_subclass == ADB_DBC_SUBCLASS && usb_protocol == ADB_DBC_PROTOCOL))
++        return true;
++    else
++        return false;
++
+ }
+
+ bool should_use_libusb() {
+--
+2.17.1


### PR DESCRIPTION
This patch provides a raw device interface on xhci Debug capability.
This abstracts dbc functionality to user space inorder to facilitate
various frameworks to utilize xhci debug capability.

Tracked-On: OAM-66343
Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>