### PR TITLE
usb: gadget: NCM: Enabling USB NCM gadget for WHL

### DIFF
--- a/android_p/google_diff/clk/device/intel/project-celadon/0006-usb-gadget-NCM-Enabling-USB-NCM-gadget-for-WHL.patch
+++ b/android_p/google_diff/clk/device/intel/project-celadon/0006-usb-gadget-NCM-Enabling-USB-NCM-gadget-for-WHL.patch
@@ -1,0 +1,37 @@
+From 209ded29deb3ceacc65f886260c17ccab16d66cb Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Fri, 19 Jul 2019 10:17:01 +0530
+Subject: [PATCH] usb: gadget: NCM: Enabling USB NCM gadget for WHL
+
+Enable USB CDC NCM gadget for WHL platform.
+
+Tracked-On: 83965
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+---
+ kernel_config/kernel_64_defconfig | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/kernel_config/kernel_64_defconfig b/kernel_config/kernel_64_defconfig
+index 33a4c2f..2f667dd 100644
+--- a/kernel_config/kernel_64_defconfig
++++ b/kernel_config/kernel_64_defconfig
+@@ -4734,6 +4734,7 @@ CONFIG_USB_U_ETHER=y
+ CONFIG_USB_F_RNDIS=y
+ CONFIG_USB_F_FS=y
+ CONFIG_USB_F_ACM=y
++CONFIG_USB_F_NCM=y
+ CONFIG_USB_F_UVC=m
+ CONFIG_USB_F_MIDI=y
+ CONFIG_USB_F_AUDIO_SRC=y
+@@ -4742,7 +4743,7 @@ CONFIG_USB_CONFIGFS=y
+ # CONFIG_USB_CONFIGFS_SERIAL is not set
+ CONFIG_USB_CONFIGFS_ACM=y
+ # CONFIG_USB_CONFIGFS_OBEX is not set
+-# CONFIG_USB_CONFIGFS_NCM is not set
++CONFIG_USB_CONFIGFS_NCM=y
+ # CONFIG_USB_CONFIGFS_ECM is not set
+ # CONFIG_USB_CONFIGFS_ECM_SUBSET is not set
+ CONFIG_USB_CONFIGFS_RNDIS=y
+-- 
+2.21.0
+


### PR DESCRIPTION
Enable USB CDC NCM gadget for WHL platform.

Tracked-On: OAM-83965
Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>