### PR TITLE
 Disable webview multi-process

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/675915_2-disable-webview-multi-process.patch
+++ b/aosp_diff/preliminary/frameworks/base/675915_2-disable-webview-multi-process.patch
@@ -1,0 +1,34 @@
+From 72edbc6b3cbf066fd1f538c656ee7650e8926788 Mon Sep 17 00:00:00 2001
+From: jchen10 <jie.a.chen@intel.com>
+Date: Sat, 15 Jun 2019 15:33:56 +0800
+Subject: [PATCH] disable webview multi-process
+
+Change-Id: I9c8f5c6ca4a77c71e38d4074beef1fff3d2f6f59
+---
+
+diff --git a/core/res/res/xml/config_webview_packages.xml b/core/res/res/xml/config_webview_packages.xml
+index f062b59..f4d8e18 100644
+--- a/core/res/res/xml/config_webview_packages.xml
++++ b/core/res/res/xml/config_webview_packages.xml
+@@ -18,4 +18,7 @@
+     <!-- The default WebView implementation -->
+     <webviewprovider description="Android WebView" packageName="com.android.webview" availableByDefault="true">
+     </webviewprovider>
++    <webviewprovider description="Chrome Debug" packageName="com.google.android.apps.chrome">
++        <!-- Ignore this package on user/release builds unless preinstalled. -->
++    </webviewprovider>
+ </webviewproviders>
+diff --git a/services/core/java/com/android/server/webkit/SystemImpl.java b/services/core/java/com/android/server/webkit/SystemImpl.java
+index a9a6b19..ea7fae4 100644
+--- a/services/core/java/com/android/server/webkit/SystemImpl.java
++++ b/services/core/java/com/android/server/webkit/SystemImpl.java
+@@ -275,7 +275,8 @@
+         // Multiprocess is enabled for all 64-bit devices, since the ability to run the renderer
+         // process in 32-bit when it's a separate process typically results in a net memory saving.
+         // Multiprocess is also enabled for 32-bit devices unless they report they are "low ram".
+-        return Build.SUPPORTED_64_BIT_ABIS.length > 0 || !ActivityManager.isLowRamDeviceStatic();
++        // return Build.SUPPORTED_64_BIT_ABIS.length > 0 || !ActivityManager.isLowRamDeviceStatic();
++        return false;
+     }
+ 
+     // flags declaring we want extra info from the package manager for webview providers


### PR DESCRIPTION
This is a workaround for the x86-x64 alignment issue. Full
discussions can be found at:
https://bugs.chromium.org/p/chromium/issues/detail?id=781095

Tracked-On: OAM-88687
Signed-off-by: Cao, KevinX <kevinx.cao@intel.com>