### PR TITLE
Optimization check for pointer and array

### DIFF
--- a/android_p/google_diff/cel_apl/hardware/intel/kernelflinger/0009-Optimization-check-for-pointer-and-array.patch
+++ b/android_p/google_diff/cel_apl/hardware/intel/kernelflinger/0009-Optimization-check-for-pointer-and-array.patch
@@ -1,0 +1,43 @@
+From 0b155258e828a9ad1f444612219324420a31c97c Mon Sep 17 00:00:00 2001
+From: sunxunou <xunoux.sun@intel.com>
+Date: Sun, 5 May 2019 14:51:02 +0800
+Subject: [PATCH] Optimization check for pointer and array
+
+1. Null check for pointer 'lun_str' before dereferenced.
+2. Initialize 'file' and 'tree1d' array before dereferenced.
+
+Tracked-On: OAM-80041
+Signed-off-by: sunxunou <xunoux.sun@intel.com>
+Reviewed-on: https://android.intel.com:443/552997
+---
+ installer.c             | 1 +
+ libkernelflinger/upng.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/installer.c b/installer.c
+index df5ed05..1d97986 100644
+--- a/installer.c
++++ b/installer.c
+@@ -329,6 +329,7 @@ static void installer_split_and_joint_flash(CHAR16 **filename,
+ 	EFI_FILE *file[num];
+ 	UINT32 blk_count;
+ 
++	memset(file, 0, sizeof(file));
+ 	const UINTN HEADER_SIZE = offsetof(flash_buffer_t, d);
+ 	const UINTN MAX_DATA_SIZE = dl->max_size - HEADER_SIZE;
+ 	for (UINTN i = 0; i < num; i++) {
+diff --git a/libkernelflinger/upng.c b/libkernelflinger/upng.c
+index 08ae9a8..710d333 100644
+--- a/libkernelflinger/upng.c
++++ b/libkernelflinger/upng.c
+@@ -262,6 +262,7 @@ static void huffman_tree_create_lengths(upng_t* upng, huffman_tree* tree,
+ 	/* initialize local vectors */
+ 	memset(blcount, 0, sizeof(blcount));
+ 	memset(nextcode, 0, sizeof(nextcode));
++	memset(tree1d, 0, sizeof(tree1d));
+ 
+ 	/* Step 1: count number of instances of each code length */
+ 	for (bits = 0; bits < tree->numcodes; bits++) {
+-- 
+2.20.1
+

--- a/android_p/google_diff/cel_kbl/hardware/intel/kernelflinger/0009-Optimization-check-for-pointer-and-array.patch
+++ b/android_p/google_diff/cel_kbl/hardware/intel/kernelflinger/0009-Optimization-check-for-pointer-and-array.patch
@@ -1,0 +1,43 @@
+From 0b155258e828a9ad1f444612219324420a31c97c Mon Sep 17 00:00:00 2001
+From: sunxunou <xunoux.sun@intel.com>
+Date: Sun, 5 May 2019 14:51:02 +0800
+Subject: [PATCH] Optimization check for pointer and array
+
+1. Null check for pointer 'lun_str' before dereferenced.
+2. Initialize 'file' and 'tree1d' array before dereferenced.
+
+Tracked-On: OAM-80041
+Signed-off-by: sunxunou <xunoux.sun@intel.com>
+Reviewed-on: https://android.intel.com:443/552997
+---
+ installer.c             | 1 +
+ libkernelflinger/upng.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/installer.c b/installer.c
+index df5ed05..1d97986 100644
+--- a/installer.c
++++ b/installer.c
+@@ -329,6 +329,7 @@ static void installer_split_and_joint_flash(CHAR16 **filename,
+ 	EFI_FILE *file[num];
+ 	UINT32 blk_count;
+ 
++	memset(file, 0, sizeof(file));
+ 	const UINTN HEADER_SIZE = offsetof(flash_buffer_t, d);
+ 	const UINTN MAX_DATA_SIZE = dl->max_size - HEADER_SIZE;
+ 	for (UINTN i = 0; i < num; i++) {
+diff --git a/libkernelflinger/upng.c b/libkernelflinger/upng.c
+index 08ae9a8..710d333 100644
+--- a/libkernelflinger/upng.c
++++ b/libkernelflinger/upng.c
+@@ -262,6 +262,7 @@ static void huffman_tree_create_lengths(upng_t* upng, huffman_tree* tree,
+ 	/* initialize local vectors */
+ 	memset(blcount, 0, sizeof(blcount));
+ 	memset(nextcode, 0, sizeof(nextcode));
++	memset(tree1d, 0, sizeof(tree1d));
+ 
+ 	/* Step 1: count number of instances of each code length */
+ 	for (bits = 0; bits < tree->numcodes; bits++) {
+-- 
+2.20.1
+

--- a/android_p/google_diff/celadon/hardware/intel/kernelflinger/0009-Optimization-check-for-pointer-and-array.patch
+++ b/android_p/google_diff/celadon/hardware/intel/kernelflinger/0009-Optimization-check-for-pointer-and-array.patch
@@ -1,0 +1,43 @@
+From 0b155258e828a9ad1f444612219324420a31c97c Mon Sep 17 00:00:00 2001
+From: sunxunou <xunoux.sun@intel.com>
+Date: Sun, 5 May 2019 14:51:02 +0800
+Subject: [PATCH] Optimization check for pointer and array
+
+1. Null check for pointer 'lun_str' before dereferenced.
+2. Initialize 'file' and 'tree1d' array before dereferenced.
+
+Tracked-On: OAM-80041
+Signed-off-by: sunxunou <xunoux.sun@intel.com>
+Reviewed-on: https://android.intel.com:443/552997
+---
+ installer.c             | 1 +
+ libkernelflinger/upng.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/installer.c b/installer.c
+index df5ed05..1d97986 100644
+--- a/installer.c
++++ b/installer.c
+@@ -329,6 +329,7 @@ static void installer_split_and_joint_flash(CHAR16 **filename,
+ 	EFI_FILE *file[num];
+ 	UINT32 blk_count;
+ 
++	memset(file, 0, sizeof(file));
+ 	const UINTN HEADER_SIZE = offsetof(flash_buffer_t, d);
+ 	const UINTN MAX_DATA_SIZE = dl->max_size - HEADER_SIZE;
+ 	for (UINTN i = 0; i < num; i++) {
+diff --git a/libkernelflinger/upng.c b/libkernelflinger/upng.c
+index 08ae9a8..710d333 100644
+--- a/libkernelflinger/upng.c
++++ b/libkernelflinger/upng.c
+@@ -262,6 +262,7 @@ static void huffman_tree_create_lengths(upng_t* upng, huffman_tree* tree,
+ 	/* initialize local vectors */
+ 	memset(blcount, 0, sizeof(blcount));
+ 	memset(nextcode, 0, sizeof(nextcode));
++	memset(tree1d, 0, sizeof(tree1d));
+ 
+ 	/* Step 1: count number of instances of each code length */
+ 	for (bits = 0; bits < tree->numcodes; bits++) {
+-- 
+2.20.1
+

--- a/android_p/google_diff/clk/hardware/intel/kernelflinger/0009-Optimization-check-for-pointer-and-array.patch
+++ b/android_p/google_diff/clk/hardware/intel/kernelflinger/0009-Optimization-check-for-pointer-and-array.patch
@@ -1,0 +1,43 @@
+From 0b155258e828a9ad1f444612219324420a31c97c Mon Sep 17 00:00:00 2001
+From: sunxunou <xunoux.sun@intel.com>
+Date: Sun, 5 May 2019 14:51:02 +0800
+Subject: [PATCH] Optimization check for pointer and array
+
+1. Null check for pointer 'lun_str' before dereferenced.
+2. Initialize 'file' and 'tree1d' array before dereferenced.
+
+Tracked-On: OAM-80041
+Signed-off-by: sunxunou <xunoux.sun@intel.com>
+Reviewed-on: https://android.intel.com:443/552997
+---
+ installer.c             | 1 +
+ libkernelflinger/upng.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/installer.c b/installer.c
+index df5ed05..1d97986 100644
+--- a/installer.c
++++ b/installer.c
+@@ -329,6 +329,7 @@ static void installer_split_and_joint_flash(CHAR16 **filename,
+ 	EFI_FILE *file[num];
+ 	UINT32 blk_count;
+ 
++	memset(file, 0, sizeof(file));
+ 	const UINTN HEADER_SIZE = offsetof(flash_buffer_t, d);
+ 	const UINTN MAX_DATA_SIZE = dl->max_size - HEADER_SIZE;
+ 	for (UINTN i = 0; i < num; i++) {
+diff --git a/libkernelflinger/upng.c b/libkernelflinger/upng.c
+index 08ae9a8..710d333 100644
+--- a/libkernelflinger/upng.c
++++ b/libkernelflinger/upng.c
+@@ -262,6 +262,7 @@ static void huffman_tree_create_lengths(upng_t* upng, huffman_tree* tree,
+ 	/* initialize local vectors */
+ 	memset(blcount, 0, sizeof(blcount));
+ 	memset(nextcode, 0, sizeof(nextcode));
++	memset(tree1d, 0, sizeof(tree1d));
+ 
+ 	/* Step 1: count number of instances of each code length */
+ 	for (bits = 0; bits < tree->numcodes; bits++) {
+-- 
+2.20.1
+


### PR DESCRIPTION
 1. Null check for pointer 'lun_str' before dereferenced.
 2. Initialize 'file' and 'tree1d' array before dereferenced.

Tracked-On: OAM-80260
Signed-off-by: Meng Xianglin <xianglinx.meng@intel.com>