### PR TITLE
Fix for CTS testAllowWhileIdleJobInTempwhitelist

### DIFF
--- a/android_p/google_diff/cel_kbl/frameworks/base/0032-Fix-for-CTS-testAllowWhileIdleJobInTempwhitelist.patch
+++ b/android_p/google_diff/cel_kbl/frameworks/base/0032-Fix-for-CTS-testAllowWhileIdleJobInTempwhitelist.patch
@@ -1,0 +1,43 @@
+From b301c04757ffc3f772921b0f604c45fb8db24366 Mon Sep 17 00:00:00 2001
+From: Kulwinder Singh <kulwinder.singh@mediatek.com>
+Date: Fri, 31 Aug 2018 13:14:03 +0530
+Subject: [PATCH] Fix for CTS testAllowWhileIdleJobInTempwhitelist
+
+In this test case when all constraints to run the jobs are satisfied,
+then to make job ready to run, intent MSG_CHECK_JOB is send to job handler.
+But this intent is not dispatched to job handler.
+
+BUG: 113778907
+Test:After these changes this CTS case always passed.
+
+Change-Id: I8c63361dcd7ade19b724c9bc2fdf78d5f10c8d71
+Merged-In: I8c63361dcd7ade19b724c9bc2fdf78d5f10c8d71
+
+Feature: CTS(*)
+---
+ .../core/java/com/android/server/job/JobSchedulerService.java   | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/services/core/java/com/android/server/job/JobSchedulerService.java b/services/core/java/com/android/server/job/JobSchedulerService.java
+index 0b7c5b943e5..64641b3ab8b 100644
+--- a/services/core/java/com/android/server/job/JobSchedulerService.java
++++ b/services/core/java/com/android/server/job/JobSchedulerService.java
+@@ -1596,6 +1596,7 @@ public class JobSchedulerService extends com.android.server.SystemService
+                         }
+                     } break;
+                     case MSG_CHECK_JOB:
++                        removeMessages(MSG_CHECK_JOB);
+                         if (mReportedActive) {
+                             // if jobs are currently being run, queue all ready jobs for execution.
+                             queueReadyJobsForExecutionLocked();
+@@ -1652,7 +1653,6 @@ public class JobSchedulerService extends com.android.server.SystemService
+                 }
+                 maybeRunPendingJobsLocked();
+                 // Don't remove JOB_EXPIRED in case one came along while processing the queue.
+-                removeMessages(MSG_CHECK_JOB);
+             }
+         }
+     }
+-- 
+2.21.0
+


### PR DESCRIPTION
In this test case when all constraints to run the jobs are satisfied,
then to make job ready to run, intent MSG_CHECK_JOB is send to job handler.
But this intent is not dispatched to job handler.

BUG: 113778907
Test:After these changes this CTS case always passed.

Change-Id: I8c63361dcd7ade19b724c9bc2fdf78d5f10c8d71
Merged-In: I8c63361dcd7ade19b724c9bc2fdf78d5f10c8d71

Feature: CTS(*)

Tracked-On: https://jira.devtools.intel.com/browse/OAM-
Signed-off-by: Wang, ArvinX <arvinx.wang@intel.com>