### PR TITLE
civ: Disable Bluetooth in settings

### DIFF
--- a/aosp_diff/caas/frameworks/native/03_Remove-Bluetooth-feature-as-BT-control-is-in-the-Hos.patch
+++ b/aosp_diff/caas/frameworks/native/03_Remove-Bluetooth-feature-as-BT-control-is-in-the-Hos.patch
@@ -1,0 +1,26 @@
+From 2c4e8bec07ff79210cca68fed4d467a87bb8e771 Mon Sep 17 00:00:00 2001
+From: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Date: Thu, 5 Mar 2020 14:19:14 +0530
+Subject: [PATCH] Remove Bluetooth feature as BT control is in the Host
+
+Tracked-On:
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+---
+ data/etc/tablet_core_hardware.xml | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/data/etc/tablet_core_hardware.xml b/data/etc/tablet_core_hardware.xml
+index 52524ca95..eb6116d40 100644
+--- a/data/etc/tablet_core_hardware.xml
++++ b/data/etc/tablet_core_hardware.xml
+@@ -31,7 +31,6 @@
+     <feature name="android.hardware.location.network" />
+     <feature name="android.hardware.sensor.compass" />
+     <feature name="android.hardware.sensor.accelerometer" />
+-    <feature name="android.hardware.bluetooth" />
+     <feature name="android.hardware.touchscreen" />
+     <feature name="android.hardware.touchscreen.multitouch" />
+     <feature name="android.hardware.touchscreen.multitouch.distinct" />
+-- 
+2.17.1
+

--- a/aosp_diff/caas/packages/apps/Settings/0001-Disable-BT-in-settings.patch
+++ b/aosp_diff/caas/packages/apps/Settings/0001-Disable-BT-in-settings.patch
@@ -1,0 +1,28 @@
+From 2c90aec152375186ceea1daf7a92707d689a0314 Mon Sep 17 00:00:00 2001
+From: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Date: Wed, 12 Feb 2020 08:43:27 +0530
+Subject: [PATCH] Disable BT in settings
+
+Tracked-On:
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+---
+ src/com/android/settings/SettingsActivity.java | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/settings/SettingsActivity.java b/src/com/android/settings/SettingsActivity.java
+index 3b01b327ea..b34d85922c 100644
+--- a/src/com/android/settings/SettingsActivity.java
++++ b/src/com/android/settings/SettingsActivity.java
+@@ -607,7 +607,8 @@ public class SettingsActivity extends SettingsBaseActivity
+         somethingChanged = setTileEnabled(changedList,
+                 new ComponentName(packageName,
+                         Settings.ConnectedDeviceDashboardActivity.class.getName()),
+-                !UserManager.isDeviceInDemoMode(this) /* enabled */,
++                !UserManager.isDeviceInDemoMode(this) /* enabled */ &&
++		pm.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH),
+                 isAdmin) || somethingChanged;
+ 
+         somethingChanged = setTileEnabled(changedList, new ComponentName(packageName,
+-- 
+2.17.1
+


### PR DESCRIPTION
In case of CIV when enabling host controlled configuration
for BT, Settings will disable the Bluetooth tile for Turn ON
based on the Package manager feature FEATURE_BLUETOOTH

Tracked-On:
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>