### PR TITLE
Disable RBC on cel_apl and celadon

### DIFF
--- a/android_p/google_diff/cel_apl/vendor/intel/external/project-celadon/hwcomposer/0001-Disable-RBC.patch
+++ b/android_p/google_diff/cel_apl/vendor/intel/external/project-celadon/hwcomposer/0001-Disable-RBC.patch
@@ -1,0 +1,34 @@
+From 2fcc2da1fe97ad197ec99313009861e649c37c94 Mon Sep 17 00:00:00 2001
+From: HeYue <yue.he@intel.com>
+Date: Fri, 24 May 2019 09:42:36 +0800
+Subject: [PATCH] Disable RBC
+
+On clk, if connect two displays, 4K as primary display. The RBC
+will cause 4K display stuck.
+Disable RBC temporary as this issue block feature.
+
+Test: 4K display works well, do not have other issue.
+Tracked-On:https://jira.devtools.intel.com/browse/OAM-80004
+Signed-off-by: HeYue <yue.he@intel.com>
+---
+ Android.common.mk | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Android.common.mk b/Android.common.mk
+index 28e1ce7..18ae5f7 100644
+--- a/Android.common.mk
++++ b/Android.common.mk
+@@ -140,8 +140,8 @@ LOCAL_C_INCLUDES += \
+ 	$(LOCAL_PATH)/../mesa/include
+ else
+ LOCAL_CPPFLAGS += \
+-	-DUSE_GL \
+-	-DENABLE_RBC
++	-DUSE_GL
++#	-DENABLE_RBC
+ endif
+ 
+ ifneq ($(strip $(HWC_DISABLE_VA_DRIVER)), true)
+-- 
+2.7.4
+

--- a/android_p/google_diff/celadon/vendor/intel/external/project-celadon/hwcomposer/0001-Disable-RBC.patch
+++ b/android_p/google_diff/celadon/vendor/intel/external/project-celadon/hwcomposer/0001-Disable-RBC.patch
@@ -1,0 +1,34 @@
+From 2fcc2da1fe97ad197ec99313009861e649c37c94 Mon Sep 17 00:00:00 2001
+From: HeYue <yue.he@intel.com>
+Date: Fri, 24 May 2019 09:42:36 +0800
+Subject: [PATCH] Disable RBC
+
+On clk, if connect two displays, 4K as primary display. The RBC
+will cause 4K display stuck.
+Disable RBC temporary as this issue block feature.
+
+Test: 4K display works well, do not have other issue.
+Tracked-On:https://jira.devtools.intel.com/browse/OAM-80004
+Signed-off-by: HeYue <yue.he@intel.com>
+---
+ Android.common.mk | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Android.common.mk b/Android.common.mk
+index 28e1ce7..18ae5f7 100644
+--- a/Android.common.mk
++++ b/Android.common.mk
+@@ -140,8 +140,8 @@ LOCAL_C_INCLUDES += \
+ 	$(LOCAL_PATH)/../mesa/include
+ else
+ LOCAL_CPPFLAGS += \
+-	-DUSE_GL \
+-	-DENABLE_RBC
++	-DUSE_GL
++#	-DENABLE_RBC
+ endif
+ 
+ ifneq ($(strip $(HWC_DISABLE_VA_DRIVER)), true)
+-- 
+2.7.4
+


### PR DESCRIPTION
The RBC will cause 4K display stuck

Test: 4K display works well, no regression.
Tracked-On: OAM-84580
Signed-off-by: HeYue <yue.he@intel.com>