### PR TITLE
Add sepolicy rules for kernel 5.4 and fix some CTS issues

### DIFF
--- a/android/cic/system/core/0017-Align-the-dumpable-value-of-a-process-with-bare-meta.patch
+++ b/android/cic/system/core/0017-Align-the-dumpable-value-of-a-process-with-bare-meta.patch
@@ -1,0 +1,31 @@
+From 284ace56f18dbdaa268a101957a024665c8bce89 Mon Sep 17 00:00:00 2001
+From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
+Date: Mon, 13 Apr 2020 13:32:13 +0800
+Subject: [PATCH] Align the dumpable value of a process with bare metal android
+
+Change-Id: I64364c25ba7e7730bbc32296c185ee54a5d83b28
+Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
+---
+ debuggerd/handler/debuggerd_handler.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/debuggerd/handler/debuggerd_handler.cpp b/debuggerd/handler/debuggerd_handler.cpp
+index 05e6efa60..d137ecc9b 100644
+--- a/debuggerd/handler/debuggerd_handler.cpp
++++ b/debuggerd/handler/debuggerd_handler.cpp
+@@ -527,6 +527,12 @@ static void debuggerd_signal_handler(int signal_number, siginfo_t* info, void* c
+   // and then wait for it to terminate.
+   futex_wait(&thread_info.pseudothread_tid, child_pid);
+ 
++  // We cannot set the dumpable value to SUID_DUMP_ROOT(2), change this value to
++  // SUID_DUMP_DISABLE(0).
++  if (orig_dumpable == 2) {
++    orig_dumpable = 0;
++  }
++
+   // Restore PR_SET_DUMPABLE to its original value.
+   if (prctl(PR_SET_DUMPABLE, orig_dumpable) != 0) {
+     fatal_errno("failed to restore dumpable");
+-- 
+2.20.1
+

--- a/android/cic/system/sepolicy/04_0001_1-BACKPORT-Policies-to-get-Android-booted-with-5.4-abo.patch
+++ b/android/cic/system/sepolicy/04_0001_1-BACKPORT-Policies-to-get-Android-booted-with-5.4-abo.patch
@@ -1,0 +1,277 @@
+From 0e8b485d6d2d41ca25035a4123007b311c3b2382 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sun, 29 Mar 2020 15:44:15 +0530
+Subject: [PATCH] BACKPORT: Policies to get Android booted with 5.4 & above
+ kernels
+
+Following patches are ported:
+update sepolicy for fs notification hooks
+neverallow_macros: add watch* perms
+global_macros: trim back various watch* permissions
+access_vectors: re-organize common file perms
+
+Change-Id: Icd01ba01c038e945d1c8b8db718e93bddfa76087
+Tracked-On:
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ prebuilts/api/28.0/private/access_vectors   | 38 +++++----------------
+ prebuilts/api/28.0/public/global_macros     |  4 +--
+ prebuilts/api/28.0/public/neverallow_macros |  2 +-
+ private/access_vectors                      | 38 +++++----------------
+ public/global_macros                        |  4 +--
+ public/neverallow_macros                    |  2 +-
+ 6 files changed, 24 insertions(+), 64 deletions(-)
+
+diff --git a/prebuilts/api/28.0/private/access_vectors b/prebuilts/api/28.0/private/access_vectors
+index 898c884cd..eb2a9254c 100644
+--- a/prebuilts/api/28.0/private/access_vectors
++++ b/prebuilts/api/28.0/private/access_vectors
+@@ -27,6 +27,14 @@ common file
+ 	execute
+ 	quotaon
+ 	mounton
++	audit_access
++	open
++	execmod
++	watch
++	watch_mount
++	watch_sb
++	watch_with_perm
++	watch_reads
+ }
+ 
+ 
+@@ -153,6 +161,7 @@ class filesystem
+ 	associate
+ 	quotamod
+ 	quotaget
++	watch
+ }
+ 
+ class dir
+@@ -163,9 +172,6 @@ inherits file
+ 	reparent
+ 	search
+ 	rmdir
+-	open
+-	audit_access
+-	execmod
+ }
+ 
+ class file
+@@ -173,52 +179,26 @@ inherits file
+ {
+ 	execute_no_trans
+ 	entrypoint
+-	execmod
+-	open
+-	audit_access
+ }
+ 
+ class lnk_file
+ inherits file
+-{
+-	open
+-	audit_access
+-	execmod
+-}
+ 
+ class chr_file
+ inherits file
+ {
+ 	execute_no_trans
+ 	entrypoint
+-	execmod
+-	open
+-	audit_access
+ }
+ 
+ class blk_file
+ inherits file
+-{
+-	open
+-	audit_access
+-	execmod
+-}
+ 
+ class sock_file
+ inherits file
+-{
+-	open
+-	audit_access
+-	execmod
+-}
+ 
+ class fifo_file
+ inherits file
+-{
+-	open
+-	audit_access
+-	execmod
+-}
+ 
+ class fd
+ {
+diff --git a/prebuilts/api/28.0/public/global_macros b/prebuilts/api/28.0/public/global_macros
+index 5dab5ab0c..21a0d8b69 100644
+--- a/prebuilts/api/28.0/public/global_macros
++++ b/prebuilts/api/28.0/public/global_macros
+@@ -21,7 +21,7 @@ define(`ipc_class_set', `{ sem msgq shm ipc }')
+ # Common groupings of permissions.
+ #
+ define(`x_file_perms', `{ getattr execute execute_no_trans map }')
+-define(`r_file_perms', `{ getattr open read ioctl lock map }')
++define(`r_file_perms', `{ getattr open read ioctl lock map watch watch_reads }')
+ define(`w_file_perms', `{ open append write lock map }')
+ define(`rx_file_perms', `{ r_file_perms x_file_perms }')
+ define(`ra_file_perms', `{ r_file_perms append }')
+@@ -29,7 +29,7 @@ define(`rw_file_perms', `{ r_file_perms w_file_perms }')
+ define(`rwx_file_perms', `{ rw_file_perms x_file_perms }')
+ define(`create_file_perms', `{ create rename setattr unlink rw_file_perms }')
+ 
+-define(`r_dir_perms', `{ open getattr read search ioctl lock }')
++define(`r_dir_perms', `{ open getattr read search ioctl lock watch watch_reads }')
+ define(`w_dir_perms', `{ open search write add_name remove_name lock }')
+ define(`ra_dir_perms', `{ r_dir_perms add_name write }')
+ define(`rw_dir_perms', `{ r_dir_perms w_dir_perms }')
+diff --git a/prebuilts/api/28.0/public/neverallow_macros b/prebuilts/api/28.0/public/neverallow_macros
+index e2b6ed1af..59fa441d2 100644
+--- a/prebuilts/api/28.0/public/neverallow_macros
++++ b/prebuilts/api/28.0/public/neverallow_macros
+@@ -1,7 +1,7 @@
+ #
+ # Common neverallow permissions
+ define(`no_w_file_perms', `{ append create link unlink relabelfrom rename setattr write }')
+-define(`no_rw_file_perms', `{ no_w_file_perms open read ioctl lock }')
++define(`no_rw_file_perms', `{ no_w_file_perms open read ioctl lock watch watch_mount watch_sb watch_with_perm watch_reads }')
+ define(`no_x_file_perms', `{ execute execute_no_trans }')
+ define(`no_w_dir_perms',  `{ add_name create link relabelfrom remove_name rename reparent rmdir setattr write }')
+ 
+diff --git a/private/access_vectors b/private/access_vectors
+index 898c884cd..eb2a9254c 100644
+--- a/private/access_vectors
++++ b/private/access_vectors
+@@ -27,6 +27,14 @@ common file
+ 	execute
+ 	quotaon
+ 	mounton
++	audit_access
++	open
++	execmod
++	watch
++	watch_mount
++	watch_sb
++	watch_with_perm
++	watch_reads
+ }
+ 
+ 
+@@ -153,6 +161,7 @@ class filesystem
+ 	associate
+ 	quotamod
+ 	quotaget
++	watch
+ }
+ 
+ class dir
+@@ -163,9 +172,6 @@ inherits file
+ 	reparent
+ 	search
+ 	rmdir
+-	open
+-	audit_access
+-	execmod
+ }
+ 
+ class file
+@@ -173,52 +179,26 @@ inherits file
+ {
+ 	execute_no_trans
+ 	entrypoint
+-	execmod
+-	open
+-	audit_access
+ }
+ 
+ class lnk_file
+ inherits file
+-{
+-	open
+-	audit_access
+-	execmod
+-}
+ 
+ class chr_file
+ inherits file
+ {
+ 	execute_no_trans
+ 	entrypoint
+-	execmod
+-	open
+-	audit_access
+ }
+ 
+ class blk_file
+ inherits file
+-{
+-	open
+-	audit_access
+-	execmod
+-}
+ 
+ class sock_file
+ inherits file
+-{
+-	open
+-	audit_access
+-	execmod
+-}
+ 
+ class fifo_file
+ inherits file
+-{
+-	open
+-	audit_access
+-	execmod
+-}
+ 
+ class fd
+ {
+diff --git a/public/global_macros b/public/global_macros
+index 5dab5ab0c..21a0d8b69 100644
+--- a/public/global_macros
++++ b/public/global_macros
+@@ -21,7 +21,7 @@ define(`ipc_class_set', `{ sem msgq shm ipc }')
+ # Common groupings of permissions.
+ #
+ define(`x_file_perms', `{ getattr execute execute_no_trans map }')
+-define(`r_file_perms', `{ getattr open read ioctl lock map }')
++define(`r_file_perms', `{ getattr open read ioctl lock map watch watch_reads }')
+ define(`w_file_perms', `{ open append write lock map }')
+ define(`rx_file_perms', `{ r_file_perms x_file_perms }')
+ define(`ra_file_perms', `{ r_file_perms append }')
+@@ -29,7 +29,7 @@ define(`rw_file_perms', `{ r_file_perms w_file_perms }')
+ define(`rwx_file_perms', `{ rw_file_perms x_file_perms }')
+ define(`create_file_perms', `{ create rename setattr unlink rw_file_perms }')
+ 
+-define(`r_dir_perms', `{ open getattr read search ioctl lock }')
++define(`r_dir_perms', `{ open getattr read search ioctl lock watch watch_reads }')
+ define(`w_dir_perms', `{ open search write add_name remove_name lock }')
+ define(`ra_dir_perms', `{ r_dir_perms add_name write }')
+ define(`rw_dir_perms', `{ r_dir_perms w_dir_perms }')
+diff --git a/public/neverallow_macros b/public/neverallow_macros
+index e2b6ed1af..59fa441d2 100644
+--- a/public/neverallow_macros
++++ b/public/neverallow_macros
+@@ -1,7 +1,7 @@
+ #
+ # Common neverallow permissions
+ define(`no_w_file_perms', `{ append create link unlink relabelfrom rename setattr write }')
+-define(`no_rw_file_perms', `{ no_w_file_perms open read ioctl lock }')
++define(`no_rw_file_perms', `{ no_w_file_perms open read ioctl lock watch watch_mount watch_sb watch_with_perm watch_reads }')
+ define(`no_x_file_perms', `{ execute execute_no_trans }')
+ define(`no_w_dir_perms',  `{ add_name create link relabelfrom remove_name rename reparent rmdir setattr write }')
+ 
+-- 
+2.20.1
+


### PR DESCRIPTION
1. Add sepolicy rules for kernel 5.4

2. Fix some CTS test case issues
The dumpable value of some processes may be affected by suid_dumpable
defined in /proc/sys/fs/suid_dumpable. For the processes that have extra
capabilities assigned through init.rc or fs config files, their dumpable
vaules are set to suid_dumpable.
The value of suid_dumpable of bare metal android is SUID_DUMP_DISABLE(0),
but this value maybe be changed to SUID_DUMP_ROOT(2) in ubuntu by some
host services, such as apport. This may introduce some regressions for the
processes of android in container, and it may also impact the CTS result.
So we need to set suid_dumpable's value back to SUID_DUMP_DISABLE if we detect
its value was set to SUID_DUMP_ROOT.

Tracked-On: OAM-90488
Tracked-On: OAM-90692
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>