### PR TITLE
Fix no open network notification issue

### DIFF
--- a/aosp_diff/celadon_ivi/frameworks/opt/net/wifi/678279_1-Fix-no-open-network-notification-issue.patch
+++ b/aosp_diff/celadon_ivi/frameworks/opt/net/wifi/678279_1-Fix-no-open-network-notification-issue.patch
@@ -1,0 +1,33 @@
+From 1ea0948e4224e9e76415cbbdc3d42a3cf23fa17d Mon Sep 17 00:00:00 2001
+From: "Cao, KevinX" <kevinx.cao@intel.com>
+Date: Mon, 19 Aug 2019 17:06:33 +0800
+Subject: [PATCH] Fix no open network notification issue
+
+The default notification user id is 0,but the current user id for car is
+10.In CarNotificationListener,only posed notification for current user
+and USER_ALL.So need to set userId for this notification.
+
+Change-Id: I24ca97c8109d1f8e8ce003967cd6010a3535ce53
+Tracked-On: OAM-84682
+Signed-off-by: Cao, KevinX <kevinx.cao@intel.com>
+---
+ .../java/com/android/server/wifi/AvailableNetworkNotifier.java | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/service/java/com/android/server/wifi/AvailableNetworkNotifier.java b/service/java/com/android/server/wifi/AvailableNetworkNotifier.java
+index 7def2f37a..88c8ab176 100644
+--- a/service/java/com/android/server/wifi/AvailableNetworkNotifier.java
++++ b/service/java/com/android/server/wifi/AvailableNetworkNotifier.java
+@@ -416,7 +416,8 @@ public class AvailableNetworkNotifier {
+     }
+
+     private void postNotification(Notification notification) {
+-        getNotificationManager().notify(mSystemMessageNotificationId, notification);
++        getNotificationManager().notifyAsUser(null, mSystemMessageNotificationId, notification,
++                UserHandle.CURRENT);
+     }
+
+     private void handleConnectToNetworkAction() {
+--
+2.17.1
+


### PR DESCRIPTION
The default notification user id is 0,but the current user id for car is
10.In CarNotificationListener,only posed notification for current user
and USER_ALL.So need to set userId for this notification.

Tracked-On: OAM-84682
Signed-off-by: Cao, KevinX <kevinx.cao@intel.com>