### PR TITLE
usb: xhci: dbc: Porting DbC to kernel version 4.19.46

### DIFF
--- a/android_p/google_diff/clk/kernel/project-celadon/0010-usb-xhci-dbc-Fixing-typo-error.patch
+++ b/android_p/google_diff/clk/kernel/project-celadon/0010-usb-xhci-dbc-Fixing-typo-error.patch
@@ -1,0 +1,48 @@
+From 921d078c42929dcc19ac5bd2918e6a1473867fb9 Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Wed, 20 Feb 2019 19:50:55 +0200
+Subject: [PATCH 1/7] usb: xhci: dbc: Fixing typo error.
+
+Replaced "xhci_dbc_flush_reqests" with xhci_dbc_flush_requests".
+
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Signed-off-by: Mathias Nyman <mathias.nyman@linux.intel.com>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/usb/host/xhci-dbgcap.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/usb/host/xhci-dbgcap.c b/drivers/usb/host/xhci-dbgcap.c
+index ba841c569c48..d932cc31711e 100644
+--- a/drivers/usb/host/xhci-dbgcap.c
++++ b/drivers/usb/host/xhci-dbgcap.c
+@@ -181,7 +181,7 @@ static void xhci_dbc_flush_endpoint_requests(struct dbc_ep *dep)
+ 		xhci_dbc_flush_single_request(req);
+ }
+ 
+-static void xhci_dbc_flush_reqests(struct xhci_dbc *dbc)
++static void xhci_dbc_flush_requests(struct xhci_dbc *dbc)
+ {
+ 	xhci_dbc_flush_endpoint_requests(&dbc->eps[BULK_OUT]);
+ 	xhci_dbc_flush_endpoint_requests(&dbc->eps[BULK_IN]);
+@@ -688,7 +688,7 @@ static enum evtreturn xhci_dbc_do_handle_events(struct xhci_dbc *dbc)
+ 		    !(portsc & DBC_PORTSC_CONN_STATUS)) {
+ 			xhci_info(xhci, "DbC cable unplugged\n");
+ 			dbc->state = DS_ENABLED;
+-			xhci_dbc_flush_reqests(dbc);
++			xhci_dbc_flush_requests(dbc);
+ 
+ 			return EVT_DISC;
+ 		}
+@@ -698,7 +698,7 @@ static enum evtreturn xhci_dbc_do_handle_events(struct xhci_dbc *dbc)
+ 			xhci_info(xhci, "DbC port reset\n");
+ 			writel(portsc, &dbc->regs->portsc);
+ 			dbc->state = DS_ENABLED;
+-			xhci_dbc_flush_reqests(dbc);
++			xhci_dbc_flush_requests(dbc);
+ 
+ 			return EVT_DISC;
+ 		}
+-- 
+2.21.0
+

--- a/android_p/google_diff/clk/kernel/project-celadon/0011-usb-xhci-dbc-make-DbC-modular-introducing-dbc_functi.patch
+++ b/android_p/google_diff/clk/kernel/project-celadon/0011-usb-xhci-dbc-make-DbC-modular-introducing-dbc_functi.patch
@@ -1,0 +1,456 @@
+From a01ea3d831f906f1006af70d00b7a0797fae46b5 Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Tue, 18 Jun 2019 12:37:03 +0530
+Subject: [PATCH 2/7] usb: xhci: dbc: make DbC modular, introducing
+ dbc_function structure
+
+This patch introduces the dbc_function structure as a first step in
+making DbC modular and capable in exposing different user interfaces using
+different "functions", which may implement the callbacks exposed here
+according to the driver's need.
+
+Only one "function" can be registered at a time.
+The generic way to enable a DbC function would be, using sys-fs:
+
+Locate the directory for PCI enumerated XHCI host controller in the
+sysfs path.
+e.g.: cd /sys/bus/pci/devices/0000:00:14.0
+$ echo "enable" > dbc
+
+This is done AFTER the function is selected at build time. Only 1 function
+can be selected at a time.
+
+Signed-off-by: Rajaram Regupathy <rajaram.regupathy@intel.com>
+Signed-off-by: Abhilash K V <abhilash.k.v@intel.com>
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+---
+ drivers/usb/host/xhci-dbgcap.c | 159 ++++++++++++++++++++++-----------
+ drivers/usb/host/xhci-dbgcap.h |  32 ++++++-
+ 2 files changed, 138 insertions(+), 53 deletions(-)
+
+diff --git a/drivers/usb/host/xhci-dbgcap.c b/drivers/usb/host/xhci-dbgcap.c
+index d932cc31711e..0fc2db43e3b0 100644
+--- a/drivers/usb/host/xhci-dbgcap.c
++++ b/drivers/usb/host/xhci-dbgcap.c
+@@ -9,11 +9,14 @@
+ #include <linux/dma-mapping.h>
+ #include <linux/slab.h>
+ #include <linux/nls.h>
++#include <linux/module.h>
+ 
+ #include "xhci.h"
+ #include "xhci-trace.h"
+ #include "xhci-dbgcap.h"
+ 
++static struct dbc_function *dbc_registered_func;
++
+ static inline void *
+ dbc_dma_alloc_coherent(struct xhci_hcd *xhci, size_t size,
+ 		       dma_addr_t *dma_handle, gfp_t flags)
+@@ -35,41 +38,42 @@ dbc_dma_free_coherent(struct xhci_hcd *xhci, size_t size,
+ 				  size, cpu_addr, dma_handle);
+ }
+ 
+-static u32 xhci_dbc_populate_strings(struct dbc_str_descs *strings)
++static u32 xhci_dbc_populate_strings(struct dbc_str_descs *strings,
++					struct dbc_function *func)
+ {
+ 	struct usb_string_descriptor	*s_desc;
+ 	u32				string_length;
+ 
+ 	/* Serial string: */
+ 	s_desc = (struct usb_string_descriptor *)strings->serial;
+-	utf8s_to_utf16s(DBC_STRING_SERIAL, strlen(DBC_STRING_SERIAL),
++	utf8s_to_utf16s(func->string.serial, strlen(func->string.serial),
+ 			UTF16_LITTLE_ENDIAN, (wchar_t *)s_desc->wData,
+ 			DBC_MAX_STRING_LENGTH);
+ 
+-	s_desc->bLength		= (strlen(DBC_STRING_SERIAL) + 1) * 2;
++	s_desc->bLength		= (strlen(func->string.serial) + 1) * 2;
+ 	s_desc->bDescriptorType	= USB_DT_STRING;
+ 	string_length		= s_desc->bLength;
+ 	string_length		<<= 8;
+ 
+ 	/* Product string: */
+ 	s_desc = (struct usb_string_descriptor *)strings->product;
+-	utf8s_to_utf16s(DBC_STRING_PRODUCT, strlen(DBC_STRING_PRODUCT),
++	utf8s_to_utf16s(func->string.product, strlen(func->string.product),
+ 			UTF16_LITTLE_ENDIAN, (wchar_t *)s_desc->wData,
+ 			DBC_MAX_STRING_LENGTH);
+ 
+-	s_desc->bLength		= (strlen(DBC_STRING_PRODUCT) + 1) * 2;
++	s_desc->bLength		= (strlen(func->string.product) + 1) * 2;
+ 	s_desc->bDescriptorType	= USB_DT_STRING;
+ 	string_length		+= s_desc->bLength;
+ 	string_length		<<= 8;
+ 
+ 	/* Manufacture string: */
+ 	s_desc = (struct usb_string_descriptor *)strings->manufacturer;
+-	utf8s_to_utf16s(DBC_STRING_MANUFACTURER,
+-			strlen(DBC_STRING_MANUFACTURER),
++	utf8s_to_utf16s(func->string.manufacturer,
++			strlen(func->string.manufacturer),
+ 			UTF16_LITTLE_ENDIAN, (wchar_t *)s_desc->wData,
+ 			DBC_MAX_STRING_LENGTH);
+ 
+-	s_desc->bLength		= (strlen(DBC_STRING_MANUFACTURER) + 1) * 2;
++	s_desc->bLength		= (strlen(func->string.manufacturer) + 1) * 2;
+ 	s_desc->bDescriptorType	= USB_DT_STRING;
+ 	string_length		+= s_desc->bLength;
+ 	string_length		<<= 8;
+@@ -84,7 +88,9 @@ static u32 xhci_dbc_populate_strings(struct dbc_str_descs *strings)
+ 	return string_length;
+ }
+ 
+-static void xhci_dbc_init_contexts(struct xhci_hcd *xhci, u32 string_length)
++static void xhci_dbc_init_contexts(struct xhci_hcd *xhci,
++					struct dbc_function *func,
++					u32 string_length)
+ {
+ 	struct xhci_dbc		*dbc;
+ 	struct dbc_info_context	*info;
+@@ -124,10 +130,10 @@ static void xhci_dbc_init_contexts(struct xhci_hcd *xhci, u32 string_length)
+ 	/* Set DbC context and info registers: */
+ 	xhci_write_64(xhci, dbc->ctx->dma, &dbc->regs->dccp);
+ 
+-	dev_info = cpu_to_le32((DBC_VENDOR_ID << 16) | DBC_PROTOCOL);
++	dev_info = cpu_to_le32((func->vid << 16) | func->protocol);
+ 	writel(dev_info, &dbc->regs->devinfo1);
+ 
+-	dev_info = cpu_to_le32((DBC_DEVICE_REV << 16) | DBC_PRODUCT_ID);
++	dev_info = cpu_to_le32((func->device_rev << 16) | func->pid);
+ 	writel(dev_info, &dbc->regs->devinfo2);
+ }
+ 
+@@ -181,11 +187,13 @@ static void xhci_dbc_flush_endpoint_requests(struct dbc_ep *dep)
+ 		xhci_dbc_flush_single_request(req);
+ }
+ 
+-static void xhci_dbc_flush_requests(struct xhci_dbc *dbc)
++
++void xhci_dbc_flush_requests(struct xhci_dbc *dbc)
+ {
+ 	xhci_dbc_flush_endpoint_requests(&dbc->eps[BULK_OUT]);
+ 	xhci_dbc_flush_endpoint_requests(&dbc->eps[BULK_IN]);
+ }
++EXPORT_SYMBOL_GPL(xhci_dbc_flush_requests);
+ 
+ struct dbc_request *
+ dbc_alloc_request(struct dbc_ep *dep, gfp_t gfp_flags)
+@@ -205,6 +213,7 @@ dbc_alloc_request(struct dbc_ep *dep, gfp_t gfp_flags)
+ 
+ 	return req;
+ }
++EXPORT_SYMBOL_GPL(dbc_alloc_request);
+ 
+ void
+ dbc_free_request(struct dbc_ep *dep, struct dbc_request *req)
+@@ -213,6 +222,7 @@ dbc_free_request(struct dbc_ep *dep, struct dbc_request *req)
+ 
+ 	kfree(req);
+ }
++EXPORT_SYMBOL_GPL(dbc_free_request);
+ 
+ static void
+ xhci_dbc_queue_trb(struct xhci_ring *ring, u32 field1,
+@@ -344,6 +354,7 @@ int dbc_ep_queue(struct dbc_ep *dep, struct dbc_request *req,
+ 
+ 	return ret;
+ }
++EXPORT_SYMBOL_GPL(dbc_ep_queue);
+ 
+ static inline void xhci_dbc_do_eps_init(struct xhci_hcd *xhci, bool direction)
+ {
+@@ -371,7 +382,9 @@ static void xhci_dbc_eps_exit(struct xhci_hcd *xhci)
+ 	memset(dbc->eps, 0, sizeof(struct dbc_ep) * ARRAY_SIZE(dbc->eps));
+ }
+ 
+-static int xhci_dbc_mem_init(struct xhci_hcd *xhci, gfp_t flags)
++static int xhci_dbc_mem_init(struct xhci_hcd *xhci,
++				struct dbc_function *func,
++				gfp_t flags)
+ {
+ 	int			ret;
+ 	dma_addr_t		deq;
+@@ -418,8 +431,8 @@ static int xhci_dbc_mem_init(struct xhci_hcd *xhci, gfp_t flags)
+ 	xhci_write_64(xhci, deq, &dbc->regs->erdp);
+ 
+ 	/* Setup strings and contexts: */
+-	string_length = xhci_dbc_populate_strings(dbc->string);
+-	xhci_dbc_init_contexts(xhci, string_length);
++	string_length = xhci_dbc_populate_strings(dbc->string, func);
++	xhci_dbc_init_contexts(xhci, func, string_length);
+ 
+ 	mmiowb();
+ 
+@@ -480,20 +493,9 @@ static int xhci_do_dbc_start(struct xhci_hcd *xhci)
+ 	u32			ctrl;
+ 	struct xhci_dbc		*dbc = xhci->dbc;
+ 
+-	if (dbc->state != DS_DISABLED)
++	if (dbc->state != DS_INITIALIZED)
+ 		return -EINVAL;
+ 
+-	writel(0, &dbc->regs->control);
+-	ret = xhci_handshake(&dbc->regs->control,
+-			     DBC_CTRL_DBC_ENABLE,
+-			     0, 1000);
+-	if (ret)
+-		return ret;
+-
+-	ret = xhci_dbc_mem_init(xhci, GFP_ATOMIC);
+-	if (ret)
+-		return ret;
+-
+ 	ctrl = readl(&dbc->regs->control);
+ 	writel(ctrl | DBC_CTRL_DBC_ENABLE | DBC_CTRL_PORT_ENABLE,
+ 	       &dbc->regs->control);
+@@ -554,9 +556,13 @@ static void xhci_dbc_stop(struct xhci_hcd *xhci)
+ 
+ 	cancel_delayed_work_sync(&dbc->event_work);
+ 
+-	if (port->registered)
+-		xhci_dbc_tty_unregister_device(xhci);
+-
++	if (port->registered &&
++	    dbc_registered_func &&
++	    dbc_registered_func->post_disconnect) {
++		ret = dbc_registered_func->post_disconnect(dbc);
++		if (ret)
++			xhci_err(xhci, "dbc post_disconnect error %d\n", ret);
++	}
+ 	spin_lock_irqsave(&dbc->lock, flags);
+ 	ret = xhci_do_dbc_stop(xhci);
+ 	spin_unlock_irqrestore(&dbc->lock, flags);
+@@ -800,16 +806,12 @@ static void xhci_dbc_handle_events(struct work_struct *work)
+ 
+ 	switch (evtr) {
+ 	case EVT_GSER:
+-		ret = xhci_dbc_tty_register_device(xhci);
+-		if (ret) {
+-			xhci_err(xhci, "failed to alloc tty device\n");
+-			break;
+-		}
+-
+-		xhci_info(xhci, "DbC now attached to /dev/ttyDBC0\n");
++		if (dbc_registered_func->post_config)
++			dbc_registered_func->post_config(dbc);
+ 		break;
+ 	case EVT_DISC:
+-		xhci_dbc_tty_unregister_device(xhci);
++		if (dbc_registered_func->post_disconnect)
++			ret = dbc_registered_func->post_disconnect(dbc);
+ 		break;
+ 	case EVT_DONE:
+ 		break;
+@@ -914,46 +916,76 @@ static ssize_t dbc_store(struct device *dev,
+ 			 struct device_attribute *attr,
+ 			 const char *buf, size_t count)
+ {
++	struct xhci_dbc		*dbc;
+ 	struct xhci_hcd		*xhci;
++	int			ret = 0;
+ 
+ 	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
+ 
+-	if (!strncmp(buf, "enable", 6))
++	if (!strncmp(buf, "enable", 6) && dbc->state == DS_DISABLED) {
++		if (!dbc_registered_func)
++			return -EINVAL;
++		if (!try_module_get(dbc_registered_func->owner))
++			return -ENODEV;
++		ret = xhci_dbc_mem_init(dbc->xhci, dbc_registered_func,
++						GFP_ATOMIC);
++		if (ret)
++			goto err;
++		if (dbc_registered_func->run)
++			ret = dbc_registered_func->run(dbc);
++		if (ret) {
++			xhci_dbc_mem_cleanup(xhci);
++			dbc->state = DS_DISABLED;
++			goto err;
++		}
+ 		xhci_dbc_start(xhci);
+-	else if (!strncmp(buf, "disable", 7))
++	} else if (!strncmp(buf, "disable", 7) && dbc->state != DS_DISABLED) {
++		if (!dbc_registered_func)
++			return -EINVAL;
+ 		xhci_dbc_stop(xhci);
+-	else
++		if (dbc_registered_func->stop)
++			dbc_registered_func->stop(dbc);
++		module_put(dbc_registered_func->owner);
++	} else
+ 		return -EINVAL;
+ 
+ 	return count;
++err:
++	module_put(dbc_registered_func->owner);
++	return ret;
+ }
+ 
+ static DEVICE_ATTR_RW(dbc);
+ 
++static struct attribute *dbc_dev_attributes[] = {
++	&dev_attr_dbc.attr,
++	NULL
++};
++
++static const struct attribute_group dbc_dev_attrib_grp = {
++	.attrs = dbc_dev_attributes,
++};
++
++
+ int xhci_dbc_init(struct xhci_hcd *xhci)
+ {
+ 	int			ret;
+ 	struct device		*dev = xhci_to_hcd(xhci)->self.controller;
+ 
+ 	ret = xhci_do_dbc_init(xhci);
+-	if (ret)
+-		goto init_err3;
+-
+-	ret = xhci_dbc_tty_register_driver(xhci);
+ 	if (ret)
+ 		goto init_err2;
+ 
+-	ret = device_create_file(dev, &dev_attr_dbc);
++	ret = sysfs_create_group(&dev->kobj, &dbc_dev_attrib_grp);
+ 	if (ret)
+ 		goto init_err1;
+ 
+ 	return 0;
+ 
+ init_err1:
+-	xhci_dbc_tty_unregister_driver();
+-init_err2:
+ 	xhci_do_dbc_exit(xhci);
+-init_err3:
++init_err2:
+ 	return ret;
+ }
+ 
+@@ -965,11 +997,38 @@ void xhci_dbc_exit(struct xhci_hcd *xhci)
+ 		return;
+ 
+ 	device_remove_file(dev, &dev_attr_dbc);
+-	xhci_dbc_tty_unregister_driver();
+ 	xhci_dbc_stop(xhci);
+ 	xhci_do_dbc_exit(xhci);
+ }
+ 
++static inline int is_invalid(int val)
++{
++	return (val <  0 || val > 0xffff);
++}
++
++int xhci_dbc_register_function(struct dbc_function *func)
++{
++	if (dbc_registered_func)
++		return -EBUSY;
++
++	if (is_invalid(func->protocol) ||
++		is_invalid(func->vid) ||
++		is_invalid(func->pid) ||
++		is_invalid(func->device_rev))
++		return -EINVAL;
++	if (!func->run || !func->stop)
++		return -EINVAL;
++	dbc_registered_func = func;
++	return 0;
++}
++EXPORT_SYMBOL_GPL(xhci_dbc_register_function);
++
++void xhci_dbc_unregister_function(void)
++{
++	dbc_registered_func = NULL;
++}
++EXPORT_SYMBOL_GPL(xhci_dbc_unregister_function);
++
+ #ifdef CONFIG_PM
+ int xhci_dbc_suspend(struct xhci_hcd *xhci)
+ {
+diff --git a/drivers/usb/host/xhci-dbgcap.h b/drivers/usb/host/xhci-dbgcap.h
+index ce0c6072bd48..b4d5622a9030 100644
+--- a/drivers/usb/host/xhci-dbgcap.h
++++ b/drivers/usb/host/xhci-dbgcap.h
+@@ -11,6 +11,7 @@
+ 
+ #include <linux/tty.h>
+ #include <linux/kfifo.h>
++#include <linux/kernel.h>
+ 
+ struct dbc_regs {
+ 	__le32	capability;
+@@ -48,9 +49,9 @@ struct dbc_info_context {
+ 
+ #define DBC_MAX_PACKET			1024
+ #define DBC_MAX_STRING_LENGTH		64
+-#define DBC_STRING_MANUFACTURER		"Linux Foundation"
+-#define DBC_STRING_PRODUCT		"Linux USB Debug Target"
+-#define DBC_STRING_SERIAL		"0001"
++#define DBC_STR_MANUFACTURER		"Linux Foundation"
++#define DBC_STR_PRODUCT		"Linux USB Debug Target"
++#define DBC_STR_SERIAL			"0001"
+ #define	DBC_CONTEXT_SIZE		64
+ 
+ /*
+@@ -75,6 +76,7 @@ struct dbc_str_descs {
+ #define DBC_PRODUCT_ID			0x0010	/* device 0010 */
+ #define DBC_DEVICE_REV			0x0010	/* 0.10 */
+ 
++
+ enum dbc_state {
+ 	DS_DISABLED = 0,
+ 	DS_INITIALIZED,
+@@ -108,6 +110,25 @@ struct dbc_ep {
+ 	unsigned			direction:1;
+ };
+ 
++struct dbc_function {
++	char				func_name[32];
++	/* string descriptors */
++	struct dbc_str_descs            string;
++	/* other device or interface descriptors */
++	u16				protocol;
++	u16				vid;
++	u16				pid;
++	u16				device_rev;
++
++	/* callbacks */
++	int (*run)(struct xhci_dbc *dbc);
++	int (*post_config)(struct xhci_dbc *dbc);
++	int (*post_disconnect)(struct xhci_dbc *dbc);
++	int (*stop)(struct xhci_dbc *dbc);
++
++	/* module owner */
++	struct module			*owner;
++};
+ #define DBC_QUEUE_SIZE			16
+ #define DBC_WRITE_BUF_SIZE		8192
+ 
+@@ -151,6 +172,8 @@ struct xhci_dbc {
+ 	struct dbc_ep			eps[2];
+ 
+ 	struct dbc_port			port;
++	/* priv pointer for a function */
++	void                            *func_priv;
+ };
+ 
+ #define dbc_bulkout_ctx(d)		\
+@@ -200,8 +223,11 @@ void xhci_dbc_tty_unregister_driver(void);
+ int xhci_dbc_tty_register_device(struct xhci_hcd *xhci);
+ void xhci_dbc_tty_unregister_device(struct xhci_hcd *xhci);
+ struct dbc_request *dbc_alloc_request(struct dbc_ep *dep, gfp_t gfp_flags);
++void xhci_dbc_flush_reqests(struct xhci_dbc *dbc);
+ void dbc_free_request(struct dbc_ep *dep, struct dbc_request *req);
+ int dbc_ep_queue(struct dbc_ep *dep, struct dbc_request *req, gfp_t gfp_flags);
++int xhci_dbc_register_function(struct dbc_function *func);
++void xhci_dbc_unregister_function(void);
+ #ifdef CONFIG_PM
+ int xhci_dbc_suspend(struct xhci_hcd *xhci);
+ int xhci_dbc_resume(struct xhci_hcd *xhci);
+-- 
+2.21.0
+

--- a/android_p/google_diff/clk/kernel/project-celadon/0012-usb-xhci-dbc-DbC-TTY-driver-to-use-new-interface.patch
+++ b/android_p/google_diff/clk/kernel/project-celadon/0012-usb-xhci-dbc-DbC-TTY-driver-to-use-new-interface.patch
@@ -1,0 +1,241 @@
+From f7c3349c2ea95b414294505255420db67d101b9b Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Tue, 18 Jun 2019 12:42:13 +0530
+Subject: [PATCH 3/7] usb: xhci: dbc: DbC TTY driver to use new interface
+
+Change DbC TTY driver to use the new modular interface exposed by the DbC
+core. This will allow other function drivers with a different interface
+also to use DbC.
+
+[no need to add running number to tty driver name, remove it. -Mathias]
+Signed-off-by: Rajaram Regupathy <rajaram.regupathy@intel.com>
+Signed-off-by: Abhilash K V <abhilash.k.v@intel.com>
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Signed-off-by: Mathias Nyman <mathias.nyman@linux.intel.com>
+---
+ drivers/usb/host/Kconfig       | 15 ++++++-
+ drivers/usb/host/Makefile      |  4 +-
+ drivers/usb/host/xhci-dbgcap.h |  4 --
+ drivers/usb/host/xhci-dbgtty.c | 81 ++++++++++++++++++++++++++++++----
+ 4 files changed, 90 insertions(+), 14 deletions(-)
+
+diff --git a/drivers/usb/host/Kconfig b/drivers/usb/host/Kconfig
+index 1a4ea98cac2a..d98cc75e96fd 100644
+--- a/drivers/usb/host/Kconfig
++++ b/drivers/usb/host/Kconfig
+@@ -29,13 +29,26 @@ config USB_XHCI_HCD
+ if USB_XHCI_HCD
+ config USB_XHCI_DBGCAP
+ 	bool "xHCI support for debug capability"
+-	depends on TTY
+ 	---help---
+ 	  Say 'Y' to enable the support for the xHCI debug capability. Make
+ 	  sure that your xHCI host supports the extended debug capability and
+ 	  you want a TTY serial device based on the xHCI debug capability
+ 	  before enabling this option. If unsure, say 'N'.
+ 
++choice
++	prompt "Select function for debug capability"
++	depends on USB_XHCI_DBGCAP
++
++config USB_XHCI_DBGCAP_TTY
++	tristate "xHCI DbC tty driver support"
++	depends on USB_XHCI_HCD && USB_XHCI_DBGCAP && TTY
++	help
++	  Say 'Y' to enable the support for the tty driver interface to xHCI
++	  debug capability. This will expose a /dev/ttyDBC* device node on device
++	  which may be used by the usb-debug driver on the debug host.
++	  If unsure, say 'N'.
++endchoice
++
+ config USB_XHCI_PCI
+        tristate
+        depends on USB_PCI
+diff --git a/drivers/usb/host/Makefile b/drivers/usb/host/Makefile
+index e6235269c151..4899ac84cfa7 100644
+--- a/drivers/usb/host/Makefile
++++ b/drivers/usb/host/Makefile
+@@ -16,9 +16,11 @@ xhci-hcd-y += xhci-ring.o xhci-hub.o xhci-dbg.o
+ xhci-hcd-y += xhci-trace.o
+ 
+ ifneq ($(CONFIG_USB_XHCI_DBGCAP), )
+-	xhci-hcd-y += xhci-dbgcap.o xhci-dbgtty.o
++	xhci-hcd-y += xhci-dbgcap.o
+ endif
+ 
++obj-$(CONFIG_USB_XHCI_DBGCAP_TTY) += xhci-dbgtty.o
++
+ ifneq ($(CONFIG_USB_XHCI_MTK), )
+ 	xhci-hcd-y += xhci-mtk-sch.o
+ endif
+diff --git a/drivers/usb/host/xhci-dbgcap.h b/drivers/usb/host/xhci-dbgcap.h
+index b4d5622a9030..302e6ca72370 100644
+--- a/drivers/usb/host/xhci-dbgcap.h
++++ b/drivers/usb/host/xhci-dbgcap.h
+@@ -218,10 +218,6 @@ static inline struct dbc_ep *get_out_ep(struct xhci_hcd *xhci)
+ #ifdef CONFIG_USB_XHCI_DBGCAP
+ int xhci_dbc_init(struct xhci_hcd *xhci);
+ void xhci_dbc_exit(struct xhci_hcd *xhci);
+-int xhci_dbc_tty_register_driver(struct xhci_hcd *xhci);
+-void xhci_dbc_tty_unregister_driver(void);
+-int xhci_dbc_tty_register_device(struct xhci_hcd *xhci);
+-void xhci_dbc_tty_unregister_device(struct xhci_hcd *xhci);
+ struct dbc_request *dbc_alloc_request(struct dbc_ep *dep, gfp_t gfp_flags);
+ void xhci_dbc_flush_reqests(struct xhci_dbc *dbc);
+ void dbc_free_request(struct dbc_ep *dep, struct dbc_request *req);
+diff --git a/drivers/usb/host/xhci-dbgtty.c b/drivers/usb/host/xhci-dbgtty.c
+index aff79ff5aba4..f75a95006c51 100644
+--- a/drivers/usb/host/xhci-dbgtty.c
++++ b/drivers/usb/host/xhci-dbgtty.c
+@@ -7,13 +7,15 @@
+  * Author: Lu Baolu <baolu.lu@linux.intel.com>
+  */
+ 
++#include <linux/module.h>
+ #include <linux/slab.h>
+ #include <linux/tty.h>
+ #include <linux/tty_flip.h>
+-
+ #include "xhci.h"
+ #include "xhci-dbgcap.h"
+ 
++#define DBC_STR_FUNC_TTY    "TTY"
++
+ static unsigned int
+ dbc_send_packet(struct dbc_port *port, char *packet, unsigned int size)
+ {
+@@ -279,12 +281,11 @@ static const struct tty_operations dbc_tty_ops = {
+ 	.unthrottle		= dbc_tty_unthrottle,
+ };
+ 
+-static struct tty_driver *dbc_tty_driver;
+-
+-int xhci_dbc_tty_register_driver(struct xhci_hcd *xhci)
++static int xhci_dbc_tty_register_driver(struct xhci_hcd *xhci)
+ {
+ 	int			status;
+ 	struct xhci_dbc		*dbc = xhci->dbc;
++	struct tty_driver	*dbc_tty_driver;
+ 
+ 	dbc_tty_driver = tty_alloc_driver(1, TTY_DRIVER_REAL_RAW |
+ 					  TTY_DRIVER_DYNAMIC_DEV);
+@@ -296,7 +297,6 @@ int xhci_dbc_tty_register_driver(struct xhci_hcd *xhci)
+ 
+ 	dbc_tty_driver->driver_name = "dbc_serial";
+ 	dbc_tty_driver->name = "ttyDBC";
+-
+ 	dbc_tty_driver->type = TTY_DRIVER_TYPE_SERIAL;
+ 	dbc_tty_driver->subtype = SERIAL_TYPE_NORMAL;
+ 	dbc_tty_driver->init_termios = tty_std_termios;
+@@ -315,16 +315,19 @@ int xhci_dbc_tty_register_driver(struct xhci_hcd *xhci)
+ 		put_tty_driver(dbc_tty_driver);
+ 		dbc_tty_driver = NULL;
+ 	}
++	dbc->func_priv = dbc_tty_driver;
+ 
+ 	return status;
+ }
+ 
+-void xhci_dbc_tty_unregister_driver(void)
++static void xhci_dbc_tty_unregister_driver(struct xhci_dbc *dbc)
+ {
++	struct tty_driver	*dbc_tty_driver =
++					(struct tty_driver *) dbc->func_priv;
+ 	if (dbc_tty_driver) {
+ 		tty_unregister_driver(dbc_tty_driver);
+ 		put_tty_driver(dbc_tty_driver);
+-		dbc_tty_driver = NULL;
++		dbc->func_priv = NULL;
+ 	}
+ }
+ 
+@@ -440,12 +443,14 @@ xhci_dbc_tty_exit_port(struct dbc_port *port)
+ 	tty_port_destroy(&port->port);
+ }
+ 
+-int xhci_dbc_tty_register_device(struct xhci_hcd *xhci)
++static int xhci_dbc_tty_register_device(struct xhci_hcd *xhci)
+ {
+ 	int			ret;
+ 	struct device		*tty_dev;
+ 	struct xhci_dbc		*dbc = xhci->dbc;
+ 	struct dbc_port		*port = &dbc->port;
++	struct tty_driver	*dbc_tty_driver =
++					(struct tty_driver *) dbc->func_priv;
+ 
+ 	xhci_dbc_tty_init_port(xhci, port);
+ 	tty_dev = tty_port_register_device(&port->port,
+@@ -493,6 +498,8 @@ void xhci_dbc_tty_unregister_device(struct xhci_hcd *xhci)
+ {
+ 	struct xhci_dbc		*dbc = xhci->dbc;
+ 	struct dbc_port		*port = &dbc->port;
++	struct tty_driver	*dbc_tty_driver =
++					(struct tty_driver *) dbc->func_priv;
+ 
+ 	tty_unregister_device(dbc_tty_driver, 0);
+ 	xhci_dbc_tty_exit_port(port);
+@@ -503,3 +510,61 @@ void xhci_dbc_tty_unregister_device(struct xhci_hcd *xhci)
+ 	xhci_dbc_free_requests(get_out_ep(xhci), &port->read_queue);
+ 	xhci_dbc_free_requests(get_in_ep(xhci), &port->write_pool);
+ }
++
++static int dbc_tty_post_config(struct xhci_dbc *dbc)
++{
++	return xhci_dbc_tty_register_device(dbc->xhci);
++}
++
++static int dbc_tty_post_disconnect(struct xhci_dbc *dbc)
++{
++	xhci_dbc_tty_unregister_device(dbc->xhci);
++	return 0;
++}
++
++static int dbc_tty_run(struct xhci_dbc *dbc)
++{
++	return  xhci_dbc_tty_register_driver(dbc->xhci);
++}
++
++static int dbc_tty_stop(struct xhci_dbc *dbc)
++{
++	xhci_dbc_tty_unregister_driver(dbc);
++	return 0;
++}
++
++static struct dbc_function tty_func = {
++	.owner = THIS_MODULE,
++	.string = {
++		.manufacturer = DBC_STR_MANUFACTURER,
++		.product = DBC_STR_PRODUCT,
++		.serial = DBC_STR_SERIAL,
++	},
++	.protocol = DBC_PROTOCOL,
++	.vid =     DBC_VENDOR_ID,
++	.pid =     DBC_PRODUCT_ID,
++	.device_rev = DBC_DEVICE_REV,
++	.func_name = DBC_STR_FUNC_TTY,
++
++	.post_config = dbc_tty_post_config,
++	.post_disconnect = dbc_tty_post_disconnect,
++	.run = dbc_tty_run,
++	.stop = dbc_tty_stop,
++};
++
++static int __init xhci_dbc_tty_init(void)
++{
++	return xhci_dbc_register_function(&tty_func);
++}
++
++static void __exit xhci_dbc_tty_fini(void)
++{
++	xhci_dbc_unregister_function();
++}
++
++late_initcall(xhci_dbc_tty_init);
++module_exit(xhci_dbc_tty_fini);
++
++MODULE_DESCRIPTION("xHCI DbC tty driver");
++MODULE_AUTHOR("Baoulu Lu");
++MODULE_LICENSE("GPL");
+-- 
+2.21.0
+

--- a/android_p/google_diff/clk/kernel/project-celadon/0013-usb-xhci-dbc-Provide-sysfs-option-to-configure-dbc-d.patch
+++ b/android_p/google_diff/clk/kernel/project-celadon/0013-usb-xhci-dbc-Provide-sysfs-option-to-configure-dbc-d.patch
@@ -1,0 +1,534 @@
+From 7a8a16709d1169a59a3f85f0ad505e7389e0f8bd Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Tue, 18 Jun 2019 12:43:20 +0530
+Subject: [PATCH 4/7] usb: xhci: dbc: Provide sysfs option to configure dbc
+ descriptors
+
+Show the active dbc function and dbc descriptors, allowing
+user space to dynamically modify the descriptors
+
+The DBC specific sysfs attributes are separated into two groups,
+in the first group there are dbc & dbc_function sysfs attributes and in
+second group all other DBC descriptor specific sysfs attributes.
+
+First group of attributes will be populated at the time of dbc_init and
+second group of attributes will only be populated when "dbc" attribute
+value is set to "enable".
+
+Whenever "dbc" attribute value will be "disable" then second group
+of attributes will be removed.
+
+Signed-off-by: Rajaram Regupathy <rajaram.regupathy@intel.com>
+Signed-off-by: Gururaj K <gururaj.k@intel.com>
+Signed-off-by: Abhilash K V <abhilash.k.v@intel.com>
+Signed-off-by: K V, Abhilash <abhilash.k.v@intel.com>
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+---
+ .../testing/sysfs-bus-pci-drivers-xhci_hcd    | 112 ++++++
+ drivers/usb/host/xhci-dbgcap.c                | 339 ++++++++++++++++++
+ 2 files changed, 451 insertions(+)
+
+diff --git a/Documentation/ABI/testing/sysfs-bus-pci-drivers-xhci_hcd b/Documentation/ABI/testing/sysfs-bus-pci-drivers-xhci_hcd
+index 0088aba4caa8..b46b6afc6c4a 100644
+--- a/Documentation/ABI/testing/sysfs-bus-pci-drivers-xhci_hcd
++++ b/Documentation/ABI/testing/sysfs-bus-pci-drivers-xhci_hcd
+@@ -23,3 +23,115 @@ Description:
+ 		Reading this attribute gives the state of the DbC. It
+ 		can be one of the following states: disabled, enabled,
+ 		initialized, connected, configured and stalled.
++
++What:		/sys/bus/pci/drivers/xhci_hcd/.../dbc_function
++Date:		June 2018
++Contact:	Rajaram Regupathy <rajaram.regupathy@intel.com>
++Description:
++		xHCI USB host controllers provide Debug Capability (Dbc)
++		as an extended feature. When configured Dbc presents a
++		debug device which is fully compliant with the USB
++		framework.
++
++		This framework can be utilized to provide various interfaces.
++		By Default, it is configured to provide a serial Interface.
++
++		This attribute lets us configure the interface provided
++		by Dbc functionality. By Default, this attribute value
++		is "TTY" corresponding to the the serial interface. Other
++		values can be supported in future to provide a varied
++		interface to use DbC.
++
++		Reading this attribute gives the interface which is
++		currently configured with DbC. If it is "TTY" then serial
++		interface is configured.
++
++What:		/sys/bus/pci/drivers/xhci_hcd/.../dbc_manufacturer
++Date:		June 2018
++Contact:	Rajaram Regupathy <rajaram.regupathy@intel.com>
++Description:
++		xHCI USB host controllers provide Debug Capability (Dbc)
++		as an extended feature. When configured Dbc presents a
++		debug device which is fully compliant with the USB
++		framework.
++		This attribute lets us change the manufacturer name as
++		presented by the debug device in the USB Manufacturer String
++		descriptor. The default value is "Linux Foundation".
++
++What:		/sys/bus/pci/drivers/xhci_hcd/.../dbc_product
++Date:		June 2018
++Contact:	Rajaram Regupathy <rajaram.regupathy@intel.com>
++Description:
++		xHCI USB host controllers provide Debug Capability (Dbc)
++		as an extended feature. When configured Dbc presents a
++		debug device which is fully compliant with the USB
++		framework.
++		This attribute lets us change the product name as
++		presented by the debug device in the USB Product String
++		descriptor. The default value is "Linux USB Debug Target".
++
++What:		/sys/bus/pci/drivers/xhci_hcd/.../dbc_serial
++Date:		June 2018
++Contact:	Rajaram Regupathy <rajaram.regupathy@intel.com>
++Description:
++		xHCI USB host controllers provide Debug Capability (Dbc)
++		as an extended feature. When configured Dbc presents a
++		debug device which is fully compliant with the USB
++		framework.
++		This attribute lets us change the serial number as
++		presented by the debug device in the USB Serial Number String
++		descriptor. The default value is "0001".
++
++What:		/sys/bus/pci/drivers/xhci_hcd/.../dbc_protocol
++Date:		June 2018
++Contact:	Rajaram Regupathy <rajaram.regupathy@intel.com>
++Description:
++		xHCI USB host controllers provide Debug Capability (Dbc)
++		as an extended feature. When configured Dbc presents a
++		debug device which is fully compliant with the USB
++		framework.
++		This attribute lets us change the bInterfaceProtocol field as
++		presented by the debug device in the USB Interface descriptor.
++
++		The default value is  1  (GNU Remote Debug command).
++		Other permissible value is 0 which is for vendor defined debug
++		target.
++
++What:		/sys/bus/pci/drivers/xhci_hcd/.../dbc_vid
++Date:		June 2018
++Contact:	Rajaram Regupathy <rajaram.regupathy@intel.com>
++Description:
++		xHCI USB host controllers provide Debug Capability (Dbc)
++		as an extended feature. When configured Dbc presents a
++		debug device which is fully compliant with the USB
++		framework.
++		This attribute lets us change the idVendor field as
++		presented by the debug device in the USB Device descriptor.
++		The default value is 0x1d6b (Linux Foundation).
++		It can be any 16-bit integer.
++
++
++What:		/sys/bus/pci/drivers/xhci_hcd/.../dbc_pid
++Date:		June 2018
++Contact:	Rajaram Regupathy <rajaram.regupathy@intel.com>
++Description:
++		xHCI USB host controllers provide Debug Capability (Dbc)
++		as an extended feature. When configured Dbc presents a
++		debug device which is fully compliant with the USB
++		framework.
++		This attribute lets us change the idProduct field as
++		presented by the debug device in the USB Device descriptor.
++		The default value is 0x0010. It can be any 16-bit integer.
++
++What:		/sys/bus/pci/drivers/xhci_hcd/.../dbc_device_rev
++Date:		June 2018
++Contact:	Rajaram Regupathy <rajaram.regupathy@intel.com>
++Description:
++		xHCI USB host controllers provide Debug Capability (Dbc)
++		as an extended feature. When configured Dbc presents a
++		debug device which is fully compliant with the USB
++		framework.
++		This attribute lets us change the bcdDevice field as
++		presented by the debug device in the USB Device descriptor.
++		The default value is 0x0010 (device rev 0.10).
++		It can be any 16-bit integer.
+diff --git a/drivers/usb/host/xhci-dbgcap.c b/drivers/usb/host/xhci-dbgcap.c
+index 0fc2db43e3b0..08c31b457f1d 100644
+--- a/drivers/usb/host/xhci-dbgcap.c
++++ b/drivers/usb/host/xhci-dbgcap.c
+@@ -875,6 +875,315 @@ static int xhci_do_dbc_init(struct xhci_hcd *xhci)
+ 	return 0;
+ }
+ 
++static ssize_t dbc_function_show(struct device *dev,
++			struct device_attribute *attr,
++			char *buf)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	int    count = 0;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (!dbc)
++		return -ENODEV;
++	if (!dbc_registered_func)
++		count += sprintf(buf, "%s\n", "none");
++	else
++		count += sprintf(buf, "%s\n", dbc_registered_func->func_name);
++
++	return count;
++}
++
++static ssize_t dbc_manufacturer_show(struct device *dev,
++			struct device_attribute *attr,
++			char *buf)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	struct usb_string_descriptor    *s_desc;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (!dbc || !dbc->string)
++		return -ENODEV;
++	s_desc = (struct usb_string_descriptor *) dbc->string->manufacturer;
++	return utf16s_to_utf8s((wchar_t *) s_desc->wData, s_desc->bLength / 2,
++			UTF16_LITTLE_ENDIAN, buf, DBC_MAX_STRING_LENGTH);
++}
++
++static ssize_t dbc_manufacturer_store(struct device *dev,
++			 struct device_attribute *attr,
++			 const char *buf, size_t size)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	struct usb_string_descriptor    *s_desc;
++	int ret;
++	struct dbc_info_context	*info;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (dbc->state != DS_DISABLED)
++		return -EBUSY;
++	s_desc = (struct usb_string_descriptor *) dbc->string->manufacturer;
++	ret =  utf8s_to_utf16s(buf, strlen(buf),
++				UTF16_LITTLE_ENDIAN, (wchar_t *)s_desc->wData,
++				DBC_MAX_STRING_LENGTH);
++	if (ret < 0)
++		return ret;
++	s_desc->bLength         = (strlen(buf) + 1) * 2;
++	info			= (struct dbc_info_context *)dbc->ctx->bytes;
++	info->length		= (info->length & ~(0xffu << 8))
++					|  (s_desc->bLength) << 8;
++	return size;
++}
++
++static ssize_t dbc_product_show(struct device *dev,
++			struct device_attribute *attr,
++			char *buf)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	struct usb_string_descriptor    *s_desc;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (!dbc || !dbc->string)
++		return -ENODEV;
++	s_desc = (struct usb_string_descriptor *) dbc->string->product;
++	return utf16s_to_utf8s((wchar_t *) s_desc->wData, s_desc->bLength / 2,
++			UTF16_LITTLE_ENDIAN, buf, DBC_MAX_STRING_LENGTH);
++}
++
++static ssize_t dbc_product_store(struct device *dev,
++			 struct device_attribute *attr,
++			 const char *buf, size_t size)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	struct usb_string_descriptor    *s_desc;
++	int ret;
++	struct dbc_info_context	*info;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (dbc->state != DS_DISABLED)
++		return -EBUSY;
++	s_desc = (struct usb_string_descriptor *) dbc->string->serial;
++	ret = utf8s_to_utf16s(buf, strlen(buf),
++				UTF16_LITTLE_ENDIAN, (wchar_t *)s_desc->wData,
++				DBC_MAX_STRING_LENGTH);
++	if (ret < 0)
++		return ret;
++	s_desc->bLength         = (strlen(buf) + 1) * 2;
++	info			= (struct dbc_info_context *)dbc->ctx->bytes;
++	info->length		= (info->length & ~(0xffu << 16))
++					 |  (s_desc->bLength) << 16;
++	return size;
++}
++
++static ssize_t dbc_serial_show(struct device *dev,
++			struct device_attribute *attr,
++			char *buf)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	struct usb_string_descriptor    *s_desc;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (!dbc || !dbc->string)
++		return -ENODEV;
++	s_desc = (struct usb_string_descriptor *) dbc->string->serial;
++	return utf16s_to_utf8s((wchar_t *) s_desc->wData, s_desc->bLength / 2,
++			UTF16_LITTLE_ENDIAN, buf, DBC_MAX_STRING_LENGTH);
++}
++
++static ssize_t dbc_serial_store(struct device *dev,
++			 struct device_attribute *attr,
++			 const char *buf, size_t size)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	struct usb_string_descriptor    *s_desc;
++	int ret;
++	struct dbc_info_context	*info;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (dbc->state != DS_DISABLED)
++		return -EBUSY;
++	s_desc = (struct usb_string_descriptor *) dbc->string->serial;
++	ret = utf8s_to_utf16s(buf, strlen(buf),
++				UTF16_LITTLE_ENDIAN, (wchar_t *)s_desc->wData,
++				DBC_MAX_STRING_LENGTH);
++	if (ret < 0)
++		return ret;
++	s_desc->bLength         = (strlen(buf) + 1) * 2;
++	info			= (struct dbc_info_context *)dbc->ctx->bytes;
++	info->length		= (info->length & ~(0xffu << 24))
++					 |  (s_desc->bLength) << 24;
++	return size;
++}
++
++static ssize_t dbc_protocol_show(struct device *dev,
++			struct device_attribute *attr,
++			char *buf)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	void __iomem *ptr;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	ptr = &dbc->regs->devinfo1;
++	return sprintf(buf, "%02x\n", le32_to_cpu(readl(ptr)) & 0xff);
++}
++
++static ssize_t dbc_protocol_store(struct device *dev,
++			 struct device_attribute *attr,
++			 const char *buf, size_t size)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	int value;
++	int ret;
++	void __iomem *ptr;
++	u32 dev_info;
++
++	ret = kstrtoint(buf, 0, &value);
++	if (ret || value < 0 || value > 0xff)
++		return -EINVAL;
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (dbc->state != DS_DISABLED)
++		return -EBUSY;
++	ptr = &dbc->regs->devinfo1;
++	dev_info = le32_to_cpu(readl(ptr));
++	dev_info = cpu_to_le32((dev_info & ~(0xffu)) | value);
++	writel(dev_info, ptr);
++	return size;
++}
++
++static ssize_t dbc_vid_show(struct device *dev,
++			struct device_attribute *attr,
++			char *buf)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	void __iomem *ptr;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	ptr = &dbc->regs->devinfo1;
++	return sprintf(buf, "%04x\n", ((u32)le32_to_cpu(readl(ptr))) >> 16);
++}
++
++static ssize_t dbc_vid_store(struct device *dev,
++			 struct device_attribute *attr,
++			 const char *buf, size_t size)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	int value;
++	int ret;
++	void __iomem *ptr;
++	u32 dev_info;
++
++	ret = kstrtoint(buf, 0, &value);
++	if (ret || value < 0 || value > 0xffff)
++		return -EINVAL;
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (dbc->state != DS_DISABLED)
++		return -EBUSY;
++	ptr = &dbc->regs->devinfo1;
++	dev_info = le32_to_cpu(readl(ptr));
++	dev_info = cpu_to_le32((dev_info & ~(0xffffu << 16)) | (value << 16));
++	writel(dev_info, ptr);
++	return size;
++}
++
++
++static ssize_t dbc_pid_show(struct device *dev,
++			struct device_attribute *attr,
++			char *buf)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	void __iomem *ptr;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	ptr = &dbc->regs->devinfo2;
++	return sprintf(buf, "%04x\n", le32_to_cpu(readl(ptr)) & 0xffff);
++}
++
++static ssize_t dbc_pid_store(struct device *dev,
++			 struct device_attribute *attr,
++			 const char *buf, size_t size)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	int value;
++	int ret;
++	void __iomem *ptr;
++	u32 dev_info;
++
++	ret = kstrtoint(buf, 0, &value);
++	if (ret || value < 0 || value > 0xffff)
++		return -EINVAL;
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (dbc->state != DS_DISABLED)
++		return -EBUSY;
++	ptr = &dbc->regs->devinfo2;
++	dev_info = le32_to_cpu(readl(ptr));
++	dev_info = cpu_to_le32((dev_info & ~(0xffffu)) | value);
++	writel(dev_info, ptr);
++	return size;
++}
++
++static ssize_t dbc_device_rev_show(struct device *dev,
++			struct device_attribute *attr,
++			char *buf)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	void __iomem *ptr;
++
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	ptr = &dbc->regs->devinfo2;
++	return sprintf(buf, "%04x\n",  ((u32)le32_to_cpu(readl(ptr))) >> 16);
++}
++
++static ssize_t dbc_device_rev_store(struct device *dev,
++			 struct device_attribute *attr,
++			 const char *buf, size_t size)
++{
++	struct xhci_dbc         *dbc;
++	struct xhci_hcd         *xhci;
++	int value;
++	int ret;
++	void __iomem *ptr;
++	u32 dev_info;
++
++	ret = kstrtoint(buf, 0, &value);
++	if (ret || value < 0 || value > 0xffff)
++		return -EINVAL;
++	xhci = hcd_to_xhci(dev_get_drvdata(dev));
++	dbc = xhci->dbc;
++	if (dbc->state != DS_DISABLED)
++		return -EBUSY;
++	ptr = &dbc->regs->devinfo2;
++	dev_info = le32_to_cpu(readl(ptr));
++	dev_info = cpu_to_le32((dev_info & ~(0xffffu << 16)) | (value << 16));
++	writel(dev_info, ptr);
++	return size;
++}
++
+ static ssize_t dbc_show(struct device *dev,
+ 			struct device_attribute *attr,
+ 			char *buf)
+@@ -912,6 +1221,29 @@ static ssize_t dbc_show(struct device *dev,
+ 	return sprintf(buf, "%s\n", p);
+ }
+ 
++static DEVICE_ATTR_RW(dbc_manufacturer);
++static DEVICE_ATTR_RW(dbc_product);
++static DEVICE_ATTR_RW(dbc_serial);
++static DEVICE_ATTR_RW(dbc_protocol);
++static DEVICE_ATTR_RW(dbc_vid);
++static DEVICE_ATTR_RW(dbc_pid);
++static DEVICE_ATTR_RW(dbc_device_rev);
++
++static struct attribute *dbc_descriptor_attributes[] = {
++	&dev_attr_dbc_manufacturer.attr,
++	&dev_attr_dbc_product.attr,
++	&dev_attr_dbc_serial.attr,
++	&dev_attr_dbc_protocol.attr,
++	&dev_attr_dbc_vid.attr,
++	&dev_attr_dbc_pid.attr,
++	&dev_attr_dbc_device_rev.attr,
++	NULL
++};
++
++static const struct attribute_group dbc_descriptor_attrib_grp = {
++	.attrs = dbc_descriptor_attributes,
++};
++
+ static ssize_t dbc_store(struct device *dev,
+ 			 struct device_attribute *attr,
+ 			 const char *buf, size_t count)
+@@ -940,6 +1272,10 @@ static ssize_t dbc_store(struct device *dev,
+ 			goto err;
+ 		}
+ 		xhci_dbc_start(xhci);
++		ret = sysfs_create_group(&dev->kobj,
++					 &dbc_descriptor_attrib_grp);
++		if (ret)
++			goto err;
+ 	} else if (!strncmp(buf, "disable", 7) && dbc->state != DS_DISABLED) {
+ 		if (!dbc_registered_func)
+ 			return -EINVAL;
+@@ -947,6 +1283,7 @@ static ssize_t dbc_store(struct device *dev,
+ 		if (dbc_registered_func->stop)
+ 			dbc_registered_func->stop(dbc);
+ 		module_put(dbc_registered_func->owner);
++		sysfs_remove_group(&dev->kobj, &dbc_descriptor_attrib_grp);
+ 	} else
+ 		return -EINVAL;
+ 
+@@ -957,9 +1294,11 @@ static ssize_t dbc_store(struct device *dev,
+ }
+ 
+ static DEVICE_ATTR_RW(dbc);
++static DEVICE_ATTR_RO(dbc_function);
+ 
+ static struct attribute *dbc_dev_attributes[] = {
+ 	&dev_attr_dbc.attr,
++	&dev_attr_dbc_function.attr,
+ 	NULL
+ };
+ 
+-- 
+2.21.0
+

--- a/android_p/google_diff/clk/kernel/project-celadon/0014-usb-xhci-dbc-Add-a-dbc-raw-driver-to-provide-a-raw-i.patch
+++ b/android_p/google_diff/clk/kernel/project-celadon/0014-usb-xhci-dbc-Add-a-dbc-raw-driver-to-provide-a-raw-i.patch
@@ -1,0 +1,429 @@
+From 7e6bb04781394fbbb7b5da0b4e5c1e9e0c035717 Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Tue, 18 Jun 2019 12:44:28 +0530
+Subject: [PATCH 5/7] usb: xhci: dbc: Add a dbc raw driver to provide a raw
+ interface on DbC
+
+This patch provides a raw device interface on xhci Debug capability.
+This abstracts dbc functionality to user space inorder to facilitate
+various frameworks to utilize xhci debug capability.
+
+It helps to render the target as an usb debug class device on host and
+establish an usb connection by providing two bulk endpoints.
+
+[don't dynamically allocate tiny space for name only -Mathias]
+Signed-off-by: Rajaram Regupathy <rajaram.regupathy@intel.com>
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Signed-off-by: Abhilash K V <abhilash.k.v@intel.com>
+Reviewed-by: Mathias Nyman <mathias.nyman@linux.intel.com>
+---
+ drivers/usb/host/Kconfig       |   9 +
+ drivers/usb/host/Makefile      |   1 +
+ drivers/usb/host/xhci-dbgraw.c | 363 +++++++++++++++++++++++++++++++++
+ 3 files changed, 373 insertions(+)
+ create mode 100644 drivers/usb/host/xhci-dbgraw.c
+
+diff --git a/drivers/usb/host/Kconfig b/drivers/usb/host/Kconfig
+index d98cc75e96fd..1d3518767c49 100644
+--- a/drivers/usb/host/Kconfig
++++ b/drivers/usb/host/Kconfig
+@@ -47,6 +47,15 @@ config USB_XHCI_DBGCAP_TTY
+ 	  debug capability. This will expose a /dev/ttyDBC* device node on device
+ 	  which may be used by the usb-debug driver on the debug host.
+ 	  If unsure, say 'N'.
++
++config USB_XHCI_DBGCAP_RAW
++       tristate "xHCI DbC raw driver support"
++       depends on USB_XHCI_HCD && USB_XHCI_DBGCAP
++       help
++         Say 'Y' to enable the support for the raw driver interface to xHCI
++         debug capability. This will expose a device node corresponding to
++         1 bulk IN and 1 bulk OUT endpoints to be presented to debug host.
++         If unsure, say 'N'.
+ endchoice
+ 
+ config USB_XHCI_PCI
+diff --git a/drivers/usb/host/Makefile b/drivers/usb/host/Makefile
+index 4899ac84cfa7..fd79b25e253b 100644
+--- a/drivers/usb/host/Makefile
++++ b/drivers/usb/host/Makefile
+@@ -20,6 +20,7 @@ ifneq ($(CONFIG_USB_XHCI_DBGCAP), )
+ endif
+ 
+ obj-$(CONFIG_USB_XHCI_DBGCAP_TTY) += xhci-dbgtty.o
++obj-$(CONFIG_USB_XHCI_DBGCAP_RAW) += xhci-dbgraw.o
+ 
+ ifneq ($(CONFIG_USB_XHCI_MTK), )
+ 	xhci-hcd-y += xhci-mtk-sch.o
+diff --git a/drivers/usb/host/xhci-dbgraw.c b/drivers/usb/host/xhci-dbgraw.c
+new file mode 100644
+index 000000000000..caa050698eb8
+--- /dev/null
++++ b/drivers/usb/host/xhci-dbgraw.c
+@@ -0,0 +1,363 @@
++// SPDX-License-Identifier: GPL-2.0+
++/**
++ * Raw DbC for xHCI debug capability
++ *
++ * Copyright (C) 2019 Intel Corporation
++ *
++ * Author: Rajaram Regupathy <rajaram.regupathy@intel.com>
++ */
++
++#include <linux/idr.h>
++#include <linux/module.h>
++#include <linux/miscdevice.h>
++#include <linux/sizes.h>
++#include <linux/slab.h>
++
++#include "xhci.h"
++#include "xhci-dbgcap.h"
++
++#define DBC_XHCI_MINORS     8
++#define DBC_STR_FUNC_RAW    "RAW"
++#define DBC_RAW_BULK_BUFFER_SIZE  (SZ_64K)
++
++static DEFINE_IDR(dbc_minors);
++
++struct dbc_dev {
++	struct mutex dev_excl;
++	struct mutex read_excl;
++	struct mutex write_excl;
++
++	wait_queue_head_t read_wq;
++	wait_queue_head_t write_wq;
++
++	int error;
++	bool in_use;
++	char name[16];
++	struct xhci_dbc *dbc;
++	struct miscdevice misc_dev;
++};
++
++static void xhci_dbc_free_req(struct dbc_ep *dep, struct dbc_request *req)
++{
++	kfree(req->buf);
++	dbc_free_request(dep, req);
++}
++
++struct dbc_request *xhci_dbc_alloc_requests(struct dbc_ep *dep,
++		void (*fn)(struct xhci_hcd *, struct dbc_request *))
++{
++	struct dbc_request *req;
++
++	req = dbc_alloc_request(dep, GFP_KERNEL);
++	if (!req)
++		return req;
++
++	req->length = DBC_RAW_BULK_BUFFER_SIZE;
++	req->buf = kmalloc(req->length, GFP_KERNEL);
++	if (!req->buf)
++		xhci_dbc_free_req(dep, req);
++
++	req->complete = fn;
++
++	return req;
++}
++
++static void dbc_complete_in(struct xhci_hcd *xhci,
++				struct dbc_request *req)
++{
++	struct xhci_dbc *dbc = (struct xhci_dbc *) xhci->dbc;
++	struct dbc_dev *dev = (struct dbc_dev *) dbc->func_priv;
++
++	if (req->status)
++		dev->error = req->status;
++
++	wake_up(&dev->write_wq);
++}
++
++static void dbc_complete_out(struct xhci_hcd *xhci,
++				struct dbc_request *req)
++{
++	struct xhci_dbc *dbc = (struct xhci_dbc *) xhci->dbc;
++	struct dbc_dev *dev = (struct dbc_dev *) dbc->func_priv;
++
++	if (req->status)
++		dev->error = req->status;
++
++	wake_up(&dev->read_wq);
++}
++
++static ssize_t dbc_read(struct file *fp, char __user *buf,
++				size_t count, loff_t *pos)
++{
++	int status = 0;
++	struct dbc_dev *dev = (struct dbc_dev *) fp->private_data;
++	struct xhci_dbc   *dbc = dev->dbc;
++	struct dbc_request *req;
++	struct dbc_port   *port = &dbc->port;
++	int r = count, xfer;
++	int ret;
++
++	if (dbc->state != DS_CONFIGURED)
++		return -EAGAIN;
++
++	port->in = get_in_ep(dbc->xhci);
++
++	mutex_lock(&dev->read_excl);
++
++	req = xhci_dbc_alloc_requests(port->in, dbc_complete_out);
++	if (!req) {
++		r = -ENOMEM;
++		goto alloc_fail;
++	}
++
++	req->actual = 0;
++
++	xfer = min_t(size_t, count, DBC_RAW_BULK_BUFFER_SIZE);
++	req->length = xfer;
++
++	status = dbc_ep_queue(port->in, req, GFP_ATOMIC);
++	if (status) {
++		dev->error = status;
++		r = status;
++		goto request_fail;
++	}
++
++	ret = wait_event_interruptible(dev->read_wq,
++			(req->status != -EINPROGRESS));
++
++	if (ret < 0) {
++		r = ret;
++		goto request_fail;
++	}
++
++	if (dev->error) {
++		r = dev->error;
++		goto request_fail;
++	}
++
++	xfer = (req->actual < count) ? req->actual : count;
++	if (!req->actual) {
++		r = 0;
++	} else {
++		r = copy_to_user(buf, req->buf, xfer);
++		if (!r)
++			r = xfer;
++	}
++
++request_fail:
++	xhci_dbc_free_req(port->in, req);
++alloc_fail:
++	mutex_unlock(&dev->read_excl);
++
++	return r;
++}
++
++static ssize_t dbc_write(struct file *fp, const char __user *buf,
++				size_t count, loff_t *pos)
++{
++	int status = 0;
++	struct dbc_dev *dev = (struct dbc_dev *) fp->private_data;
++	struct xhci_dbc *dbc = dev->dbc;
++	struct dbc_request *req = 0;
++	struct dbc_port   *port = &dbc->port;
++	int r = count, xfer;
++	int ret;
++
++	if (dbc->state != DS_CONFIGURED)
++		return -EAGAIN;
++
++	port->out = get_out_ep(dbc->xhci);
++
++	mutex_lock(&dev->write_excl);
++
++	/* get an idle tx request to use */
++	req = xhci_dbc_alloc_requests(port->out, dbc_complete_in);
++	if (!req) {
++		r = -ENOMEM;
++		goto alloc_fail;
++	}
++
++	req->actual = 0;
++	xfer = min_t(size_t, count, DBC_RAW_BULK_BUFFER_SIZE);
++
++	ret = copy_from_user(req->buf, buf, xfer);
++	if (ret) {
++		r = ret;
++		goto request_fail;
++	}
++	r = xfer;
++	req->length = xfer;
++	status = dbc_ep_queue(port->out, req, GFP_ATOMIC);
++	if (status) {
++		dev->error = status;
++		r = status;
++		goto request_fail;
++	}
++
++	ret = wait_event_interruptible(dev->write_wq,
++			(req->status != -EINPROGRESS));
++	if (ret < 0)
++		r = ret;
++
++request_fail:
++	xhci_dbc_free_req(port->out, req);
++alloc_fail:
++	mutex_unlock(&dev->write_excl);
++
++	return r;
++}
++
++static int dbc_open(struct inode *ip, struct file *fp)
++{
++	struct dbc_dev *dbc_dev;
++	struct xhci_dbc *dbc;
++	int r = 0;
++
++	dbc_dev = container_of(fp->private_data, struct dbc_dev, misc_dev);
++
++	mutex_lock(&dbc_dev->dev_excl);
++	if (dbc_dev->in_use) {
++		r = -EBUSY;
++		goto err;
++	}
++
++	dbc = dbc_dev->dbc;
++	if (!dbc) {
++		r =  -ENODEV;
++		goto err;
++	}
++
++	dbc_dev->in_use = true;
++	fp->private_data = dbc_dev;
++
++	/* clear the error latch */
++	dbc_dev->error = 0;
++err:
++	mutex_unlock(&dbc_dev->dev_excl);
++
++	return r;
++}
++
++static int dbc_release(struct inode *ip, struct file *fp)
++{
++	struct dbc_dev *dbc_dev = (struct dbc_dev *) fp->private_data;
++
++
++	mutex_lock(&dbc_dev->dev_excl);
++	dbc_dev->in_use = false;
++	fp->private_data = NULL;
++	mutex_unlock(&dbc_dev->dev_excl);
++
++	return 0;
++}
++
++static const struct file_operations dbc_fops = {
++	.owner = THIS_MODULE,
++	.read = dbc_read,
++	.write = dbc_write,
++	.open = dbc_open,
++	.release = dbc_release,
++};
++
++static int dbc_raw_register_device(struct xhci_hcd *xhci)
++{
++	struct device *devm = xhci->main_hcd->self.controller;
++	struct xhci_dbc *dbc = xhci->dbc;
++	struct dbc_dev *dev;
++	int ret;
++	int id;
++
++	dev = devm_kzalloc(devm, sizeof(*dev), GFP_KERNEL);
++	if (!dev)
++		return -ENOMEM;
++
++	mutex_init(&dev->dev_excl);
++	mutex_init(&dev->read_excl);
++	mutex_init(&dev->write_excl);
++
++	init_waitqueue_head(&dev->read_wq);
++	init_waitqueue_head(&dev->write_wq);
++
++	id = idr_alloc(&dbc_minors, dbc, 0, DBC_XHCI_MINORS,
++			GFP_KERNEL);
++	if (id < 0)
++		return id;
++	snprintf(dev->name, sizeof(dev->name), "dbc_raw%d", id);
++	dev->misc_dev.name = dev->name;
++	dev->misc_dev.minor = MISC_DYNAMIC_MINOR;
++
++	dev->misc_dev.fops = &dbc_fops;
++
++	ret = misc_register(&dev->misc_dev);
++	if (ret) {
++		kfree(dev->misc_dev.name);
++		pr_err("failed to register misc dev: %d\n", ret);
++		goto error;
++	}
++
++	dev->dbc = dbc;
++	dbc->func_priv = (void *) dev;
++	return ret;
++
++error:
++	idr_remove(&dbc_minors, id);
++
++	return ret;
++}
++
++static void dbc_raw_unregister_device(struct xhci_hcd *xhci)
++{
++	struct xhci_dbc *dbc = xhci->dbc;
++	struct dbc_dev *dbc_dev = (struct dbc_dev *) dbc->func_priv;
++
++	if (dbc_dev) {
++		idr_remove(&dbc_minors, dbc_dev->misc_dev.minor);
++		misc_deregister(&dbc_dev->misc_dev);
++	}
++	idr_destroy(&dbc_minors);
++}
++
++static int dbc_raw_run(struct xhci_dbc *dbc)
++{
++	return dbc_raw_register_device(dbc->xhci);
++}
++
++static int dbc_raw_stop(struct xhci_dbc *dbc)
++{
++	dbc_raw_unregister_device(dbc->xhci);
++	return 0;
++}
++
++static struct dbc_function raw_func = {
++	.owner = THIS_MODULE,
++	.string = {
++		.manufacturer = DBC_STR_MANUFACTURER,
++		.product = DBC_STR_PRODUCT,
++		.serial = DBC_STR_SERIAL,
++	},
++	.protocol = DBC_PROTOCOL,
++	.vid = DBC_VENDOR_ID,
++	.pid = DBC_PRODUCT_ID,
++	.device_rev = DBC_DEVICE_REV,
++	.func_name = DBC_STR_FUNC_RAW,
++
++	.run = dbc_raw_run,
++	.stop = dbc_raw_stop,
++};
++
++static int __init xhci_dbc_raw_init(void)
++{
++	return xhci_dbc_register_function(&raw_func);
++}
++
++static void __exit xhci_dbc_raw_fini(void)
++{
++	xhci_dbc_unregister_function();
++}
++
++late_initcall(xhci_dbc_raw_init);
++module_exit(xhci_dbc_raw_fini);
++
++MODULE_DESCRIPTION("xHCI DbC raw driver");
++MODULE_AUTHOR("Rajaram Regupathy");
++MODULE_LICENSE("GPL v2");
+-- 
+2.21.0
+

--- a/android_p/google_diff/clk/kernel/project-celadon/0015-usb-xhci-dbc-Document-describe-about-dbc-raw-interfa.patch
+++ b/android_p/google_diff/clk/kernel/project-celadon/0015-usb-xhci-dbc-Document-describe-about-dbc-raw-interfa.patch
@@ -1,0 +1,178 @@
+From 0c220b787bae50b41742218ad6a4a7101b696e38 Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Sat, 23 Mar 2019 00:59:20 +0530
+Subject: [PATCH 6/7] usb: xhci: dbc: Document describe about dbc raw interface
+
+This patch have explaination about the new DBC interface called
+dbc raw interface. This cover the capability, target setup and
+use case info.
+
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+---
+ Documentation/usb/dbc_raw.rst | 132 ++++++++++++++++++++++++++++++++++
+ Documentation/usb/index.rst   |  14 ++++
+ 2 files changed, 146 insertions(+)
+ create mode 100644 Documentation/usb/dbc_raw.rst
+ create mode 100644 Documentation/usb/index.rst
+
+diff --git a/Documentation/usb/dbc_raw.rst b/Documentation/usb/dbc_raw.rst
+new file mode 100644
+index 000000000000..d7bf9023d9a7
+--- /dev/null
++++ b/Documentation/usb/dbc_raw.rst
+@@ -0,0 +1,132 @@
++======================================
++This described about DBC RAW Interface
++======================================
++
++Content
++========
++
++- DBC Overview
++- Motivation
++- DBC RAW Capabilities
++- Target Build Setup
++- Target Test Setup
++- Host Target Connection
++- Experiment Test Result
++- DBC TTY Use Cases
++- DBC RAW Use Cases
++- Conclusion
++
++DBC Overview
++-------------
++xDBC stands for the USB Debug capability provided extensible Host Controller
++Interface. Universal Serial Bus is a host controlled Bus. Host Controller is
++a hardware whose functionality is to manage usb bus and usb host ports. It is
++responsible for initiating and managing all usb transfers. Extensible Host
++Controller Interface (xHCI) is a register-level interface which provides a
++mechanism by which the host controller (xHC) can communicate with the Operating
++System of the host computer. In addition to exposing register interfaces
++essential for proper functioning of the xHC it also supports many extended
++capabilities which can optionally be implemented by xHC.
++
++It includes Extended Power Management Capability, I/O Virtualization capability
++USB Legacy support capability among many others. USB Debug Capability is one of
++the main extended capabilities supported by xHCI.
++
++This functionality enables low-level system debug over USB. The xHCI debug
++capabilities (xDBC) provides a means of connecting two systems where the system
++is a Debug Host and the other is a Debug target. This is achieved through
++emulating a debug device by using xDBC on the debug target. The debug device
++presented by the debug target can be used by debug host for low level system
++debugging of target.
++
++Motivation
++-----------
++In this patch-set we learn the requirement of new DBC interface called DBC RAW,
++which can be used for platform debugging, large data transfer with comparatively
++10x faster data rate than DBC TTY and it have all the USB specific error handling
++mechanism enabled which DBC TTY doesn't have.
++
++DBC RAW Capabilities
++---------------------
++* Current transfer rate of up to 25.4 MB/s from host to target (using Blocking APIs).
++* Current transfer rate of up to 28.8 MB/s from target to host (using Blocking APIs).
++* Have further scope of improvement in transfer rate of up to USB 3.x speed.
++* This interface can bind with multiple target xHCI (i.e. /dev/dbc_raw0, raw1 etc).
++* It helps to render the target as an usb debug class device on host and establish
++  an usb connection by providing two bulk endpoints.
++* It has support to handle halt bit and send STALL packet.
++
++Target Build Setup
++-------------------
++* Make sure to use Kernel of version >= 4.13.
++* Enable USB_XHCI_DBGCAP in Kernel menuconfig.
++	Device Drivers  ---> USB support  ---> xHCI support for debug capability [Y]
++* Enable DBC RAW in kernel menuconfig.
++	Device Drivers  ---> USB support  ---> Select function for debug capability
++							(xHCI DbC raw driver support)
++* Build Image.
++
++Target Test Setup
++------------------
++* Flash binary with above changes in the target board.
++* Cross check the current DBC function interface, it should be RAW in this case
++  otherwise TTY, below is the sysfs entry for the dbc_function (it's a read only file,
++  switching b/w RAW and TTY is only possible at build time):
++	root@target:/ # cat /sys/bus/pci/devices/0000\:00\:14.0/dbc_function
++	RWA
++* Enable DBC with the following command:
++	root@target:/ # echo enable > /sys/bus/pci/devices/0000\:00\:14.0/dbc
++
++Host Target Connection
++-----------------------
++* Connect Type A to Type A cable between Target and Host.
++* Make sure it is an usb 3.0 cable.
++* At this point debug device should be enumerated on Host side.
++* On Target side dbc sysfs attribute should change to configured state and
++  dbc_raw0 character device should appear under dev directory.
++
++	On Target-:
++		root@target:/ # cat /sys/bus/pci/devices/0000\:00\:14.0/dbc
++		configured
++
++	Target dmesg-:
++		[   32.420018] xhci_hcd 0000:00:14.0: DbC connected
++		[   32.676014] xhci_hcd 0000:00:14.0: DbC configured
++
++	Host dmesg-:
++		[3613626.064257] usb 2-1: new SuperSpeed USB device number 46 using xhci_hcd
++		[3613626.084391] usb 2-1: LPM exit latency is zeroed, disabling LPM.
++		[3613626.084642] usb 2-1: New USB device found, idVendor=1d6b, idProduct=0010
++		[3613626.084647] usb 2-1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
++		[3613626.084651] usb 2-1: Product: Linux USB Debug Target
++		[3613626.084655] usb 2-1: Manufacturer: Linux Foundation
++		[3613626.084658] usb 2-1: SerialNumber: 0001
++
++Experiment Test Result
++-----------------------
++* Transferred 32MB data from host to target with packet size 16KB using blocking
++  APIs and achieved 25.4 MB/s with no data loss.
++* Transferred 32MB data from target to host with packet size 16KB using blocking
++  APIs and achieved 28.8 MB/s with no data loss.
++
++DBC TTY Use Cases
++------------------
++* Used for platform debugging via USB interface, in the absence of serial port.
++* It replace the need of using external serial-to-USB device for console access
++  or for low level debugging.
++* Used to send/receive data between platforms with the limited bandwidth.
++
++DBC RAW Use Cases
++------------------
++* Used at different platform (i.e. Linux, Android, Chrome etc.) for debugging
++  via USB interface.
++* It replace the need of using external serial-to-USB device for console access
++  or for low level debugging.
++* Transfer data with high data rate between platforms via DBC RAW without using
++  USB device controller.
++
++Conclusion
++-----------
++DBC RAW interface transfer data with 10x time faster than DBC TTY. And handle
++all the USB specific error like STALL packet, when the endpoint has had an error
++and its halt bit has been set.
+diff --git a/Documentation/usb/index.rst b/Documentation/usb/index.rst
+new file mode 100644
+index 000000000000..2e3b76a105af
+--- /dev/null
++++ b/Documentation/usb/index.rst
+@@ -0,0 +1,14 @@
++===============================
++Welcome to USB's documentation!
++===============================
++
++.. toctree::
++
++   dbc_raw
++
++.. only::  subproject and html
++
++   Indices
++   =======
++
++   * :ref:`genindex`
+-- 
+2.21.0
+

--- a/android_p/google_diff/clk/kernel/project-celadon/0016-usb-xhci-dbc-Reading-serial-number-from-kernel-CMDLI.patch
+++ b/android_p/google_diff/clk/kernel/project-celadon/0016-usb-xhci-dbc-Reading-serial-number-from-kernel-CMDLI.patch
@@ -1,0 +1,48 @@
+From 54b4231941be4517abb027b8c7ea1abddff7ce99 Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Thu, 2 May 2019 15:50:30 +0530
+Subject: [PATCH 7/7] usb: xhci: dbc: Reading serial number from kernel CMDLINE
+
+Adding support to read platform serial number from the kernel cmdline
+argument for DbC RAW driver.
+
+Tracked-On: OAM-69212
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+---
+ drivers/usb/host/xhci-dbgraw.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/usb/host/xhci-dbgraw.c b/drivers/usb/host/xhci-dbgraw.c
+index caa050698eb8..b1445ccf6007 100644
+--- a/drivers/usb/host/xhci-dbgraw.c
++++ b/drivers/usb/host/xhci-dbgraw.c
+@@ -22,6 +22,10 @@
+ 
+ static DEFINE_IDR(dbc_minors);
+ 
++static char *serialno = DBC_STR_SERIAL;
++module_param(serialno, charp, S_IRUGO | S_IWUSR);
++MODULE_PARM_DESC(serialno, "Use Platform Serial No. as DbC device serial No.");
++
+ struct dbc_dev {
+ 	struct mutex dev_excl;
+ 	struct mutex read_excl;
+@@ -333,7 +337,6 @@ static struct dbc_function raw_func = {
+ 	.string = {
+ 		.manufacturer = DBC_STR_MANUFACTURER,
+ 		.product = DBC_STR_PRODUCT,
+-		.serial = DBC_STR_SERIAL,
+ 	},
+ 	.protocol = DBC_PROTOCOL,
+ 	.vid = DBC_VENDOR_ID,
+@@ -347,6 +350,7 @@ static struct dbc_function raw_func = {
+ 
+ static int __init xhci_dbc_raw_init(void)
+ {
++	strcpy(&raw_func.string.serial, serialno);
+ 	return xhci_dbc_register_function(&raw_func);
+ }
+ 
+-- 
+2.21.0
+


### PR DESCRIPTION
Porting all the DbC patches to the latest kernel version
4.19.46 for WHL-NUC.

Tracked-On: OAM-83170
Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>