### PR TITLE
Fix some CTS test case issues

### DIFF
--- a/android/cic/system/core/0001-Align-the-dumpable-value-of-a-process-with-bare-meta.patch
+++ b/android/cic/system/core/0001-Align-the-dumpable-value-of-a-process-with-bare-meta.patch
@@ -1,0 +1,31 @@
+From 284ace56f18dbdaa268a101957a024665c8bce89 Mon Sep 17 00:00:00 2001
+From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
+Date: Mon, 13 Apr 2020 13:32:13 +0800
+Subject: [PATCH] Align the dumpable value of a process with bare metal android
+
+Change-Id: I64364c25ba7e7730bbc32296c185ee54a5d83b28
+Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
+---
+ debuggerd/handler/debuggerd_handler.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/debuggerd/handler/debuggerd_handler.cpp b/debuggerd/handler/debuggerd_handler.cpp
+index 05e6efa60..d137ecc9b 100644
+--- a/debuggerd/handler/debuggerd_handler.cpp
++++ b/debuggerd/handler/debuggerd_handler.cpp
+@@ -527,6 +527,12 @@ static void debuggerd_signal_handler(int signal_number, siginfo_t* info, void* c
+   // and then wait for it to terminate.
+   futex_wait(&thread_info.pseudothread_tid, child_pid);
+ 
++  // We cannot set the dumpable value to SUID_DUMP_ROOT(2), change this value to
++  // SUID_DUMP_DISABLE(0).
++  if (orig_dumpable == 2) {
++    orig_dumpable = 0;
++  }
++
+   // Restore PR_SET_DUMPABLE to its original value.
+   if (prctl(PR_SET_DUMPABLE, orig_dumpable) != 0) {
+     fatal_errno("failed to restore dumpable");
+-- 
+2.20.1
+


### PR DESCRIPTION
The dumpable value of some processes may be affected by suid_dumpable
defined in /proc/sys/fs/suid_dumpable. For the processes that have extra
capabilities assigned through init.rc or fs config files, their dumpable
vaules are set to suid_dumpable.
The value of suid_dumpable of bare metal android is SUID_DUMP_DISABLE(0),
but this value maybe be changed to SUID_DUMP_ROOT(2) in ubuntu by some
host services, such as apport. This may introduce some regressions for the
processes of android in container, and it may also impact the CTS result.
So we need to set suid_dumpable's value back to SUID_DUMP_DISABLE if we detect
its value was set to SUID_DUMP_ROOT.

Tracked-On: OAM-90728
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>