### PR TITLE
Fix bluetooth crash when stack unable to start HCI_MODULE

### DIFF
--- a/aosp_diff/caas/system/bt/0001-Fix-bluetooth-crash-when-stack-unable-to-start-HCI_M.patch
+++ b/aosp_diff/caas/system/bt/0001-Fix-bluetooth-crash-when-stack-unable-to-start-HCI_M.patch
@@ -1,0 +1,112 @@
+From 5380c089007afabb3f33428fa0ee814f6ff6fa61 Mon Sep 17 00:00:00 2001
+From: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Date: Mon, 9 Mar 2020 11:55:32 +0530
+Subject: [PATCH] Fix bluetooth crash when stack unable to start HCI_MODULE
+
+When BT is in Host controlled mode for CIV, if user tries
+to turn ON, Bluetooth crashes continously. Added fix in
+stack to gracefully shutdown HCI_MODULE if it is unable to
+start it.
+
+Tracked-On: OAM-89874
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+---
+ btcore/src/module.cc         |  2 +-
+ hci/src/hci_layer.cc         | 12 +++++++++++-
+ hci/src/hci_layer_android.cc |  7 +++++--
+ main/bte_main.cc             | 10 ++++++++--
+ 4 files changed, 25 insertions(+), 6 deletions(-)
+
+diff --git a/btcore/src/module.cc b/btcore/src/module.cc
+index d22600656..2e86f88fc 100644
+--- a/btcore/src/module.cc
++++ b/btcore/src/module.cc
+@@ -102,7 +102,7 @@ void module_shut_down(const module_t* module) {
+   CHECK(state <= MODULE_STATE_STARTED);
+ 
+   // Only something to do if the module was actually started
+-  if (state < MODULE_STATE_STARTED) return;
++  if (state < MODULE_STATE_STARTED && strcmp(module->name, "hci_module")) return;
+ 
+   LOG_INFO(LOG_TAG, "%s Shutting down module \"%s\"", __func__, module->name);
+   if (!call_lifecycle_function(module->shut_down)) {
+diff --git a/hci/src/hci_layer.cc b/hci/src/hci_layer.cc
+index ed2908cdd..ff9735124 100644
+--- a/hci/src/hci_layer.cc
++++ b/hci/src/hci_layer.cc
+@@ -142,6 +142,12 @@ void initialization_complete() {
+   hci_thread.DoInThread(FROM_HERE, base::Bind(&event_finish_startup, nullptr));
+ }
+ 
++ void initialization_failure() {
++  static char fail = 'F';
++  hci_thread.DoInThread(FROM_HERE, base::Bind(&event_finish_startup, (void*) &fail));
++}
++
++
+ void hci_event_received(const base::Location& from_here, BT_HDR* packet) {
+   btsnoop->capture(packet, true);
+ 
+@@ -347,7 +353,11 @@ static void event_finish_startup(UNUSED_ATTR void* context) {
+   if (!startup_future) {
+     return;
+   }
+-  future_ready(startup_future, FUTURE_SUCCESS);
++  if ((char*) context == nullptr)
++    future_ready(startup_future, FUTURE_SUCCESS);
++  else
++    future_ready(startup_future, FUTURE_FAIL);
++
+   startup_future = NULL;
+ }
+ 
+diff --git a/hci/src/hci_layer_android.cc b/hci/src/hci_layer_android.cc
+index 92be0df59..d0f28cc73 100644
+--- a/hci/src/hci_layer_android.cc
++++ b/hci/src/hci_layer_android.cc
+@@ -48,6 +48,7 @@ using ::android::hardware::bluetooth::V1_0::IBluetoothHciCallbacks;
+ using ::android::hardware::bluetooth::V1_0::Status;
+ 
+ extern void initialization_complete();
++extern void initialization_failure();
+ extern void hci_event_received(const base::Location& from_here, BT_HDR* packet);
+ extern void acl_event_received(BT_HDR* packet);
+ extern void sco_data_received(BT_HDR* packet);
+@@ -84,8 +85,10 @@ class BluetoothHciCallbacks : public IBluetoothHciCallbacks {
+   }
+ 
+   Return<void> initializationComplete(Status status) {
+-    CHECK(status == Status::SUCCESS);
+-    initialization_complete();
++    if (status == Status::SUCCESS)
++      initialization_complete();
++    else
++      initialization_failure();
+     return Void();
+   }
+ 
+diff --git a/main/bte_main.cc b/main/bte_main.cc
+index 049843933..06fa1d415 100644
+--- a/main/bte_main.cc
++++ b/main/bte_main.cc
+@@ -154,9 +154,15 @@ void bte_main_cleanup() {
+  *****************************************************************************/
+ void bte_main_enable() {
+   APPL_TRACE_DEBUG("%s", __func__);
+-
++  bool ret;
+   module_start_up(get_module(BTSNOOP_MODULE));
+-  module_start_up(get_module(HCI_MODULE));
++  ret = module_start_up(get_module(HCI_MODULE));
++  if (!ret) {
++    APPL_TRACE_DEBUG("%s: failed to start hci module",__func__);
++    module_shut_down(get_module(HCI_MODULE));
++    module_shut_down(get_module(BTSNOOP_MODULE));
++    return;
++  }
+ 
+   BTU_StartUp();
+ }
+-- 
+2.17.1
+


### PR DESCRIPTION
When BT is in Host controlled mode for CIV, if user tries
to turn ON, Bluetooth crashes continously. Added fix in
stack to gracefully shutdown HCI_MODULE if it is unable to
start it.

Tracked-On: OAM-89874
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>