### PR TITLE
Enabling display timeout on IVI.

### DIFF
--- a/aosp_diff/celadon_ivi/packages/services/Car/681243_1-Enabling-display-timeout-on-IVI.patch
+++ b/aosp_diff/celadon_ivi/packages/services/Car/681243_1-Enabling-display-timeout-on-IVI.patch
@@ -1,0 +1,33 @@
+From e1d1c1beb17edfd963c6404499dbd1bc037a8f7b Mon Sep 17 00:00:00 2001
+From: Madhusudhan S <madhusudhan.s@intel.com>
+Date: Wed, 14 Nov 2018 16:28:15 +0530
+Subject: [PATCH] Enabling display timeout on IVI.
+
+Changing SCREEN_DIM_WAKE_LOCK to PARTIAL_WAKE_LOCK
+since SCREEN_DIM_WAKE_LOCK never allows to timeout
+display.
+
+Change-Id: I1093054cdcc55f20502ddcd78afe2f4b3ddfd250
+Tracked-on:
+Signed-off-by: Madhusudhan S <madhusudhan.s@intel.com>
+Signed-off-by: xichen12 <xi.a.chen@intel.com>
+---
+ service/src/com/android/car/systeminterface/WakeLockInterface.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/service/src/com/android/car/systeminterface/WakeLockInterface.java b/service/src/com/android/car/systeminterface/WakeLockInterface.java
+index cde6e5b..771d625 100644
+--- a/service/src/com/android/car/systeminterface/WakeLockInterface.java
++++ b/service/src/com/android/car/systeminterface/WakeLockInterface.java
+@@ -36,7 +36,7 @@ public interface WakeLockInterface {
+         DefaultImpl(Context context) {
+             PowerManager powerManager =
+                     (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+-            mFullWakeLock = powerManager.newWakeLock(PowerManager.SCREEN_DIM_WAKE_LOCK,
++            mFullWakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK,
+                 CarLog.TAG_POWER);
+             mPartialWakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK,
+                 CarLog.TAG_POWER);
+-- 
+2.7.4
+


### PR DESCRIPTION
Changing SCREEN_DIM_WAKE_LOCK to PARTIAL_WAKE_LOCK
since SCREEN_DIM_WAKE_LOCK never allows to timeout
display.

Tracked-On: OAM-86883
Signed-off-by: xichen12 <xi.a.chen@intel.com>