### PR TITLE
[CELADON] HDMI plug/unplug events are not reported using getevent iss…

### DIFF
--- a/bsp_diff/common/kernel/lts2018/0001-CELADON-HDMI-plug-unplug-events-are-not-reported-usi.patch
+++ b/bsp_diff/common/kernel/lts2018/0001-CELADON-HDMI-plug-unplug-events-are-not-reported-usi.patch
@@ -1,0 +1,24 @@
+From 00ba9a55d8aaa05ec2b0e3f42c0344c06991d88c Mon Sep 17 00:00:00 2001
+From: swaroopb <swaroop.balan@intel.com>
+Date: Mon, 16 Sep 2019 09:47:58 +0530
+Subject: [PATCH] [CELADON] HDMI plug/unplug events are not reported using
+ getevent issue is seen in Commercial KBL NUC
+
+Tracked-On: OAM-86570
+Signed-off-by: swaroopb <swaroop.balan@intel.com>
+---
+ sound/pci/hda/Makefile | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/sound/pci/hda/Makefile b/sound/pci/hda/Makefile
+index b57432f00056..822e9ed3c94a 100644
+--- a/sound/pci/hda/Makefile
++++ b/sound/pci/hda/Makefile
+@@ -1,3 +1,4 @@
++CONFIG_SND_HDA_CODEC_HDMI := y
+ # SPDX-License-Identifier: GPL-2.0
+ snd-hda-intel-objs := hda_intel.o
+ snd-hda-tegra-objs := hda_tegra.o
+-- 
+2.22.0
+


### PR DESCRIPTION
…ue is seen in Commercial KBL NUC

Tracked-On: OAM-86570
Signed-off-by: swaroopb <swaroop.balan@intel.com>