### PR TITLE
Fix race condition in btusb_sco_snd_card driver

### DIFF
--- a/android_p/google_diff/cel_apl/kernel/project-celadon/0011-Fix-race-condition-in-btusb_sco_snd_card-driver.patch
+++ b/android_p/google_diff/cel_apl/kernel/project-celadon/0011-Fix-race-condition-in-btusb_sco_snd_card-driver.patch
@@ -1,0 +1,63 @@
+From 69cac31a07f49044ad5f2e87888be046c0ae03b2 Mon Sep 17 00:00:00 2001
+From: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Date: Tue, 2 Jul 2019 14:29:33 +0530
+Subject: [PATCH] Fix race  condition in btusb_sco_snd_card driver
+
+Issue: Race condition occurs in the prepare call.
+Prepare for playback and capture will call configure_endpoints
+method to configure the TX and RX endpoints. When the prepare
+is called for playback first, configure_endpoints method is
+called which sets and BTUSB_ISOC_TX_EP_CONFIGURED and proceed
+to do endpoint configuration. Prepare call can be called for
+the capture during this time which calls the configure_endpoints
+again. Since the BTUSB_ISOC_TX_EP_CONFIGURED is already set,
+the configure_enpoints for the capture returns and it will
+proceed to initialise the capture URBs. Since the endpoints
+were in the process of configuration, the EP descriptors are
+not getting populated properly at the time of initialising
+capture URB, submission of capture URB to fail. Similarly
+issue will also occur if capture is called first and prepare
+is called next.
+
+Fix: Added mutex locking for the configure_endpoints method
+
+Tracked-On:
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+---
+ sound/usb/btusb/btusb_sco_snd_card.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/sound/usb/btusb/btusb_sco_snd_card.c b/sound/usb/btusb/btusb_sco_snd_card.c
+index 25c3f6e6d080..889bcd5367d5 100644
+--- a/sound/usb/btusb/btusb_sco_snd_card.c
++++ b/sound/usb/btusb/btusb_sco_snd_card.c
+@@ -15,6 +15,7 @@
+ #include <linux/jiffies.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
++#include <linux/mutex.h>
+ #include <linux/types.h>
+ #include <linux/usb.h>
+ #include <linux/usbdevice_fs.h>
+@@ -47,6 +48,7 @@
+ #define MIN_PERIODS	                   4
+ 
+ static struct usb_driver btusb_sco_driver;
++static DEFINE_MUTEX(config_mutex);
+ 
+ struct capture_data_cb {
+ 	unsigned char *buf;
+@@ -616,7 +618,10 @@ static int bt_pcm_prepare(struct snd_pcm_substream *substream)
+ 	dev = &(data->udev->dev);
+ 	// TODO: Does endpoint needs to be configured separately for Tx and Rx
+ 	// endpoints?
++	mutex_lock(&config_mutex);
+ 	err = configure_endpoints(substream);
++	mutex_unlock(&config_mutex);
++
+ 	if (err < 0) {
+ 		dev_err(dev, "failed to configure Endpoints err:%d\n", err);
+ 		return err;
+-- 
+2.17.1
+

--- a/android_p/google_diff/cel_kbl/kernel/project-celadon/0018-Fix-race-condition-in-btusb_sco_snd_card-driver.patch
+++ b/android_p/google_diff/cel_kbl/kernel/project-celadon/0018-Fix-race-condition-in-btusb_sco_snd_card-driver.patch
@@ -1,0 +1,63 @@
+From 69cac31a07f49044ad5f2e87888be046c0ae03b2 Mon Sep 17 00:00:00 2001
+From: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Date: Tue, 2 Jul 2019 14:29:33 +0530
+Subject: [PATCH] Fix race  condition in btusb_sco_snd_card driver
+
+Issue: Race condition occurs in the prepare call.
+Prepare for playback and capture will call configure_endpoints
+method to configure the TX and RX endpoints. When the prepare
+is called for playback first, configure_endpoints method is
+called which sets and BTUSB_ISOC_TX_EP_CONFIGURED and proceed
+to do endpoint configuration. Prepare call can be called for
+the capture during this time which calls the configure_endpoints
+again. Since the BTUSB_ISOC_TX_EP_CONFIGURED is already set,
+the configure_enpoints for the capture returns and it will
+proceed to initialise the capture URBs. Since the endpoints
+were in the process of configuration, the EP descriptors are
+not getting populated properly at the time of initialising
+capture URB, submission of capture URB to fail. Similarly
+issue will also occur if capture is called first and prepare
+is called next.
+
+Fix: Added mutex locking for the configure_endpoints method
+
+Tracked-On:
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+---
+ sound/usb/btusb/btusb_sco_snd_card.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/sound/usb/btusb/btusb_sco_snd_card.c b/sound/usb/btusb/btusb_sco_snd_card.c
+index 25c3f6e6d080..889bcd5367d5 100644
+--- a/sound/usb/btusb/btusb_sco_snd_card.c
++++ b/sound/usb/btusb/btusb_sco_snd_card.c
+@@ -15,6 +15,7 @@
+ #include <linux/jiffies.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
++#include <linux/mutex.h>
+ #include <linux/types.h>
+ #include <linux/usb.h>
+ #include <linux/usbdevice_fs.h>
+@@ -47,6 +48,7 @@
+ #define MIN_PERIODS	                   4
+ 
+ static struct usb_driver btusb_sco_driver;
++static DEFINE_MUTEX(config_mutex);
+ 
+ struct capture_data_cb {
+ 	unsigned char *buf;
+@@ -616,7 +618,10 @@ static int bt_pcm_prepare(struct snd_pcm_substream *substream)
+ 	dev = &(data->udev->dev);
+ 	// TODO: Does endpoint needs to be configured separately for Tx and Rx
+ 	// endpoints?
++	mutex_lock(&config_mutex);
+ 	err = configure_endpoints(substream);
++	mutex_unlock(&config_mutex);
++
+ 	if (err < 0) {
+ 		dev_err(dev, "failed to configure Endpoints err:%d\n", err);
+ 		return err;
+-- 
+2.17.1
+

--- a/android_p/google_diff/celadon/kernel/project-celadon/0009-Fix-race-condition-in-btusb_sco_snd_card-driver.patch
+++ b/android_p/google_diff/celadon/kernel/project-celadon/0009-Fix-race-condition-in-btusb_sco_snd_card-driver.patch
@@ -1,0 +1,63 @@
+From 69cac31a07f49044ad5f2e87888be046c0ae03b2 Mon Sep 17 00:00:00 2001
+From: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Date: Tue, 2 Jul 2019 14:29:33 +0530
+Subject: [PATCH] Fix race  condition in btusb_sco_snd_card driver
+
+Issue: Race condition occurs in the prepare call.
+Prepare for playback and capture will call configure_endpoints
+method to configure the TX and RX endpoints. When the prepare
+is called for playback first, configure_endpoints method is
+called which sets and BTUSB_ISOC_TX_EP_CONFIGURED and proceed
+to do endpoint configuration. Prepare call can be called for
+the capture during this time which calls the configure_endpoints
+again. Since the BTUSB_ISOC_TX_EP_CONFIGURED is already set,
+the configure_enpoints for the capture returns and it will
+proceed to initialise the capture URBs. Since the endpoints
+were in the process of configuration, the EP descriptors are
+not getting populated properly at the time of initialising
+capture URB, submission of capture URB to fail. Similarly
+issue will also occur if capture is called first and prepare
+is called next.
+
+Fix: Added mutex locking for the configure_endpoints method
+
+Tracked-On:
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+---
+ sound/usb/btusb/btusb_sco_snd_card.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/sound/usb/btusb/btusb_sco_snd_card.c b/sound/usb/btusb/btusb_sco_snd_card.c
+index 25c3f6e6d080..889bcd5367d5 100644
+--- a/sound/usb/btusb/btusb_sco_snd_card.c
++++ b/sound/usb/btusb/btusb_sco_snd_card.c
+@@ -15,6 +15,7 @@
+ #include <linux/jiffies.h>
+ #include <linux/kernel.h>
+ #include <linux/module.h>
++#include <linux/mutex.h>
+ #include <linux/types.h>
+ #include <linux/usb.h>
+ #include <linux/usbdevice_fs.h>
+@@ -47,6 +48,7 @@
+ #define MIN_PERIODS	                   4
+ 
+ static struct usb_driver btusb_sco_driver;
++static DEFINE_MUTEX(config_mutex);
+ 
+ struct capture_data_cb {
+ 	unsigned char *buf;
+@@ -616,7 +618,10 @@ static int bt_pcm_prepare(struct snd_pcm_substream *substream)
+ 	dev = &(data->udev->dev);
+ 	// TODO: Does endpoint needs to be configured separately for Tx and Rx
+ 	// endpoints?
++	mutex_lock(&config_mutex);
+ 	err = configure_endpoints(substream);
++	mutex_unlock(&config_mutex);
++
+ 	if (err < 0) {
+ 		dev_err(dev, "failed to configure Endpoints err:%d\n", err);
+ 		return err;
+-- 
+2.17.1
+


### PR DESCRIPTION
Issue: Race condition occurs in the prepare call.
Prepare for playback and capture will call configure_endpoints
method to configure the TX and RX endpoints. When the prepare
is called for playback first, configure_endpoints method is
called which sets and BTUSB_ISOC_TX_EP_CONFIGURED and proceed
to do endpoint configuration. Prepare call can be called for
the capture during this time which calls the configure_endpoints
again. Since the BTUSB_ISOC_TX_EP_CONFIGURED is already set,
the configure_enpoints for the capture returns and it will
proceed to initialise the capture URBs. Since the endpoints
were in the process of configuration, the EP descriptors are
not getting populated properly at the time of initialising
capture URB, submission of capture URB to fail. Similarly
issue will also occur if capture is called first and prepare
is called next.

Fix: Added mutex locking for the configure_endpoints method

Tracked-On: OAM-81187
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>