### PR TITLE
google_diff: fix the get ModemActivityTimeout when defaultPhone is null

### DIFF
--- a/aosp_diff/celadon_ivi/packages/services/Telephony/679837_4-fix-the-get-ModemActivityTimeout-when-defaultPhone-is-null.patch
+++ b/aosp_diff/celadon_ivi/packages/services/Telephony/679837_4-fix-the-get-ModemActivityTimeout-when-defaultPhone-is-null.patch
@@ -1,0 +1,33 @@
+From da70856a2f7ba2f29eb5dcd1ce71deec1a59f225 Mon Sep 17 00:00:00 2001
+From: Zhen Han <zhen.han@intel.com>
+Date: Fri, 06 Sep 2019 14:22:40 +0800
+Subject: [PATCH] Telephony: return ModemActivityInfo when defaultPhone is null
+
+It will be timeout in getting ModemActivityInfo
+when no modem or defaultphone is present in the Andorid platforms
+(e.g.: Android TV or IVI). Specifically, it would wastes 2s and
+result in CTS test failure finally in waiting the result of
+this message requeset and result in CTS test failure.
+
+This patch returns ModemActivityInfo with all fields set to 0
+when defaultPhone is null.
+
+Change-Id: I4210a90e1fe6a7e0e087caf69831813dd2adf434
+Tracked-On:
+Signed-off-by: Zhen Han <zhen.han@intel.com>
+---
+
+diff --git a/src/com/android/phone/PhoneInterfaceManager.java b/src/com/android/phone/PhoneInterfaceManager.java
+index d0ed9bd..ae39e2f 100755
+--- a/src/com/android/phone/PhoneInterfaceManager.java
++++ b/src/com/android/phone/PhoneInterfaceManager.java
+@@ -844,6 +844,9 @@
+                     onCompleted = obtainMessage(EVENT_GET_MODEM_ACTIVITY_INFO_DONE, request);
+                     if (defaultPhone != null) {
+                         defaultPhone.getModemActivityInfo(onCompleted, request.workSource);
++                    } else {
++                        request.result = new ModemActivityInfo(0, 0, 0, null, 0, 0);
++                        notifyRequester(request);
+                     }
+                     break;
+ 


### PR DESCRIPTION
Currently, the CTS case of BatteryStatsValidationTest#testRealtime is
failed
because it is always timeout in getting modem energy information in GP.

The root cause is no modem is present in GP then the information cannot
be getted
as the defaultphone is null.

to unblock beta miletone first. It will be submit to Google for a review
and merge.

Change-Id: I545b85ae10f83f0d43a73f8298a1bff2cbecaec2
Tracked-On: https://jira.devtools.intel.com/browse/OAM-84993
Signed-off-by: Zhen Han <zhen.han@intel.com>