### PR TITLE
kernelflinger: adb: dbc: Adding serial number support in kernel cmdli…

### DIFF
--- a/android_p/0001-adb-dbc-Adding-kernel-cmdline-for-DbC-Raw-serialno.patch
+++ b/android_p/0001-adb-dbc-Adding-kernel-cmdline-for-DbC-Raw-serialno.patch
@@ -1,0 +1,33 @@
+From 1a4945b7d2c604e8c18a7c604ea40f1af9b5bf27 Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Fri, 26 Apr 2019 12:34:20 +0530
+Subject: [PATCH] adb: dbc: Adding kernel cmdline for DbC Raw serialno
+
+Adding a kernel cmdline argument "xhci-dbgraw.serialno"
+to read the platform serial number. And later same is used
+in usb xhci dbgraw driver.
+
+Tracked-On:
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+---
+ libkernelflinger/android.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libkernelflinger/android.c b/libkernelflinger/android.c
+index 31dc9da..8f2e7af 100644
+--- a/libkernelflinger/android.c
++++ b/libkernelflinger/android.c
+@@ -1058,8 +1058,8 @@ static EFI_STATUS setup_command_line(
+         serialno = get_serial_number();
+         if (serialno) {
+                 ret = prepend_command_line(&cmdline16,
+-                                L"androidboot.serialno=%a g_ffs.iSerialNumber=%a",
+-                                serialno, serialno);
++                                L"androidboot.serialno=%a g_ffs.iSerialNumber=%a xhci-dbgraw.serialno=%a",
++				serialno, serialno, serialno);
+                 if (EFI_ERROR(ret))
+                         goto out;
+         }
+-- 
+2.21.0
+


### PR DESCRIPTION
…ne for KBL

Adding serial number support in kernel CMDLINE argument(xhci-dbgraw.serialno)
for DbC RAW driver.

Tracked-On: OAM-69212
Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>