### PR TITLE
Fix unable to show overview button

### DIFF
--- a/android_p/google_diff/celadon/frameworks/base/0030--Fix-unable-to-show-overview-button.patch
+++ b/android_p/google_diff/celadon/frameworks/base/0030--Fix-unable-to-show-overview-button.patch
@@ -1,0 +1,30 @@
+From ccfedd6073dc4d9feb777b2da3aabf92ac9d6198 Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Tue, 9 Jul 2019 18:20:46 +0800
+Subject: [PATCH] Fix unable to show overview button
+
+Overview button is not show due to the menu_container's layout_width
+is too large.
+
+Tracked-On: OAM-83824
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ packages/SystemUI/res/layout/menu_ime.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/packages/SystemUI/res/layout/menu_ime.xml b/packages/SystemUI/res/layout/menu_ime.xml
+index 9130fb45489..3136d411ba2 100644
+--- a/packages/SystemUI/res/layout/menu_ime.xml
++++ b/packages/SystemUI/res/layout/menu_ime.xml
+@@ -17,7 +17,7 @@
+ <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+     xmlns:systemui="http://schemas.android.com/apk/res-auto"
+     android:id="@+id/menu_container"
+-    android:layout_width="match_parent"
++    android:layout_width="@dimen/navigation_key_width"
+     android:layout_height="match_parent"
+     android:importantForAccessibility="no"
+     >
+-- 
+2.21.0
+

--- a/android_p/google_diff/clk/frameworks/base/0030--Fix-unable-to-show-overview-button.patch
+++ b/android_p/google_diff/clk/frameworks/base/0030--Fix-unable-to-show-overview-button.patch
@@ -1,0 +1,30 @@
+From ccfedd6073dc4d9feb777b2da3aabf92ac9d6198 Mon Sep 17 00:00:00 2001
+From: "Wang, ArvinX" <arvinx.wang@intel.com>
+Date: Tue, 9 Jul 2019 18:20:46 +0800
+Subject: [PATCH] Fix unable to show overview button
+
+Overview button is not show due to the menu_container's layout_width
+is too large.
+
+Tracked-On: OAM-83824
+Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>
+---
+ packages/SystemUI/res/layout/menu_ime.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/packages/SystemUI/res/layout/menu_ime.xml b/packages/SystemUI/res/layout/menu_ime.xml
+index 9130fb45489..3136d411ba2 100644
+--- a/packages/SystemUI/res/layout/menu_ime.xml
++++ b/packages/SystemUI/res/layout/menu_ime.xml
+@@ -17,7 +17,7 @@
+ <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+     xmlns:systemui="http://schemas.android.com/apk/res-auto"
+     android:id="@+id/menu_container"
+-    android:layout_width="match_parent"
++    android:layout_width="@dimen/navigation_key_width"
+     android:layout_height="match_parent"
+     android:importantForAccessibility="no"
+     >
+-- 
+2.21.0
+


### PR DESCRIPTION
Overview button is not show due to the menu_container's layout_width
is too large.

Tracked-On: OAM-83824
Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>