### PR TITLE
wifi: Disable capabilities not yet supported

### DIFF
--- a/aosp_diff/celadon_ivi/hardware/interfaces/679603_1-wifi-Disable-capabilities-not-yet-supported.patch
+++ b/aosp_diff/celadon_ivi/hardware/interfaces/679603_1-wifi-Disable-capabilities-not-yet-supported.patch
@@ -1,0 +1,54 @@
+From 0727a7a500a11a2f28bd4c4625d1328e033371af Mon Sep 17 00:00:00 2001
+From: Amrita Raju <amrita.raju@intel.com>
+Date: Fri, 8 Feb 2019 09:55:05 +0530
+Subject: [PATCH] wifi: Disable capabilities not yet supported
+
+As E2E support is not yet implemented for following capabilities,
+removing them.
+DEBUG_RING_BUFFER_VENDOR_DATA, DEBUG_HOST_WAKE_REASON_STATS,
+DEBUG_ERROR_ALERTS and APF.
+
+Change-Id: I70e9c2344029bc71a1f4ea4b9136b55254c084d3
+Tracked-On: OAM-85134
+Signed-off-by: Amrita Raju <amrita.raju@intel.com>
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ wifi/1.3/default/hidl_struct_util.cpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/wifi/1.3/default/hidl_struct_util.cpp b/wifi/1.3/default/hidl_struct_util.cpp
+index 2e4db7048..9e9231f82 100644
+--- a/wifi/1.3/default/hidl_struct_util.cpp
++++ b/wifi/1.3/default/hidl_struct_util.cpp
+@@ -157,8 +157,8 @@ bool convertLegacyFeaturesToHidlChipCapabilities(
+ 
+     // There are no flags for these 3 in the legacy feature set. Adding them to
+     // the set because all the current devices support it.
+-    *hidl_caps |= HidlChipCaps::DEBUG_RING_BUFFER_VENDOR_DATA;
+-    *hidl_caps |= HidlChipCaps::DEBUG_HOST_WAKE_REASON_STATS;
++    //*hidl_caps |= HidlChipCaps::DEBUG_RING_BUFFER_VENDOR_DATA;
++    //*hidl_caps |= HidlChipCaps::DEBUG_HOST_WAKE_REASON_STATS;
+     *hidl_caps |= HidlChipCaps::DEBUG_ERROR_ALERTS;
+     return true;
+ }
+@@ -371,7 +371,7 @@ bool convertLegacyFeaturesToHidlStaCapabilities(
+         return false;
+     }
+     *hidl_caps = {};
+-    using HidlStaIfaceCaps = IWifiStaIface::StaIfaceCapabilityMask;
++    //using HidlStaIfaceCaps = IWifiStaIface::StaIfaceCapabilityMask;
+     for (const auto feature : {legacy_hal::WIFI_LOGGER_PACKET_FATE_SUPPORTED}) {
+         if (feature & legacy_logger_feature_set) {
+             *hidl_caps |=
+@@ -391,7 +391,7 @@ bool convertLegacyFeaturesToHidlStaCapabilities(
+     }
+     // There is no flag for this one in the legacy feature set. Adding it to the
+     // set because all the current devices support it.
+-    *hidl_caps |= HidlStaIfaceCaps::APF;
++    //*hidl_caps |= HidlStaIfaceCaps::APF;
+     return true;
+ }
+ 
+-- 
+2.17.1
+

--- a/aosp_diff/celadon_tablet/hardware/interfaces/679603_1-wifi-Disable-capabilities-not-yet-supported.patch
+++ b/aosp_diff/celadon_tablet/hardware/interfaces/679603_1-wifi-Disable-capabilities-not-yet-supported.patch
@@ -1,0 +1,54 @@
+From 0727a7a500a11a2f28bd4c4625d1328e033371af Mon Sep 17 00:00:00 2001
+From: Amrita Raju <amrita.raju@intel.com>
+Date: Fri, 8 Feb 2019 09:55:05 +0530
+Subject: [PATCH] wifi: Disable capabilities not yet supported
+
+As E2E support is not yet implemented for following capabilities,
+removing them.
+DEBUG_RING_BUFFER_VENDOR_DATA, DEBUG_HOST_WAKE_REASON_STATS,
+DEBUG_ERROR_ALERTS and APF.
+
+Change-Id: I70e9c2344029bc71a1f4ea4b9136b55254c084d3
+Tracked-On: OAM-85134
+Signed-off-by: Amrita Raju <amrita.raju@intel.com>
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ wifi/1.3/default/hidl_struct_util.cpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/wifi/1.3/default/hidl_struct_util.cpp b/wifi/1.3/default/hidl_struct_util.cpp
+index 2e4db7048..9e9231f82 100644
+--- a/wifi/1.3/default/hidl_struct_util.cpp
++++ b/wifi/1.3/default/hidl_struct_util.cpp
+@@ -157,8 +157,8 @@ bool convertLegacyFeaturesToHidlChipCapabilities(
+ 
+     // There are no flags for these 3 in the legacy feature set. Adding them to
+     // the set because all the current devices support it.
+-    *hidl_caps |= HidlChipCaps::DEBUG_RING_BUFFER_VENDOR_DATA;
+-    *hidl_caps |= HidlChipCaps::DEBUG_HOST_WAKE_REASON_STATS;
++    //*hidl_caps |= HidlChipCaps::DEBUG_RING_BUFFER_VENDOR_DATA;
++    //*hidl_caps |= HidlChipCaps::DEBUG_HOST_WAKE_REASON_STATS;
+     *hidl_caps |= HidlChipCaps::DEBUG_ERROR_ALERTS;
+     return true;
+ }
+@@ -371,7 +371,7 @@ bool convertLegacyFeaturesToHidlStaCapabilities(
+         return false;
+     }
+     *hidl_caps = {};
+-    using HidlStaIfaceCaps = IWifiStaIface::StaIfaceCapabilityMask;
++    //using HidlStaIfaceCaps = IWifiStaIface::StaIfaceCapabilityMask;
+     for (const auto feature : {legacy_hal::WIFI_LOGGER_PACKET_FATE_SUPPORTED}) {
+         if (feature & legacy_logger_feature_set) {
+             *hidl_caps |=
+@@ -391,7 +391,7 @@ bool convertLegacyFeaturesToHidlStaCapabilities(
+     }
+     // There is no flag for this one in the legacy feature set. Adding it to the
+     // set because all the current devices support it.
+-    *hidl_caps |= HidlStaIfaceCaps::APF;
++    //*hidl_caps |= HidlStaIfaceCaps::APF;
+     return true;
+ }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
As E2E support is not yet implemented for following capabilities,
removing them.
DEBUG_RING_BUFFER_VENDOR_DATA, DEBUG_HOST_WAKE_REASON_STATS,
DEBUG_ERROR_ALERTS and APF.

Change-Id: I70e9c2344029bc71a1f4ea4b9136b55254c084d3
Tracked-On: OAM-85134
Signed-off-by: Amrita Raju <amrita.raju@intel.com>
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>