### PR TITLE
usb: dwc3: uvc: Changes for making UVC-gadget work

### DIFF
--- a/host/lts2018/usb/0003-uvc-gadget-Kernel-changes-to-enable-UVC-gadget.patch
+++ b/host/lts2018/usb/0003-uvc-gadget-Kernel-changes-to-enable-UVC-gadget.patch
@@ -1,0 +1,119 @@
+From 9abe566e5b121b81d6279a379ca75a4a6fd12742 Mon Sep 17 00:00:00 2001
+From: saranya <saranya.gopal@intel.com>
+Date: Thu, 19 Mar 2020 11:25:44 +0530
+Subject: [PATCH] uvc-gadget: Kernel changes to enable UVC-gadget
+
+This patch adds a WA in dwc3 driver to handle
+isoc requests properly. It also adds change in
+uvc gadget function so that UVC gadget streaming
+with real camera works.
+
+Signed-off-by: saranya <saranya.gopal@intel.com>
+---
+ drivers/usb/dwc3/gadget.c         | 34 +++++++++++++++++++++++++++----
+ drivers/usb/gadget/function/uvc.h |  2 +-
+ 2 files changed, 31 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/usb/dwc3/gadget.c b/drivers/usb/dwc3/gadget.c
+index e4ffbbfe68d9..b1ade5b81b3d 100644
+--- a/drivers/usb/dwc3/gadget.c
++++ b/drivers/usb/dwc3/gadget.c
+@@ -358,6 +358,7 @@ int dwc3_send_gadget_ep_cmd(struct dwc3_ep *dep, unsigned cmd,
+ 				 * give a hint to the gadget driver that this is
+ 				 * the case by returning -EAGAIN.
+ 				 */
++				pr_err("%s: bus expiry", __func__);
+ 				ret = -EAGAIN;
+ 				break;
+ 			default:
+@@ -1258,6 +1259,18 @@ static int __dwc3_gadget_get_frame(struct dwc3 *dwc)
+ 	return DWC3_DSTS_SOFFN(reg);
+ }
+ 
++#define DWC3_EVENT_PRAM_MAX_SOFFN      0x3fff
++#define DWC3_EVENT_PRAM_SOFFN_MASK     0x3fff
++
++static bool __dwc3_gadget_target_frame_elapsed(struct dwc3_ep *dep)
++{
++	u16 cframe =  __dwc3_gadget_get_frame(dep->dwc);
++	u16 eframe = dep->frame_number & DWC3_EVENT_PRAM_SOFFN_MASK;
++
++	return (((eframe - cframe) & DWC3_EVENT_PRAM_SOFFN_MASK)
++		> DWC3_EVENT_PRAM_MAX_SOFFN / 2);
++}
++
+ /**
+  * dwc3_gadget_start_isoc_quirk - workaround invalid frame number
+  * @dep: isoc endpoint
+@@ -1377,7 +1390,7 @@ static int __dwc3_gadget_start_isoc(struct dwc3_ep *dep)
+ {
+ 	struct dwc3 *dwc = dep->dwc;
+ 	int ret;
+-	int i;
++	//int i;
+ 
+ 	if (list_empty(&dep->pending_list)) {
+ 		dep->flags |= DWC3_EP_PENDING_REQUEST;
+@@ -1393,7 +1406,7 @@ static int __dwc3_gadget_start_isoc(struct dwc3_ep *dep)
+ 		if (dwc->gadget.speed <= USB_SPEED_HIGH && dep->direction)
+ 			return dwc3_gadget_start_isoc_quirk(dep);
+ 	}
+-
++#if 0
+ 	for (i = 0; i < DWC3_ISOC_MAX_RETRIES; i++) {
+ 		dep->frame_number = DWC3_ALIGN_FRAME(dep, i + 1);
+ 
+@@ -1401,7 +1414,12 @@ static int __dwc3_gadget_start_isoc(struct dwc3_ep *dep)
+ 		if (ret != -EAGAIN)
+ 			break;
+ 	}
+-
++#endif
++	pr_info("Enabling WA for isoc transfer\n");
++	while (__dwc3_gadget_target_frame_elapsed(dep))
++		dep->frame_number = DWC3_ALIGN_FRAME(dep, 4);
++	dep->frame_number = DWC3_ALIGN_FRAME(dep, 4);
++	ret = __dwc3_gadget_kick_transfer(dep);
+ 	return ret;
+ }
+ 
+@@ -1446,6 +1464,15 @@ static int __dwc3_gadget_ep_queue(struct dwc3_ep *dep, struct dwc3_request *req)
+ 				return __dwc3_gadget_start_isoc(dep);
+ 			}
+ 		}
++
++		if ((dep->flags & DWC3_EP_TRANSFER_STARTED) &&
++		    list_empty(&dep->started_list) &&
++		    ((dep->frame_number & 0x3fff) !=
++		    __dwc3_gadget_get_frame(dwc))) {
++			dwc3_stop_active_transfer(dep, true);
++			dep->flags = DWC3_EP_ENABLED;
++			return 0;
++		}
+ 	}
+ 
+ 	return __dwc3_gadget_kick_transfer(dep);
+@@ -2497,7 +2524,6 @@ static void dwc3_gadget_endpoint_transfer_in_progress(struct dwc3_ep *dep,
+ 		if (list_empty(&dep->started_list))
+ 			stop = true;
+ 	}
+-
+ 	dwc3_gadget_ep_cleanup_completed_requests(dep, event, status);
+ 
+ 	if (stop) {
+diff --git a/drivers/usb/gadget/function/uvc.h b/drivers/usb/gadget/function/uvc.h
+index 93cf78b420fe..f63180f0effc 100644
+--- a/drivers/usb/gadget/function/uvc.h
++++ b/drivers/usb/gadget/function/uvc.h
+@@ -64,7 +64,7 @@ extern unsigned int uvc_gadget_trace_param;
+  * Driver specific constants
+  */
+ 
+-#define UVC_NUM_REQUESTS			4
++#define UVC_NUM_REQUESTS			16
+ #define UVC_MAX_REQUEST_SIZE			64
+ #define UVC_MAX_EVENTS				4
+ 
+-- 
+2.21.0
+


### PR DESCRIPTION
dwc3 controller driver has issues with handling
isochronous data transfer. dwc3 should always request for
future frame from the UVC gadget. But, when an expired
frame is encountered, bus expiry error is seen and isoc
transfer is stopped. So, dwc3 driver should check for
frame number before kick starting the isoc data transfer.
Also, dwc3 should stop active transfer and restart the
request if it is queued too late. This was tested in KBL.

Tracked-On: OAM-90903
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>