### PR TITLE
Add dedicated BTUSB devices to USB blacklist

### DIFF
--- a/android_p/google_diff/cel_apl/frameworks/base/0029-Add-the-dedicated-btusb-device-to-blacklist.patch
+++ b/android_p/google_diff/cel_apl/frameworks/base/0029-Add-the-dedicated-btusb-device-to-blacklist.patch
@@ -1,0 +1,35 @@
+From 27af087358fbd81f0f7d1dda35a934bb02bf91d5 Mon Sep 17 00:00:00 2001
+From: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Date: Wed, 8 May 2019 10:11:09 +0530
+Subject: [PATCH] Add the dedicated btusb device to blacklist
+
+Inorder to prevent car usb handler using the btusb devices
+btusb devices were added to the usb blacklist.
+
+add Jfp and Thp modules to the blacklist
+
+Change-Id: I319e1e9b33142ae1424cb6fe8a2f4aec779df31a
+Tracked-On: OAM-80209
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+---
+ services/usb/java/com/android/server/usb/UsbHostManager.java | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/services/usb/java/com/android/server/usb/UsbHostManager.java b/services/usb/java/com/android/server/usb/UsbHostManager.java
+index 55f996e1..0f0c3d5c 100644
+--- a/services/usb/java/com/android/server/usb/UsbHostManager.java
++++ b/services/usb/java/com/android/server/usb/UsbHostManager.java
+@@ -234,7 +234,9 @@ public class UsbHostManager {
+     //TODO: move the ids to the config of platform
+     private VendorIdProductId[] mVidPidBlackList = {
+              new VendorIdProductId(0x8087,0x0a2b),
+-             new VendorIdProductId(0x8087,0x0aa7), //dedicated for BT in Celadon
++             new VendorIdProductId(0x8087,0x0aa7),
++             new VendorIdProductId(0x8087,0x0aaa),
++             new VendorIdProductId(0x8087,0x0025), //dedicated for BT in Celadon
+     };
+     /*
+      * UsbHostManager
+-- 
+2.17.1
+

--- a/android_p/google_diff/cel_kbl/frameworks/base/0030-Add-the-dedicated-btusb-device-to-blacklist.patch
+++ b/android_p/google_diff/cel_kbl/frameworks/base/0030-Add-the-dedicated-btusb-device-to-blacklist.patch
@@ -1,0 +1,35 @@
+From 27af087358fbd81f0f7d1dda35a934bb02bf91d5 Mon Sep 17 00:00:00 2001
+From: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Date: Wed, 8 May 2019 10:11:09 +0530
+Subject: [PATCH] Add the dedicated btusb device to blacklist
+
+Inorder to prevent car usb handler using the btusb devices
+btusb devices were added to the usb blacklist.
+
+add Jfp and Thp modules to the blacklist
+
+Change-Id: I319e1e9b33142ae1424cb6fe8a2f4aec779df31a
+Tracked-On: OAM-80209
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+---
+ services/usb/java/com/android/server/usb/UsbHostManager.java | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/services/usb/java/com/android/server/usb/UsbHostManager.java b/services/usb/java/com/android/server/usb/UsbHostManager.java
+index 55f996e1..0f0c3d5c 100644
+--- a/services/usb/java/com/android/server/usb/UsbHostManager.java
++++ b/services/usb/java/com/android/server/usb/UsbHostManager.java
+@@ -234,7 +234,9 @@ public class UsbHostManager {
+     //TODO: move the ids to the config of platform
+     private VendorIdProductId[] mVidPidBlackList = {
+              new VendorIdProductId(0x8087,0x0a2b),
+-             new VendorIdProductId(0x8087,0x0aa7), //dedicated for BT in Celadon
++             new VendorIdProductId(0x8087,0x0aa7),
++             new VendorIdProductId(0x8087,0x0aaa),
++             new VendorIdProductId(0x8087,0x0025), //dedicated for BT in Celadon
+     };
+     /*
+      * UsbHostManager
+-- 
+2.17.1
+


### PR DESCRIPTION
Inorder to prevent car usb handler using the btusb devices,
these devices are added to the usb blacklist.

adding Jfp and Thp modules to the blacklist

Tracked-On: OAM-80209
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>