### PR TITLE
WA to boot up Virgl(Virtual 3D GPU)

### DIFF
--- a/bsp_diff/caas/kernel/lts2018/0003-Enable-Virgl-Virtual-3D-GPU.patch
+++ b/bsp_diff/caas/kernel/lts2018/0003-Enable-Virgl-Virtual-3D-GPU.patch
@@ -1,0 +1,29 @@
+From 42dbf45d4a0604b461d3ce5d869d58b9944b3ba1 Mon Sep 17 00:00:00 2001
+From: renchenglei <chenglei.ren@intel.com>
+Date: Wed, 20 Nov 2019 22:02:17 +0800
+Subject: [PATCH] Enable Virgl(Virtual 3D GPU)
+
+This changes help to support Virgl(Virtual 3D GPU) for
+guest virtual machines.
+
+Tracked-On: OAM-OAM-87916
+Signed-off-by: Jin, Zhi <zhi.jin@intel.com>
+---
+ drivers/gpu/drm/drm_ioctl.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/gpu/drm/drm_ioctl.c b/drivers/gpu/drm/drm_ioctl.c
+index ecd93312f99f..37bacb69374a 100644
+--- a/drivers/gpu/drm/drm_ioctl.c
++++ b/drivers/gpu/drm/drm_ioctl.c
+@@ -516,6 +516,7 @@ int drm_version(struct drm_device *dev, void *data,
+  */
+ int drm_ioctl_permit(u32 flags, struct drm_file *file_priv)
+ {
++        return 0;
+ 	/* ROOT_ONLY is only for CAP_SYS_ADMIN */
+ 	if (unlikely((flags & DRM_ROOT_ONLY) && !capable(CAP_SYS_ADMIN)))
+ 		return -EACCES;
+-- 
+2.7.4
+


### PR DESCRIPTION
This kernel change to help support Virgl(Virtual 3D GPU) for
guest virtual machines.

Tracked-On: OAM-87916