### PR TITLE
USBGadgetHAL: Setting the correct sequence for switching data transfe…

### DIFF
--- a/android_p/google_diff/clk/frameworks/base/0033-Fix-Mtp-not-enumerated-during-ptm-mtp-switch.patch
+++ b/android_p/google_diff/clk/frameworks/base/0033-Fix-Mtp-not-enumerated-during-ptm-mtp-switch.patch
@@ -1,0 +1,69 @@
+diff --git a/services/usb/java/com/android/server/usb/UsbDeviceManager.java b/services/usb/java/com/android/server/usb/UsbDeviceManager.java
+index 655363e..285ac89 100644
+--- a/services/usb/java/com/android/server/usb/UsbDeviceManager.java
++++ b/services/usb/java/com/android/server/usb/UsbDeviceManager.java
+@@ -51,6 +51,7 @@
+ import android.hidl.manager.V1_0.IServiceManager;
+ import android.hidl.manager.V1_0.IServiceNotification;
+ import android.os.BatteryManager;
++import android.os.ConditionVariable;
+ import android.os.Environment;
+ import android.os.FileUtils;
+ import android.os.Handler;
+@@ -1694,6 +1695,8 @@
+ 
+         private final Object mGadgetProxyLock = new Object();
+ 
++        private final ConditionVariable isCbReceived = new ConditionVariable();
++
+         /**
+          * Cookie sent for usb gadget hal death notification.
+          */
+@@ -1873,6 +1876,7 @@
+                  */
+                 if ((mCurrentRequest != mRequest) || !hasMessages(MSG_SET_FUNCTIONS_TIMEOUT)
+                         || (mFunctions != functions)) {
++                    isCbReceived.open();
+                     return;
+                 }
+ 
+@@ -1884,6 +1888,7 @@
+                     Slog.e(TAG, "Setting default fuctions");
+                     sendEmptyMessage(MSG_SET_CHARGING_FUNCTIONS);
+                 }
++                isCbReceived.open();
+             }
+ 
+             @Override
+@@ -1909,6 +1914,22 @@
+                     return;
+                 }
+                 try {
++                    /**
++                     * Usb Gadget HAL must be set to FUNCTION_NONE configuration before setting new
++                     * one. This is necessary because existing HAL must finish it's work before adbd
++                     * restarting.
++                     * This sequence of actions is used in the absence of Usb Gadget HAL.
++                     * It prevents the race condition between Usb Gadget HAL and adbd.
++                     */
++                    UsbGadgetCallback usbGadgetCallback = new UsbGadgetCallback(mCurrentRequest,
++                            config, chargingFunctions);
++                    isCbReceived.close();
++                    mGadgetProxy.setCurrentUsbFunctions(UsbManager.FUNCTION_NONE, usbGadgetCallback,
++                            SET_FUNCTIONS_TIMEOUT_MS - SET_FUNCTIONS_LEEWAY_MS);
++                    if (!(isCbReceived.block(SET_FUNCTIONS_TIMEOUT_MS - SET_FUNCTIONS_LEEWAY_MS))) {
++                        Slog.e(TAG, "Callback was received with unsuccessful status");
++                    }
++
+                     if ((config & UsbManager.FUNCTION_ADB) != 0) {
+                         /**
+                          * Start adbd if ADB function is included in the configuration.
+@@ -1920,8 +1941,6 @@
+                          */
+                         setSystemProperty(CTL_STOP, ADBD);
+                     }
+-                    UsbGadgetCallback usbGadgetCallback = new UsbGadgetCallback(mCurrentRequest,
+-                            config, chargingFunctions);
+                     mGadgetProxy.setCurrentUsbFunctions(config, usbGadgetCallback,
+                             SET_FUNCTIONS_TIMEOUT_MS - SET_FUNCTIONS_LEEWAY_MS);
+                     sendMessageDelayed(MSG_SET_FUNCTIONS_TIMEOUT, chargingFunctions,


### PR DESCRIPTION
…r mode

There is race condition between USB Gadget HAL and adbd without setting
Usb Gadget HAL to FUNCTION_NONE mode in case of fast switching data
transfer mode.
HAL must complete all it's processes before adbd restarting. Now processes
are started simultaneously, but the setting of Usb functions should occur
after the readiness of the adbd.
Google review:https://android-review.googlesource.com/c/platform/frameworks/base/+/1094109/4/

Signed-off-by: revatipx <revatix.prasad@intel.com>