### PR TITLE
netd: Disable Active FTP helper

### DIFF
--- a/android_p/google_diff/clk/system/netd/0002-netd-Disable-Active-FTP-helper.patch
+++ b/android_p/google_diff/clk/system/netd/0002-netd-Disable-Active-FTP-helper.patch
@@ -1,0 +1,32 @@
+From f206ae874d2787d8ac2dbe5aebce4a6f7d67edf9 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Tue, 10 Sep 2019 17:13:14 +0530
+Subject: [PATCH] netd: Disable Active FTP helper
+
+Wi-Fi Tethering fails as Active FTP helper ip rule
+results in iptable update failure.
+
+Tracked-On: OAM-85649
+Signed-off-by: Gaganpreet kaur <gaganpreetx.kaur@intel.com>
+---
+ server/TetherController.cpp | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/server/TetherController.cpp b/server/TetherController.cpp
+index 06eaf94..6e805f5 100644
+--- a/server/TetherController.cpp
++++ b/server/TetherController.cpp
+@@ -630,10 +630,6 @@ int TetherController::setForwardRules(bool add, const char *intIface, const char
+     }
+ 
+     std::vector<std::string> v4 = {
+-        "*raw",
+-        StringPrintf("%s %s -p tcp --dport 21 -i %s -j CT --helper ftp",
+-                     op, LOCAL_RAW_PREROUTING, intIface),
+-        "COMMIT",
+         "*filter",
+         StringPrintf("%s %s -i %s -o %s -m state --state ESTABLISHED,RELATED -g %s",
+                      op, LOCAL_FORWARD, extIface, intIface, LOCAL_TETHER_COUNTERS_CHAIN),
+-- 
+2.7.4
+


### PR DESCRIPTION
Wi-Fi Tethering fails as Active FTP helper ip rule
results in iptable update failure.

Tracked-On: OAM-85649
Signed-off-by: Gaganpreet kaur <gaganpreetx.kaur@intel.com>
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>