### PR TITLE
edit 'make publish_ci'

### DIFF
--- a/android_p/google_diff/cel_apl/device/intel/build/0001-edit-make-publish_ci.patch
+++ b/android_p/google_diff/cel_apl/device/intel/build/0001-edit-make-publish_ci.patch
@@ -1,7 +1,7 @@
-From eb61093121a69c3942bacffaead8cbd6f4f114cf Mon Sep 17 00:00:00 2001
+From b53393fe2f26ea00360f6f426478ffb09dc32d57 Mon Sep 17 00:00:00 2001
 From: sgnanase <sundar.gnanasekaran@intel.com>
 Date: Wed, 16 Jan 2019 18:31:18 +0530
-Subject: [PATCH] [WORKAROUND][CELADON] edit 'make publish_ci'
+Subject: [PATCH] edit 'make publish_ci'
 
 gpt image is around 14G in size.
 Hence, removing upload of *gpt_image to artifactory
@@ -11,14 +11,14 @@ untic artifactory speed is improved
 
 Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>
 ---
- tasks/publish.mk | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ tasks/publish.mk | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/tasks/publish.mk b/tasks/publish.mk
-index f7071f5..4ef6cc6 100644
+index 5c6c46f..68deb8d 100644
 --- a/tasks/publish.mk
 +++ b/tasks/publish.mk
-@@ -185,7 +185,7 @@ endif # PUBLISH_CONF
+@@ -193,7 +193,7 @@ endif # PUBLISH_CONF
  PUBLISH_CI_FILES := $(DIST_DIR)/fastboot $(DIST_DIR)/adb
  .PHONY: publish_ci
  ifeq ($(KERNELFLINGER_SUPPORT_NON_EFI_BOOT), false)
@@ -27,7 +27,7 @@ index f7071f5..4ef6cc6 100644
  	$(if $(wildcard $(publish_dest)), \
  	  $(foreach f,$(PUBLISH_CI_FILES), \
  	    $(if $(wildcard $(f)),$(ACP) $(f) $(publish_dest);,)),)
-@@ -198,7 +198,7 @@ publish_windows_tools: $(PLATFORM_RMA_TOOLS_CROSS_ZIP)
+@@ -206,7 +206,7 @@ publish_windows_tools: $(PLATFORM_RMA_TOOLS_CROSS_ZIP)
  	@$(hide) mkdir -p $(publish_tool_destw)
  	@$(hide) $(ACP) $(PLATFORM_RMA_TOOLS_CROSS_ZIP) $(publish_tool_destw)
  else
@@ -36,6 +36,13 @@ index f7071f5..4ef6cc6 100644
  	$(if $(wildcard $(publish_dest)), \
  	  $(foreach f,$(PUBLISH_CI_FILES), \
  	    $(if $(wildcard $(f)),$(ACP) $(f) $(publish_dest);,)),)
+@@ -239,5 +239,5 @@ PUBLISH_GOALS := $(DEFAULT_GOAL)
+ endif
+ 
+ .PHONY: publish
+-publish: publish_mkdir_dest $(PUBLISH_GOALS) publish_ifwi publish_gptimage publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) publish_kf4abl_symbols $(PUB_CMCC_ZIP) publish_androidia_image
++publish: publish_mkdir_dest $(PUBLISH_GOALS) publish_ifwi publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) publish_kf4abl_symbols $(PUB_CMCC_ZIP) publish_androidia_image
+ 	@$(ACP) $(DIST_DIR)/* $(publish_dest)
 -- 
-2.20.1
+2.21.0
 

--- a/android_p/google_diff/cel_kbl/device/intel/build/0001-edit-make-publish_ci.patch
+++ b/android_p/google_diff/cel_kbl/device/intel/build/0001-edit-make-publish_ci.patch
@@ -1,7 +1,7 @@
-From eb61093121a69c3942bacffaead8cbd6f4f114cf Mon Sep 17 00:00:00 2001
+From b53393fe2f26ea00360f6f426478ffb09dc32d57 Mon Sep 17 00:00:00 2001
 From: sgnanase <sundar.gnanasekaran@intel.com>
 Date: Wed, 16 Jan 2019 18:31:18 +0530
-Subject: [PATCH] [WORKAROUND][CELADON] edit 'make publish_ci'
+Subject: [PATCH] edit 'make publish_ci'
 
 gpt image is around 14G in size.
 Hence, removing upload of *gpt_image to artifactory
@@ -11,14 +11,14 @@ untic artifactory speed is improved
 
 Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>
 ---
- tasks/publish.mk | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ tasks/publish.mk | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/tasks/publish.mk b/tasks/publish.mk
-index f7071f5..4ef6cc6 100644
+index 5c6c46f..68deb8d 100644
 --- a/tasks/publish.mk
 +++ b/tasks/publish.mk
-@@ -185,7 +185,7 @@ endif # PUBLISH_CONF
+@@ -193,7 +193,7 @@ endif # PUBLISH_CONF
  PUBLISH_CI_FILES := $(DIST_DIR)/fastboot $(DIST_DIR)/adb
  .PHONY: publish_ci
  ifeq ($(KERNELFLINGER_SUPPORT_NON_EFI_BOOT), false)
@@ -27,7 +27,7 @@ index f7071f5..4ef6cc6 100644
  	$(if $(wildcard $(publish_dest)), \
  	  $(foreach f,$(PUBLISH_CI_FILES), \
  	    $(if $(wildcard $(f)),$(ACP) $(f) $(publish_dest);,)),)
-@@ -198,7 +198,7 @@ publish_windows_tools: $(PLATFORM_RMA_TOOLS_CROSS_ZIP)
+@@ -206,7 +206,7 @@ publish_windows_tools: $(PLATFORM_RMA_TOOLS_CROSS_ZIP)
  	@$(hide) mkdir -p $(publish_tool_destw)
  	@$(hide) $(ACP) $(PLATFORM_RMA_TOOLS_CROSS_ZIP) $(publish_tool_destw)
  else
@@ -36,6 +36,13 @@ index f7071f5..4ef6cc6 100644
  	$(if $(wildcard $(publish_dest)), \
  	  $(foreach f,$(PUBLISH_CI_FILES), \
  	    $(if $(wildcard $(f)),$(ACP) $(f) $(publish_dest);,)),)
+@@ -239,5 +239,5 @@ PUBLISH_GOALS := $(DEFAULT_GOAL)
+ endif
+ 
+ .PHONY: publish
+-publish: publish_mkdir_dest $(PUBLISH_GOALS) publish_ifwi publish_gptimage publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) publish_kf4abl_symbols $(PUB_CMCC_ZIP) publish_androidia_image
++publish: publish_mkdir_dest $(PUBLISH_GOALS) publish_ifwi publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) publish_kf4abl_symbols $(PUB_CMCC_ZIP) publish_androidia_image
+ 	@$(ACP) $(DIST_DIR)/* $(publish_dest)
 -- 
-2.20.1
+2.21.0
 

--- a/android_p/google_diff/celadon/device/intel/build/0001-edit-make-publish_ci.patch
+++ b/android_p/google_diff/celadon/device/intel/build/0001-edit-make-publish_ci.patch
@@ -1,7 +1,7 @@
-From eb61093121a69c3942bacffaead8cbd6f4f114cf Mon Sep 17 00:00:00 2001
+From b53393fe2f26ea00360f6f426478ffb09dc32d57 Mon Sep 17 00:00:00 2001
 From: sgnanase <sundar.gnanasekaran@intel.com>
 Date: Wed, 16 Jan 2019 18:31:18 +0530
-Subject: [PATCH] [WORKAROUND][CELADON] edit 'make publish_ci'
+Subject: [PATCH] edit 'make publish_ci'
 
 gpt image is around 14G in size.
 Hence, removing upload of *gpt_image to artifactory
@@ -11,14 +11,14 @@ untic artifactory speed is improved
 
 Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>
 ---
- tasks/publish.mk | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
+ tasks/publish.mk | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/tasks/publish.mk b/tasks/publish.mk
-index f7071f5..4ef6cc6 100644
+index 5c6c46f..68deb8d 100644
 --- a/tasks/publish.mk
 +++ b/tasks/publish.mk
-@@ -185,7 +185,7 @@ endif # PUBLISH_CONF
+@@ -193,7 +193,7 @@ endif # PUBLISH_CONF
  PUBLISH_CI_FILES := $(DIST_DIR)/fastboot $(DIST_DIR)/adb
  .PHONY: publish_ci
  ifeq ($(KERNELFLINGER_SUPPORT_NON_EFI_BOOT), false)
@@ -27,7 +27,7 @@ index f7071f5..4ef6cc6 100644
  	$(if $(wildcard $(publish_dest)), \
  	  $(foreach f,$(PUBLISH_CI_FILES), \
  	    $(if $(wildcard $(f)),$(ACP) $(f) $(publish_dest);,)),)
-@@ -198,7 +198,7 @@ publish_windows_tools: $(PLATFORM_RMA_TOOLS_CROSS_ZIP)
+@@ -206,7 +206,7 @@ publish_windows_tools: $(PLATFORM_RMA_TOOLS_CROSS_ZIP)
  	@$(hide) mkdir -p $(publish_tool_destw)
  	@$(hide) $(ACP) $(PLATFORM_RMA_TOOLS_CROSS_ZIP) $(publish_tool_destw)
  else
@@ -36,6 +36,13 @@ index f7071f5..4ef6cc6 100644
  	$(if $(wildcard $(publish_dest)), \
  	  $(foreach f,$(PUBLISH_CI_FILES), \
  	    $(if $(wildcard $(f)),$(ACP) $(f) $(publish_dest);,)),)
+@@ -239,5 +239,5 @@ PUBLISH_GOALS := $(DEFAULT_GOAL)
+ endif
+ 
+ .PHONY: publish
+-publish: publish_mkdir_dest $(PUBLISH_GOALS) publish_ifwi publish_gptimage publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) publish_kf4abl_symbols $(PUB_CMCC_ZIP) publish_androidia_image
++publish: publish_mkdir_dest $(PUBLISH_GOALS) publish_ifwi publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) publish_kf4abl_symbols $(PUB_CMCC_ZIP) publish_androidia_image
+ 	@$(ACP) $(DIST_DIR)/* $(publish_dest)
 -- 
-2.20.1
+2.21.0
 

--- a/android_p/google_diff/clk/device/intel/build/0001-edit-make-publish_ci.patch
+++ b/android_p/google_diff/clk/device/intel/build/0001-edit-make-publish_ci.patch
@@ -1,0 +1,48 @@
+From b53393fe2f26ea00360f6f426478ffb09dc32d57 Mon Sep 17 00:00:00 2001
+From: sgnanase <sundar.gnanasekaran@intel.com>
+Date: Wed, 16 Jan 2019 18:31:18 +0530
+Subject: [PATCH] edit 'make publish_ci'
+
+gpt image is around 14G in size.
+Hence, removing upload of *gpt_image to artifactory
+untic artifactory speed is improved
+
+<To be reverted once we have artifactory issue fixed>
+
+Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>
+---
+ tasks/publish.mk | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/tasks/publish.mk b/tasks/publish.mk
+index 5c6c46f..68deb8d 100644
+--- a/tasks/publish.mk
++++ b/tasks/publish.mk
+@@ -193,7 +193,7 @@ endif # PUBLISH_CONF
+ PUBLISH_CI_FILES := $(DIST_DIR)/fastboot $(DIST_DIR)/adb
+ .PHONY: publish_ci
+ ifeq ($(KERNELFLINGER_SUPPORT_NON_EFI_BOOT), false)
+-publish_ci: publish_liveimage publish_ota_flashfile publish_gptimage publish_ifwi publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) $(PUB_CMCC_ZIP) $(PLATFORM_RMA_TOOLS_ZIP)
++publish_ci: publish_liveimage publish_ota_flashfile publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) $(PUB_CMCC_ZIP) $(PLATFORM_RMA_TOOLS_ZIP)
+ 	$(if $(wildcard $(publish_dest)), \
+ 	  $(foreach f,$(PUBLISH_CI_FILES), \
+ 	    $(if $(wildcard $(f)),$(ACP) $(f) $(publish_dest);,)),)
+@@ -206,7 +206,7 @@ publish_windows_tools: $(PLATFORM_RMA_TOOLS_CROSS_ZIP)
+ 	@$(hide) mkdir -p $(publish_tool_destw)
+ 	@$(hide) $(ACP) $(PLATFORM_RMA_TOOLS_CROSS_ZIP) $(publish_tool_destw)
+ else
+-publish_ci: publish_liveimage publish_ota_flashfile publish_gptimage publish_ifwi publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) $(PUB_CMCC_ZIP)
++publish_ci: publish_liveimage publish_ota_flashfile publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) $(PUB_CMCC_ZIP)
+ 	$(if $(wildcard $(publish_dest)), \
+ 	  $(foreach f,$(PUBLISH_CI_FILES), \
+ 	    $(if $(wildcard $(f)),$(ACP) $(f) $(publish_dest);,)),)
+@@ -239,5 +239,5 @@ PUBLISH_GOALS := $(DEFAULT_GOAL)
+ endif
+ 
+ .PHONY: publish
+-publish: publish_mkdir_dest $(PUBLISH_GOALS) publish_ifwi publish_gptimage publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) publish_kf4abl_symbols $(PUB_CMCC_ZIP) publish_androidia_image
++publish: publish_mkdir_dest $(PUBLISH_GOALS) publish_ifwi publish_firmware_symbols $(PUB_OSAGNOSTIC_TAG) publish_kf4abl_symbols $(PUB_CMCC_ZIP) publish_androidia_image
+ 	@$(ACP) $(DIST_DIR)/* $(publish_dest)
+-- 
+2.21.0
+


### PR DESCRIPTION
gpt image is around 14G in size.
Hence, removing upload of *gpt_image to artifactory
untic artifactory speed is improved

<To be reverted once we have artifactory issue fixed>

Tracked-On: OAM-82994
Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>