### PR TITLE
Overview button is not show due to the menu_container's layout_width …

### DIFF
--- a/android/common/frameworks/base/0001-Menu-ime-button-takes-nav-button-width-to-show-recen.patch
+++ b/android/common/frameworks/base/0001-Menu-ime-button-takes-nav-button-width-to-show-recen.patch
@@ -1,0 +1,44 @@
+From eb9bf01fd879fa29049ceb5b8b6a74a9f916c928 Mon Sep 17 00:00:00 2001
+From: Matthew Ng <ngmatthew@google.com>
+Date: Tue, 3 Jul 2018 14:24:04 -0700
+Subject: [PATCH] Menu ime button takes nav button width to show recents button
+ for tablets
+
+Menu ime button was pushing the recents button out of screen because of
+the order of the nav layout (where right side was before the recents
+button) and menu ime button took full width (match parent). Fixed with
+a fixed width for menu ime button to show the recents button on nav bar
+for tablets (screen density smaller than ~250).
+
+Change-Id: I61a0206e40b7a69d52db4a97a1b76767ba752f85
+Fixes: 77913318
+Test: 'adb shell wm density 240' on phone
+---
+ packages/SystemUI/res/layout/menu_ime.xml | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/packages/SystemUI/res/layout/menu_ime.xml b/packages/SystemUI/res/layout/menu_ime.xml
+index 9130fb45489..8a3a0b19c89 100644
+--- a/packages/SystemUI/res/layout/menu_ime.xml
++++ b/packages/SystemUI/res/layout/menu_ime.xml
+@@ -17,13 +17,13 @@
+ <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+     xmlns:systemui="http://schemas.android.com/apk/res-auto"
+     android:id="@+id/menu_container"
+-    android:layout_width="match_parent"
++    android:layout_width="@dimen/navigation_key_width"
+     android:layout_height="match_parent"
+     android:importantForAccessibility="no"
+     >
+-    <!-- Use width & height=match_parent for parent FrameLayout and buttons because they are placed
+-    inside a view that has a size controlled by weight. Ensure weight is large enough to support
+-    icon size. -->
++    <!-- Use nav button width & height=match_parent for parent FrameLayout and buttons because they
++    are placed inside a view that has a size controlled by weight. Ensure weight is large enough to
++    support icon size. -->
+ 
+     <com.android.systemui.statusbar.policy.KeyButtonView
+         android:id="@+id/menu"
+-- 
+2.21.0
+


### PR DESCRIPTION
…is too large.

Patch is ported form Google master.

Tracked-On: OAM-90839
Signed-off-by: bxu10x <bingx.xu@intel.com>