### PR TITLE
Fix the issue of failed to use simulate RPMB if physical RPMB not found

### DIFF
--- a/android_p/google_diff/clk/hardware/intel/kernelflinger/0009-Fix-the-issue-of-failed-to-use-simulate-RPMB-if-phys.patch
+++ b/android_p/google_diff/clk/hardware/intel/kernelflinger/0009-Fix-the-issue-of-failed-to-use-simulate-RPMB-if-phys.patch
@@ -1,0 +1,32 @@
+From bd56c4c3a0311d9efc88303e6ae55427c37c33eb Mon Sep 17 00:00:00 2001
+From: "Yanhongx.Zhou" <yanhongx.zhou@intel.com>
+Date: Thu, 9 May 2019 19:27:56 +0800
+Subject: [PATCH 9/9] Fix the issue of failed to use simulate RPMB if physical
+ RPMB not found
+
+Use simulate RPMB if physical RPMB not found.But kernelflinger failed to
+use simulate RPMB if physical RPMB is not found.
+
+Jira: None.
+Test: None.
+
+Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>
+---
+ libkernelflinger/rpmb/rpmb_storage.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libkernelflinger/rpmb/rpmb_storage.c b/libkernelflinger/rpmb/rpmb_storage.c
+index 5bb86f7..4a55782 100644
+--- a/libkernelflinger/rpmb/rpmb_storage.c
++++ b/libkernelflinger/rpmb/rpmb_storage.c
+@@ -750,6 +750,7 @@ EFI_STATUS rpmb_storage_init(void)
+ 				}
+ 				debug(L"Can't find physical RPMB, use simulate RPMB now");
+ 				real = FALSE;
++				ret = EFI_SUCCESS;
+ 			}
+ 		}
+ 	}
+-- 
+2.20.1
+


### PR DESCRIPTION
Use simulate RPMB if physical RPMB not found.But kernelflinger failed to
use simulate RPMB if physical RPMB is not found.

Tracked-On: OAM-80290
Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>