### PR TITLE
[PATCH] BACKPORT: Policies to get Android booted with 5.4 & above

### DIFF
--- a/aosp_diff/caas/system/sepolicy/0002-PATCH-BACKPORT-Policies-to-get-Android-booted-with-5.patch
+++ b/aosp_diff/caas/system/sepolicy/0002-PATCH-BACKPORT-Policies-to-get-Android-booted-with-5.patch
@@ -1,0 +1,275 @@
+From 2adb4baecbc93092874b27e9ab5a2145ad511930 Mon Sep 17 00:00:00 2001
+From: "Zhong,Fangjian" <fangjian.zhong@intel.com>
+Date: Wed, 22 Apr 2020 15:11:10 +0800
+Subject: [PATCH] [PATCH] BACKPORT: Policies to get Android booted with 5.4 &
+ above  kernels
+
+ Following patches are ported:
+ update sepolicy for fs notification hooks
+ neverallow_macros: add watch* perms
+ global_macros: trim back various watch* permissions
+ access_vectors: re-organize common file perms
+
+Tracked-On:
+---
+ prebuilts/api/28.0/private/access_vectors   | 38 +++++++----------------------
+ prebuilts/api/28.0/public/global_macros     |  4 +--
+ prebuilts/api/28.0/public/neverallow_macros |  2 +-
+ private/access_vectors                      | 38 +++++++----------------------
+ public/global_macros                        |  4 +--
+ public/neverallow_macros                    |  2 +-
+ 6 files changed, 24 insertions(+), 64 deletions(-)
+
+diff --git a/prebuilts/api/28.0/private/access_vectors b/prebuilts/api/28.0/private/access_vectors
+index 898c884..eb2a925 100644
+--- a/prebuilts/api/28.0/private/access_vectors
++++ b/prebuilts/api/28.0/private/access_vectors
+@@ -27,6 +27,14 @@ common file
+ 	execute
+ 	quotaon
+ 	mounton
++	audit_access
++	open
++	execmod
++	watch
++	watch_mount
++	watch_sb
++	watch_with_perm
++	watch_reads
+ }
+ 
+ 
+@@ -153,6 +161,7 @@ class filesystem
+ 	associate
+ 	quotamod
+ 	quotaget
++	watch
+ }
+ 
+ class dir
+@@ -163,9 +172,6 @@ inherits file
+ 	reparent
+ 	search
+ 	rmdir
+-	open
+-	audit_access
+-	execmod
+ }
+ 
+ class file
+@@ -173,52 +179,26 @@ inherits file
+ {
+ 	execute_no_trans
+ 	entrypoint
+-	execmod
+-	open
+-	audit_access
+ }
+ 
+ class lnk_file
+ inherits file
+-{
+-	open
+-	audit_access
+-	execmod
+-}
+ 
+ class chr_file
+ inherits file
+ {
+ 	execute_no_trans
+ 	entrypoint
+-	execmod
+-	open
+-	audit_access
+ }
+ 
+ class blk_file
+ inherits file
+-{
+-	open
+-	audit_access
+-	execmod
+-}
+ 
+ class sock_file
+ inherits file
+-{
+-	open
+-	audit_access
+-	execmod
+-}
+ 
+ class fifo_file
+ inherits file
+-{
+-	open
+-	audit_access
+-	execmod
+-}
+ 
+ class fd
+ {
+diff --git a/prebuilts/api/28.0/public/global_macros b/prebuilts/api/28.0/public/global_macros
+index 5dab5ab..21a0d8b 100644
+--- a/prebuilts/api/28.0/public/global_macros
++++ b/prebuilts/api/28.0/public/global_macros
+@@ -21,7 +21,7 @@ define(`ipc_class_set', `{ sem msgq shm ipc }')
+ # Common groupings of permissions.
+ #
+ define(`x_file_perms', `{ getattr execute execute_no_trans map }')
+-define(`r_file_perms', `{ getattr open read ioctl lock map }')
++define(`r_file_perms', `{ getattr open read ioctl lock map watch watch_reads }')
+ define(`w_file_perms', `{ open append write lock map }')
+ define(`rx_file_perms', `{ r_file_perms x_file_perms }')
+ define(`ra_file_perms', `{ r_file_perms append }')
+@@ -29,7 +29,7 @@ define(`rw_file_perms', `{ r_file_perms w_file_perms }')
+ define(`rwx_file_perms', `{ rw_file_perms x_file_perms }')
+ define(`create_file_perms', `{ create rename setattr unlink rw_file_perms }')
+ 
+-define(`r_dir_perms', `{ open getattr read search ioctl lock }')
++define(`r_dir_perms', `{ open getattr read search ioctl lock watch watch_reads }')
+ define(`w_dir_perms', `{ open search write add_name remove_name lock }')
+ define(`ra_dir_perms', `{ r_dir_perms add_name write }')
+ define(`rw_dir_perms', `{ r_dir_perms w_dir_perms }')
+diff --git a/prebuilts/api/28.0/public/neverallow_macros b/prebuilts/api/28.0/public/neverallow_macros
+index e2b6ed1..59fa441 100644
+--- a/prebuilts/api/28.0/public/neverallow_macros
++++ b/prebuilts/api/28.0/public/neverallow_macros
+@@ -1,7 +1,7 @@
+ #
+ # Common neverallow permissions
+ define(`no_w_file_perms', `{ append create link unlink relabelfrom rename setattr write }')
+-define(`no_rw_file_perms', `{ no_w_file_perms open read ioctl lock }')
++define(`no_rw_file_perms', `{ no_w_file_perms open read ioctl lock watch watch_mount watch_sb watch_with_perm watch_reads }')
+ define(`no_x_file_perms', `{ execute execute_no_trans }')
+ define(`no_w_dir_perms',  `{ add_name create link relabelfrom remove_name rename reparent rmdir setattr write }')
+ 
+diff --git a/private/access_vectors b/private/access_vectors
+index b77dcc1..7e5e69e 100644
+--- a/private/access_vectors
++++ b/private/access_vectors
+@@ -27,6 +27,14 @@ common file
+ 	execute
+ 	quotaon
+ 	mounton
++	audit_access
++	open
++	execmod
++	watch
++	watch_mount
++	watch_sb
++	watch_with_perm
++	watch_reads
+ }
+ 
+ 
+@@ -153,6 +161,7 @@ class filesystem
+ 	associate
+ 	quotamod
+ 	quotaget
++	watch
+ }
+ 
+ class dir
+@@ -163,9 +172,6 @@ inherits file
+ 	reparent
+ 	search
+ 	rmdir
+-	open
+-	audit_access
+-	execmod
+ }
+ 
+ class file
+@@ -173,52 +179,26 @@ inherits file
+ {
+ 	execute_no_trans
+ 	entrypoint
+-	execmod
+-	open
+-	audit_access
+ }
+ 
+ class lnk_file
+ inherits file
+-{
+-	open
+-	audit_access
+-	execmod
+-}
+ 
+ class chr_file
+ inherits file
+ {
+ 	execute_no_trans
+ 	entrypoint
+-	execmod
+-	open
+-	audit_access
+ }
+ 
+ class blk_file
+ inherits file
+-{
+-	open
+-	audit_access
+-	execmod
+-}
+ 
+ class sock_file
+ inherits file
+-{
+-	open
+-	audit_access
+-	execmod
+-}
+ 
+ class fifo_file
+ inherits file
+-{
+-	open
+-	audit_access
+-	execmod
+-}
+ 
+ class fd
+ {
+diff --git a/public/global_macros b/public/global_macros
+index 1a1d593..2c87fde 100644
+--- a/public/global_macros
++++ b/public/global_macros
+@@ -22,7 +22,7 @@ define(`ipc_class_set', `{ sem msgq shm ipc }')
+ # Common groupings of permissions.
+ #
+ define(`x_file_perms', `{ getattr execute execute_no_trans map }')
+-define(`r_file_perms', `{ getattr open read ioctl lock map }')
++define(`r_file_perms', `{ getattr open read ioctl lock map watch watch_reads }')
+ define(`w_file_perms', `{ open append write lock map }')
+ define(`rx_file_perms', `{ r_file_perms x_file_perms }')
+ define(`ra_file_perms', `{ r_file_perms append }')
+@@ -30,7 +30,7 @@ define(`rw_file_perms', `{ r_file_perms w_file_perms }')
+ define(`rwx_file_perms', `{ rw_file_perms x_file_perms }')
+ define(`create_file_perms', `{ create rename setattr unlink rw_file_perms }')
+ 
+-define(`r_dir_perms', `{ open getattr read search ioctl lock }')
++define(`r_dir_perms', `{ open getattr read search ioctl lock watch watch_reads }')
+ define(`w_dir_perms', `{ open search write add_name remove_name lock }')
+ define(`ra_dir_perms', `{ r_dir_perms add_name write }')
+ define(`rw_dir_perms', `{ r_dir_perms w_dir_perms }')
+diff --git a/public/neverallow_macros b/public/neverallow_macros
+index e2b6ed1..59fa441 100644
+--- a/public/neverallow_macros
++++ b/public/neverallow_macros
+@@ -1,7 +1,7 @@
+ #
+ # Common neverallow permissions
+ define(`no_w_file_perms', `{ append create link unlink relabelfrom rename setattr write }')
+-define(`no_rw_file_perms', `{ no_w_file_perms open read ioctl lock }')
++define(`no_rw_file_perms', `{ no_w_file_perms open read ioctl lock watch watch_mount watch_sb watch_with_perm watch_reads }')
+ define(`no_x_file_perms', `{ execute execute_no_trans }')
+ define(`no_w_dir_perms',  `{ add_name create link relabelfrom remove_name rename reparent rmdir setattr write }')
+ 
+-- 
+2.7.4
+


### PR DESCRIPTION
 kernels

 Following patches are ported:
 update sepolicy for fs notification hooks
 neverallow_macros: add watch* perms
 global_macros: trim back various watch* permissions
 access_vectors: re-organize common file perms