### PR TITLE
system:core: Changes to create dev node for usb printers

### DIFF
--- a/aosp_diff/caas/system/core/02_1-system-core-init-Add-support-for-creation-of-usb-pri.patch
+++ b/aosp_diff/caas/system/core/02_1-system-core-init-Add-support-for-creation-of-usb-pri.patch
@@ -1,0 +1,46 @@
+From 0533434fa7dd57cbbc34d396bf6303483d8d398e Mon Sep 17 00:00:00 2001
+From: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+Date: Mon, 24 Feb 2020 11:49:20 +0530
+Subject: [PATCH] system:core:init: Add support for creation of usb printer in
+ android
+
+These changes will allow creation of dev node for usb printer connected to
+android devices
+
+Tracked-On: OAM-89678
+Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+---
+ init/devices.cpp   | 4 ++++
+ rootdir/ueventd.rc | 1 +
+ 2 files changed, 5 insertions(+)
+
+diff --git a/init/devices.cpp b/init/devices.cpp
+index 159c75e03..370e53cde 100644
+--- a/init/devices.cpp
++++ b/init/devices.cpp
+@@ -449,6 +449,10 @@ void DeviceHandler::HandleUevent(const Uevent& uevent) {
+             int device_id = uevent.minor % 128 + 1;
+             devpath = StringPrintf("/dev/bus/usb/%03d/%03d", bus_id, device_id);
+         }
++    } else if (uevent.subsystem == "usbmisc") {
++        if (!uevent.device_name.empty()) {
++            devpath = "/dev/" + uevent.device_name;
++    	}
+     } else if (StartsWith(uevent.subsystem, "usb")) {
+         // ignore other USB events
+         return;
+diff --git a/rootdir/ueventd.rc b/rootdir/ueventd.rc
+index 451f5adf3..1344ff967 100644
+--- a/rootdir/ueventd.rc
++++ b/rootdir/ueventd.rc
+@@ -37,6 +37,7 @@ subsystem sound
+ /dev/binder               0666   root       root
+ /dev/hwbinder             0666   root       root
+ /dev/vndbinder            0666   root       root
++/dev/usb/lp*		   0666	  root       root
+
+ /dev/pmsg0                0222   root       log
+
+--
+2.17.1
+


### PR DESCRIPTION
Create a dev node for usb printer and apply permissions for the same.

Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>