### PR TITLE
[WHL] Enabling capture source as mic

### DIFF
--- a/android_p/google_diff/clk/device/intel/project-celadon/0004-Enable-capture-source-for-WHL-target.patch
+++ b/android_p/google_diff/clk/device/intel/project-celadon/0004-Enable-capture-source-for-WHL-target.patch
@@ -1,0 +1,31 @@
+From 6e1d6552db13239958e767886e0410a928388eeb Mon Sep 17 00:00:00 2001
+From: Karan Patidar <karan.patidar@intel.com>
+Date: Mon, 13 May 2019 15:04:26 +0530
+Subject: [PATCH] Enable capture source for WHL target
+
+Disabling Auto Mute and enabling Capture Source as MIC for
+WHL target.
+
+Tracked-On: OAM-80371
+Signed-off-by: Karan Patidar <karan.patidar@intel.com>
+---
+ common/audio/default/mixer_paths_0.xml | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/common/audio/default/mixer_paths_0.xml b/common/audio/default/mixer_paths_0.xml
+index 1f8f905..b7a193f 100644
+--- a/common/audio/default/mixer_paths_0.xml
++++ b/common/audio/default/mixer_paths_0.xml
+@@ -5,6 +5,9 @@
+   <ctl name="Headphone Playback Switch" value="1 1" />
+   <ctl name="Speaker Playback Switch" value="0 0" />
+   <ctl name="Capture Switch" value="0 0" />
++  <ctl name="Auto-Mute Mode" value="0" />
++  <ctl name="Capture Source" value="Mic" />
++
+ 
+   <path name="speaker">
+     <ctl name="Master Playback Switch" value="1" />
+-- 
+2.20.1
+


### PR DESCRIPTION
With this mixer_path patch we enabled Capture Source as Mic
and disabled Auto Mute mode.

Tracked-On: OAM-80371
Signed-off-by: Karan Patidar <karan.patidar@intel.com>