### PR TITLE
usb: ACM: Enabling USB Host CDC ACM class

### DIFF
--- a/android_p/google_diff/clk/device/intel/project-celadon/0007-usb-ACM-Enabling-USB-Host-CDC-ACM-class.patch
+++ b/android_p/google_diff/clk/device/intel/project-celadon/0007-usb-ACM-Enabling-USB-Host-CDC-ACM-class.patch
@@ -1,0 +1,29 @@
+From 93b9c6d260c195644e10f8d189a28fc3e04cb97a Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Mon, 22 Jul 2019 12:40:00 +0530
+Subject: [PATCH] usb: ACM: Enabling USB Host CDC ACM class
+
+Enable USB Host CDC ACM class for WHL.
+
+Tracked-On: 84164
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+---
+ kernel_config/kernel_64_defconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel_config/kernel_64_defconfig b/kernel_config/kernel_64_defconfig
+index 9fc6a0a..e0c48fe 100644
+--- a/kernel_config/kernel_64_defconfig
++++ b/kernel_config/kernel_64_defconfig
+@@ -4542,7 +4542,7 @@ CONFIG_USB_HCD_BCMA=m
+ #
+ # USB Device Class drivers
+ #
+-CONFIG_USB_ACM=m
++CONFIG_USB_ACM=y
+ CONFIG_USB_PRINTER=m
+ CONFIG_USB_WDM=m
+ CONFIG_USB_TMC=m
+-- 
+2.21.0
+


### PR DESCRIPTION
Enable USB Host CDC ACM class for WHL.

Tracked-On: 84164
Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>