### PR TITLE
[Revert Me] Always return the disabled state for selinux

### DIFF
--- a/android/cic/external/selinux/0001-return-the-disabled-state-for-selinux.patch
+++ b/android/cic/external/selinux/0001-return-the-disabled-state-for-selinux.patch
@@ -1,0 +1,27 @@
+From b058e9b57a9acec15f90432586cf1a65de27008f Mon Sep 17 00:00:00 2001
+From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
+Date: Fri, 20 Mar 2020 15:32:43 +0800
+Subject: [PATCH] return the disabled state for selinux
+
+Change-Id: I2cabbab133153f1fd256f9ee744583e640420a21
+Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
+---
+ libselinux/src/enabled.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libselinux/src/enabled.c b/libselinux/src/enabled.c
+index dd628fba..114c4163 100644
+--- a/libselinux/src/enabled.c
++++ b/libselinux/src/enabled.c
+@@ -14,7 +14,7 @@ int is_selinux_enabled(void)
+  	 * will assume that if a selinux file system is mounted, then
+  	 * selinux is enabled. */
+ #ifdef ANDROID
+-	return (selinux_mnt ? 1 : 0);
++	return 0;
+ #else
+ 	return (selinux_mnt && has_selinux_config);
+ #endif
+-- 
+2.20.1
+

--- a/android/cic_dev/external/selinux/0001-return-the-disabled-state-for-selinux.patch
+++ b/android/cic_dev/external/selinux/0001-return-the-disabled-state-for-selinux.patch
@@ -1,0 +1,27 @@
+From b058e9b57a9acec15f90432586cf1a65de27008f Mon Sep 17 00:00:00 2001
+From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
+Date: Fri, 20 Mar 2020 15:32:43 +0800
+Subject: [PATCH] return the disabled state for selinux
+
+Change-Id: I2cabbab133153f1fd256f9ee744583e640420a21
+Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
+---
+ libselinux/src/enabled.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libselinux/src/enabled.c b/libselinux/src/enabled.c
+index dd628fba..114c4163 100644
+--- a/libselinux/src/enabled.c
++++ b/libselinux/src/enabled.c
+@@ -14,7 +14,7 @@ int is_selinux_enabled(void)
+  	 * will assume that if a selinux file system is mounted, then
+  	 * selinux is enabled. */
+ #ifdef ANDROID
+-	return (selinux_mnt ? 1 : 0);
++	return 0;
+ #else
+ 	return (selinux_mnt && has_selinux_config);
+ #endif
+-- 
+2.20.1
+


### PR DESCRIPTION
Since SELinux is not enabled in cic now, there are many
APIs exsiting in frameworks need to take some actions basing
on the SELinux's state. They are often check the mount
point of /sys/fs/selinux, if it exists, then they think SELinux
is enabled. This is not a correct way for cic.

Since SELinux is not enabled in cic, so we always return the
disabled state for SELinux.

Tracked-On: OAM-89804
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>