### PR TITLE
Fix is to check cpu_freq for 0 value.

### DIFF
--- a/android_p/google_diff/cel_apl/hardware/intel/kernelflinger/0009-Fix-is-to-check-cpu_freq-for-0-value.patch
+++ b/android_p/google_diff/cel_apl/hardware/intel/kernelflinger/0009-Fix-is-to-check-cpu_freq-for-0-value.patch
@@ -1,0 +1,52 @@
+From 204bff5fbf80602ea413ddc247fbc614cfb624b6 Mon Sep 17 00:00:00 2001
+From: "Mehmood, Arshad" <arshad.mehmood@intel.com>
+Date: Fri, 31 May 2019 11:28:45 +0800
+Subject: [PATCH 9/9] Fix is to check cpu_freq for 0 value.
+
+RDMSR returns 0 in VM thus causing divide by error below.  Fix is to
+check cpu_freq for 0 value and set the flag "time_stamp = FALSE" and
+return.
+
+Tracked-On: OAM-80206
+Signed-off-by: Mehmood, Arshad <arshad.mehmood@intel.com>
+Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>
+---
+ libkernelflinger/timer.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/libkernelflinger/timer.c b/libkernelflinger/timer.c
+index 32d7076..55680b4 100644
+--- a/libkernelflinger/timer.c
++++ b/libkernelflinger/timer.c
+@@ -47,6 +47,7 @@
+ //Array for recording boot time of every stage
+ static unsigned bt_stamp[TM_POINT_LAST];
+ static unsigned int efi_enter_point = 0;
++static BOOLEAN  time_stamp = TRUE;
+ 
+ typedef union
+ {
+@@ -98,6 +99,11 @@ uint32_t boottime_in_msec(void)
+ 
+ 	cpu_freq = get_cpu_freq();
+ 
++	if (cpu_freq == 0) {
++		time_stamp = FALSE;
++		return 0;
++	}
++
+ 	tick = __RDTSC();
+ 	bt_us = (((unsigned) (tick >> 6)) / cpu_freq) << 6;
+ 	bt_ms = bt_us / 1000;
+@@ -107,7 +113,7 @@ uint32_t boottime_in_msec(void)
+ 
+ void set_boottime_stamp(int num)
+ {
+-	if ((num < 0) || (num >= TM_POINT_LAST))
++	if ((num < 0) || (num >= TM_POINT_LAST) || time_stamp == FALSE)
+ 		return;
+ 
+ 	bt_stamp[num] = boottime_in_msec();
+-- 
+2.20.1
+


### PR DESCRIPTION
RDMSR returns 0 in VM thus causing divide by error below.  Fix is to
check cpu_freq for 0 value and set a flag "time_stamp = FALSE" and
exit the boot time calculation.

Tracked-On: OAM-80206
Signed-off-by: Yanhongx.Zhou <yanhongx.zhou@intel.com>