### PR TITLE
Fix data source for HEIF exif extractor

### DIFF
--- a/android_p/google_diff/clk/frameworks/base/0030-Fix-data-source-for-HEIF-exif-extractor.patch
+++ b/android_p/google_diff/clk/frameworks/base/0030-Fix-data-source-for-HEIF-exif-extractor.patch
@@ -1,0 +1,62 @@
+From efced71891187415243f2521679b88577966c326 Mon Sep 17 00:00:00 2001
+From: Chong Zhang <chz@google.com>
+Date: Thu, 26 Jul 2018 15:54:18 -0700
+Subject: [PATCH] Fix data source for HEIF exif extractor
+
+Do not allow the source to read past available bytes, since
+the underlying input stream may not be able to seek after that.
+
+For input streams from files, the available bytes is usually the
+file size, and we usually don't have problem when the file is
+of decent size. But when the file is very small, some of the
+extractors (other than mp4) would request bytes past the end
+of the file, which goes over the available range. Once that
+condition is hit, we can't reset to the offet needed for
+mp4 extractor and heif parsing would fail.
+
+bug: 111897855
+bug: 117625929
+test: open heic files of various sizes in Files (Downloads) app,
+check that ExifInterface shouldn't encounter any exceptions.
+
+Change-Id: I668ff900f4155dc310cb7ea8977bbe091791c5d7
+(cherry picked from commit f2b041dce0b855ecc7eec6514b5b0c3785378855)
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-71757
+Signed-off-by: Dan Liang <dan.liang@intel.com>
+Reviewed-on: https://android.intel.com:443/651908
+---
+ media/java/android/media/ExifInterface.java | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/media/java/android/media/ExifInterface.java b/media/java/android/media/ExifInterface.java
+index aa457092ca3..450a65641b8 100644
+--- a/media/java/android/media/ExifInterface.java
++++ b/media/java/android/media/ExifInterface.java
+@@ -2537,7 +2537,9 @@ public class ExifInterface {
+                     if (size == 0) {
+                         return 0;
+                     }
+-                    if (position < 0) {
++                    // We don't allow read positions after the available bytes,
++                    // the input stream won't be able to seek back then.
++                    if (position < 0 || position >= in.available()) {
+                         return -1;
+                     }
+                     try {
+@@ -2546,6 +2548,13 @@ public class ExifInterface {
+                             mPosition = position;
+                         }
+ 
++                        // If the read will cause us to go over the available bytes,
++                        // reduce the size so that we stay in the available range.
++                        // Otherwise the input stream may not be able to seek back.
++                        if (mPosition + size > in.available()) {
++                            size = in.available() - (int)mPosition;
++                        }
++
+                         int bytesRead = in.read(buffer, offset, size);
+                         if (bytesRead >= 0) {
+                             mPosition += bytesRead;
+-- 
+2.20.1
+


### PR DESCRIPTION
Do not allow the source to read past available bytes, since
the underlying input stream may not be able to seek after that.

For input streams from files, the available bytes is usually the
file size, and we usually don't have problem when the file is
of decent size. But when the file is very small, some of the
extractors (other than mp4) would request bytes past the end
of the file, which goes over the available range. Once that
condition is hit, we can't reset to the offet needed for
mp4 extractor and heif parsing would fail

Tracked-On: OAM-79903
Signed-off-by: varunjex <varunx.jeevangoudar@intel.com>
Signed-off-by: swaroopb <swaroop.balan@intel.com>