### PR TITLE
usb: xhci: dbc: Reading serial number from kernel CMDLINE

### DIFF
--- a/android_p/google_diff/cel_kbl/kernel/project-celadon/0008-usb-xhci-dbc-Reading-serial-number-from-kernel-CMDLI.patch
+++ b/android_p/google_diff/cel_kbl/kernel/project-celadon/0008-usb-xhci-dbc-Reading-serial-number-from-kernel-CMDLI.patch
@@ -1,0 +1,48 @@
+From 3b824b5d4ac3ba09282fd852b2def71c170ad4da Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Thu, 2 May 2019 15:50:30 +0530
+Subject: [PATCH] usb: xhci: dbc: Reading serial number from kernel CMDLINE
+
+Adding support to read platform serial number from the kernel cmdline
+argument for DbC RAW driver.
+
+Tracked-On: OAM-69212
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+---
+ drivers/usb/host/xhci-dbgraw.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/usb/host/xhci-dbgraw.c b/drivers/usb/host/xhci-dbgraw.c
+index a55c4d7a2040..998bda939a7e 100644
+--- a/drivers/usb/host/xhci-dbgraw.c
++++ b/drivers/usb/host/xhci-dbgraw.c
+@@ -21,6 +21,10 @@
+ 
+ static DEFINE_IDR(dbc_minors);
+ 
++static char *serialno = DBC_STR_SERIAL;
++module_param(serialno, charp, S_IRUGO | S_IWUSR);
++MODULE_PARM_DESC(serialno, "Use Platform Serial No. as DbC device serial No.");
++
+ struct dbc_dev {
+ 	struct mutex dev_excl;
+ 	struct mutex read_excl;
+@@ -335,7 +339,6 @@ static struct dbc_function raw_func = {
+ 	.string = {
+ 		.manufacturer = DBC_STR_MANUFACTURER,
+ 		.product = DBC_STR_PRODUCT,
+-		.serial = DBC_STR_SERIAL,
+ 	},
+ 	.protocol = DBC_PROTOCOL,
+ 	.vid = DBC_VENDOR_ID,
+@@ -349,6 +352,7 @@ static struct dbc_function raw_func = {
+ 
+ static int __init xhci_dbc_raw_init(void)
+ {
++	strcpy(&raw_func.string.serial, serialno);
+ 	return xhci_dbc_register_function(&raw_func);
+ }
+ 
+-- 
+2.21.0
+

--- a/android_p/google_diff/clk/kernel/project-celadon/0006-usb-xhci-dbc-Reading-serial-number-from-kernel-CMDLI.patch
+++ b/android_p/google_diff/clk/kernel/project-celadon/0006-usb-xhci-dbc-Reading-serial-number-from-kernel-CMDLI.patch
@@ -1,0 +1,48 @@
+From 3b824b5d4ac3ba09282fd852b2def71c170ad4da Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Thu, 2 May 2019 15:50:30 +0530
+Subject: [PATCH] usb: xhci: dbc: Reading serial number from kernel CMDLINE
+
+Adding support to read platform serial number from the kernel cmdline
+argument for DbC RAW driver.
+
+Tracked-On: OAM-69212
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+---
+ drivers/usb/host/xhci-dbgraw.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/usb/host/xhci-dbgraw.c b/drivers/usb/host/xhci-dbgraw.c
+index a55c4d7a2040..998bda939a7e 100644
+--- a/drivers/usb/host/xhci-dbgraw.c
++++ b/drivers/usb/host/xhci-dbgraw.c
+@@ -21,6 +21,10 @@
+ 
+ static DEFINE_IDR(dbc_minors);
+ 
++static char *serialno = DBC_STR_SERIAL;
++module_param(serialno, charp, S_IRUGO | S_IWUSR);
++MODULE_PARM_DESC(serialno, "Use Platform Serial No. as DbC device serial No.");
++
+ struct dbc_dev {
+ 	struct mutex dev_excl;
+ 	struct mutex read_excl;
+@@ -335,7 +339,6 @@ static struct dbc_function raw_func = {
+ 	.string = {
+ 		.manufacturer = DBC_STR_MANUFACTURER,
+ 		.product = DBC_STR_PRODUCT,
+-		.serial = DBC_STR_SERIAL,
+ 	},
+ 	.protocol = DBC_PROTOCOL,
+ 	.vid = DBC_VENDOR_ID,
+@@ -349,6 +352,7 @@ static struct dbc_function raw_func = {
+ 
+ static int __init xhci_dbc_raw_init(void)
+ {
++	strcpy(&raw_func.string.serial, serialno);
+ 	return xhci_dbc_register_function(&raw_func);
+ }
+ 
+-- 
+2.21.0
+


### PR DESCRIPTION
Adding support to read platform serial number from the kernel cmdline
argument for DbC RAW driver.

Tracked-On: OAM-69212
Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>