### PR TITLE
Fix race condition in btusb_sco_snd_card driver

### DIFF
--- a/android_p/google_diff/cel_apl/kernel/project-celadon/0009-Fix-for-race-condition-in-configuring-the-TX-and-RX.patch
+++ b/android_p/google_diff/cel_apl/kernel/project-celadon/0009-Fix-for-race-condition-in-configuring-the-TX-and-RX.patch
@@ -1,0 +1,48 @@
+From ab8d01a1c6a651a7dadf23c1b7af5f7814796555 Mon Sep 17 00:00:00 2001
+From: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Date: Wed, 5 Jun 2019 21:28:57 +0530
+Subject: [PATCH] Fix race  condition in btusb_sco_snd_card driver
+
+Fix for race condition in configuring the TX and RX EP, by
+adding mutex lock
+
+Tracked-On: OAM-81187
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+---
+ sound/usb/btusb/btusb_sco_snd_card.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/sound/usb/btusb/btusb_sco_snd_card.c b/sound/usb/btusb/btusb_sco_snd_card.c
+index b2cbb9ca8f42..5bed5300508f 100644
+--- a/sound/usb/btusb/btusb_sco_snd_card.c
++++ b/sound/usb/btusb/btusb_sco_snd_card.c
+@@ -15,6 +15,7 @@
+ #include <linux/jiffies.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
++#include <linux/mutex.h>
+ #include <linux/types.h>
+ #include <linux/usb.h>
+ #include <linux/usbdevice_fs.h>
+@@ -46,6 +47,8 @@
+ #define PRD_SIZE_MAX	                   PAGE_SIZE  /*4096*/
+ #define MIN_PERIODS	                   4
+ 
++static DEFINE_MUTEX(config_mutex);
++
+ struct capture_data_cb {
+ 	unsigned char *buf;
+ 	unsigned int pos;
+@@ -614,7 +617,9 @@ static int bt_pcm_prepare(struct snd_pcm_substream *substream)
+ 	dev = &(data->udev->dev);
+ 	// TODO: Does endpoint needs to be configured separately for Tx and Rx
+ 	// endpoints?
++	mutex_lock(&config_mutex);
+ 	err = configure_endpoints(substream);
++	mutex_unlock(&config_mutex);
+ 	if (err < 0) {
+ 		dev_err(dev, "failed to configure Endpoints err:%d\n", err);
+ 		return err;
+-- 
+2.17.1
+

--- a/android_p/google_diff/cel_kbl/kernel/project-celadon/0010-Fix-for-race-condition-in-configuring-the-TX-and-RX.patch
+++ b/android_p/google_diff/cel_kbl/kernel/project-celadon/0010-Fix-for-race-condition-in-configuring-the-TX-and-RX.patch
@@ -1,0 +1,48 @@
+From ab8d01a1c6a651a7dadf23c1b7af5f7814796555 Mon Sep 17 00:00:00 2001
+From: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Date: Wed, 5 Jun 2019 21:28:57 +0530
+Subject: [PATCH] Fix race  condition in btusb_sco_snd_card driver
+
+Fix for race condition in configuring the TX and RX EP, by
+adding mutex lock
+
+Tracked-On: OAM-81187
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+---
+ sound/usb/btusb/btusb_sco_snd_card.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/sound/usb/btusb/btusb_sco_snd_card.c b/sound/usb/btusb/btusb_sco_snd_card.c
+index b2cbb9ca8f42..5bed5300508f 100644
+--- a/sound/usb/btusb/btusb_sco_snd_card.c
++++ b/sound/usb/btusb/btusb_sco_snd_card.c
+@@ -15,6 +15,7 @@
+ #include <linux/jiffies.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
++#include <linux/mutex.h>
+ #include <linux/types.h>
+ #include <linux/usb.h>
+ #include <linux/usbdevice_fs.h>
+@@ -46,6 +47,8 @@
+ #define PRD_SIZE_MAX	                   PAGE_SIZE  /*4096*/
+ #define MIN_PERIODS	                   4
+ 
++static DEFINE_MUTEX(config_mutex);
++
+ struct capture_data_cb {
+ 	unsigned char *buf;
+ 	unsigned int pos;
+@@ -614,7 +617,9 @@ static int bt_pcm_prepare(struct snd_pcm_substream *substream)
+ 	dev = &(data->udev->dev);
+ 	// TODO: Does endpoint needs to be configured separately for Tx and Rx
+ 	// endpoints?
++	mutex_lock(&config_mutex);
+ 	err = configure_endpoints(substream);
++	mutex_unlock(&config_mutex);
+ 	if (err < 0) {
+ 		dev_err(dev, "failed to configure Endpoints err:%d\n", err);
+ 		return err;
+-- 
+2.17.1
+

--- a/android_p/google_diff/celadon/kernel/project-celadon/0007-Fix-for-race-condition-in-configuring-the-TX-and-RX-.patch
+++ b/android_p/google_diff/celadon/kernel/project-celadon/0007-Fix-for-race-condition-in-configuring-the-TX-and-RX-.patch
@@ -1,0 +1,48 @@
+From ab8d01a1c6a651a7dadf23c1b7af5f7814796555 Mon Sep 17 00:00:00 2001
+From: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Date: Wed, 5 Jun 2019 21:28:57 +0530
+Subject: [PATCH] Fix race  condition in btusb_sco_snd_card driver
+
+Fix for race condition in configuring the TX and RX EP, by
+adding mutex lock
+
+Tracked-On: OAM-81187
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+---
+ sound/usb/btusb/btusb_sco_snd_card.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/sound/usb/btusb/btusb_sco_snd_card.c b/sound/usb/btusb/btusb_sco_snd_card.c
+index b2cbb9ca8f42..5bed5300508f 100644
+--- a/sound/usb/btusb/btusb_sco_snd_card.c
++++ b/sound/usb/btusb/btusb_sco_snd_card.c
+@@ -15,6 +15,7 @@
+ #include <linux/jiffies.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
++#include <linux/mutex.h>
+ #include <linux/types.h>
+ #include <linux/usb.h>
+ #include <linux/usbdevice_fs.h>
+@@ -46,6 +47,8 @@
+ #define PRD_SIZE_MAX	                   PAGE_SIZE  /*4096*/
+ #define MIN_PERIODS	                   4
+ 
++static DEFINE_MUTEX(config_mutex);
++
+ struct capture_data_cb {
+ 	unsigned char *buf;
+ 	unsigned int pos;
+@@ -614,7 +617,9 @@ static int bt_pcm_prepare(struct snd_pcm_substream *substream)
+ 	dev = &(data->udev->dev);
+ 	// TODO: Does endpoint needs to be configured separately for Tx and Rx
+ 	// endpoints?
++	mutex_lock(&config_mutex);
+ 	err = configure_endpoints(substream);
++	mutex_unlock(&config_mutex);
+ 	if (err < 0) {
+ 		dev_err(dev, "failed to configure Endpoints err:%d\n", err);
+ 		return err;
+-- 
+2.17.1
+


### PR DESCRIPTION
Fix for race condition in configuring the TX and RX EP, by
adding mutex lock

Tracked-On:
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>