### PR TITLE
usb: ACM: Enabling USB Host CDC ACM class

### DIFF
--- a/android_p/google_diff/cel_kbl/device/intel/project-celadon/0006-usb-ACM-Enabling-USB-Host-CDC-ACM-class.patch
+++ b/android_p/google_diff/cel_kbl/device/intel/project-celadon/0006-usb-ACM-Enabling-USB-Host-CDC-ACM-class.patch
@@ -1,0 +1,29 @@
+From 865b95e077b98ffae4c24f4397a298da1ef99599 Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Tue, 23 Jul 2019 10:45:19 +0530
+Subject: [PATCH] usb: ACM: Enabling USB Host CDC ACM class
+
+Enable USB Host CDC ACM class for KBL-P.
+
+Tracked-On: OAM-84169
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+---
+ kernel_config/kernel_64_defconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel_config/kernel_64_defconfig b/kernel_config/kernel_64_defconfig
+index 2bbfbc5..052166f 100644
+--- a/kernel_config/kernel_64_defconfig
++++ b/kernel_config/kernel_64_defconfig
+@@ -4537,7 +4537,7 @@ CONFIG_USB_HCD_BCMA=m
+ #
+ # USB Device Class drivers
+ #
+-CONFIG_USB_ACM=m
++CONFIG_USB_ACM=y
+ CONFIG_USB_PRINTER=m
+ CONFIG_USB_WDM=m
+ CONFIG_USB_TMC=m
+-- 
+2.21.0
+


### PR DESCRIPTION
Enable USB Host CDC ACM class for KBL-P.

Tracked-On: OAM-84169
Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>