### PR TITLE
Kernelflinger: Disable NVMe RPMB supported in WHL

### DIFF
--- a/android_p/google_diff/clk/hardware/intel/kernelflinger/0007-Disable-NVMe-RPMB-supported-in-WHL.patch
+++ b/android_p/google_diff/clk/hardware/intel/kernelflinger/0007-Disable-NVMe-RPMB-supported-in-WHL.patch
@@ -1,0 +1,40 @@
+From 46f639768ad3def92fb21c8e00139356424919fb Mon Sep 17 00:00:00 2001
+From: "Yanhongx.Zhou" <yanhongx.zhou@intel.com>
+Date: Sun, 5 May 2019 11:12:05 +0800
+Subject: [PATCH 7/7] Disable NVMe RPMB supported in WHL
+
+In WHL RVP, the NVMe RPMB is not supported and cause flash failed.
+
+Jira: None.
+Test: None.
+
+Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>
+---
+ libkernelflinger/rpmb/rpmb.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libkernelflinger/rpmb/rpmb.c b/libkernelflinger/rpmb/rpmb.c
+index edc1cd5..3f9e1ee 100644
+--- a/libkernelflinger/rpmb/rpmb.c
++++ b/libkernelflinger/rpmb/rpmb.c
+@@ -261,7 +261,7 @@ EFI_STATUS rpmb_init(EFI_HANDLE disk_handle)
+ 		}
+ 		error(L"init virtual media rpmb using pass through failed");
+ 		break;
+-	case STORAGE_NVME:
++	/*case STORAGE_NVME:
+ 		storage_rpmb_ops = get_nvme_storage_rpmb_ops();
+ 		if (!storage_rpmb_ops) {
+ 			error(L"failed to get nvme rpmb operation instance");
+@@ -272,7 +272,7 @@ EFI_STATUS rpmb_init(EFI_HANDLE disk_handle)
+ 			return EFI_SUCCESS;
+ 		}
+ 		error(L"init nvme rpmb failed");
+-		break;
++		break;*/
+ 	default:
+ 		error(L"boot device not supported");
+ 		return EFI_NOT_FOUND;
+-- 
+2.20.1
+


### PR DESCRIPTION
In WHL RVP, the NVMe RPMB is not supported and cause flash failed.
But we also need to support eMMC RPMB using one binary.
So we need to disable the NVMe RPMB suuport in clk lunch target.

Tracked-On: OAM-80029
Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>