### PR TITLE
usb: gadget: ACM: Enabling USB ACM gadget for WHL

### DIFF
--- a/android_p/google_diff/clk/device/intel/project-celadon/0005-usb-gadget-ACM-Enabling-USB-ACM-gadget-for-WHL.patch
+++ b/android_p/google_diff/clk/device/intel/project-celadon/0005-usb-gadget-ACM-Enabling-USB-ACM-gadget-for-WHL.patch
@@ -1,0 +1,36 @@
+From 38556934dc48454caa7fcbc5fc98207ab45caf11 Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Mon, 15 Jul 2019 11:35:10 +0530
+Subject: [PATCH] usb: gadget: ACM: Enabling USB ACM gadget for WHL
+
+Enable USB CDC ACM gadget for WHL platform.
+
+Tracked-On: OAM-83964
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+---
+ kernel_config/kernel_64_defconfig | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/kernel_config/kernel_64_defconfig b/kernel_config/kernel_64_defconfig
+index fd5f170..ab39e6a 100644
+--- a/kernel_config/kernel_64_defconfig
++++ b/kernel_config/kernel_64_defconfig
+@@ -4731,13 +4731,14 @@ CONFIG_USB_LIBCOMPOSITE=y
+ CONFIG_USB_U_ETHER=y
+ CONFIG_USB_F_RNDIS=y
+ CONFIG_USB_F_FS=y
++CONFIG_USB_F_ACM=y
+ CONFIG_USB_F_UVC=m
+ CONFIG_USB_F_MIDI=y
+ CONFIG_USB_F_AUDIO_SRC=y
+ CONFIG_USB_F_ACC=y
+ CONFIG_USB_CONFIGFS=y
+ # CONFIG_USB_CONFIGFS_SERIAL is not set
+-# CONFIG_USB_CONFIGFS_ACM is not set
++CONFIG_USB_CONFIGFS_ACM=y
+ # CONFIG_USB_CONFIGFS_OBEX is not set
+ # CONFIG_USB_CONFIGFS_NCM is not set
+ # CONFIG_USB_CONFIGFS_ECM is not set
+-- 
+2.17.1
+


### PR DESCRIPTION
Enable USB CDC ACM gadget for WHL platform.

Tracked-On: OAM-83964
Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>