### PR TITLE
USB camera patches to support hotplug Feature and USB 3.x Cameras

### DIFF
--- a/aosp_diff/caas/frameworks/av/03_1-Camera-Fix-crash-while-disconnecting-USB-Camera.patch
+++ b/aosp_diff/caas/frameworks/av/03_1-Camera-Fix-crash-while-disconnecting-USB-Camera.patch
@@ -1,0 +1,41 @@
+From a34167138fc1c61e228032a13ad3eb0b7b4f47b1 Mon Sep 17 00:00:00 2001
+From: Muhammad Aksar <muhammad.aksar@intel.com>
+Date: Wed, 20 Nov 2019 14:38:15 +0530
+Subject: [PATCH] Camera: Fix crash while disconnecting USB Camera
+
+unnecessarily sending error notification when
+disconnecting the USB camera and hence it causes
+camera service crash. Then need to kill the service
+or restart the system forcefully. This patch would
+be avoided this situation.
+
+This patch will not effect MIPI-CSI Camera(s) or
+other normal Camera use cases.
+
+Tracked-On: OAM-88490
+Signed-off-by: Muhammad Aksar <muhammad.aksar@intel.com>
+---
+ services/camera/libcameraservice/CameraService.cpp | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/services/camera/libcameraservice/CameraService.cpp b/services/camera/libcameraservice/CameraService.cpp
+index 3e62102..ec83193 100644
+--- a/services/camera/libcameraservice/CameraService.cpp
++++ b/services/camera/libcameraservice/CameraService.cpp
+@@ -358,13 +358,6 @@ void CameraService::onDeviceStatusChanged(const String8& id,
+         if (clientToDisconnect.get() != nullptr) {
+             ALOGI("%s: Client for camera ID %s evicted due to device status change from HAL",
+                     __FUNCTION__, id.string());
+-            // Notify the client of disconnection
+-            clientToDisconnect->notifyError(
+-                    hardware::camera2::ICameraDeviceCallbacks::ERROR_CAMERA_DISCONNECTED,
+-                    CaptureResultExtras{});
+-            // Ensure not in binder RPC so client disconnect PID checks work correctly
+-            LOG_ALWAYS_FATAL_IF(CameraThreadState::getCallingPid() != getpid(),
+-                    "onDeviceStatusChanged must be called from the camera service process!");
+             clientToDisconnect->disconnect();
+         }
+ 
+-- 
+2.7.4
+

--- a/aosp_diff/caas/hardware/interfaces/02_1-Add-support-for-advanced-USB-3.x-based-Cameras.patch
+++ b/aosp_diff/caas/hardware/interfaces/02_1-Add-support-for-advanced-USB-3.x-based-Cameras.patch
@@ -1,0 +1,46 @@
+From 747d6759ab9eec0dfc1a89d150720a93beef611f Mon Sep 17 00:00:00 2001
+From: Muhammad Aksar <muhammad.aksar@intel.com>
+Date: Thu, 14 Nov 2019 18:31:41 +0530
+Subject: [PATCH] Add support for advanced USB 3.x based Cameras
+
+Adding support for most advanced USB bridge
+Cameras like MIPI-CSI to USB and GMSL/SerDes
+to USB camera in the HAL. This Camera can be
+used in applications like Automotive, Consumer-
+electronics, teleconferencing, AI etc.
+
+Avoiding empty frame rate check here since
+this kind of Camera(s) will not give frame rate
+info during the configuration time.
+
+This will patch not effect the normal USB-
+cameras use cases.
+
+Tracked-On: OAM-88590
+Signed-off-by: Muhammad Aksar <muhammad.aksar@intel.com>
+---
+ camera/device/3.4/default/ExternalCameraDevice.cpp | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/camera/device/3.4/default/ExternalCameraDevice.cpp b/camera/device/3.4/default/ExternalCameraDevice.cpp
+index 9a2fddf..c3c9627 100644
+--- a/camera/device/3.4/default/ExternalCameraDevice.cpp
++++ b/camera/device/3.4/default/ExternalCameraDevice.cpp
+@@ -935,9 +935,11 @@ void ExternalCameraDevice::updateFpsBounds(
+     }
+ 
+     getFrameRateList(fd, fpsUpperBound, &format);
+-    if (!format.frameRates.empty()) {
+-        outFmts.push_back(format);
+-    }
++    // HAL tries to support even if the Camera sensor retuns
++    // empty supported frame rate list. This will help to
++    // support different types of Cameras since some
++    // USB Cameras will not return the proper frame rates.
++    outFmts.push_back(format);
+ }
+ 
+ void ExternalCameraDevice::initSupportedFormatsLocked(int fd) {
+-- 
+2.7.4
+

--- a/aosp_diff/celadon_ivi/frameworks/av/03_1-Camera-Fix-crash-while-disconnecting-USB-Camera.patch
+++ b/aosp_diff/celadon_ivi/frameworks/av/03_1-Camera-Fix-crash-while-disconnecting-USB-Camera.patch
@@ -1,0 +1,41 @@
+From a34167138fc1c61e228032a13ad3eb0b7b4f47b1 Mon Sep 17 00:00:00 2001
+From: Muhammad Aksar <muhammad.aksar@intel.com>
+Date: Wed, 20 Nov 2019 14:38:15 +0530
+Subject: [PATCH] Camera: Fix crash while disconnecting USB Camera
+
+unnecessarily sending error notification when
+disconnecting the USB camera and hence it causes
+camera service crash. Then need to kill the service
+or restart the system forcefully. This patch would
+be avoided this situation.
+
+This patch will not effect MIPI-CSI Camera(s) or
+other normal Camera use cases.
+
+Tracked-On: OAM-88490
+Signed-off-by: Muhammad Aksar <muhammad.aksar@intel.com>
+---
+ services/camera/libcameraservice/CameraService.cpp | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/services/camera/libcameraservice/CameraService.cpp b/services/camera/libcameraservice/CameraService.cpp
+index 3e62102..ec83193 100644
+--- a/services/camera/libcameraservice/CameraService.cpp
++++ b/services/camera/libcameraservice/CameraService.cpp
+@@ -358,13 +358,6 @@ void CameraService::onDeviceStatusChanged(const String8& id,
+         if (clientToDisconnect.get() != nullptr) {
+             ALOGI("%s: Client for camera ID %s evicted due to device status change from HAL",
+                     __FUNCTION__, id.string());
+-            // Notify the client of disconnection
+-            clientToDisconnect->notifyError(
+-                    hardware::camera2::ICameraDeviceCallbacks::ERROR_CAMERA_DISCONNECTED,
+-                    CaptureResultExtras{});
+-            // Ensure not in binder RPC so client disconnect PID checks work correctly
+-            LOG_ALWAYS_FATAL_IF(CameraThreadState::getCallingPid() != getpid(),
+-                    "onDeviceStatusChanged must be called from the camera service process!");
+             clientToDisconnect->disconnect();
+         }
+ 
+-- 
+2.7.4
+

--- a/aosp_diff/celadon_ivi/hardware/interfaces/02_1-Add-support-for-advanced-USB-3.x-based-Cameras.patch
+++ b/aosp_diff/celadon_ivi/hardware/interfaces/02_1-Add-support-for-advanced-USB-3.x-based-Cameras.patch
@@ -1,0 +1,46 @@
+From 747d6759ab9eec0dfc1a89d150720a93beef611f Mon Sep 17 00:00:00 2001
+From: Muhammad Aksar <muhammad.aksar@intel.com>
+Date: Thu, 14 Nov 2019 18:31:41 +0530
+Subject: [PATCH] Add support for advanced USB 3.x based Cameras
+
+Adding support for most advanced USB bridge
+Cameras like MIPI-CSI to USB and GMSL/SerDes
+to USB camera in the HAL. This Camera can be
+used in applications like Automotive, Consumer-
+electronics, teleconferencing, AI etc.
+
+Avoiding empty frame rate check here since
+this kind of Camera(s) will not give frame rate
+info during the configuration time.
+
+This will patch not effect the normal USB-
+cameras use cases.
+
+Tracked-On: OAM-88590
+Signed-off-by: Muhammad Aksar <muhammad.aksar@intel.com>
+---
+ camera/device/3.4/default/ExternalCameraDevice.cpp | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/camera/device/3.4/default/ExternalCameraDevice.cpp b/camera/device/3.4/default/ExternalCameraDevice.cpp
+index 9a2fddf..c3c9627 100644
+--- a/camera/device/3.4/default/ExternalCameraDevice.cpp
++++ b/camera/device/3.4/default/ExternalCameraDevice.cpp
+@@ -935,9 +935,11 @@ void ExternalCameraDevice::updateFpsBounds(
+     }
+ 
+     getFrameRateList(fd, fpsUpperBound, &format);
+-    if (!format.frameRates.empty()) {
+-        outFmts.push_back(format);
+-    }
++    // HAL tries to support even if the Camera sensor retuns
++    // empty supported frame rate list. This will help to
++    // support different types of Cameras since some
++    // USB Cameras will not return the proper frame rates.
++    outFmts.push_back(format);
+ }
+ 
+ void ExternalCameraDevice::initSupportedFormatsLocked(int fd) {
+-- 
+2.7.4
+

--- a/aosp_diff/celadon_tablet/frameworks/av/02_1-Camera-Fix-crash-while-disconnecting-USB-Camera.patch
+++ b/aosp_diff/celadon_tablet/frameworks/av/02_1-Camera-Fix-crash-while-disconnecting-USB-Camera.patch
@@ -1,0 +1,41 @@
+From a34167138fc1c61e228032a13ad3eb0b7b4f47b1 Mon Sep 17 00:00:00 2001
+From: Muhammad Aksar <muhammad.aksar@intel.com>
+Date: Wed, 20 Nov 2019 14:38:15 +0530
+Subject: [PATCH] Camera: Fix crash while disconnecting USB Camera
+
+unnecessarily sending error notification when
+disconnecting the USB camera and hence it causes
+camera service crash. Then need to kill the service
+or restart the system forcefully. This patch would
+be avoided this situation.
+
+This patch will not effect MIPI-CSI Camera(s) or
+other normal Camera use cases.
+
+Tracked-On: OAM-88490
+Signed-off-by: Muhammad Aksar <muhammad.aksar@intel.com>
+---
+ services/camera/libcameraservice/CameraService.cpp | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/services/camera/libcameraservice/CameraService.cpp b/services/camera/libcameraservice/CameraService.cpp
+index 3e62102..ec83193 100644
+--- a/services/camera/libcameraservice/CameraService.cpp
++++ b/services/camera/libcameraservice/CameraService.cpp
+@@ -358,13 +358,6 @@ void CameraService::onDeviceStatusChanged(const String8& id,
+         if (clientToDisconnect.get() != nullptr) {
+             ALOGI("%s: Client for camera ID %s evicted due to device status change from HAL",
+                     __FUNCTION__, id.string());
+-            // Notify the client of disconnection
+-            clientToDisconnect->notifyError(
+-                    hardware::camera2::ICameraDeviceCallbacks::ERROR_CAMERA_DISCONNECTED,
+-                    CaptureResultExtras{});
+-            // Ensure not in binder RPC so client disconnect PID checks work correctly
+-            LOG_ALWAYS_FATAL_IF(CameraThreadState::getCallingPid() != getpid(),
+-                    "onDeviceStatusChanged must be called from the camera service process!");
+             clientToDisconnect->disconnect();
+         }
+ 
+-- 
+2.7.4
+

--- a/aosp_diff/celadon_tablet/hardware/interfaces/02_1-Add-support-for-advanced-USB-3.x-based-Cameras.patch
+++ b/aosp_diff/celadon_tablet/hardware/interfaces/02_1-Add-support-for-advanced-USB-3.x-based-Cameras.patch
@@ -1,0 +1,46 @@
+From 747d6759ab9eec0dfc1a89d150720a93beef611f Mon Sep 17 00:00:00 2001
+From: Muhammad Aksar <muhammad.aksar@intel.com>
+Date: Thu, 14 Nov 2019 18:31:41 +0530
+Subject: [PATCH] Add support for advanced USB 3.x based Cameras
+
+Adding support for most advanced USB bridge
+Cameras like MIPI-CSI to USB and GMSL/SerDes
+to USB camera in the HAL. This Camera can be
+used in applications like Automotive, Consumer-
+electronics, teleconferencing, AI etc.
+
+Avoiding empty frame rate check here since
+this kind of Camera(s) will not give frame rate
+info during the configuration time.
+
+This will patch not effect the normal USB-
+cameras use cases.
+
+Tracked-On: OAM-88590
+Signed-off-by: Muhammad Aksar <muhammad.aksar@intel.com>
+---
+ camera/device/3.4/default/ExternalCameraDevice.cpp | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/camera/device/3.4/default/ExternalCameraDevice.cpp b/camera/device/3.4/default/ExternalCameraDevice.cpp
+index 9a2fddf..c3c9627 100644
+--- a/camera/device/3.4/default/ExternalCameraDevice.cpp
++++ b/camera/device/3.4/default/ExternalCameraDevice.cpp
+@@ -935,9 +935,11 @@ void ExternalCameraDevice::updateFpsBounds(
+     }
+ 
+     getFrameRateList(fd, fpsUpperBound, &format);
+-    if (!format.frameRates.empty()) {
+-        outFmts.push_back(format);
+-    }
++    // HAL tries to support even if the Camera sensor retuns
++    // empty supported frame rate list. This will help to
++    // support different types of Cameras since some
++    // USB Cameras will not return the proper frame rates.
++    outFmts.push_back(format);
+ }
+ 
+ void ExternalCameraDevice::initSupportedFormatsLocked(int fd) {
+-- 
+2.7.4
+


### PR DESCRIPTION
Add USB camera hot-plug support and enabling
USB 3.X cameras.

Tracked-On: OAM-88490
Signed-off-by: Muhammad Aksar <muhammad.aksar@intel.com>