### PR TITLE
Set config_quickSettingsSupported to false for IVI

### DIFF
--- a/aosp_diff/celadon_ivi/packages/services/Car/681730_1-Set-config_quickSettingsSupported-to-false-for-IVI.patch
+++ b/aosp_diff/celadon_ivi/packages/services/Car/681730_1-Set-config_quickSettingsSupported-to-false-for-IVI.patch
@@ -1,0 +1,25 @@
+From 6caaa08e0511526c3fa34e3614b6166ea0bcc6ab Mon Sep 17 00:00:00 2001
+From: shellyxx <shellyx.xie@intel.com>
+Date: Sat, 12 Oct 2019 10:59:36 +0800
+Subject: [PATCH] Set config_quickSettingsSupported to false for IVI 
+
+No quickSettings on IVI system, so disable it. 
+
+Change-Id: I1ca84abfcb5cadc9ecb0a63bdcbbc330bcd624dd
+Tracked-On: OAM-88196
+Signed-off-by: Xie, Shellyx <shellyx.xie@intel.com>
+---
+
+diff --git a/car_product/overlay/frameworks/base/core/res/res/values/config.xml b/car_product/overlay/frameworks/base/core/res/res/values/config.xml
+index 1e42d58..c4af1ed 100644
+--- a/car_product/overlay/frameworks/base/core/res/res/values/config.xml
++++ b/car_product/overlay/frameworks/base/core/res/res/values/config.xml
+@@ -90,5 +90,8 @@
+     <!-- True if the device supports system decorations on secondary displays. -->
+     <bool name="config_supportsSystemDecorsOnSecondaryDisplays">false</bool>
+ 
++    <!-- Whether the device supports quick settings and its associated APIs -->
++    <bool name="config_quickSettingsSupported">false</bool>
++
+     <string name="config_dataUsageSummaryComponent">com.android.car.settings/com.android.car.settings.datausage.DataWarningAndLimitActivity</string>
+ </resources>


### PR DESCRIPTION
No quickSettings on IVI system, so disable it.

Tracked-On: OAM-88196
Signed-off-by: Xie, Shellyx <shellyx.xie@intel.com>