### PR TITLE
VtsHalWifiHostapdV1_1Target module has multiple methods failing

### DIFF
--- a/aosp_diff/preliminary/external/wpa_supplicant_8/679768_5-VtsHalWifiHostapdV1_1Target_module_has_multiple_methods_failing.patch
+++ b/aosp_diff/preliminary/external/wpa_supplicant_8/679768_5-VtsHalWifiHostapdV1_1Target_module_has_multiple_methods_failing.patch
@@ -1,0 +1,46 @@
+From 467c979600341aafee195ade4fface48807063b6 Mon Sep 17 00:00:00 2001
+From: Amrita Raju <amrita.raju@intel.com>
+Date: Thu, 05 Sep 2019 13:45:16 +0530
+Subject: [PATCH] VtsHalWifiHostapdV1_1Target module has multiple methods failing
+
+ACS(Automatic channel Selection) is not supported when creating
+a WiFi Hotspot. Hence setting AP band to 2.4Ghz.
+
+Adding to check on channel range to detect invalid channel range
+parameters.
+
+Tracked-On: OAM-85124
+Signed-off-by: Amrita Raju <amrita.raju@intel.com>
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+---
+
+diff --git a/hostapd/hidl/1.1/hostapd.cpp b/hostapd/hidl/1.1/hostapd.cpp
+index 0298537..9a0fc69 100644
+--- a/hostapd/hidl/1.1/hostapd.cpp
++++ b/hostapd/hidl/1.1/hostapd.cpp
+@@ -164,13 +164,18 @@
+ 		}
+ 		break;
+ 	case IHostapd::Band::BAND_ANY:
+-		hw_mode_as_string = "hw_mode=any";
+-		if (iface_params.V1_0.channelParams.enableAcs) {
+-			ht_cap_vht_oper_chwidth_as_string =
+-			    "ht_capab=[HT40+]\n"
+-			    "vht_oper_chwidth=1";
+-		}
+-		break;
++		/* Downgrade IHostapd.Band.BAND_ANY to
++		 * IHostapd.Band.BAND_2_4_GHZ as ACS is not supported
++		 */
++                hw_mode_as_string = "hw_mode=g";
++		/* Adding check to detect invalid channel range in VTS test cases
++		 * Eg. HostapdHidlTest.AddPskAccessPointWithAcsAndInvalidChannelRange.
++		 */
++                for (const auto &range : iface_params.channelParams.acsChannelRanges) {
++                    if ((range.start < 1 || range.start > 14) && (range.end < 1 || range.end > 14))
++                          return "";
++                }
++                break;
+ 	default:
+ 		wpa_printf(MSG_ERROR, "Invalid band");
+ 		return "";


### PR DESCRIPTION
ACS(Automatic channel Selection) is not supported when creating
a WiFi Hotspot. Hence setting AP band to 2.4Ghz. Adding to check
on channel range to detect invalid channel range parameters.

Tracked-on:  OAM-85124
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>