### PR TITLE
Add an option to record screen with Hevc encoder

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/av/0001-Add-an-option-to-record-screen-with-Hevc-encoder.patch
+++ b/android_p/google_diff/cel_apl/frameworks/av/0001-Add-an-option-to-record-screen-with-Hevc-encoder.patch
@@ -1,0 +1,122 @@
+From 795d0b7e0ea995f036989129218c748caa0db7e2 Mon Sep 17 00:00:00 2001
+From: yingzhex <yingzhenx.li@intel.com>
+Date: Thu, 2 Aug 2018 14:11:34 +0800
+Subject: [PATCH] Add an option to record screen with Hevc encoder
+
+Change-Id: I5ef3e83907d8447bda28e09a548bbb04d8c9490c
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-66600
+Signed-off-by: yingzhex <yingzhenx.li@intel.com>
+---
+ cmds/screenrecord/screenrecord.cpp | 25 +++++++++++++++++++------
+ 1 file changed, 19 insertions(+), 6 deletions(-)
+
+diff --git a/cmds/screenrecord/screenrecord.cpp b/cmds/screenrecord/screenrecord.cpp
+index 4603515..7cbff1a 100644
+--- a/cmds/screenrecord/screenrecord.cpp
++++ b/cmds/screenrecord/screenrecord.cpp
+@@ -66,6 +66,8 @@ static const uint32_t kMaxTimeLimitSec = 180;       // 3 minutes
+ static const uint32_t kFallbackWidth = 1280;        // 720p
+ static const uint32_t kFallbackHeight = 720;
+ static const char* kMimeTypeAvc = "video/avc";
++static const char* kMimeTypeHevc = "video/hevc";
++static const char* kMimeTypeString = kMimeTypeAvc;
+ 
+ // Command-line parameters.
+ static bool gVerbose = false;           // chatty on stdout
+@@ -73,7 +75,7 @@ static bool gRotate = false;            // rotate 90 degrees
+ static bool gMonotonicTime = false;     // use system monotonic time for timestamps
+ static bool gPersistentSurface = false; // use persistent surface
+ static enum {
+-    FORMAT_MP4, FORMAT_H264, FORMAT_FRAMES, FORMAT_RAW_FRAMES
++    FORMAT_MP4, FORMAT_H264, FORMAT_H265, FORMAT_FRAMES, FORMAT_RAW_FRAMES
+ } gOutputFormat = FORMAT_MP4;           // data format for output
+ static AString gCodecName = "";         // codec name override
+ static bool gSizeSpecified = false;     // was size explicitly requested?
+@@ -157,14 +159,14 @@ static status_t prepareEncoder(float displayFps, sp<MediaCodec>* pCodec,
+ 
+     if (gVerbose) {
+         printf("Configuring recorder for %dx%d %s at %.2fMbps\n",
+-                gVideoWidth, gVideoHeight, kMimeTypeAvc, gBitRate / 1000000.0);
++                gVideoWidth, gVideoHeight, kMimeTypeString, gBitRate / 1000000.0);
+         fflush(stdout);
+     }
+ 
+     sp<AMessage> format = new AMessage;
+     format->setInt32("width", gVideoWidth);
+     format->setInt32("height", gVideoHeight);
+-    format->setString("mime", kMimeTypeAvc);
++    format->setString("mime", kMimeTypeString);
+     format->setInt32("color-format", OMX_COLOR_FormatAndroidOpaque);
+     format->setInt32("bitrate", gBitRate);
+     format->setFloat("frame-rate", displayFps);
+@@ -176,10 +178,10 @@ static status_t prepareEncoder(float displayFps, sp<MediaCodec>* pCodec,
+     ALOGV("Creating codec");
+     sp<MediaCodec> codec;
+     if (gCodecName.empty()) {
+-        codec = MediaCodec::CreateByType(looper, kMimeTypeAvc, true);
++        codec = MediaCodec::CreateByType(looper, kMimeTypeString, true);
+         if (codec == NULL) {
+             fprintf(stderr, "ERROR: unable to create %s codec instance\n",
+-                    kMimeTypeAvc);
++                    kMimeTypeString);
+             return UNKNOWN_ERROR;
+         }
+     } else {
+@@ -515,7 +517,7 @@ static status_t runEncoder(const sp<MediaCodec>& encoder,
+ }
+ 
+ /*
+- * Raw H.264 byte stream output requested.  Send the output to stdout
++ * Raw H.264/H.265 byte stream output requested.  Send the output to stdout
+  * if desired.  If the output is a tty, reconfigure it to avoid the
+  * CRLF line termination that we see with "adb shell" commands.
+  */
+@@ -690,6 +692,7 @@ static status_t recordScreen(const char* fileName) {
+             break;
+         }
+         case FORMAT_H264:
++        case FORMAT_H265:
+         case FORMAT_FRAMES:
+         case FORMAT_RAW_FRAMES: {
+             rawFp = prepareRawOutput(fileName);
+@@ -902,6 +905,8 @@ static void usage() {
+         "    in videos captured to illustrate bugs.\n"
+         "--time-limit TIME\n"
+         "    Set the maximum recording time, in seconds.  Default / maximum is %d.\n"
++        "--codec HEVC\n"
++        "    Select HEVC encoder. If not specified, AVC encoder is used.\n"
+         "--verbose\n"
+         "    Display interesting information on stdout.\n"
+         "--help\n"
+@@ -931,6 +936,7 @@ int main(int argc, char* const argv[]) {
+         { "output-format",      required_argument,  NULL, 'o' },
+         { "codec-name",         required_argument,  NULL, 'N' },
+         { "monotonic-time",     no_argument,        NULL, 'm' },
++        { "codec",              required_argument,  NULL, 'c' },
+         { "persistent-surface", no_argument,        NULL, 'p' },
+         { NULL,                 0,                  NULL, 0 }
+     };
+@@ -1002,6 +1008,8 @@ int main(int argc, char* const argv[]) {
+                 gOutputFormat = FORMAT_MP4;
+             } else if (strcmp(optarg, "h264") == 0) {
+                 gOutputFormat = FORMAT_H264;
++            } else if (strcmp(optarg, "h265") == 0) {
++                gOutputFormat = FORMAT_H265;
+             } else if (strcmp(optarg, "frames") == 0) {
+                 gOutputFormat = FORMAT_FRAMES;
+             } else if (strcmp(optarg, "raw-frames") == 0) {
+@@ -1017,6 +1025,11 @@ int main(int argc, char* const argv[]) {
+         case 'm':
+             gMonotonicTime = true;
+             break;
++        case 'c':
++            if (strcmp(optarg, "HEVC") == 0) {
++                kMimeTypeString = kMimeTypeHevc;
++            }
++            break;
+         case 'p':
+             gPersistentSurface = true;
+             break;
+-- 
+2.7.4
+

--- a/android_p/google_diff/cel_kbl/frameworks/av/0001-Add-an-option-to-record-screen-with-Hevc-encoder.patch
+++ b/android_p/google_diff/cel_kbl/frameworks/av/0001-Add-an-option-to-record-screen-with-Hevc-encoder.patch
@@ -1,0 +1,122 @@
+From 795d0b7e0ea995f036989129218c748caa0db7e2 Mon Sep 17 00:00:00 2001
+From: yingzhex <yingzhenx.li@intel.com>
+Date: Thu, 2 Aug 2018 14:11:34 +0800
+Subject: [PATCH] Add an option to record screen with Hevc encoder
+
+Change-Id: I5ef3e83907d8447bda28e09a548bbb04d8c9490c
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-66600
+Signed-off-by: yingzhex <yingzhenx.li@intel.com>
+---
+ cmds/screenrecord/screenrecord.cpp | 25 +++++++++++++++++++------
+ 1 file changed, 19 insertions(+), 6 deletions(-)
+
+diff --git a/cmds/screenrecord/screenrecord.cpp b/cmds/screenrecord/screenrecord.cpp
+index 4603515..7cbff1a 100644
+--- a/cmds/screenrecord/screenrecord.cpp
++++ b/cmds/screenrecord/screenrecord.cpp
+@@ -66,6 +66,8 @@ static const uint32_t kMaxTimeLimitSec = 180;       // 3 minutes
+ static const uint32_t kFallbackWidth = 1280;        // 720p
+ static const uint32_t kFallbackHeight = 720;
+ static const char* kMimeTypeAvc = "video/avc";
++static const char* kMimeTypeHevc = "video/hevc";
++static const char* kMimeTypeString = kMimeTypeAvc;
+ 
+ // Command-line parameters.
+ static bool gVerbose = false;           // chatty on stdout
+@@ -73,7 +75,7 @@ static bool gRotate = false;            // rotate 90 degrees
+ static bool gMonotonicTime = false;     // use system monotonic time for timestamps
+ static bool gPersistentSurface = false; // use persistent surface
+ static enum {
+-    FORMAT_MP4, FORMAT_H264, FORMAT_FRAMES, FORMAT_RAW_FRAMES
++    FORMAT_MP4, FORMAT_H264, FORMAT_H265, FORMAT_FRAMES, FORMAT_RAW_FRAMES
+ } gOutputFormat = FORMAT_MP4;           // data format for output
+ static AString gCodecName = "";         // codec name override
+ static bool gSizeSpecified = false;     // was size explicitly requested?
+@@ -157,14 +159,14 @@ static status_t prepareEncoder(float displayFps, sp<MediaCodec>* pCodec,
+ 
+     if (gVerbose) {
+         printf("Configuring recorder for %dx%d %s at %.2fMbps\n",
+-                gVideoWidth, gVideoHeight, kMimeTypeAvc, gBitRate / 1000000.0);
++                gVideoWidth, gVideoHeight, kMimeTypeString, gBitRate / 1000000.0);
+         fflush(stdout);
+     }
+ 
+     sp<AMessage> format = new AMessage;
+     format->setInt32("width", gVideoWidth);
+     format->setInt32("height", gVideoHeight);
+-    format->setString("mime", kMimeTypeAvc);
++    format->setString("mime", kMimeTypeString);
+     format->setInt32("color-format", OMX_COLOR_FormatAndroidOpaque);
+     format->setInt32("bitrate", gBitRate);
+     format->setFloat("frame-rate", displayFps);
+@@ -176,10 +178,10 @@ static status_t prepareEncoder(float displayFps, sp<MediaCodec>* pCodec,
+     ALOGV("Creating codec");
+     sp<MediaCodec> codec;
+     if (gCodecName.empty()) {
+-        codec = MediaCodec::CreateByType(looper, kMimeTypeAvc, true);
++        codec = MediaCodec::CreateByType(looper, kMimeTypeString, true);
+         if (codec == NULL) {
+             fprintf(stderr, "ERROR: unable to create %s codec instance\n",
+-                    kMimeTypeAvc);
++                    kMimeTypeString);
+             return UNKNOWN_ERROR;
+         }
+     } else {
+@@ -515,7 +517,7 @@ static status_t runEncoder(const sp<MediaCodec>& encoder,
+ }
+ 
+ /*
+- * Raw H.264 byte stream output requested.  Send the output to stdout
++ * Raw H.264/H.265 byte stream output requested.  Send the output to stdout
+  * if desired.  If the output is a tty, reconfigure it to avoid the
+  * CRLF line termination that we see with "adb shell" commands.
+  */
+@@ -690,6 +692,7 @@ static status_t recordScreen(const char* fileName) {
+             break;
+         }
+         case FORMAT_H264:
++        case FORMAT_H265:
+         case FORMAT_FRAMES:
+         case FORMAT_RAW_FRAMES: {
+             rawFp = prepareRawOutput(fileName);
+@@ -902,6 +905,8 @@ static void usage() {
+         "    in videos captured to illustrate bugs.\n"
+         "--time-limit TIME\n"
+         "    Set the maximum recording time, in seconds.  Default / maximum is %d.\n"
++        "--codec HEVC\n"
++        "    Select HEVC encoder. If not specified, AVC encoder is used.\n"
+         "--verbose\n"
+         "    Display interesting information on stdout.\n"
+         "--help\n"
+@@ -931,6 +936,7 @@ int main(int argc, char* const argv[]) {
+         { "output-format",      required_argument,  NULL, 'o' },
+         { "codec-name",         required_argument,  NULL, 'N' },
+         { "monotonic-time",     no_argument,        NULL, 'm' },
++        { "codec",              required_argument,  NULL, 'c' },
+         { "persistent-surface", no_argument,        NULL, 'p' },
+         { NULL,                 0,                  NULL, 0 }
+     };
+@@ -1002,6 +1008,8 @@ int main(int argc, char* const argv[]) {
+                 gOutputFormat = FORMAT_MP4;
+             } else if (strcmp(optarg, "h264") == 0) {
+                 gOutputFormat = FORMAT_H264;
++            } else if (strcmp(optarg, "h265") == 0) {
++                gOutputFormat = FORMAT_H265;
+             } else if (strcmp(optarg, "frames") == 0) {
+                 gOutputFormat = FORMAT_FRAMES;
+             } else if (strcmp(optarg, "raw-frames") == 0) {
+@@ -1017,6 +1025,11 @@ int main(int argc, char* const argv[]) {
+         case 'm':
+             gMonotonicTime = true;
+             break;
++        case 'c':
++            if (strcmp(optarg, "HEVC") == 0) {
++                kMimeTypeString = kMimeTypeHevc;
++            }
++            break;
+         case 'p':
+             gPersistentSurface = true;
+             break;
+-- 
+2.7.4
+

--- a/android_p/google_diff/celadon/frameworks/av/0001-Add-an-option-to-record-screen-with-Hevc-encoder.patch
+++ b/android_p/google_diff/celadon/frameworks/av/0001-Add-an-option-to-record-screen-with-Hevc-encoder.patch
@@ -1,0 +1,122 @@
+From 795d0b7e0ea995f036989129218c748caa0db7e2 Mon Sep 17 00:00:00 2001
+From: yingzhex <yingzhenx.li@intel.com>
+Date: Thu, 2 Aug 2018 14:11:34 +0800
+Subject: [PATCH] Add an option to record screen with Hevc encoder
+
+Change-Id: I5ef3e83907d8447bda28e09a548bbb04d8c9490c
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-66600
+Signed-off-by: yingzhex <yingzhenx.li@intel.com>
+---
+ cmds/screenrecord/screenrecord.cpp | 25 +++++++++++++++++++------
+ 1 file changed, 19 insertions(+), 6 deletions(-)
+
+diff --git a/cmds/screenrecord/screenrecord.cpp b/cmds/screenrecord/screenrecord.cpp
+index 4603515..7cbff1a 100644
+--- a/cmds/screenrecord/screenrecord.cpp
++++ b/cmds/screenrecord/screenrecord.cpp
+@@ -66,6 +66,8 @@ static const uint32_t kMaxTimeLimitSec = 180;       // 3 minutes
+ static const uint32_t kFallbackWidth = 1280;        // 720p
+ static const uint32_t kFallbackHeight = 720;
+ static const char* kMimeTypeAvc = "video/avc";
++static const char* kMimeTypeHevc = "video/hevc";
++static const char* kMimeTypeString = kMimeTypeAvc;
+ 
+ // Command-line parameters.
+ static bool gVerbose = false;           // chatty on stdout
+@@ -73,7 +75,7 @@ static bool gRotate = false;            // rotate 90 degrees
+ static bool gMonotonicTime = false;     // use system monotonic time for timestamps
+ static bool gPersistentSurface = false; // use persistent surface
+ static enum {
+-    FORMAT_MP4, FORMAT_H264, FORMAT_FRAMES, FORMAT_RAW_FRAMES
++    FORMAT_MP4, FORMAT_H264, FORMAT_H265, FORMAT_FRAMES, FORMAT_RAW_FRAMES
+ } gOutputFormat = FORMAT_MP4;           // data format for output
+ static AString gCodecName = "";         // codec name override
+ static bool gSizeSpecified = false;     // was size explicitly requested?
+@@ -157,14 +159,14 @@ static status_t prepareEncoder(float displayFps, sp<MediaCodec>* pCodec,
+ 
+     if (gVerbose) {
+         printf("Configuring recorder for %dx%d %s at %.2fMbps\n",
+-                gVideoWidth, gVideoHeight, kMimeTypeAvc, gBitRate / 1000000.0);
++                gVideoWidth, gVideoHeight, kMimeTypeString, gBitRate / 1000000.0);
+         fflush(stdout);
+     }
+ 
+     sp<AMessage> format = new AMessage;
+     format->setInt32("width", gVideoWidth);
+     format->setInt32("height", gVideoHeight);
+-    format->setString("mime", kMimeTypeAvc);
++    format->setString("mime", kMimeTypeString);
+     format->setInt32("color-format", OMX_COLOR_FormatAndroidOpaque);
+     format->setInt32("bitrate", gBitRate);
+     format->setFloat("frame-rate", displayFps);
+@@ -176,10 +178,10 @@ static status_t prepareEncoder(float displayFps, sp<MediaCodec>* pCodec,
+     ALOGV("Creating codec");
+     sp<MediaCodec> codec;
+     if (gCodecName.empty()) {
+-        codec = MediaCodec::CreateByType(looper, kMimeTypeAvc, true);
++        codec = MediaCodec::CreateByType(looper, kMimeTypeString, true);
+         if (codec == NULL) {
+             fprintf(stderr, "ERROR: unable to create %s codec instance\n",
+-                    kMimeTypeAvc);
++                    kMimeTypeString);
+             return UNKNOWN_ERROR;
+         }
+     } else {
+@@ -515,7 +517,7 @@ static status_t runEncoder(const sp<MediaCodec>& encoder,
+ }
+ 
+ /*
+- * Raw H.264 byte stream output requested.  Send the output to stdout
++ * Raw H.264/H.265 byte stream output requested.  Send the output to stdout
+  * if desired.  If the output is a tty, reconfigure it to avoid the
+  * CRLF line termination that we see with "adb shell" commands.
+  */
+@@ -690,6 +692,7 @@ static status_t recordScreen(const char* fileName) {
+             break;
+         }
+         case FORMAT_H264:
++        case FORMAT_H265:
+         case FORMAT_FRAMES:
+         case FORMAT_RAW_FRAMES: {
+             rawFp = prepareRawOutput(fileName);
+@@ -902,6 +905,8 @@ static void usage() {
+         "    in videos captured to illustrate bugs.\n"
+         "--time-limit TIME\n"
+         "    Set the maximum recording time, in seconds.  Default / maximum is %d.\n"
++        "--codec HEVC\n"
++        "    Select HEVC encoder. If not specified, AVC encoder is used.\n"
+         "--verbose\n"
+         "    Display interesting information on stdout.\n"
+         "--help\n"
+@@ -931,6 +936,7 @@ int main(int argc, char* const argv[]) {
+         { "output-format",      required_argument,  NULL, 'o' },
+         { "codec-name",         required_argument,  NULL, 'N' },
+         { "monotonic-time",     no_argument,        NULL, 'm' },
++        { "codec",              required_argument,  NULL, 'c' },
+         { "persistent-surface", no_argument,        NULL, 'p' },
+         { NULL,                 0,                  NULL, 0 }
+     };
+@@ -1002,6 +1008,8 @@ int main(int argc, char* const argv[]) {
+                 gOutputFormat = FORMAT_MP4;
+             } else if (strcmp(optarg, "h264") == 0) {
+                 gOutputFormat = FORMAT_H264;
++            } else if (strcmp(optarg, "h265") == 0) {
++                gOutputFormat = FORMAT_H265;
+             } else if (strcmp(optarg, "frames") == 0) {
+                 gOutputFormat = FORMAT_FRAMES;
+             } else if (strcmp(optarg, "raw-frames") == 0) {
+@@ -1017,6 +1025,11 @@ int main(int argc, char* const argv[]) {
+         case 'm':
+             gMonotonicTime = true;
+             break;
++        case 'c':
++            if (strcmp(optarg, "HEVC") == 0) {
++                kMimeTypeString = kMimeTypeHevc;
++            }
++            break;
+         case 'p':
+             gPersistentSurface = true;
+             break;
+-- 
+2.7.4
+

--- a/android_p/google_diff/clk/frameworks/av/0001-Add-an-option-to-record-screen-with-Hevc-encoder.patch
+++ b/android_p/google_diff/clk/frameworks/av/0001-Add-an-option-to-record-screen-with-Hevc-encoder.patch
@@ -1,0 +1,122 @@
+From 795d0b7e0ea995f036989129218c748caa0db7e2 Mon Sep 17 00:00:00 2001
+From: yingzhex <yingzhenx.li@intel.com>
+Date: Thu, 2 Aug 2018 14:11:34 +0800
+Subject: [PATCH] Add an option to record screen with Hevc encoder
+
+Change-Id: I5ef3e83907d8447bda28e09a548bbb04d8c9490c
+Tracked-On: https://jira01.devtools.intel.com/browse/OAM-66600
+Signed-off-by: yingzhex <yingzhenx.li@intel.com>
+---
+ cmds/screenrecord/screenrecord.cpp | 25 +++++++++++++++++++------
+ 1 file changed, 19 insertions(+), 6 deletions(-)
+
+diff --git a/cmds/screenrecord/screenrecord.cpp b/cmds/screenrecord/screenrecord.cpp
+index 4603515..7cbff1a 100644
+--- a/cmds/screenrecord/screenrecord.cpp
++++ b/cmds/screenrecord/screenrecord.cpp
+@@ -66,6 +66,8 @@ static const uint32_t kMaxTimeLimitSec = 180;       // 3 minutes
+ static const uint32_t kFallbackWidth = 1280;        // 720p
+ static const uint32_t kFallbackHeight = 720;
+ static const char* kMimeTypeAvc = "video/avc";
++static const char* kMimeTypeHevc = "video/hevc";
++static const char* kMimeTypeString = kMimeTypeAvc;
+ 
+ // Command-line parameters.
+ static bool gVerbose = false;           // chatty on stdout
+@@ -73,7 +75,7 @@ static bool gRotate = false;            // rotate 90 degrees
+ static bool gMonotonicTime = false;     // use system monotonic time for timestamps
+ static bool gPersistentSurface = false; // use persistent surface
+ static enum {
+-    FORMAT_MP4, FORMAT_H264, FORMAT_FRAMES, FORMAT_RAW_FRAMES
++    FORMAT_MP4, FORMAT_H264, FORMAT_H265, FORMAT_FRAMES, FORMAT_RAW_FRAMES
+ } gOutputFormat = FORMAT_MP4;           // data format for output
+ static AString gCodecName = "";         // codec name override
+ static bool gSizeSpecified = false;     // was size explicitly requested?
+@@ -157,14 +159,14 @@ static status_t prepareEncoder(float displayFps, sp<MediaCodec>* pCodec,
+ 
+     if (gVerbose) {
+         printf("Configuring recorder for %dx%d %s at %.2fMbps\n",
+-                gVideoWidth, gVideoHeight, kMimeTypeAvc, gBitRate / 1000000.0);
++                gVideoWidth, gVideoHeight, kMimeTypeString, gBitRate / 1000000.0);
+         fflush(stdout);
+     }
+ 
+     sp<AMessage> format = new AMessage;
+     format->setInt32("width", gVideoWidth);
+     format->setInt32("height", gVideoHeight);
+-    format->setString("mime", kMimeTypeAvc);
++    format->setString("mime", kMimeTypeString);
+     format->setInt32("color-format", OMX_COLOR_FormatAndroidOpaque);
+     format->setInt32("bitrate", gBitRate);
+     format->setFloat("frame-rate", displayFps);
+@@ -176,10 +178,10 @@ static status_t prepareEncoder(float displayFps, sp<MediaCodec>* pCodec,
+     ALOGV("Creating codec");
+     sp<MediaCodec> codec;
+     if (gCodecName.empty()) {
+-        codec = MediaCodec::CreateByType(looper, kMimeTypeAvc, true);
++        codec = MediaCodec::CreateByType(looper, kMimeTypeString, true);
+         if (codec == NULL) {
+             fprintf(stderr, "ERROR: unable to create %s codec instance\n",
+-                    kMimeTypeAvc);
++                    kMimeTypeString);
+             return UNKNOWN_ERROR;
+         }
+     } else {
+@@ -515,7 +517,7 @@ static status_t runEncoder(const sp<MediaCodec>& encoder,
+ }
+ 
+ /*
+- * Raw H.264 byte stream output requested.  Send the output to stdout
++ * Raw H.264/H.265 byte stream output requested.  Send the output to stdout
+  * if desired.  If the output is a tty, reconfigure it to avoid the
+  * CRLF line termination that we see with "adb shell" commands.
+  */
+@@ -690,6 +692,7 @@ static status_t recordScreen(const char* fileName) {
+             break;
+         }
+         case FORMAT_H264:
++        case FORMAT_H265:
+         case FORMAT_FRAMES:
+         case FORMAT_RAW_FRAMES: {
+             rawFp = prepareRawOutput(fileName);
+@@ -902,6 +905,8 @@ static void usage() {
+         "    in videos captured to illustrate bugs.\n"
+         "--time-limit TIME\n"
+         "    Set the maximum recording time, in seconds.  Default / maximum is %d.\n"
++        "--codec HEVC\n"
++        "    Select HEVC encoder. If not specified, AVC encoder is used.\n"
+         "--verbose\n"
+         "    Display interesting information on stdout.\n"
+         "--help\n"
+@@ -931,6 +936,7 @@ int main(int argc, char* const argv[]) {
+         { "output-format",      required_argument,  NULL, 'o' },
+         { "codec-name",         required_argument,  NULL, 'N' },
+         { "monotonic-time",     no_argument,        NULL, 'm' },
++        { "codec",              required_argument,  NULL, 'c' },
+         { "persistent-surface", no_argument,        NULL, 'p' },
+         { NULL,                 0,                  NULL, 0 }
+     };
+@@ -1002,6 +1008,8 @@ int main(int argc, char* const argv[]) {
+                 gOutputFormat = FORMAT_MP4;
+             } else if (strcmp(optarg, "h264") == 0) {
+                 gOutputFormat = FORMAT_H264;
++            } else if (strcmp(optarg, "h265") == 0) {
++                gOutputFormat = FORMAT_H265;
+             } else if (strcmp(optarg, "frames") == 0) {
+                 gOutputFormat = FORMAT_FRAMES;
+             } else if (strcmp(optarg, "raw-frames") == 0) {
+@@ -1017,6 +1025,11 @@ int main(int argc, char* const argv[]) {
+         case 'm':
+             gMonotonicTime = true;
+             break;
++        case 'c':
++            if (strcmp(optarg, "HEVC") == 0) {
++                kMimeTypeString = kMimeTypeHevc;
++            }
++            break;
+         case 'p':
+             gPersistentSurface = true;
+             break;
+-- 
+2.7.4
+


### PR DESCRIPTION
This change is to add an option in screen recorder to enable hevc encoder.

Tracked-On: OAM-79950
Signed-off-by: tianmi.chen <tianmi.chen@intel.com>