### PR TITLE
For GVT-d on EHL and ICL, remove VTD activity

### DIFF
--- a/bsp_diff/caas/kernel/lts2019-yocto/06_0001-For-GVT-d-on-EHL-and-ICL-remove-VTD-activity.patch
+++ b/bsp_diff/caas/kernel/lts2019-yocto/06_0001-For-GVT-d-on-EHL-and-ICL-remove-VTD-activity.patch
@@ -1,0 +1,31 @@
+From 4c2f080fde6a14f2d22a4178d7b94e8189521b20 Mon Sep 17 00:00:00 2001
+From: Shaofeng Tang <shaofeng.tang@intel.com>
+Date: Tue, 14 Apr 2020 15:07:40 +0800
+Subject: [PATCH] For GVT-d on EHL and ICL, remove VTD activity
+
+Since all GPU resource will be pass-through to Guest.
+No need to active VTD on guest.
+
+Tests: Work well with GVT-d on EHL and ICL
+Tracked-On: https://jira.devtools.intel.com/browse/OAM-90840
+Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>
+---
+ drivers/gpu/drm/i915/i915_drv.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/i915/i915_drv.h b/drivers/gpu/drm/i915/i915_drv.h
+index 6fdeceb..e51cc7c 100644
+--- a/drivers/gpu/drm/i915/i915_drv.h
++++ b/drivers/gpu/drm/i915/i915_drv.h
+@@ -1751,7 +1751,7 @@ static inline bool intel_vtd_active(void)
+ 
+ static inline bool intel_scanout_needs_vtd_wa(struct drm_i915_private *dev_priv)
+ {
+-	return INTEL_GEN(dev_priv) >= 6 && intel_vtd_active();
++	return INTEL_GEN(dev_priv) >= 6;
+ }
+ 
+ static inline bool
+-- 
+1.9.1
+


### PR DESCRIPTION
Since all GPU resource will be pass-through to Guest.
No need to active VTD on guest.

Tests: Work well with GVT-d on EHL and ICL
Tracked-On: https://jira.devtools.intel.com/browse/OAM-90840
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>