### PR TITLE
Handle HDMI audio device in framework

### DIFF
--- a/aosp_diff/celadon_ivi/frameworks/av/680693_1-Change-HDMI-audio-priority-on-celadon.patch
+++ b/aosp_diff/celadon_ivi/frameworks/av/680693_1-Change-HDMI-audio-priority-on-celadon.patch
@@ -1,0 +1,38 @@
+From a8156d5b7c45c2c896c113edc9f8b6da0425c2d3 Mon Sep 17 00:00:00 2001
+From: "M, Kumar K" <kumar.k.m@intel.com>
+Date: Tue, 17 Sep 2019 19:39:24 +0530
+Subject: [PATCH] Change HDMI audio priority on celadon
+
+Signed-off-by: M, Kumar K <kumar.k.m@intel.com>
+Change-Id: I55862204ef71f69bc88c79fe2259f7cb8365699a
+---
+ services/audiopolicy/enginedefault/src/Engine.cpp | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/services/audiopolicy/enginedefault/src/Engine.cpp b/services/audiopolicy/enginedefault/src/Engine.cpp
+index 04170ac..2c7d6b1 100644
+--- a/services/audiopolicy/enginedefault/src/Engine.cpp
++++ b/services/audiopolicy/enginedefault/src/Engine.cpp
+@@ -426,9 +426,6 @@ audio_devices_t Engine::getDeviceForStrategyInt(legacy_strategy strategy,
+             device2 = availableOutputDevicesType & AUDIO_DEVICE_OUT_WIRED_HEADPHONE;
+         }
+         if (device2 == AUDIO_DEVICE_NONE) {
+-            device2 = availableOutputDevicesType & AUDIO_DEVICE_OUT_LINE;
+-        }
+-        if (device2 == AUDIO_DEVICE_NONE) {
+             device2 = availableOutputDevicesType & AUDIO_DEVICE_OUT_WIRED_HEADSET;
+         }
+         if (device2 == AUDIO_DEVICE_NONE) {
+@@ -443,6 +440,9 @@ audio_devices_t Engine::getDeviceForStrategyInt(legacy_strategy strategy,
+         if (device2 == AUDIO_DEVICE_NONE) {
+             device2 = availableOutputDevicesType & AUDIO_DEVICE_OUT_DGTL_DOCK_HEADSET;
+         }
++        if (device2 == AUDIO_DEVICE_NONE) {
++            device2 = availableOutputDevicesType & AUDIO_DEVICE_OUT_LINE;
++        }
+         if ((device2 == AUDIO_DEVICE_NONE) && (strategy != STRATEGY_SONIFICATION)) {
+             // no sonification on aux digital (e.g. HDMI)
+             device2 = availableOutputDevicesType & AUDIO_DEVICE_OUT_AUX_DIGITAL;
+-- 
+1.9.1
+

--- a/aosp_diff/celadon_ivi/frameworks/base/680601_1-Handle-HDMI-audio-in-wiredaccessory-mgr.patch
+++ b/aosp_diff/celadon_ivi/frameworks/base/680601_1-Handle-HDMI-audio-in-wiredaccessory-mgr.patch
@@ -1,0 +1,52 @@
+From 6c5e7c1921950213511d637e88a5349aee327f86 Mon Sep 17 00:00:00 2001
+From: "M, Kumar K" <kumar.k.m@intel.com>
+Date: Wed, 18 Sep 2019 12:16:57 +0530
+Subject: [PATCH] Handle HDMI audio device in framework
+
+Handle HDMI device in wired acc manager and default policy.
+
+Tracked-On: OAM-84728
+Signed-off-by: M, Kumar K <kumar.k.m@intel.com>
+---
+ .../core/java/com/android/server/WiredAccessoryManager.java  | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+ mode change 100644 => 100755 services/core/java/com/android/server/WiredAccessoryManager.java
+
+diff --git a/services/core/java/com/android/server/WiredAccessoryManager.java b/services/core/java/com/android/server/WiredAccessoryManager.java
+old mode 100644
+new mode 100755
+index 9bbc315..2ef9e46
+--- a/services/core/java/com/android/server/WiredAccessoryManager.java
++++ b/services/core/java/com/android/server/WiredAccessoryManager.java
+@@ -166,6 +166,10 @@ final class WiredAccessoryManager implements WiredAccessoryCallbacks {
+                 case SW_MICROPHONE_INSERT_BIT:
+                     headset = BIT_HEADSET;
+                     break;
++ 
++                case SW_HEADPHONE_INSERT_BIT | SW_LINEOUT_INSERT_BIT:
++		    headset = BIT_HEADSET;
++                    break;
+ 
+                 default:
+                     headset = 0;
+@@ -404,13 +408,13 @@ final class WiredAccessoryManager implements WiredAccessoryCallbacks {
+             //
+             // If the kernel does not have an "hdmi_audio" switch, just fall back on the older
+             // "hdmi" switch instead.
+-            uei = new UEventInfo(NAME_HDMI_AUDIO, BIT_HDMI_AUDIO, 0, 0);
++	    uei = new UEventInfo(NAME_HDMI_AUDIO, BIT_HDMI_AUDIO, BIT_LINEOUT, 0);
+             if (uei.checkSwitchExists()) {
+                 retVal.add(uei);
+             } else {
+-                uei = new UEventInfo(NAME_HDMI, BIT_HDMI_AUDIO, 0, 0);
+-                if (uei.checkSwitchExists()) {
+-                    retVal.add(uei);
++                uei = new UEventInfo(NAME_HDMI, BIT_HDMI_AUDIO, BIT_LINEOUT, 0);
++	            if (uei.checkSwitchExists()) {
++                   retVal.add(uei);
+                 } else {
+                     Slog.w(TAG, "This kernel does not have HDMI audio support");
+                 }
+-- 
+1.9.1
+


### PR DESCRIPTION
Handle HDMI audio device in framework

Handle HDMI device in wired acc manager and default policy.

Tracked-On: OAM-84728
Signed-off-by: M, Kumar K <kumar.k.m@intel.com>