### PR TITLE
[Revert me] Remove some security features for CIC

### DIFF
--- a/android/cic/frameworks/base/0001-Remove-selinux-related-operation.patch
+++ b/android/cic/frameworks/base/0001-Remove-selinux-related-operation.patch
@@ -1,0 +1,46 @@
+From 509bf67b3c74b954f29227d943d8b8cc2c270c66 Mon Sep 17 00:00:00 2001
+From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
+Date: Wed, 11 Mar 2020 13:45:10 +0800
+Subject: [PATCH] remove selinux related operations
+
+Change-Id: Ic4f231174ca22d044b6e3b6b2809ac073263bfc9
+Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
+---
+ .../java/com/android/server/pm/PackageInstallerService.java  | 4 ----
+ .../java/com/android/server/pm/PackageManagerService.java    | 5 -----
+ 2 files changed, 9 deletions(-)
+
+diff --git a/services/core/java/com/android/server/pm/PackageInstallerService.java b/services/core/java/com/android/server/pm/PackageInstallerService.java
+index 0b32d1a5d69..aa0a935538a 100644
+--- a/services/core/java/com/android/server/pm/PackageInstallerService.java
++++ b/services/core/java/com/android/server/pm/PackageInstallerService.java
+@@ -652,10 +652,6 @@ public class PackageInstallerService extends IPackageInstaller.Stub {
+             // This purposefully throws if directory already exists
+             throw new IOException("Failed to prepare session dir: " + stageDir, e);
+         }
+-
+-        if (!SELinux.restorecon(stageDir)) {
+-            throw new IOException("Failed to restorecon session dir: " + stageDir);
+-        }
+     }
+ 
+     private String buildExternalStageCid(int sessionId) {
+diff --git a/services/core/java/com/android/server/pm/PackageManagerService.java b/services/core/java/com/android/server/pm/PackageManagerService.java
+index f1f3a140550..6e3dcbc9ea9 100644
+--- a/services/core/java/com/android/server/pm/PackageManagerService.java
++++ b/services/core/java/com/android/server/pm/PackageManagerService.java
+@@ -15919,11 +15919,6 @@ public class PackageManagerService extends IPackageManager.Stub
+                 return false;
+             }
+ 
+-            if (!SELinux.restoreconRecursive(afterCodeFile)) {
+-                Slog.w(TAG, "Failed to restorecon");
+-                return false;
+-            }
+-
+             // Reflect the rename internally
+             codeFile = afterCodeFile;
+             resourceFile = afterCodeFile;
+-- 
+2.20.1
+

--- a/android/cic_dev/frameworks/base/0001-Remove-selinux-related-operation.patch
+++ b/android/cic_dev/frameworks/base/0001-Remove-selinux-related-operation.patch
@@ -1,0 +1,46 @@
+From 509bf67b3c74b954f29227d943d8b8cc2c270c66 Mon Sep 17 00:00:00 2001
+From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
+Date: Wed, 11 Mar 2020 13:45:10 +0800
+Subject: [PATCH] remove selinux related operations
+
+Change-Id: Ic4f231174ca22d044b6e3b6b2809ac073263bfc9
+Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
+---
+ .../java/com/android/server/pm/PackageInstallerService.java  | 4 ----
+ .../java/com/android/server/pm/PackageManagerService.java    | 5 -----
+ 2 files changed, 9 deletions(-)
+
+diff --git a/services/core/java/com/android/server/pm/PackageInstallerService.java b/services/core/java/com/android/server/pm/PackageInstallerService.java
+index 0b32d1a5d69..aa0a935538a 100644
+--- a/services/core/java/com/android/server/pm/PackageInstallerService.java
++++ b/services/core/java/com/android/server/pm/PackageInstallerService.java
+@@ -652,10 +652,6 @@ public class PackageInstallerService extends IPackageInstaller.Stub {
+             // This purposefully throws if directory already exists
+             throw new IOException("Failed to prepare session dir: " + stageDir, e);
+         }
+-
+-        if (!SELinux.restorecon(stageDir)) {
+-            throw new IOException("Failed to restorecon session dir: " + stageDir);
+-        }
+     }
+ 
+     private String buildExternalStageCid(int sessionId) {
+diff --git a/services/core/java/com/android/server/pm/PackageManagerService.java b/services/core/java/com/android/server/pm/PackageManagerService.java
+index f1f3a140550..6e3dcbc9ea9 100644
+--- a/services/core/java/com/android/server/pm/PackageManagerService.java
++++ b/services/core/java/com/android/server/pm/PackageManagerService.java
+@@ -15919,11 +15919,6 @@ public class PackageManagerService extends IPackageManager.Stub
+                 return false;
+             }
+ 
+-            if (!SELinux.restoreconRecursive(afterCodeFile)) {
+-                Slog.w(TAG, "Failed to restorecon");
+-                return false;
+-            }
+-
+             // Reflect the rename internally
+             codeFile = afterCodeFile;
+             resourceFile = afterCodeFile;
+-- 
+2.20.1
+

--- a/android/cic_dev/system/core/0001-remove-secure-adb-for-cic_dev.patch
+++ b/android/cic_dev/system/core/0001-remove-secure-adb-for-cic_dev.patch
@@ -1,0 +1,27 @@
+From b1ddd9f935c9b37aba180282804a5305de45fe7b Mon Sep 17 00:00:00 2001
+From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
+Date: Wed, 11 Mar 2020 09:58:45 +0800
+Subject: [PATCH] remove secure adb for cic_dev
+
+Change-Id: Ie5e43f8e5b50dbda1be6d00de275d280d694e6ac
+Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
+---
+ adb/adbd_auth.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/adb/adbd_auth.cpp b/adb/adbd_auth.cpp
+index 3fd2b3194..6217da8a8 100644
+--- a/adb/adbd_auth.cpp
++++ b/adb/adbd_auth.cpp
+@@ -44,7 +44,7 @@ static struct adisconnect usb_disconnect = { usb_disconnected, nullptr};
+ static atransport* usb_transport;
+ static bool needs_retry = false;
+ 
+-bool auth_required = true;
++bool auth_required = false;
+ 
+ bool adbd_auth_verify(const char* token, size_t token_size, const std::string& sig) {
+     static constexpr const char* key_paths[] = { "/adb_keys", "/data/misc/adb/adb_keys", nullptr };
+-- 
+2.20.1
+


### PR DESCRIPTION
1. remove some selinux related operations, sicne currently
   selinux is not enabled for both cic_dev and the new cic
   target
2. remove secure adb for cic_dev basing on the requirement
   of Lenovo.

Tracked-On: OAM-89793
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>