### PR TITLE
google_diff: fix getting CPU power failed

### DIFF
--- a/aosp_diff/celadon_ivi/frameworks/base/680830_3-fix-getting-CPU-power-failed.patch
+++ b/aosp_diff/celadon_ivi/frameworks/base/680830_3-fix-getting-CPU-power-failed.patch
@@ -1,0 +1,44 @@
+From 7a6f53bb6451091ac95c1bd99e8a3f0941af34e2 Mon Sep 17 00:00:00 2001
+From: Zhen Han <zhen.han@intel.com>
+Date: Wed, 11 Sep 2019 21:11:55 +0800
+Subject: [PATCH] WA: Return non zero cpu time consume if no kernel sysfs support
+
+The cpuClusterTimes is needed for BatteryStatsHelper.java to caculate
+system service consumed power in processAppUsage(). It will read
+the sysfs node of "/sys/devices/system/cpu/cpu%d/cpufreq/stats/time_in_state“
+which is not supported in LTS2018.
+
+This is a WA patch which will return one constant non-zero cpu consuming time
+if finding kenrel feature is not supported. It will be reverted after porting
+patches for an old kernel version.
+
+Change-Id: Ifc38513da188713ee08429cdaa8ed8cad86c6f6c
+Tracked-On: https://jira.devtools.intel.com/browse/OAM-86942
+Signed-off-by: Zhen Han <zhen.han@intel.com>
+Signed-off-by: Xin Sun <xinx.sun@intel.com>
+---
+
+diff --git a/core/java/com/android/internal/os/KernelCpuSpeedReader.java b/core/java/com/android/internal/os/KernelCpuSpeedReader.java
+index 98fea01..1ce1a79 100644
+--- a/core/java/com/android/internal/os/KernelCpuSpeedReader.java
++++ b/core/java/com/android/internal/os/KernelCpuSpeedReader.java
+@@ -41,6 +41,7 @@
+     private final int mNumSpeedSteps;
+     private final long[] mLastSpeedTimesMs;
+     private final long[] mDeltaSpeedTimesMs;
++    private final int FAKE_CPUSPEED_TIME = 10;
+ 
+     // How long a CPU jiffy is in milliseconds.
+     private final long mJiffyMillis;
+@@ -85,8 +86,9 @@
+                 speedIndex++;
+             }
+         } catch (IOException e) {
+-            Slog.e(TAG, "Failed to read cpu-freq: " + e.getMessage());
+-            Arrays.fill(mDeltaSpeedTimesMs, 0);
++            Slog.e(TAG, "Failed to read cpu-freq: " + e.getMessage() +
++                   ", and force set fake data value " + FAKE_CPUSPEED_TIME);
++            Arrays.fill(mDeltaSpeedTimesMs, FAKE_CPUSPEED_TIME);
+         } finally {
+             StrictMode.setThreadPolicy(policy);
+         }


### PR DESCRIPTION
which add an WA to return non-zero cpu consume time in case of no kenrel
sysfs support in LTS-2018.

This patch is needed for following two CTS cases. They are always failed
as
CPU power usage is zero because cpu consume time is zero. The power is
caculated
with function of “power = cunsumer time * power_profile”.
(1)
android.cts.statsd.validation.BatteryStatsValidationTests#testPowerBlameUid
(2)
android.cts.statsd.atom.UidAtomTests#testDeviceCalculatedPowerBlameUid

Change-Id: I1ee86db1cd68290afee7bbe1f2b36282f2672c70
Tracked-On: https://jira.devtools.intel.com/browse/OAM-86942
Signed-off-by: Zhen Han <zhen.han@intel.com>
Signed-off-by: Xin Sun <xinx.sun@intel.com>