### PR TITLE
Fix "drm/i915/execlists: Use per-process HWSP as scratch" merge issue

### DIFF
--- a/bsp_diff/caas/kernel/lts2019-chromium/04_0004-Fix-drm-i915-execlists-Use-per-process-HWSP-as-scrat.patch
+++ b/bsp_diff/caas/kernel/lts2019-chromium/04_0004-Fix-drm-i915-execlists-Use-per-process-HWSP-as-scrat.patch
@@ -1,0 +1,31 @@
+From 3f91a0e5c75b69b001979ef0356313c76c8e06c8 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Fri, 3 Apr 2020 19:46:57 +0530
+Subject: [PATCH] Fix "drm/i915/execlists: Use per-process HWSP as scratch"
+ merge issue
+
+Issue:
+Android doesn't boot in VM setup.
+
+Tracked-On: OAM-90590
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ drivers/gpu/drm/i915/gt/intel_lrc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/i915/gt/intel_lrc.c b/drivers/gpu/drm/i915/gt/intel_lrc.c
+index b9650e25149a..94849b8c6707 100644
+--- a/drivers/gpu/drm/i915/gt/intel_lrc.c
++++ b/drivers/gpu/drm/i915/gt/intel_lrc.c
+@@ -2054,7 +2054,7 @@ static u32 *gen9_init_indirectctx_bb(struct intel_engine_cs *engine, u32 *batch)
+ 	/* WaClearSlmSpaceAtContextSwitch:skl,bxt,kbl,glk,cfl */
+ 	batch = gen8_emit_pipe_control(batch,
+ 				       PIPE_CONTROL_FLUSH_L3 |
+-				       PIPE_CONTROL_GLOBAL_GTT_IVB |
++				       PIPE_CONTROL_STORE_DATA_INDEX |
+ 				       PIPE_CONTROL_CS_STALL |
+ 				       PIPE_CONTROL_QW_WRITE,
+ 				       LRC_PPHWSP_SCRATCH_ADDR);
+-- 
+2.17.1
+


### PR DESCRIPTION
Issue:
Android doesn't boot in VM setup.

Tracked-On: OAM-90590
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>