### PR TITLE
 resolution conflict for add keybox_provision

### DIFF
--- a/android_p/google_diff/cel_kbl/device/intel/project-celadon/0001-PATCH-Modify-cpu-arch-for-cel_kbl.patch
+++ b/android_p/google_diff/cel_kbl/device/intel/project-celadon/0001-PATCH-Modify-cpu-arch-for-cel_kbl.patch
@@ -14,7 +14,7 @@ index 130fd88..975bba6 100644
 --- a/cel_kbl/mixins.spec
 +++ b/cel_kbl/mixins.spec
 @@ -24,7 +24,7 @@ bluetooth: btusb (ivi=true)
- boot-arch: project-celadon(bootloader_policy=0x0,bootloader_len=60,magic_key_timeout=80,assume_bios_secure_boot=true,tos_partition=true,rpmb_simulate=true,disk_encryption=false,file_encryption=true,ignore_not_applicable_reset=true,self_usb_device_mode_protocol=true,system_partition_size=3584)
+ boot-arch: project-celadon(bootloader_policy=0x0,bootloader_len=60,magic_key_timeout=80,assume_bios_secure_boot=true,tos_partition=true,rpmb_simulate=true,disk_encryption=false,file_encryption=true,ignore_not_applicable_reset=true,self_usb_device_mode_protocol=true,system_partition_size=3584,keybox_provision=true)
  audio: project-celadon
  wlan: iwlwifi
 -cpu-arch: skl


### PR DESCRIPTION
when add keybox_provision parameter in mixins.sepc,it
conflict with this patch. what we change does not affect
the orginal function.

Tracked-On: OAM-83317
Signed-off-by: Zhang, Xuepeng <xuepeng.zhang@intel.com>