### PR TITLE
Fix for adb dbc offline issue

### DIFF
--- a/android_p/google_diff/cel_kbl/frameworks/base/0033-Fix-for-adb-dbc-offline-issue.patch
+++ b/android_p/google_diff/cel_kbl/frameworks/base/0033-Fix-for-adb-dbc-offline-issue.patch
@@ -1,0 +1,91 @@
+From c269df81c3e6099f9e873d664d8351e2052f0ce1 Mon Sep 17 00:00:00 2001
+From: Balaji <m.balaji@intel.com>
+Date: Tue, 20 Aug 2019 06:39:52 -0400
+Subject: [PATCH] Fix for adb dbc offline issue
+
+Adb daemon doesnt know about dbc disconnect and connect.hence offline
+issue occurs when replug.Changes made usb device manager to receive
+usb dbc event from kernel and restart adb daemon.
+
+Tracked-On: OAM-84514
+Signed-off-by: Balaji <m.balaji@intel.com>
+---
+ .../android/server/usb/UsbDeviceManager.java  | 23 ++++++++++++++++++-
+ 1 file changed, 22 insertions(+), 1 deletion(-)
+
+diff --git a/services/usb/java/com/android/server/usb/UsbDeviceManager.java b/services/usb/java/com/android/server/usb/UsbDeviceManager.java
+index 2ce44222974..368dd4ceedc 100644
+--- a/services/usb/java/com/android/server/usb/UsbDeviceManager.java
++++ b/services/usb/java/com/android/server/usb/UsbDeviceManager.java
+@@ -119,6 +119,9 @@ public class UsbDeviceManager implements ActivityManagerInternal.ScreenObserver
+      */
+     private static final String NORMAL_BOOT = "normal";
+ 
++    private static final String USB_DBC_STATE_MATCH =
++            "SUBSYSTEM=pci";
++
+     private static final String USB_STATE_MATCH =
+             "DEVPATH=/devices/virtual/android_usb/android0";
+     private static final String ACCESSORY_START_MATCH =
+@@ -365,6 +368,7 @@ public class UsbDeviceManager implements ActivityManagerInternal.ScreenObserver
+         mUEventObserver = new UsbUEventObserver();
+         mUEventObserver.startObserving(USB_STATE_MATCH);
+         mUEventObserver.startObserving(ACCESSORY_START_MATCH);
++	mUEventObserver.startObserving(USB_DBC_STATE_MATCH);
+ 
+         // register observer to listen for settings changes
+         mContentResolver.registerContentObserver(
+@@ -460,6 +464,7 @@ public class UsbDeviceManager implements ActivityManagerInternal.ScreenObserver
+ 
+         // current USB state
+         private boolean mConnected;
++	private boolean mDbcConnected;
+         private boolean mHostConnected;
+         private boolean mSourcePower;
+         private boolean mSinkPower;
+@@ -596,6 +601,9 @@ public class UsbDeviceManager implements ActivityManagerInternal.ScreenObserver
+             } else if ("CONFIGURED".equals(state)) {
+                 connected = 1;
+                 configured = 1;
++            } else if ("DBCCONNECTED".equals(state)) {
++                connected = 2;
++                configured = 1;
+             } else {
+                 Slog.e(TAG, "unknown state " + state);
+                 return;
+@@ -803,11 +811,19 @@ public class UsbDeviceManager implements ActivityManagerInternal.ScreenObserver
+ 
+         @Override
+         public void handleMessage(Message msg) {
++
++	final String ADBD = "adbd";
++	final String CTL_START = "ctl.start";
++	final String CTL_STOP = "ctl.stop";
++
+             switch (msg.what) {
+                 case MSG_UPDATE_STATE:
+                     mConnected = (msg.arg1 == 1);
+                     mConfigured = (msg.arg2 == 1);
+-
++                    if (msg.arg1==2) {
++			mConnected = (msg.arg1==2);
++			mDbcConnected = (msg.arg1==2);
++		    }
+                     updateUsbNotification(false);
+                     updateAdbNotification(false);
+                     if (mBootCompleted) {
+@@ -831,6 +847,11 @@ public class UsbDeviceManager implements ActivityManagerInternal.ScreenObserver
+                     } else {
+                         mPendingBootBroadcast = true;
+                     }
++                    if (mDbcConnected) {
++			setSystemProperty("sys.usb.controller","none");
++                        setSystemProperty(CTL_STOP, ADBD);
++			setSystemProperty(CTL_START, ADBD);
++		    }
+                     break;
+                 case MSG_UPDATE_PORT_STATE:
+                     SomeArgs args = (SomeArgs) msg.obj;
+-- 
+2.17.1
+

--- a/android_p/google_diff/cel_kbl/kernel/project-celadon/0020-usb-dbc-Fix-for-offline-issue.patch
+++ b/android_p/google_diff/cel_kbl/kernel/project-celadon/0020-usb-dbc-Fix-for-offline-issue.patch
@@ -1,0 +1,102 @@
+From b339532a8f5141e3e34678ca07e731f0f82be50a Mon Sep 17 00:00:00 2001
+From: Balaji <m.balaji@intel.com>
+Date: Tue, 20 Aug 2019 01:42:23 -0400
+Subject: [PATCH] drivers: usb: host: Fix for adb dbc offline issue
+
+Adb daemon doesnt know about dbc disconnect and connect.hence offline
+issue occurs when replug.Changes made usb dbc layer to send
+usb dbc events from kernel to restart adb daemon.
+
+Change-Id: If7ce5c0dc22ec9c624d502f2b0aa81ccf12841a0
+Tracked-On: https://jira.devtools.intel.com/browse/OAM-84534
+Signed-off-by: Balaji <m.balaji@intel.com>
+---
+ drivers/usb/host/xhci-dbgcap.c | 31 +++++++++++++++++++++++++++++++
+ drivers/usb/host/xhci-dbgcap.h |  1 +
+ 2 files changed, 32 insertions(+)
+
+diff --git a/drivers/usb/host/xhci-dbgcap.c b/drivers/usb/host/xhci-dbgcap.c
+index 08c31b457f1d..051317671f95 100644
+--- a/drivers/usb/host/xhci-dbgcap.c
++++ b/drivers/usb/host/xhci-dbgcap.c
+@@ -10,6 +10,8 @@
+ #include <linux/slab.h>
+ #include <linux/nls.h>
+ #include <linux/module.h>
++#include <linux/platform_device.h>
++#include <linux/kdev_t.h>
+ 
+ #include "xhci.h"
+ #include "xhci-trace.h"
+@@ -653,6 +655,32 @@ static void dbc_handle_xfer_event(struct xhci_hcd *xhci, union xhci_trb *event)
+ 	xhci_dbc_giveback(req, status);
+ }
+ 
++static void xhci_dbc_uevent_work(struct work_struct *data)
++{
++	struct xhci_dbc *dbc  = container_of(data, struct xhci_dbc, notify_work);
++        char *disconnected[2] = { "USB_STATE=DISCONNECTED", NULL };
++        char *connected[2]    = { "USB_STATE=DBCCONNECTED", NULL };
++        char *configured[2]   = { "USB_STATE=CONFIGURED", NULL };
++	struct xhci_hcd         *xhci = dbc->xhci;
++	struct device           *dev = xhci_to_hcd(xhci)->self.controller;
++
++	switch (dbc->state) {
++
++	case DS_CONFIGURED:
++		kobject_uevent_env(&dev->kobj,
++                                KOBJ_CHANGE, connected);
++                kobject_uevent_env(&dev->kobj,
++                                KOBJ_CHANGE, configured);
++		break;
++        case DS_ENABLED:
++
++                kobject_uevent_env(&dev->kobj,
++				KOBJ_CHANGE, disconnected);
++		break;
++
++	}
++}
++
+ static enum evtreturn xhci_dbc_do_handle_events(struct xhci_dbc *dbc)
+ {
+ 	dma_addr_t		deq;
+@@ -683,6 +711,7 @@ static enum evtreturn xhci_dbc_do_handle_events(struct xhci_dbc *dbc)
+ 			xhci_info(xhci, "DbC configured\n");
+ 			portsc = readl(&dbc->regs->portsc);
+ 			writel(portsc, &dbc->regs->portsc);
++			schedule_work(&dbc->notify_work);
+ 			return EVT_GSER;
+ 		}
+ 
+@@ -695,6 +724,7 @@ static enum evtreturn xhci_dbc_do_handle_events(struct xhci_dbc *dbc)
+ 			xhci_info(xhci, "DbC cable unplugged\n");
+ 			dbc->state = DS_ENABLED;
+ 			xhci_dbc_flush_requests(dbc);
++			schedule_work(&dbc->notify_work);
+ 
+ 			return EVT_DISC;
+ 		}
+@@ -870,6 +900,7 @@ static int xhci_do_dbc_init(struct xhci_hcd *xhci)
+ 
+ 	dbc->xhci = xhci;
+ 	INIT_DELAYED_WORK(&dbc->event_work, xhci_dbc_handle_events);
++	INIT_WORK(&dbc->notify_work, xhci_dbc_uevent_work);
+ 	spin_lock_init(&dbc->lock);
+ 
+ 	return 0;
+diff --git a/drivers/usb/host/xhci-dbgcap.h b/drivers/usb/host/xhci-dbgcap.h
+index 302e6ca72370..749cd9a788eb 100644
+--- a/drivers/usb/host/xhci-dbgcap.h
++++ b/drivers/usb/host/xhci-dbgcap.h
+@@ -174,6 +174,7 @@ struct xhci_dbc {
+ 	struct dbc_port			port;
+ 	/* priv pointer for a function */
+ 	void                            *func_priv;
++	struct work_struct              notify_work;
+ };
+ 
+ #define dbc_bulkout_ctx(d)		\
+-- 
+2.17.1
+


### PR DESCRIPTION
Adb daemon doesnt know about dbc disconnect and connect.hence offline
issue occurs when replug.Changes made usb device manager to receive
usb dbc event from kernel and restart adb daemon.

Change-Id: I3973f68d0667d332792a9176e61c7a505c4c3101
Tracked-On: OAM-84514
Signed-off-by: Balaji <m.balaji@intel.com>