### PR TITLE
[WHL_RVP] Improve headset detection logic

### DIFF
--- a/android_p/google_diff/clk/frameworks/base/0032-WHL_RVP-Improve-Wired-accessory-detection-logic.patch
+++ b/android_p/google_diff/clk/frameworks/base/0032-WHL_RVP-Improve-Wired-accessory-detection-logic.patch
@@ -1,0 +1,103 @@
+From 915f454716a0a31034cce7b3e9a70452547a0570 Mon Sep 17 00:00:00 2001
+From: Karan Patidar <karan.patidar@intel.com>
+Date: Thu, 5 Sep 2019 10:56:44 +0530
+Subject: [PATCH] [WHL_RVP] Improve Wired accessory detection logic
+
+WHL_RVP has Line out event for DP detection, which forces the
+accessory detection logic to chose unknown device when DP and
+3.5mm Headset are connected.
+Improve logic to avoid headset disconnection on WHL_RVP
+
+Tracked-On:
+Signed-off-by: Karan Patidar <karan.patidar@intel.com>
+---
+ .../android/server/WiredAccessoryManager.java | 69 ++++++++-----------
+ 1 file changed, 29 insertions(+), 40 deletions(-)
+
+diff --git a/services/core/java/com/android/server/WiredAccessoryManager.java b/services/core/java/com/android/server/WiredAccessoryManager.java
+index 719270c5cab..c9a48e99a11 100644
+--- a/services/core/java/com/android/server/WiredAccessoryManager.java
++++ b/services/core/java/com/android/server/WiredAccessoryManager.java
+@@ -127,50 +127,39 @@ final class WiredAccessoryManager implements WiredAccessoryCallbacks {
+                 + " bits=" + switchCodeToString(switchValues, switchMask)
+                 + " mask=" + Integer.toHexString(switchMask));
+ 
+-  Log.e(TAG, " notifyWiredAccessoryChanged: when=" + whenNanos
+-                + " bits=" + switchCodeToString(switchValues, switchMask)
+-                + " mask=" + Integer.toHexString(switchMask));
+-
+-
+         synchronized (mLock) {
+-            int headset;
++            int headset = 0;
+             mSwitchValues = (mSwitchValues & ~switchMask) | switchValues;
+-            switch (mSwitchValues &
+-                (SW_HEADPHONE_INSERT_BIT | SW_MICROPHONE_INSERT_BIT | SW_LINEOUT_INSERT_BIT)) {
+-                case 0:
+-			Log.v(TAG," case-0");
+-                    headset = 0;
+-                    break;
+ 
+-                case SW_HEADPHONE_INSERT_BIT:
+-			Log.v(TAG," case:SW_HEADPHONE_INSERT_BIT");
+-                    headset = BIT_HEADSET_NO_MIC;
+-                    break;
+-
+-                case SW_LINEOUT_INSERT_BIT:
+-			Log.v(TAG," case:SW_LINEOUT_INSERT_BIT");
++            if((mSwitchValues &
++                (SW_HEADPHONE_INSERT_BIT | SW_MICROPHONE_INSERT_BIT | SW_LINEOUT_INSERT_BIT)) == SW_LINEOUT_INSERT_BIT){
++                    Log.v(TAG," headset set to SW_LINEOUT_INSERT_BIT");
+                     headset = BIT_LINEOUT;
+-                    break;
+-
+-                case SW_HEADPHONE_INSERT_BIT | SW_MICROPHONE_INSERT_BIT:
+-			Log.v(TAG," case: SW_HEADPHONE_INSERT_BIT| SW_MICROPHONE_INSERT_BIT ");
+-                    headset = BIT_HEADSET;
+-                    break;
+-
+-                case SW_MICROPHONE_INSERT_BIT:
+-			Log.v(TAG," case:SW_MICROPHONE_INSERT_BIT");
+-                    headset = BIT_HEADSET;
+-                    break;
+-                
+-                case SW_HEADPHONE_INSERT_BIT | SW_LINEOUT_INSERT_BIT:
+-			Log.v(TAG," case : SW_HEADPHONE_INSERT_BIT | SW_LINEOUT_INSERT_BIT");
+-                    headset = BIT_HEADSET;
+-                    break;
+-
+-                default:
+-			Log.v(TAG," case :default");
+-                    headset = 0;
+-                    break;
++            }
++            else {
++                switch (mSwitchValues &
++                    (SW_HEADPHONE_INSERT_BIT | SW_MICROPHONE_INSERT_BIT)) {
++                    case 0:
++                        Log.v(TAG," case-0");
++                        headset = 0;
++                        break;
++                    case SW_HEADPHONE_INSERT_BIT:
++                        Log.v(TAG," case:SW_HEADPHONE_INSERT_BIT");
++                        headset = BIT_HEADSET_NO_MIC;
++                        break;
++                    case SW_HEADPHONE_INSERT_BIT | SW_MICROPHONE_INSERT_BIT:
++                        Log.v(TAG," case: SW_HEADPHONE_INSERT_BIT| SW_MICROPHONE_INSERT_BIT ");
++                        headset = BIT_HEADSET;
++                        break;
++                    case SW_MICROPHONE_INSERT_BIT:
++                        Log.v(TAG," case:SW_MICROPHONE_INSERT_BIT");
++                        headset = BIT_HEADSET;
++                        break;
++                    default:
++                        Log.v(TAG," case : default : unknown wired accessory");
++                        headset = 0;
++                        break;
++                }
+             }
+ 
+             updateLocked(NAME_H2W,
+-- 
+2.17.1
+


### PR DESCRIPTION
WHL RVP board has issue with headset and line out events,
this results in failure to detect 3.5mm Headset correctly.
Applying changes as google_diff as its specific rvp board as
of now.

Tracked-On: OAM-85625
Signed-off-by: Karan Patidar <karan.patidar@intel.com>