### PR TITLE
enable passthrough virtio-input device

### DIFF
--- a/bsp_diff/caas/kernel/lts2018/03_0003-input-passthrough-virtio-input-device.patch
+++ b/bsp_diff/caas/kernel/lts2018/03_0003-input-passthrough-virtio-input-device.patch
@@ -1,0 +1,46 @@
+From efd4b16983861b9492e7a1f22af936db26f5af2a Mon Sep 17 00:00:00 2001
+From: "Yang, Dong" <dong.yang@intel.com>
+Date: Tue, 31 Mar 2020 09:47:43 +0800
+Subject: [PATCH] input: passthrough virtio-input device
+
+The virtio-input device event should be passthrough
+and send to uplayer directly, since the events get
+from host, and already handled in host input driver.
+
+Tracked-On: OAM-90659
+Signed-off-by: Yang, Dong <dong.yang@intel.com>
+---
+ drivers/input/input.c | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git drivers/input/input.c drivers/input/input.c
+index a0d90022fcf7..f3e890df2ed3 100644
+--- drivers/input/input.c
++++ drivers/input/input.c
+@@ -371,6 +371,23 @@ static void input_handle_event(struct input_dev *dev,
+ {
+ 	int disposition = input_get_disposition(dev, type, code, &value);
+ 
++	if (dev->phys && !strncmp(dev->phys, "virtio", 6)) {
++		struct input_value *v = NULL;
++		if (!dev->vals)
++			return;
++
++		v = &dev->vals[dev->num_vals++];
++		if (!v)
++			return;
++
++		v->type = type;
++		v->code = code;
++		v->value = value;
++		input_pass_values(dev, dev->vals, dev->num_vals);
++		dev->num_vals = 0;
++		return;
++	}
++
+ 	if (disposition != INPUT_IGNORE_EVENT && type != EV_SYN)
+ 		add_input_randomness(type, code, value);
+ 
+-- 
+2.25.1
+

--- a/bsp_diff/caas/kernel/lts2019-yocto/05_0005-ANDROID-virtio-virtio_input-Set-the-amount-of-multit.patch
+++ b/bsp_diff/caas/kernel/lts2019-yocto/05_0005-ANDROID-virtio-virtio_input-Set-the-amount-of-multit.patch
@@ -1,0 +1,45 @@
+From 9200bdee93b88fe93626bd64b684b911729d17c7 Mon Sep 17 00:00:00 2001
+From: Roman Kiryanov <rkir@google.com>
+Date: Mon, 28 Oct 2019 14:34:48 -0700
+Subject: [PATCH] ANDROID: virtio: virtio_input: Set the amount of multitouch
+ slots in virtio input
+
+Virtio input was missing the the amount of multitouch
+slots and kernel was filtering out ABS_MT_SLOT events
+for a screen is touched in more than one place.
+
+Bug: 143488374
+Signed-off-by: Roman Kiryanov <rkir@google.com>
+Change-Id: I617099435af311e6b0ee127b76eafe13834ea8f8
+---
+ drivers/virtio/virtio_input.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/drivers/virtio/virtio_input.c b/drivers/virtio/virtio_input.c
+index 5ae529671b3d..c68134c5a2e6 100644
+--- a/drivers/virtio/virtio_input.c
++++ b/drivers/virtio/virtio_input.c
+@@ -3,6 +3,7 @@
+ #include <linux/virtio.h>
+ #include <linux/virtio_config.h>
+ #include <linux/input.h>
++#include <linux/input/mt.h>
+ 
+ #include <uapi/linux/virtio_ids.h>
+ #include <uapi/linux/virtio_input.h>
+@@ -164,6 +165,12 @@ static void virtinput_cfg_abs(struct virtio_input *vi, int abs)
+ 	virtio_cread(vi->vdev, struct virtio_input_config, u.abs.flat, &fl);
+ 	input_set_abs_params(vi->idev, abs, mi, ma, fu, fl);
+ 	input_abs_set_res(vi->idev, abs, re);
++	if (abs == ABS_MT_TRACKING_ID)
++		input_mt_init_slots(vi->idev,
++				    ma, /* input max finger */
++				    INPUT_MT_DIRECT
++					| INPUT_MT_DROP_UNUSED
++					| INPUT_MT_TRACK);
+ }
+ 
+ static int virtinput_init_vqs(struct virtio_input *vi)
+-- 
+2.25.1
+


### PR DESCRIPTION
Enable virtio-input device for multi-touch device.
For kernel lts2018, we use a passthrough patch.
For kernel lts2019-yocto, we back ported a patch from Google.

Tracked-On: OAM-90659
Signed-off-by: Yang, Dong <dong.yang@intel.com>