### PR TITLE
Performance Optimizations in ART Module

### DIFF
--- a/aosp_diff/caas/art/0001-Enabled-AVX2-and-FMA-compiler-Flags-for-libart-modul.patch
+++ b/aosp_diff/caas/art/0001-Enabled-AVX2-and-FMA-compiler-Flags-for-libart-modul.patch
@@ -1,0 +1,61 @@
+From 3b625824089c27a64308feb41d7cdcaf37af79fd Mon Sep 17 00:00:00 2001
+From: bodapati <shalini.salomi.bodapati@intel.com>
+Date: Tue, 5 May 2020 21:00:15 +0530
+Subject: [PATCH] Enabled AVX2 and FMA compiler Flags for libart module.
+
+Performance Impact:
+10-12% Launch Time performance improvement for top ranked apps
+13-15% Cold Launch Time performance improvement for Top Ranked Education Apps
+11-14% Warm Launch Time performance improvement for Top Ranked Education Apps
+
+Test: run-test gtest
+
+Tracked-On: https://jira.devtools.intel.com/browse/OAM-90793
+Change-Id: I36ba4a19082980c859044617a5ef5a76ba8936e0
+Signed-off-by: bodapati <shalini.salomi.bodapati@intel.com>
+---
+ build/Android.bp | 21 ++++++++++++++++++++-
+ 1 file changed, 20 insertions(+), 1 deletion(-)
+
+diff --git a/build/Android.bp b/build/Android.bp
+index 7b807d5..aecfadd 100644
+--- a/build/Android.bp
++++ b/build/Android.bp
+@@ -23,7 +23,7 @@ art_clang_tidy_errors = [
+     "android-cloexec-open",
+     "bugprone-argument-comment",
+     "bugprone-lambda-function-name",
+-    "bugprone-unused-raii",  // Protect scoped things like MutexLock.
++    "bugprone-unused-raii", // Protect scoped things like MutexLock.
+     "bugprone-unused-return-value",
+     "bugprone-virtual-near-miss",
+     "modernize-use-bool-literals",
+@@ -108,6 +108,25 @@ art_global_defaults {
+         "-D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS",
+     ],
+ 
++    arch: {
++        x86: {
++            avx2: {
++                cflags: [
++                    "-mavx2",
++                    "-mfma",
++                ],
++            },
++        },
++        x86_64: {
++            avx2: {
++                cflags: [
++                    "-mavx2",
++                    "-mfma",
++                ],
++            },
++        },
++    },
++
+     target: {
+         android: {
+             cflags: [
+-- 
+2.7.4
+

--- a/aosp_diff/caas/art/0002-Patch-supports-Intel-R-AVX-AVX2-MOV-Instruction.patch
+++ b/aosp_diff/caas/art/0002-Patch-supports-Intel-R-AVX-AVX2-MOV-Instruction.patch
@@ -1,0 +1,2696 @@
+From c1d5fec6dc68a6e1af0ddfa031f22a0e283e6a61 Mon Sep 17 00:00:00 2001
+From: jaishank <jaishankar.rajendran@intel.com>
+Date: Fri, 8 Mar 2019 15:08:17 +0530
+Subject: [PATCH] Patch supports Intel(R) AVX/AVX2 MOV Instruction
+
+This patch enhances the existing ART-Compiler
+to generate Intel(R) AVX/AVX2 MOV Instructions for
+doing SIMD Operations on Intel(R) Architecture CPUs.
+It also provides the framework for AVX/AVX2 Instruction
+encoding and dissassembly
+
+BUG: 127881558
+Test: run-test gtest
+Change-Id: I9386aecc134941a2d907f9ec6b2d5522ec5ff8b5
+Signed-off-by: bodapati <shalini.salomi.bodapati@intel.com>
+---
+ compiler/optimizing/code_generator_x86.cc       |   1 +
+ compiler/utils/x86/assembler_x86.cc             | 659 ++++++++++++----
+ compiler/utils/x86/assembler_x86.h              |  49 +-
+ compiler/utils/x86/assembler_x86_test.cc        |  72 ++
+ compiler/utils/x86_64/assembler_x86_64.cc       | 976 +++++++++++++++++++++---
+ compiler/utils/x86_64/assembler_x86_64.h        |  49 +-
+ compiler/utils/x86_64/assembler_x86_64_test.cc  |  73 ++
+ disassembler/disassembler_x86.cc                |  21 +-
+ runtime/arch/x86/instruction_set_features_x86.h |  22 +
+ 9 files changed, 1646 insertions(+), 276 deletions(-)
+
+diff --git a/compiler/optimizing/code_generator_x86.cc b/compiler/optimizing/code_generator_x86.cc
+index 95118b0..ca1723b 100644
+--- a/compiler/optimizing/code_generator_x86.cc
++++ b/compiler/optimizing/code_generator_x86.cc
+@@ -8236,6 +8236,7 @@ class JumpTableRIPFixup : public RIPFixup {
+ void CodeGeneratorX86::Finalize(CodeAllocator* allocator) {
+   // Generate the constant area if needed.
+   X86Assembler* assembler = GetAssembler();
++
+   if (!assembler->IsConstantAreaEmpty() || !fixups_to_jump_tables_.empty()) {
+     // Align to 4 byte boundary to reduce cache misses, as the data is 4 and 8
+     // byte values.
+diff --git a/compiler/utils/x86/assembler_x86.cc b/compiler/utils/x86/assembler_x86.cc
+index 4b073bd..01eb160 100644
+--- a/compiler/utils/x86/assembler_x86.cc
++++ b/compiler/utils/x86/assembler_x86.cc
+@@ -59,96 +59,11 @@ std::ostream& operator<<(std::ostream& os, const Address& addr) {
+   }
+ }
+ 
+-uint8_t X86Assembler::EmitVexByteZero(bool is_two_byte) {
+-  uint8_t vex_zero = 0xC0;
+-  if (!is_two_byte) {
+-    vex_zero |= 0xC4;
+-  } else {
+-    vex_zero |= 0xC5;
++bool X86Assembler::CpuHasAVXorAVX2FeatureFlag() {
++  if (has_AVX_ || has_AVX2_) {
++    return true;
+   }
+-  return vex_zero;
+-}
+-
+-uint8_t X86Assembler::EmitVexByte1(bool r, bool x, bool b, int mmmmm ) {
+-  // VEX Byte 1
+-  uint8_t vex_prefix = 0;
+-  if (!r) {
+-    vex_prefix |= 0x80;  // VEX.R
+-  }
+-  if (!x) {
+-    vex_prefix |= 0x40;  // VEX.X
+-  }
+-  if (!b) {
+-    vex_prefix |= 0x20;  // VEX.B
+-  }
+-
+-  // VEX.mmmmm
+-  switch (mmmmm) {
+-  case 1:
+-    // implied 0F leading opcode byte
+-    vex_prefix |= 0x01;
+-    break;
+-  case 2:
+-    // implied leading 0F 38 opcode byte
+-    vex_prefix |= 0x02;
+-    break;
+-  case 3:
+-    // implied leading OF 3A opcode byte
+-    vex_prefix |= 0x03;
+-    break;
+-  default:
+-    LOG(FATAL) << "unknown opcode bytes";
+-  }
+-  return vex_prefix;
+-}
+-
+-uint8_t X86Assembler::EmitVexByte2(bool w, int l, X86ManagedRegister operand, int pp) {
+-  uint8_t vex_prefix = 0;
+-  // VEX Byte 2
+-  if (w) {
+-    vex_prefix |= 0x80;
+-  }
+-  // VEX.vvvv
+-  if (operand.IsXmmRegister()) {
+-    XmmRegister vvvv = operand.AsXmmRegister();
+-    int inverted_reg = 15-static_cast<int>(vvvv);
+-    uint8_t reg = static_cast<uint8_t>(inverted_reg);
+-    vex_prefix |= ((reg & 0x0F) << 3);
+-  } else if (operand.IsCpuRegister()) {
+-    Register vvvv = operand.AsCpuRegister();
+-    int inverted_reg = 15 - static_cast<int>(vvvv);
+-    uint8_t reg = static_cast<uint8_t>(inverted_reg);
+-    vex_prefix |= ((reg & 0x0F) << 3);
+-  }
+-
+-  // VEX.L
+-  if (l == 256) {
+-    vex_prefix |= 0x04;
+-  }
+-
+-  // VEX.pp
+-  switch (pp) {
+-  case 0:
+-    // SIMD Pefix - None
+-    vex_prefix |= 0x00;
+-    break;
+-  case 1:
+-    // SIMD Prefix - 66
+-    vex_prefix |= 0x01;
+-    break;
+-  case 2:
+-    // SIMD Prefix - F3
+-    vex_prefix |= 0x02;
+-    break;
+-  case 3:
+-    // SIMD Prefix - F2
+-    vex_prefix |= 0x03;
+-    break;
+-  default:
+-    LOG(FATAL) << "unknown SIMD Prefix";
+-  }
+-
+-  return vex_prefix;
++  return false;
+ }
+ 
+ void X86Assembler::call(Register reg) {
+@@ -273,15 +188,11 @@ void X86Assembler::movntl(const Address& dst, Register src) {
+ 
+ void X86Assembler::blsi(Register dst, Register src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  uint8_t byte_zero = EmitVexByteZero(/*is_two_byte=*/ false);
+-  uint8_t byte_one = EmitVexByte1(/*r=*/ false,
+-                                  /*x=*/ false,
+-                                  /*b=*/ false,
+-                                  /*mmmmm=*/ 2);
+-  uint8_t byte_two = EmitVexByte2(/*w=*/ false,
+-                                  /*l=*/ 128,
+-                                  X86ManagedRegister::FromCpuRegister(dst),
+-                                  /*pp=*/ 0);
++  uint8_t byte_zero = EmitVexPrefixByteZero(false /*is_two_byte*/);
++  uint8_t byte_one  = EmitVexPrefixByteOne(false, false, false, SET_VEX_M_0F_38);
++  uint8_t byte_two  = EmitVexPrefixByteTwo(false,
++                                           X86ManagedRegister::FromCpuRegister(dst),
++                                            SET_VEX_L_128, SET_VEX_PP_NONE);
+   EmitUint8(byte_zero);
+   EmitUint8(byte_one);
+   EmitUint8(byte_two);
+@@ -291,15 +202,11 @@ void X86Assembler::blsi(Register dst, Register src) {
+ 
+ void X86Assembler::blsmsk(Register dst, Register src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  uint8_t byte_zero = EmitVexByteZero(/*is_two_byte=*/ false);
+-  uint8_t byte_one = EmitVexByte1(/*r=*/ false,
+-                                  /*x=*/ false,
+-                                  /*b=*/ false,
+-                                  /*mmmmm=*/ 2);
+-  uint8_t byte_two = EmitVexByte2(/*w=*/ false,
+-                                  /*l=*/ 128,
+-                                  X86ManagedRegister::FromCpuRegister(dst),
+-                                  /*pp=*/ 0);
++  uint8_t byte_zero = EmitVexPrefixByteZero(false /*is_two_byte*/);
++  uint8_t byte_one = EmitVexPrefixByteOne(false, false, false, SET_VEX_M_0F_38);
++  uint8_t byte_two = EmitVexPrefixByteTwo(false,
++                                         X86ManagedRegister::FromCpuRegister(dst),
++                                         SET_VEX_L_128, SET_VEX_PP_NONE);
+   EmitUint8(byte_zero);
+   EmitUint8(byte_one);
+   EmitUint8(byte_two);
+@@ -309,15 +216,11 @@ void X86Assembler::blsmsk(Register dst, Register src) {
+ 
+ void X86Assembler::blsr(Register dst, Register src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  uint8_t byte_zero = EmitVexByteZero(/*is_two_byte=*/ false);
+-  uint8_t byte_one = EmitVexByte1(/*r=*/ false,
+-                                  /*x=*/ false,
+-                                  /*b=*/ false,
+-                                  /*mmmmm=*/ 2);
+-  uint8_t byte_two = EmitVexByte2(/*w=*/ false,
+-                                  /*l=*/ 128,
+-                                  X86ManagedRegister::FromCpuRegister(dst),
+-                                  /*pp=*/ 0);
++  uint8_t byte_zero = EmitVexPrefixByteZero(false /*is_two_byte*/);
++  uint8_t byte_one = EmitVexPrefixByteOne(false, false, false,  SET_VEX_M_0F_38);
++  uint8_t byte_two = EmitVexPrefixByteTwo(false,
++                                          X86ManagedRegister::FromCpuRegister(dst),
++                                          SET_VEX_L_128, SET_VEX_PP_NONE);
+   EmitUint8(byte_zero);
+   EmitUint8(byte_one);
+   EmitUint8(byte_two);
+@@ -516,44 +419,165 @@ void X86Assembler::setb(Condition condition, Register dst) {
+ 
+ 
+ void X86Assembler::movaps(XmmRegister dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovaps(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x0F);
+   EmitUint8(0x28);
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++/**VEX.128.0F.WIG 28 /r VMOVAPS xmm1, xmm2*/
++void X86Assembler::vmovaps(XmmRegister dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  /**Instruction VEX Prefix*/
++  uint8_t byte_zero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
++  /**a REX prefix is necessary only if an instruction references one of the
++  extended registers or uses a 64-bit operand.*/
++  uint8_t byte_one = EmitVexPrefixByteOne(/**R = */false,
++                                          vvvv_reg,
++                                          SET_VEX_L_128,
++                                          SET_VEX_PP_NONE);
++  EmitUint8(byte_zero);
++  EmitUint8(byte_one);
++  /**Instruction Opcode*/
++  EmitUint8(0x28);
++  /**Instruction Operands*/
++  EmitXmmRegisterOperand(dst, src);
++}
+ 
+ void X86Assembler::movaps(XmmRegister dst, const Address& src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovaps(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x0F);
+   EmitUint8(0x28);
+   EmitOperand(dst, src);
+ }
+ 
++/**VEX.128.0F.WIG 28 /r VMOVAPS xmm1, m128*/
++void X86Assembler::vmovaps(XmmRegister dst, const Address& src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  /**Instruction VEX Prefix*/
++  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
++  /**a REX prefix is necessary only if an instruction references one of the
++  extended registers or uses a 64-bit operand.*/
++  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++                                         vvvv_reg,
++                                         SET_VEX_L_128,
++                                         SET_VEX_PP_NONE);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  /**Instruction Opcode*/
++  EmitUint8(0x28);
++  /**Instruction Operands*/
++  EmitOperand(dst, src);
++}
+ 
+ void X86Assembler::movups(XmmRegister dst, const Address& src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovups(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x0F);
+   EmitUint8(0x10);
+   EmitOperand(dst, src);
+ }
+ 
++/**VEX.128.0F.WIG 10 /r VMOVUPS xmm1, m128*/
++void X86Assembler::vmovups(XmmRegister dst, const Address& src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  /**Instruction VEX Prefix*/
++  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
++  /**a REX prefix is necessary only if an instruction references one of the
++  extended registers or uses a 64-bit operand.*/
++  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++                                         vvvv_reg,
++                                         SET_VEX_L_128,
++                                         SET_VEX_PP_NONE);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  /*Instruction Opcode*/
++  EmitUint8(0x10);
++  /*Instruction Operands*/
++  EmitOperand(dst, src);
++}
+ 
+ void X86Assembler::movaps(const Address& dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovaps(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x0F);
+   EmitUint8(0x29);
+   EmitOperand(src, dst);
+ }
+ 
++/**VEX.128.0F.WIG 29 /r VMOVAPS m128, xmm1*/
++void X86Assembler::vmovaps(const Address& dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  /**Instruction VEX Prefix*/
++  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
++  /**a REX prefix is necessary only if an instruction references one of the
++  extended registers or uses a 64-bit operand.*/
++  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++                                         vvvv_reg,
++                                         SET_VEX_L_128,
++                                         SET_VEX_PP_NONE);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  /**Instruction Opcode*/
++  EmitUint8(0x29);
++  /**Instruction Operands*/
++  EmitOperand(src, dst);
++}
+ 
+ void X86Assembler::movups(const Address& dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovups(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x0F);
+   EmitUint8(0x11);
+   EmitOperand(src, dst);
+ }
+ 
++/**VEX.128.0F.WIG 11 /r VMOVUPS m128, xmm1*/
++void X86Assembler::vmovups(const Address& dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  /**Instruction VEX Prefix*/
++  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
++  /**a REX prefix is necessary only if an instruction references one of the
++  extended registers or uses a 64-bit operand.*/
++  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++                                         vvvv_reg,
++                                         SET_VEX_L_128,
++                                         SET_VEX_PP_NONE);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x11);
++  // Instruction Operands
++  EmitOperand(src, dst);
++}
++
+ 
+ void X86Assembler::movss(XmmRegister dst, const Address& src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -705,6 +729,10 @@ void X86Assembler::divps(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86Assembler::movapd(XmmRegister dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovapd(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitUint8(0x0F);
+@@ -712,8 +740,32 @@ void X86Assembler::movapd(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++/**VEX.128.66.0F.WIG 28 /r VMOVAPD xmm1, xmm2*/
++void X86Assembler::vmovapd(XmmRegister dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  /**Instruction VEX Prefix*/
++  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
++  /**a REX prefix is necessary only if an instruction references one of the
++  extended registers or uses a 64-bit operand.*/
++  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++                                         vvvv_reg ,
++                                         SET_VEX_L_128,
++                                         SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x28);
++  // Instruction Operands
++  EmitXmmRegisterOperand(dst, src);
++}
+ 
+ void X86Assembler::movapd(XmmRegister dst, const Address& src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovapd(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitUint8(0x0F);
+@@ -721,8 +773,32 @@ void X86Assembler::movapd(XmmRegister dst, const Address& src) {
+   EmitOperand(dst, src);
+ }
+ 
++/**VEX.128.66.0F.WIG 28 /r VMOVAPD xmm1, m128*/
++void X86Assembler::vmovapd(XmmRegister dst, const Address& src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  /**Instruction VEX Prefix*/
++  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
++  /**a REX prefix is necessary only if an instruction references one of the
++  extended registers or uses a 64-bit operand.*/
++  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++                                         vvvv_reg,
++                                         SET_VEX_L_128,
++                                         SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x28);
++  // Instruction Operands
++  EmitOperand(dst, src);
++}
+ 
+ void X86Assembler::movupd(XmmRegister dst, const Address& src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovupd(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitUint8(0x0F);
+@@ -730,8 +806,33 @@ void X86Assembler::movupd(XmmRegister dst, const Address& src) {
+   EmitOperand(dst, src);
+ }
+ 
++/**VEX.128.66.0F.WIG 10 /r VMOVUPD xmm1, m128*/
++void X86Assembler::vmovupd(XmmRegister dst, const Address& src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  /**Instruction VEX Prefix*/
++  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
++  /**a REX prefix is necessary only if an instruction references one of the
++  extended registers or uses a 64-bit operand.*/
++  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++                                         vvvv_reg,
++                                         SET_VEX_L_128,
++                                         SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x10);
++  // Instruction Operands
++  EmitOperand(dst, src);
++}
++
+ 
+ void X86Assembler::movapd(const Address& dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovapd(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitUint8(0x0F);
+@@ -739,8 +840,32 @@ void X86Assembler::movapd(const Address& dst, XmmRegister src) {
+   EmitOperand(src, dst);
+ }
+ 
++/**VEX.128.66.0F.WIG 29 /r VMOVAPD m128, xmm1 */
++void X86Assembler::vmovapd(const Address& dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  /**Instruction VEX Prefix */
++  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
++  /**a REX prefix is necessary only if an instruction references one of the
++  extended registers or uses a 64-bit operand.*/
++  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++                                         vvvv_reg,
++                                         SET_VEX_L_128,
++                                         SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x29);
++  // Instruction Operands
++  EmitOperand(src, dst);
++}
+ 
+ void X86Assembler::movupd(const Address& dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovupd(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitUint8(0x0F);
+@@ -748,6 +873,26 @@ void X86Assembler::movupd(const Address& dst, XmmRegister src) {
+   EmitOperand(src, dst);
+ }
+ 
++/**VEX.128.66.0F.WIG 11 /r VMOVUPD m128, xmm1 */
++void X86Assembler::vmovupd(const Address& dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  /**Instruction VEX Prefix */
++  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
++  /**a REX prefix is necessary only if an instruction references one of the
++  extended registers or uses a 64-bit operand.**/
++  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++                                         vvvv_reg,
++                                         SET_VEX_L_128,
++                                         SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x11);
++  // Instruction Operands
++  EmitOperand(src, dst);
++}
+ 
+ void X86Assembler::flds(const Address& src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -924,6 +1069,10 @@ void X86Assembler::divpd(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86Assembler::movdqa(XmmRegister dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovdqa(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitUint8(0x0F);
+@@ -931,8 +1080,30 @@ void X86Assembler::movdqa(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++/**VEX.128.66.0F.WIG 6F /r VMOVDQA xmm1, xmm2 */
++void X86Assembler::vmovdqa(XmmRegister dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  /**Instruction VEX Prefix */
++  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
++  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++                                         vvvv_reg,
++                                         SET_VEX_L_128,
++                                         SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x6F);
++  // Instruction Operands
++  EmitXmmRegisterOperand(dst, src);
++}
+ 
+ void X86Assembler::movdqa(XmmRegister dst, const Address& src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovdqa(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitUint8(0x0F);
+@@ -940,8 +1111,30 @@ void X86Assembler::movdqa(XmmRegister dst, const Address& src) {
+   EmitOperand(dst, src);
+ }
+ 
++/**VEX.128.66.0F.WIG 6F /r VMOVDQA xmm1, m128 */
++void X86Assembler::vmovdqa(XmmRegister dst, const Address& src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  /**Instruction VEX Prefix */
++  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
++  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++                                         vvvv_reg,
++                                         SET_VEX_L_128,
++                                         SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x6F);
++  // Instruction Operands
++  EmitOperand(dst, src);
++}
+ 
+ void X86Assembler::movdqu(XmmRegister dst, const Address& src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovdqu(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0xF3);
+   EmitUint8(0x0F);
+@@ -949,8 +1142,30 @@ void X86Assembler::movdqu(XmmRegister dst, const Address& src) {
+   EmitOperand(dst, src);
+ }
+ 
++/**VEX.128.F3.0F.WIG 6F /r VMOVDQU xmm1, m128 */
++void X86Assembler::vmovdqu(XmmRegister dst, const Address& src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  /**Instruction VEX Prefix */
++  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
++  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++                                         vvvv_reg,
++                                         SET_VEX_L_128,
++                                         SET_VEX_PP_F3);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x6F);
++  // Instruction Operands
++  EmitOperand(dst, src);
++}
+ 
+ void X86Assembler::movdqa(const Address& dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovdqa(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitUint8(0x0F);
+@@ -958,8 +1173,31 @@ void X86Assembler::movdqa(const Address& dst, XmmRegister src) {
+   EmitOperand(src, dst);
+ }
+ 
++/**VEX.128.66.0F.WIG 7F /r VMOVDQA m128, xmm1 */
++void X86Assembler::vmovdqa(const Address& dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  /**Instruction VEX Prefix */
++  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
++  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++                                         vvvv_reg,
++                                         SET_VEX_L_128,
++                                         SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x7F);
++  // Instruction Operands
++  EmitOperand(src, dst);
++}
++
+ 
+ void X86Assembler::movdqu(const Address& dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovdqu(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0xF3);
+   EmitUint8(0x0F);
+@@ -967,6 +1205,24 @@ void X86Assembler::movdqu(const Address& dst, XmmRegister src) {
+   EmitOperand(src, dst);
+ }
+ 
++/**VEX.128.F3.0F.WIG 7F /r VMOVDQU m128, xmm1 */
++void X86Assembler::vmovdqu(const Address& dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  // Instruction VEX Prefix
++  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
++  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++                                         vvvv_reg,
++                                         SET_VEX_L_128,
++                                         SET_VEX_PP_F3);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x7F);
++  // Instruction Operands
++  EmitOperand(src, dst);
++}
+ 
+ void X86Assembler::paddb(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1413,24 +1669,7 @@ void X86Assembler::pand(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
+-void X86Assembler::andn(Register dst, Register src1, Register src2) {
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  uint8_t byte_zero = EmitVexByteZero(/*is_two_byte=*/ false);
+-  uint8_t byte_one = EmitVexByte1(/*r=*/ false,
+-                                  /*x=*/ false,
+-                                  /*b=*/ false,
+-                                  /*mmmmm=*/ 2);
+-  uint8_t byte_two = EmitVexByte2(/*w=*/ false,
+-                                  /*l=*/ 128,
+-                                  X86ManagedRegister::FromCpuRegister(src1),
+-                                  /*pp=*/ 0);
+-  EmitUint8(byte_zero);
+-  EmitUint8(byte_one);
+-  EmitUint8(byte_two);
+-  // Opcode field
+-  EmitUint8(0xF2);
+-  EmitRegisterOperand(dst, src2);
+-}
++
+ 
+ 
+ void X86Assembler::andnpd(XmmRegister dst, XmmRegister src) {
+@@ -1475,6 +1714,24 @@ void X86Assembler::orps(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++void X86Assembler::andn(Register dst, Register src1, Register src2) {
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t byte_zero = EmitVexPrefixByteZero(/**is_twobyte_form= */false);
++  uint8_t byte_one = EmitVexPrefixByteOne(/**R = */false,
++                                          /**X = */false,
++                                          /**B = */false,
++                                          SET_VEX_M_0F_38);
++  uint8_t byte_two = EmitVexPrefixByteTwo(/**W= */false,
++                                          X86ManagedRegister::FromCpuRegister(src1),
++                                          SET_VEX_L_128,
++                                          SET_VEX_PP_NONE);
++  EmitUint8(byte_zero);
++  EmitUint8(byte_one);
++  EmitUint8(byte_two);
++  // Opcode field
++  EmitUint8(0xF2);
++  EmitRegisterOperand(dst, src2);
++}
+ 
+ void X86Assembler::por(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -3143,5 +3400,139 @@ size_t ConstantArea::AddFloat(float v) {
+   return AddInt32(bit_cast<int32_t, float>(v));
+ }
+ 
++uint8_t X86Assembler::EmitVexPrefixByteZero(bool is_twobyte_form) {
++  /**Vex Byte 0,
++  Bits [7:0] must contain the value 11000101b (0xC5) for 2-byte Vex
++  Bits [7:0] must contain the value 11000100b (0xC4) for 3-byte Vex */
++  uint8_t vex_prefix = 0xC0;
++  if (is_twobyte_form) {
++    // 2-Byte Vex
++    vex_prefix |= TWO_BYTE_VEX;
++  } else {
++    // 3-Byte Vex
++    vex_prefix |= THREE_BYTE_VEX;
++  }
++  return vex_prefix;
++}
++
++uint8_t X86Assembler::EmitVexPrefixByteOne(bool R,
++                                           bool X,
++                                           bool B,
++                                           int SET_VEX_M) {
++  /**Vex Byte 1, */
++  uint8_t vex_prefix = VEX_INIT;
++  /** Bit[7] This bit needs to be set to '1'
++  otherwise the instruction is LES or LDS */
++  if (!R) {
++    // R .
++    vex_prefix |= SET_VEX_R;
++  }
++  /** Bit[6] This bit needs to be set to '1'
++  otherwise the instruction is LES or LDS */
++  if (!X) {
++    // X .
++    vex_prefix |= SET_VEX_X;
++  }
++  /** Bit[5] This bit needs to be set to '1' */
++  if (!B) {
++    // B .
++    vex_prefix |= SET_VEX_B;
++  }
++  /** Bits[4:0], */
++  vex_prefix |= SET_VEX_M;
++  return vex_prefix;
++}
++
++uint8_t X86Assembler::EmitVexPrefixByteOne(bool R,
++                                           X86ManagedRegister operand,
++                                           int SET_VEX_L,
++                                           int SET_VEX_PP) {
++  /**Vex Byte 1, */
++  uint8_t vex_prefix = VEX_INIT;
++  /** Bit[7] This bit needs to be set to '1'
++  otherwise the instruction is LES or LDS */
++  if (!R) {
++    // R .
++    vex_prefix |= SET_VEX_R;
++  }
++  /**Bits[6:3] - 'vvvv' the source or dest register specifier */
++  if (operand.IsNoRegister()) {
++    vex_prefix |= 0x78;
++  } else if (operand.IsXmmRegister()) {
++    XmmRegister vvvv = operand.AsXmmRegister();
++    int inverted_reg = 15 - static_cast<int>(vvvv);
++    uint8_t reg = static_cast<uint8_t>(inverted_reg);
++    vex_prefix |= ((reg & 0x0F) << 3);
++  } else if (operand.IsCpuRegister()) {
++    Register vvvv = operand.AsCpuRegister();
++    int inverted_reg = 15 - static_cast<int>(vvvv);
++    uint8_t reg = static_cast<uint8_t>(inverted_reg);
++    vex_prefix |= ((reg & 0x0F) << 3);
++  }
++  /** Bit[2] - "L" If VEX.L = 1 indicates 256-bit vector operation ,
++  VEX.L = 0 indicates 128 bit vector operation */
++  vex_prefix |= SET_VEX_L;
++  /** Bits[1:0] -  "pp" */
++  vex_prefix |= SET_VEX_PP;
++  return vex_prefix;
++}
++
++uint8_t X86Assembler::EmitVexPrefixByteTwo(bool W,
++                                           X86ManagedRegister operand,
++                                           int SET_VEX_L,
++                                           int SET_VEX_PP) {
++  /** Vex Byte 2, */
++  uint8_t vex_prefix = VEX_INIT;
++  /** Bit[7] This bits needs to be set to '1' with default value.
++  When using C4H form of VEX prefix, W value is ignored */
++  if (W) {
++    vex_prefix |= SET_VEX_W;
++  }
++  /** Bits[6:3] - 'vvvv' the source or dest register specifier */
++  if (operand.IsXmmRegister()) {
++    XmmRegister vvvv = operand.AsXmmRegister();
++    int inverted_reg = 15 - static_cast<int>(vvvv);
++    uint8_t reg = static_cast<uint8_t>(inverted_reg);
++    vex_prefix |= ((reg & 0x0F) << 3);
++  } else if (operand.IsCpuRegister()) {
++    Register vvvv = operand.AsCpuRegister();
++    int inverted_reg = 15 - static_cast<int>(vvvv);
++    uint8_t reg = static_cast<uint8_t>(inverted_reg);
++    vex_prefix |= ((reg & 0x0F) << 3);
++  }
++  /** Bit[2] - "L" If VEX.L = 1 indicates 256-bit vector operation ,
++  VEX.L = 0 indicates 128 bit vector operation */
++  vex_prefix |= SET_VEX_L;
++  // Bits[1:0] -  "pp"
++  vex_prefix |= SET_VEX_PP;
++  return vex_prefix;
++}
++
++uint8_t X86Assembler::EmitVexPrefixByteTwo(bool W,
++                                           int SET_VEX_L,
++                                           int SET_VEX_PP) {
++  /**Vex Byte 2, */
++  uint8_t vex_prefix = VEX_INIT;
++
++  /** Bit[7] This bits needs to be set to '1' with default value.
++  When using C4H form of VEX prefix, W value is ignored */
++  if (W) {
++    vex_prefix |= SET_VEX_W;
++  }
++  /** Bits[6:3] - 'vvvv' the source or dest register specifier,
++  if unused set 1111 */
++  vex_prefix |= (0x0F << 3);
++
++  /** Bit[2] - "L" If VEX.L = 1 indicates 256-bit vector operation ,
++  VEX.L = 0 indicates 128 bit vector operation */
++  vex_prefix |= SET_VEX_L;
++
++  /** Bits[1:0] -  "pp" */
++  if (SET_VEX_PP != SET_VEX_PP_NONE) {
++    vex_prefix |= SET_VEX_PP;
++  }
++  return vex_prefix;
++}
++
+ }  // namespace x86
+ }  // namespace art
+diff --git a/compiler/utils/x86/assembler_x86.h b/compiler/utils/x86/assembler_x86.h
+index 275e5c1..e84294a 100644
+--- a/compiler/utils/x86/assembler_x86.h
++++ b/compiler/utils/x86/assembler_x86.h
+@@ -19,6 +19,7 @@
+ 
+ #include <vector>
+ 
++#include "arch/x86/instruction_set_features_x86.h"
+ #include "base/arena_containers.h"
+ #include "base/array_ref.h"
+ #include "base/bit_utils.h"
+@@ -308,8 +309,12 @@ class ConstantArea {
+ 
+ class X86Assembler final : public Assembler {
+  public:
+-  explicit X86Assembler(ArenaAllocator* allocator)
+-      : Assembler(allocator), constant_area_(allocator) {}
++  explicit X86Assembler(ArenaAllocator* allocator,
++                        const X86InstructionSetFeatures* instruction_set_features = nullptr)
++                : Assembler(allocator),
++                  constant_area_(allocator),
++                  has_AVX_(instruction_set_features != nullptr ? instruction_set_features->HasAVX() : false),
++                  has_AVX2_(instruction_set_features != nullptr ? instruction_set_features->HasAVX2() :false) {}
+   virtual ~X86Assembler() {}
+ 
+   /*
+@@ -385,6 +390,12 @@ class X86Assembler final : public Assembler {
+   void movaps(const Address& dst, XmmRegister src);  // store aligned
+   void movups(const Address& dst, XmmRegister src);  // store unaligned
+ 
++  void vmovaps(XmmRegister dst, XmmRegister src);     // move
++  void vmovaps(XmmRegister dst, const Address& src);  // load aligned
++  void vmovups(XmmRegister dst, const Address& src);  // load unaligned
++  void vmovaps(const Address& dst, XmmRegister src);  // store aligned
++  void vmovups(const Address& dst, XmmRegister src);  // store unaligned
++
+   void movss(XmmRegister dst, const Address& src);
+   void movss(const Address& dst, XmmRegister src);
+   void movss(XmmRegister dst, XmmRegister src);
+@@ -412,6 +423,12 @@ class X86Assembler final : public Assembler {
+   void movapd(const Address& dst, XmmRegister src);  // store aligned
+   void movupd(const Address& dst, XmmRegister src);  // store unaligned
+ 
++  void vmovapd(XmmRegister dst, XmmRegister src);     // move
++  void vmovapd(XmmRegister dst, const Address& src);  // load aligned
++  void vmovupd(XmmRegister dst, const Address& src);  // load unaligned
++  void vmovapd(const Address& dst, XmmRegister src);  // store aligned
++  void vmovupd(const Address& dst, XmmRegister src);  // store unaligned
++
+   void movsd(XmmRegister dst, const Address& src);
+   void movsd(const Address& dst, XmmRegister src);
+   void movsd(XmmRegister dst, XmmRegister src);
+@@ -439,6 +456,12 @@ class X86Assembler final : public Assembler {
+   void movdqa(const Address& dst, XmmRegister src);  // store aligned
+   void movdqu(const Address& dst, XmmRegister src);  // store unaligned
+ 
++  void vmovdqa(XmmRegister dst, XmmRegister src);     // move
++  void vmovdqa(XmmRegister dst, const Address& src);  // load aligned
++  void vmovdqu(XmmRegister dst, const Address& src);  // load unaligned
++  void vmovdqa(const Address& dst, XmmRegister src);  // store aligned
++  void vmovdqu(const Address& dst, XmmRegister src);  // store unaligned
++
+   void paddb(XmmRegister dst, XmmRegister src);  // no addr variant (for now)
+   void psubb(XmmRegister dst, XmmRegister src);
+ 
+@@ -823,6 +846,8 @@ class X86Assembler final : public Assembler {
+   // Return the current size of the constant area.
+   size_t ConstantAreaSize() const { return constant_area_.GetSize(); }
+ 
++  bool CpuHasAVXorAVX2FeatureFlag();
++
+  private:
+   inline void EmitUint8(uint8_t value);
+   inline void EmitInt32(int32_t value);
+@@ -842,12 +867,22 @@ class X86Assembler final : public Assembler {
+   void EmitGenericShift(int rm, const Operand& operand, const Immediate& imm);
+   void EmitGenericShift(int rm, const Operand& operand, Register shifter);
+ 
+-  // Emit a 3 byte VEX Prefix
+-  uint8_t EmitVexByteZero(bool is_two_byte);
+-  uint8_t EmitVexByte1(bool r, bool x, bool b, int mmmmm);
+-  uint8_t EmitVexByte2(bool w , int l , X86ManagedRegister operand, int pp);
+-
++  uint8_t EmitVexPrefixByteZero(bool is_twobyte_form);
++  uint8_t EmitVexPrefixByteOne(bool R, bool X, bool B, int SET_VEX_M);
++  uint8_t EmitVexPrefixByteOne(bool R,
++                               X86ManagedRegister operand,
++                               int SET_VEX_L,
++                               int SET_VEX_PP);
++  uint8_t EmitVexPrefixByteTwo(bool W,
++                               X86ManagedRegister operand,
++                               int SET_VEX_L,
++                               int SET_VEX_PP);
++  uint8_t EmitVexPrefixByteTwo(bool W,
++                               int SET_VEX_L,
++                               int SET_VEX_PP);
+   ConstantArea constant_area_;
++  bool has_AVX_;     // x86 256bit SIMD AVX.
++  bool has_AVX2_;    // x86 256bit SIMD AVX 2.0.
+ 
+   DISALLOW_COPY_AND_ASSIGN(X86Assembler);
+ };
+diff --git a/compiler/utils/x86/assembler_x86_test.cc b/compiler/utils/x86/assembler_x86_test.cc
+index 1d8bfe7..5197156 100644
+--- a/compiler/utils/x86/assembler_x86_test.cc
++++ b/compiler/utils/x86/assembler_x86_test.cc
+@@ -148,6 +148,18 @@ class AssemblerX86Test : public AssemblerTest<x86::X86Assembler,
+   std::vector<x86::XmmRegister*> fp_registers_;
+ };
+ 
++class AssemblerX86AVXTest : public AssemblerX86Test {
++ public:
++  AssemblerX86AVXTest()
++      : instruction_set_features_(X86InstructionSetFeatures::FromVariant("kabylake", nullptr)) {}
++ protected:
++  x86::X86Assembler* CreateAssembler(ArenaAllocator* allocator) override {
++  return new (allocator) x86::X86Assembler(allocator, instruction_set_features_.get());
++  }
++ private:
++  std::unique_ptr<const X86InstructionSetFeatures> instruction_set_features_;
++};
++
+ //
+ // Test some repeat drivers used in the tests.
+ //
+@@ -485,62 +497,122 @@ TEST_F(AssemblerX86Test, Movaps) {
+   DriverStr(RepeatFF(&x86::X86Assembler::movaps, "movaps %{reg2}, %{reg1}"), "movaps");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VMovaps) {
++  DriverStr(RepeatFF(&x86::X86Assembler::vmovaps, "vmovaps %{reg2}, %{reg1}"), "vmovaps");
++}
++
+ TEST_F(AssemblerX86Test, MovapsLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::movaps, "movaps {mem}, %{reg}"), "movaps_load");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VMovapsLoad) {
++  DriverStr(RepeatFA(&x86::X86Assembler::vmovaps, "vmovaps {mem}, %{reg}"), "vmovaps_load");
++}
++
+ TEST_F(AssemblerX86Test, MovapsStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::movaps, "movaps %{reg}, {mem}"), "movaps_store");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VMovapsStore) {
++  DriverStr(RepeatAF(&x86::X86Assembler::vmovaps, "vmovaps %{reg}, {mem}"), "vmovaps_store");
++}
++
+ TEST_F(AssemblerX86Test, MovupsLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::movups, "movups {mem}, %{reg}"), "movups_load");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VMovupsLoad) {
++  DriverStr(RepeatFA(&x86::X86Assembler::vmovups, "vmovups {mem}, %{reg}"), "vmovups_load");
++}
++
+ TEST_F(AssemblerX86Test, MovupsStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::movups, "movups %{reg}, {mem}"), "movups_store");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VMovupsStore) {
++  DriverStr(RepeatAF(&x86::X86Assembler::vmovups, "vmovups %{reg}, {mem}"), "vmovups_store");
++}
++
+ TEST_F(AssemblerX86Test, Movapd) {
+   DriverStr(RepeatFF(&x86::X86Assembler::movapd, "movapd %{reg2}, %{reg1}"), "movapd");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VMovapd) {
++  DriverStr(RepeatFF(&x86::X86Assembler::vmovapd, "vmovapd %{reg2}, %{reg1}"), "vmovapd");
++}
++
+ TEST_F(AssemblerX86Test, MovapdLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::movapd, "movapd {mem}, %{reg}"), "movapd_load");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VMovapdLoad) {
++  DriverStr(RepeatFA(&x86::X86Assembler::vmovapd, "vmovapd {mem}, %{reg}"), "vmovapd_load");
++}
++
+ TEST_F(AssemblerX86Test, MovapdStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::movapd, "movapd %{reg}, {mem}"), "movapd_store");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VMovapdStore) {
++  DriverStr(RepeatAF(&x86::X86Assembler::vmovapd, "vmovapd %{reg}, {mem}"), "vmovapd_store");
++}
++
+ TEST_F(AssemblerX86Test, MovupdLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::movupd, "movupd {mem}, %{reg}"), "movupd_load");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VMovupdLoad) {
++  DriverStr(RepeatFA(&x86::X86Assembler::vmovupd, "vmovupd {mem}, %{reg}"), "vmovupd_load");
++}
++
+ TEST_F(AssemblerX86Test, MovupdStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::movupd, "movupd %{reg}, {mem}"), "movupd_store");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VMovupdStore) {
++  DriverStr(RepeatAF(&x86::X86Assembler::vmovupd, "vmovupd %{reg}, {mem}"), "vmovupd_store");
++}
++
+ TEST_F(AssemblerX86Test, Movdqa) {
+   DriverStr(RepeatFF(&x86::X86Assembler::movdqa, "movdqa %{reg2}, %{reg1}"), "movdqa");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VMovdqa) {
++  DriverStr(RepeatFF(&x86::X86Assembler::vmovdqa, "vmovdqa %{reg2}, %{reg1}"), "vmovdqa");
++}
++
+ TEST_F(AssemblerX86Test, MovdqaLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::movdqa, "movdqa {mem}, %{reg}"), "movdqa_load");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VMovdqaLoad) {
++  DriverStr(RepeatFA(&x86::X86Assembler::vmovdqa, "vmovdqa {mem}, %{reg}"), "vmovdqa_load");
++}
++
+ TEST_F(AssemblerX86Test, MovdqaStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::movdqa, "movdqa %{reg}, {mem}"), "movdqa_store");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VMovdqaStore) {
++  DriverStr(RepeatAF(&x86::X86Assembler::vmovdqa, "vmovdqa %{reg}, {mem}"), "vmovdqa_store");
++}
++
+ TEST_F(AssemblerX86Test, MovdquLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::movdqu, "movdqu {mem}, %{reg}"), "movdqu_load");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VMovdquLoad) {
++  DriverStr(RepeatFA(&x86::X86Assembler::vmovdqu, "vmovdqu {mem}, %{reg}"), "vmovdqu_load");
++}
++
+ TEST_F(AssemblerX86Test, MovdquStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::movdqu, "movdqu %{reg}, {mem}"), "movdqu_store");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VMovdquStore) {
++  DriverStr(RepeatAF(&x86::X86Assembler::vmovdqu, "vmovdqu %{reg}, {mem}"), "vmovdqu_store");
++}
++
+ TEST_F(AssemblerX86Test, AddPS) {
+   DriverStr(RepeatFF(&x86::X86Assembler::addps, "addps %{reg2}, %{reg1}"), "addps");
+ }
+diff --git a/compiler/utils/x86_64/assembler_x86_64.cc b/compiler/utils/x86_64/assembler_x86_64.cc
+index c118bc6..c010a68 100644
+--- a/compiler/utils/x86_64/assembler_x86_64.cc
++++ b/compiler/utils/x86_64/assembler_x86_64.cc
+@@ -64,97 +64,11 @@ std::ostream& operator<<(std::ostream& os, const Address& addr) {
+   }
+ }
+ 
+-uint8_t X86_64Assembler::EmitVexByteZero(bool is_two_byte) {
+-  uint8_t vex_zero = 0xC0;
+-  if (!is_two_byte) {
+-    vex_zero |= 0xC4;
+-  } else {
+-    vex_zero |= 0xC5;
+-  }
+-  return vex_zero;
+-}
+-
+-uint8_t X86_64Assembler::EmitVexByte1(bool r, bool x, bool b, int mmmmm) {
+-  // VEX Byte 1
+-  uint8_t vex_prefix = 0;
+-  if (!r) {
+-    vex_prefix |= 0x80;  // VEX.R
+-  }
+-  if (!x) {
+-    vex_prefix |= 0x40;  // VEX.X
+-  }
+-  if (!b) {
+-    vex_prefix |= 0x20;  // VEX.B
+-  }
+-
+-  // VEX.mmmmm
+-  switch (mmmmm) {
+-  case 1:
+-    // implied 0F leading opcode byte
+-    vex_prefix |= 0x01;
+-    break;
+-  case 2:
+-    // implied leading 0F 38 opcode byte
+-    vex_prefix |= 0x02;
+-    break;
+-  case 3:
+-    // implied leading OF 3A opcode byte
+-    vex_prefix |= 0x03;
+-    break;
+-  default:
+-    LOG(FATAL) << "unknown opcode bytes";
++bool X86_64Assembler::CpuHasAVXorAVX2FeatureFlag() {
++  if (has_AVX_ || has_AVX2_) {
++    return true;
+   }
+-
+-  return vex_prefix;
+-}
+-
+-uint8_t X86_64Assembler::EmitVexByte2(bool w, int l, X86_64ManagedRegister operand, int pp) {
+-  // VEX Byte 2
+-  uint8_t vex_prefix = 0;
+-  if (w) {
+-    vex_prefix |= 0x80;
+-  }
+-  // VEX.vvvv
+-  if (operand.IsXmmRegister()) {
+-    XmmRegister vvvv = operand.AsXmmRegister();
+-    int inverted_reg = 15-static_cast<int>(vvvv.AsFloatRegister());
+-    uint8_t reg = static_cast<uint8_t>(inverted_reg);
+-    vex_prefix |= ((reg & 0x0F) << 3);
+-  } else if (operand.IsCpuRegister()) {
+-    CpuRegister vvvv = operand.AsCpuRegister();
+-    int inverted_reg = 15 - static_cast<int>(vvvv.AsRegister());
+-    uint8_t reg = static_cast<uint8_t>(inverted_reg);
+-    vex_prefix |= ((reg & 0x0F) << 3);
+-  }
+-
+-  // VEX.L
+-  if (l == 256) {
+-    vex_prefix |= 0x04;
+-  }
+-
+-  // VEX.pp
+-  switch (pp) {
+-  case 0:
+-    // SIMD Pefix - None
+-    vex_prefix |= 0x00;
+-    break;
+-  case 1:
+-    // SIMD Prefix - 66
+-    vex_prefix |= 0x01;
+-    break;
+-  case 2:
+-    // SIMD Prefix - F3
+-    vex_prefix |= 0x02;
+-    break;
+-  case 3:
+-    // SIMD Prefix - F2
+-    vex_prefix |= 0x03;
+-    break;
+-  default:
+-    LOG(FATAL) << "unknown SIMD Prefix";
+-  }
+-
+-  return vex_prefix;
++  return false;
+ }
+ 
+ void X86_64Assembler::call(CpuRegister reg) {
+@@ -499,6 +413,10 @@ void X86_64Assembler::leal(CpuRegister dst, const Address& src) {
+ 
+ 
+ void X86_64Assembler::movaps(XmmRegister dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovaps(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitOptionalRex32(dst, src);
+   EmitUint8(0x0F);
+@@ -507,7 +425,60 @@ void X86_64Assembler::movaps(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ 
++/**VEX.128.0F.WIG 28 /r VMOVAPS xmm1, xmm2 */
++void X86_64Assembler::vmovaps(XmmRegister dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  uint8_t byte_zero, byte_one, byte_two;
++  bool is_twobyte_form = true;
++  bool load = dst.NeedsRex();
++  bool store = !load;
++
++  if (src.NeedsRex()&& dst.NeedsRex()) {
++    is_twobyte_form = false;
++  }
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  // Instruction VEX Prefix
++  byte_zero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++  if (is_twobyte_form) {
++    bool rex_bit = (load) ? dst.NeedsRex() : src.NeedsRex();
++    byte_one = EmitVexPrefixByteOne(rex_bit,
++                                    vvvv_reg,
++                                    SET_VEX_L_128,
++                                    SET_VEX_PP_NONE);
++  } else {
++    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                    /** X= */false,
++                                    src.NeedsRex(),
++                                    SET_VEX_M_0F);
++    byte_two = EmitVexPrefixByteTwo(/**W= */false,
++                                    SET_VEX_L_128,
++                                    SET_VEX_PP_NONE);
++  }
++  EmitUint8(byte_zero);
++  EmitUint8(byte_one);
++  if (!is_twobyte_form) {
++    EmitUint8(byte_two);
++  }
++  // Instruction Opcode
++  if (is_twobyte_form && store) {
++    EmitUint8(0x29);
++  } else {
++    EmitUint8(0x28);
++  }
++  // Instruction Operands
++  if (is_twobyte_form && store) {
++    EmitXmmRegisterOperand(src.LowBits(), dst);
++  } else {
++    EmitXmmRegisterOperand(dst.LowBits(), src);
++  }
++}
++
+ void X86_64Assembler::movaps(XmmRegister dst, const Address& src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovaps(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitOptionalRex32(dst, src);
+   EmitUint8(0x0F);
+@@ -515,8 +486,51 @@ void X86_64Assembler::movaps(XmmRegister dst, const Address& src) {
+   EmitOperand(dst.LowBits(), src);
+ }
+ 
++/**VEX.128.0F.WIG 28 /r VMOVAPS xmm1, m128 */
++void X86_64Assembler::vmovaps(XmmRegister dst, const Address& src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero, ByteOne, ByteTwo;
++  bool is_twobyte_form = false;
++  // Instruction VEX Prefix
++  uint8_t rex = src.rex();
++  bool Rex_x = rex & GET_REX_X;
++  bool Rex_b = rex & GET_REX_B;
++  if (!Rex_b && !Rex_x) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   vvvv_reg,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_NONE);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   Rex_x,
++                                   Rex_b,
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_NONE);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  // Instruction Opcode
++  EmitUint8(0x28);
++  // Instruction Operands
++  EmitOperand(dst.LowBits(), src);
++}
+ 
+ void X86_64Assembler::movups(XmmRegister dst, const Address& src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovups(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitOptionalRex32(dst, src);
+   EmitUint8(0x0F);
+@@ -524,8 +538,52 @@ void X86_64Assembler::movups(XmmRegister dst, const Address& src) {
+   EmitOperand(dst.LowBits(), src);
+ }
+ 
++/** VEX.128.0F.WIG 10 /r VMOVUPS xmm1, m128 */
++void X86_64Assembler::vmovups(XmmRegister dst, const Address& src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero, ByteOne, ByteTwo;
++  bool is_twobyte_form = false;
++  // Instruction VEX Prefix
++  uint8_t rex = src.rex();
++  bool Rex_x = rex & GET_REX_X;
++  bool Rex_b = rex & GET_REX_B;
++  if (!Rex_x && !Rex_b) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   vvvv_reg,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_NONE);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   Rex_x,
++                                   Rex_b,
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_NONE);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  // Instruction Opcode
++  EmitUint8(0x10);
++  // Instruction Operands
++  EmitOperand(dst.LowBits(), src);
++}
++
+ 
+ void X86_64Assembler::movaps(const Address& dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovaps(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitOptionalRex32(src, dst);
+   EmitUint8(0x0F);
+@@ -533,8 +591,52 @@ void X86_64Assembler::movaps(const Address& dst, XmmRegister src) {
+   EmitOperand(src.LowBits(), dst);
+ }
+ 
++/** VEX.128.0F.WIG 29 /r VMOVAPS m128, xmm1 */
++void X86_64Assembler::vmovaps(const Address& dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero, ByteOne, ByteTwo;
++  bool is_twobyte_form = false;
++
++  // Instruction VEX Prefix
++  uint8_t rex = dst.rex();
++  bool Rex_x = rex & GET_REX_X;
++  bool Rex_b = rex & GET_REX_B;
++  if (!Rex_b && !Rex_x) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
++                                   vvvv_reg,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_NONE);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
++                                   Rex_x ,
++                                   Rex_b ,
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_NONE);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  // Instruction Opcode
++  EmitUint8(0x29);
++  // Instruction Operands
++  EmitOperand(src.LowBits(), dst);
++}
+ 
+ void X86_64Assembler::movups(const Address& dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovups(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitOptionalRex32(src, dst);
+   EmitUint8(0x0F);
+@@ -542,6 +644,47 @@ void X86_64Assembler::movups(const Address& dst, XmmRegister src) {
+   EmitOperand(src.LowBits(), dst);
+ }
+ 
++/** VEX.128.0F.WIG 11 /r VMOVUPS m128, xmm1 */
++void X86_64Assembler::vmovups(const Address& dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero, ByteOne, ByteTwo;
++  bool is_twobyte_form = false;
++
++  // Instruction VEX Prefix
++  uint8_t rex = dst.rex();
++  bool Rex_x = rex & GET_REX_X;
++  bool Rex_b = rex & GET_REX_B;
++  if (!Rex_b && !Rex_x) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
++                                   vvvv_reg,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_NONE);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
++                                   Rex_x,
++                                   Rex_b,
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_NONE);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  // Instruction Opcode
++  EmitUint8(0x11);
++  // Instruction Operands
++  EmitOperand(src.LowBits(), dst);
++}
++
+ 
+ void X86_64Assembler::movss(XmmRegister dst, const Address& src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -754,6 +897,10 @@ void X86_64Assembler::fstps(const Address& dst) {
+ 
+ 
+ void X86_64Assembler::movapd(XmmRegister dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovapd(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -762,8 +909,59 @@ void X86_64Assembler::movapd(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++/** VEX.128.66.0F.WIG 28 /r VMOVAPD xmm1, xmm2 */
++void X86_64Assembler::vmovapd(XmmRegister dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero, ByteOne, ByteTwo;
++  bool is_twobyte_form = true;
++
++  if (src.NeedsRex() && dst.NeedsRex()) {
++    is_twobyte_form = false;
++  }
++  // Instruction VEX Prefix
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  bool load = dst.NeedsRex();
++  if (is_twobyte_form) {
++    X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++    bool rex_bit = load ? dst.NeedsRex() : src.NeedsRex();
++    ByteOne = EmitVexPrefixByteOne(rex_bit,
++                                   vvvv_reg,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /**X = */false ,
++                                   src.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  // Instruction Opcode
++  if (is_twobyte_form && !load) {
++    EmitUint8(0x29);
++  } else {
++    EmitUint8(0x28);
++  }
++  // Instruction Operands
++  if (is_twobyte_form && !load) {
++    EmitXmmRegisterOperand(src.LowBits(), dst);
++  } else {
++    EmitXmmRegisterOperand(dst.LowBits(), src);
++  }
++}
+ 
+ void X86_64Assembler::movapd(XmmRegister dst, const Address& src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovapd(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -772,8 +970,52 @@ void X86_64Assembler::movapd(XmmRegister dst, const Address& src) {
+   EmitOperand(dst.LowBits(), src);
+ }
+ 
++/** VEX.128.66.0F.WIG 28 /r VMOVAPD xmm1, m128 */
++void X86_64Assembler::vmovapd(XmmRegister dst, const Address& src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero, ByteOne, ByteTwo;
++  bool is_twobyte_form = false;
++
++  // Instruction VEX Prefix
++  uint8_t rex = src.rex();
++  bool Rex_x = rex & GET_REX_X;
++  bool Rex_b = rex & GET_REX_B;
++  if (!Rex_b && !Rex_x) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   vvvv_reg,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   Rex_x,
++                                   Rex_b,
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  // Instruction Opcode
++  EmitUint8(0x28);
++  // Instruction Operands
++  EmitOperand(dst.LowBits(), src);
++}
+ 
+ void X86_64Assembler::movupd(XmmRegister dst, const Address& src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovupd(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -782,8 +1024,51 @@ void X86_64Assembler::movupd(XmmRegister dst, const Address& src) {
+   EmitOperand(dst.LowBits(), src);
+ }
+ 
++/** VEX.128.66.0F.WIG 10 /r VMOVUPD xmm1, m128 */
++void X86_64Assembler::vmovupd(XmmRegister dst, const Address& src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero, ByteOne, ByteTwo;
++
++  // Instruction VEX Prefix
++  uint8_t rex = src.rex();
++  bool Rex_x = rex & GET_REX_X;
++  bool Rex_b = rex & GET_REX_B;
++  if (!Rex_b && !Rex_x) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   vvvv_reg,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   Rex_x,
++                                   Rex_b,
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form)
++  EmitUint8(ByteTwo);
++  // Instruction Opcode
++  EmitUint8(0x10);
++  // Instruction Operands
++  EmitOperand(dst.LowBits(), src);
++}
+ 
+ void X86_64Assembler::movapd(const Address& dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovapd(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(src, dst);
+@@ -792,8 +1077,51 @@ void X86_64Assembler::movapd(const Address& dst, XmmRegister src) {
+   EmitOperand(src.LowBits(), dst);
+ }
+ 
++/** VEX.128.66.0F.WIG 29 /r VMOVAPD m128, xmm1 */
++void X86_64Assembler::vmovapd(const Address& dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero, ByteOne, ByteTwo;
++  // Instruction VEX Prefix
++  uint8_t rex = dst.rex();
++  bool Rex_x = rex & GET_REX_X;
++  bool Rex_b = rex & GET_REX_B;
++  if (!Rex_x && !Rex_b) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
++                                   vvvv_reg,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
++                                   Rex_x,
++                                   Rex_b,
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  // Instruction Opcode
++  EmitUint8(0x29);
++  // Instruction Operands
++  EmitOperand(src.LowBits(), dst);
++}
+ 
+ void X86_64Assembler::movupd(const Address& dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovupd(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(src, dst);
+@@ -802,6 +1130,47 @@ void X86_64Assembler::movupd(const Address& dst, XmmRegister src) {
+   EmitOperand(src.LowBits(), dst);
+ }
+ 
++/** VEX.128.66.0F.WIG 11 /r VMOVUPD m128, xmm1 */
++void X86_64Assembler::vmovupd(const Address& dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero, ByteOne, ByteTwo;
++
++  // Instruction VEX Prefix
++  uint8_t rex = dst.rex();
++  bool Rex_x = rex & GET_REX_X;
++  bool Rex_b = rex & GET_REX_B;
++  if (!Rex_x && !Rex_b) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
++                                   vvvv_reg,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
++                                   Rex_x,
++                                   Rex_b,
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  // Instruction Opcode
++  EmitUint8(0x11);
++  // Instruction Operands
++  EmitOperand(src.LowBits(), dst);
++}
++
+ 
+ void X86_64Assembler::movsd(XmmRegister dst, const Address& src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -954,6 +1323,10 @@ void X86_64Assembler::divpd(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::movdqa(XmmRegister dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovdqa(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -962,8 +1335,59 @@ void X86_64Assembler::movdqa(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++/** VEX.128.66.0F.WIG 6F /r VMOVDQA xmm1, xmm2 */
++void X86_64Assembler::vmovdqa(XmmRegister dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero, ByteOne, ByteTwo;
++  bool is_twobyte_form = true;
++
++  // Instruction VEX Prefix
++  if (src.NeedsRex() && dst.NeedsRex()) {
++    is_twobyte_form = false;
++  }
++  bool load = dst.NeedsRex();
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++    bool rex_bit = load ? dst.NeedsRex() : src.NeedsRex();
++    ByteOne = EmitVexPrefixByteOne(rex_bit,
++                                   vvvv_reg,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /**X = */false,
++                                   src.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  // Instruction Opcode
++  if (is_twobyte_form && !load) {
++    EmitUint8(0x7F);
++  } else {
++    EmitUint8(0x6F);
++  }
++  // Instruction Operands
++  if (is_twobyte_form && !load) {
++    EmitXmmRegisterOperand(src.LowBits(), dst);
++  } else {
++    EmitXmmRegisterOperand(dst.LowBits(), src);
++  }
++}
+ 
+ void X86_64Assembler::movdqa(XmmRegister dst, const Address& src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovdqa(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -972,8 +1396,52 @@ void X86_64Assembler::movdqa(XmmRegister dst, const Address& src) {
+   EmitOperand(dst.LowBits(), src);
+ }
+ 
++/** VEX.128.66.0F.WIG 6F /r VMOVDQA xmm1, m128 */
++void X86_64Assembler::vmovdqa(XmmRegister dst, const Address& src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t  ByteZero, ByteOne, ByteTwo;
++  bool is_twobyte_form = false;
++
++  // Instruction VEX Prefix
++  uint8_t rex = src.rex();
++  bool Rex_x = rex & GET_REX_X;
++  bool Rex_b = rex & GET_REX_B;
++  if (!Rex_x && !Rex_b) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   vvvv_reg,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   Rex_x,
++                                   Rex_b,
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  // Instruction Opcode
++  EmitUint8(0x6F);
++  // Instruction Operands
++  EmitOperand(dst.LowBits(), src);
++}
+ 
+ void X86_64Assembler::movdqu(XmmRegister dst, const Address& src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovdqu(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0xF3);
+   EmitOptionalRex32(dst, src);
+@@ -982,8 +1450,53 @@ void X86_64Assembler::movdqu(XmmRegister dst, const Address& src) {
+   EmitOperand(dst.LowBits(), src);
+ }
+ 
++/** VEX.128.F3.0F.WIG 6F /r VMOVDQU xmm1, m128
++Load Unaligned */
++void X86_64Assembler::vmovdqu(XmmRegister dst, const Address& src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero, ByteOne, ByteTwo;
++  bool is_twobyte_form = false;
++
++  // Instruction VEX Prefix
++  uint8_t rex = src.rex();
++  bool Rex_x = rex & GET_REX_X;
++  bool Rex_b = rex & GET_REX_B;
++  if (!Rex_x && !Rex_b) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   vvvv_reg,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_F3);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   Rex_x,
++                                   Rex_b,
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_F3);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  // Instruction Opcode
++  EmitUint8(0x6F);
++  // Instruction Operands
++  EmitOperand(dst.LowBits(), src);
++}
+ 
+ void X86_64Assembler::movdqa(const Address& dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovdqa(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(src, dst);
+@@ -992,8 +1505,51 @@ void X86_64Assembler::movdqa(const Address& dst, XmmRegister src) {
+   EmitOperand(src.LowBits(), dst);
+ }
+ 
++/** VEX.128.66.0F.WIG 7F /r VMOVDQA m128, xmm1 */
++void X86_64Assembler::vmovdqa(const Address& dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero, ByteOne, ByteTwo;
++  // Instruction VEX Prefix
++  uint8_t rex = dst.rex();
++  bool Rex_x = rex & GET_REX_X;
++  bool Rex_b = rex & GET_REX_B;
++  if (!Rex_x && !Rex_b) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
++                                   vvvv_reg,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
++                                   Rex_x,
++                                   Rex_b,
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  // Instruction Opcode
++  EmitUint8(0x7F);
++  // Instruction Operands
++  EmitOperand(src.LowBits(), dst);
++}
+ 
+ void X86_64Assembler::movdqu(const Address& dst, XmmRegister src) {
++  if (CpuHasAVXorAVX2FeatureFlag()) {
++    vmovdqu(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0xF3);
+   EmitOptionalRex32(src, dst);
+@@ -1002,6 +1558,46 @@ void X86_64Assembler::movdqu(const Address& dst, XmmRegister src) {
+   EmitOperand(src.LowBits(), dst);
+ }
+ 
++/** VEX.128.F3.0F.WIG 7F /r VMOVDQU m128, xmm1 */
++void X86_64Assembler::vmovdqu(const Address& dst, XmmRegister src) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero, ByteOne, ByteTwo;
++  bool is_twobyte_form = false;
++
++  // Instruction VEX Prefix
++  uint8_t rex = dst.rex();
++  bool Rex_x = rex & GET_REX_X;
++  bool Rex_b = rex & GET_REX_B;
++  if (!Rex_b && !Rex_x) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
++                                   vvvv_reg,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_F3);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
++                                   Rex_x,
++                                   Rex_b,
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++                                   SET_VEX_L_128,
++                                   SET_VEX_PP_F3);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  // Instruction Opcode
++  EmitUint8(0x7F);
++  // Instruction Operands
++  EmitOperand(src.LowBits(), dst);
++}
+ 
+ void X86_64Assembler::paddb(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1578,15 +2174,15 @@ void X86_64Assembler::pand(XmmRegister dst, XmmRegister src) {
+ 
+ void X86_64Assembler::andn(CpuRegister dst, CpuRegister src1, CpuRegister src2) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  uint8_t byte_zero = EmitVexByteZero(/*is_two_byte=*/ false);
+-  uint8_t byte_one = EmitVexByte1(dst.NeedsRex(),
+-                                  /*x=*/ false,
+-                                  src2.NeedsRex(),
+-                                  /*mmmmm=*/ 2);
+-  uint8_t byte_two = EmitVexByte2(/*w=*/ true,
+-                                  /*l=*/ 128,
+-                                  X86_64ManagedRegister::FromCpuRegister(src1.AsRegister()),
+-                                  /*pp=*/ 0);
++  uint8_t byte_zero = EmitVexPrefixByteZero(/**is_two_byte= */false);
++  uint8_t byte_one = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                          /**X = */false,
++                                          src2.NeedsRex(),
++                                          SET_VEX_M_0F_38);
++  uint8_t byte_two = EmitVexPrefixByteTwo(/**W= */true,
++                                          X86_64ManagedRegister::FromCpuRegister(src1.AsRegister()),
++                                          SET_VEX_L_128,
++                                          SET_VEX_PP_NONE);
+   EmitUint8(byte_zero);
+   EmitUint8(byte_one);
+   EmitUint8(byte_two);
+@@ -3374,15 +3970,15 @@ void X86_64Assembler::setcc(Condition condition, CpuRegister dst) {
+ 
+ void X86_64Assembler::blsi(CpuRegister dst, CpuRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  uint8_t byte_zero = EmitVexByteZero(/*is_two_byte=*/ false);
+-  uint8_t byte_one = EmitVexByte1(/*r=*/ false,
+-                                  /*x=*/ false,
+-                                  src.NeedsRex(),
+-                                  /*mmmmm=*/ 2);
+-  uint8_t byte_two = EmitVexByte2(/*w=*/ true,
+-                                  /*l=*/ 128,
+-                                  X86_64ManagedRegister::FromCpuRegister(dst.AsRegister()),
+-                                  /*pp=*/ 0);
++  uint8_t byte_zero = EmitVexPrefixByteZero(/**is_two_byte= */false);
++  uint8_t byte_one = EmitVexPrefixByteOne(/**R = */false,
++                                          /**X = */false,
++                                          src.NeedsRex(),
++                                          SET_VEX_M_0F_38);
++  uint8_t byte_two = EmitVexPrefixByteTwo(/**W= */true,
++                                          X86_64ManagedRegister::FromCpuRegister(dst.AsRegister()),
++                                          SET_VEX_L_128,
++                                          SET_VEX_PP_NONE);
+   EmitUint8(byte_zero);
+   EmitUint8(byte_one);
+   EmitUint8(byte_two);
+@@ -3392,15 +3988,15 @@ void X86_64Assembler::blsi(CpuRegister dst, CpuRegister src) {
+ 
+ void X86_64Assembler::blsmsk(CpuRegister dst, CpuRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  uint8_t byte_zero = EmitVexByteZero(/*is_two_byte=*/ false);
+-  uint8_t byte_one = EmitVexByte1(/*r=*/ false,
+-                                  /*x=*/ false,
+-                                  src.NeedsRex(),
+-                                  /*mmmmm=*/ 2);
+-  uint8_t byte_two = EmitVexByte2(/*w=*/ true,
+-                                  /*l=*/ 128,
+-                                  X86_64ManagedRegister::FromCpuRegister(dst.AsRegister()),
+-                                  /*pp=*/ 0);
++  uint8_t byte_zero = EmitVexPrefixByteZero(/**is_two_byte= */false);
++  uint8_t byte_one = EmitVexPrefixByteOne(/**R = */false,
++                                          /**X = */false,
++                                          src.NeedsRex(),
++                                          SET_VEX_M_0F_38);
++  uint8_t byte_two = EmitVexPrefixByteTwo(/**W= */true,
++                                          X86_64ManagedRegister::FromCpuRegister(dst.AsRegister()),
++                                          SET_VEX_L_128,
++                                          SET_VEX_PP_NONE);
+   EmitUint8(byte_zero);
+   EmitUint8(byte_one);
+   EmitUint8(byte_two);
+@@ -3410,15 +4006,15 @@ void X86_64Assembler::blsmsk(CpuRegister dst, CpuRegister src) {
+ 
+ void X86_64Assembler::blsr(CpuRegister dst, CpuRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  uint8_t byte_zero = EmitVexByteZero(/*is_two_byte=*/ false);
+-  uint8_t byte_one = EmitVexByte1(/*r=*/ false,
+-                                  /*x=*/ false,
+-                                  src.NeedsRex(),
+-                                  /*mmmmm=*/ 2);
+-  uint8_t byte_two = EmitVexByte2(/*w=*/ true,
+-                                  /*l=*/ 128,
+-                                  X86_64ManagedRegister::FromCpuRegister(dst.AsRegister()),
+-                                  /*pp=*/ 0);
++  uint8_t byte_zero = EmitVexPrefixByteZero(/**is_two_byte= */false);
++  uint8_t byte_one = EmitVexPrefixByteOne(/**R = */false,
++                                          /**X = */false,
++                                          src.NeedsRex(),
++                                          SET_VEX_M_0F_38);
++  uint8_t byte_two = EmitVexPrefixByteTwo(/**W= */true,
++                                          X86_64ManagedRegister::FromCpuRegister(dst.AsRegister()),
++                                          SET_VEX_L_128,
++                                          SET_VEX_PP_NONE);
+   EmitUint8(byte_zero);
+   EmitUint8(byte_one);
+   EmitUint8(byte_two);
+@@ -3937,5 +4533,133 @@ size_t ConstantArea::AddFloat(float v) {
+   return AddInt32(bit_cast<int32_t, float>(v));
+ }
+ 
++uint8_t X86_64Assembler::EmitVexPrefixByteZero(bool is_twobyte_form) {
++  // Vex Byte 0,
++  // Bits [7:0] must contain the value 11000101b (0xC5) for 2-byte Vex
++  // Bits [7:0] must contain the value 11000100b (0xC4) for 3-byte Vex
++  uint8_t vex_prefix = 0xC0;
++  if (is_twobyte_form) {
++    vex_prefix |= TWO_BYTE_VEX;  // 2-Byte Vex
++  } else {
++    vex_prefix |= THREE_BYTE_VEX;  // 3-Byte Vex
++  }
++  return vex_prefix;
++}
++
++uint8_t X86_64Assembler::EmitVexPrefixByteOne(bool R, bool X, bool B, int SET_VEX_M) {
++  // Vex Byte 1,
++  uint8_t vex_prefix = VEX_INIT;
++  /** Bit[7] This bit needs to be set to '1'
++  otherwise the instruction is LES or LDS */
++  if (!R) {
++    // R .
++    vex_prefix |= SET_VEX_R;
++  }
++  /** Bit[6] This bit needs to be set to '1'
++  otherwise the instruction is LES or LDS */
++  if (!X) {
++    // X .
++    vex_prefix |= SET_VEX_X;
++  }
++  /** Bit[5] This bit needs to be set to '1' */
++  if (!B) {
++    // B .
++    vex_prefix |= SET_VEX_B;
++  }
++  /** Bits[4:0], Based on the instruction documentaion */
++  vex_prefix |= SET_VEX_M;
++  return vex_prefix;
++}
++
++uint8_t X86_64Assembler::EmitVexPrefixByteOne(bool R,
++                                              X86_64ManagedRegister operand,
++                                              int SET_VEX_L,
++                                              int SET_VEX_PP) {
++  // Vex Byte 1,
++  uint8_t vex_prefix = VEX_INIT;
++  /** Bit[7] This bit needs to be set to '1'
++  otherwise the instruction is LES or LDS */
++  if (!R) {
++    // R .
++    vex_prefix |= SET_VEX_R;
++  }
++  /**Bits[6:3] - 'vvvv' the source or dest register specifier */
++  if (operand.IsNoRegister()) {
++    vex_prefix |= 0x78;
++  } else if (operand.IsXmmRegister()) {
++    XmmRegister vvvv = operand.AsXmmRegister();
++    int inverted_reg = 15 - static_cast<int>(vvvv.AsFloatRegister());
++    uint8_t reg = static_cast<uint8_t>(inverted_reg);
++    vex_prefix |= ((reg & 0x0F) << 3);
++  } else if (operand.IsCpuRegister()) {
++    CpuRegister vvvv = operand.AsCpuRegister();
++    int inverted_reg = 15 - static_cast<int>(vvvv.AsRegister());
++    uint8_t reg = static_cast<uint8_t>(inverted_reg);
++    vex_prefix |= ((reg & 0x0F) << 3);
++  }
++  /** Bit[2] - "L" If VEX.L = 1 indicates 256-bit vector operation ,
++  VEX.L = 0 indicates 128 bit vector operation */
++  vex_prefix |= SET_VEX_L;
++  // Bits[1:0] -  "pp"
++  vex_prefix |= SET_VEX_PP;
++  return vex_prefix;
++}
++
++uint8_t X86_64Assembler::EmitVexPrefixByteTwo(bool W,
++                                              X86_64ManagedRegister operand,
++                                              int SET_VEX_L,
++                                              int SET_VEX_PP) {
++  // Vex Byte 2,
++  uint8_t vex_prefix = VEX_INIT;
++
++  /** Bit[7] This bits needs to be set to '1' with default value.
++  When using C4H form of VEX prefix, REX.W value is ignored */
++  if (W) {
++    vex_prefix |= SET_VEX_W;
++  }
++  // Bits[6:3] - 'vvvv' the source or dest register specifier
++  if (operand.IsXmmRegister()) {
++    XmmRegister vvvv = operand.AsXmmRegister();
++    int inverted_reg = 15 - static_cast<int>(vvvv.AsFloatRegister());
++    uint8_t reg = static_cast<uint8_t>(inverted_reg);
++    vex_prefix |= ((reg & 0x0F) << 3);
++  } else if (operand.IsCpuRegister()) {
++    CpuRegister vvvv = operand.AsCpuRegister();
++    int inverted_reg = 15 - static_cast<int>(vvvv.AsRegister());
++    uint8_t reg = static_cast<uint8_t>(inverted_reg);
++    vex_prefix |= ((reg & 0x0F) << 3);
++  }
++  /** Bit[2] - "L" If VEX.L = 1 indicates 256-bit vector operation ,
++  VEX.L = 0 indicates 128 bit vector operation */
++  vex_prefix |= SET_VEX_L;
++  // Bits[1:0] -  "pp"
++  vex_prefix |= SET_VEX_PP;
++  return vex_prefix;
++}
++
++uint8_t X86_64Assembler::EmitVexPrefixByteTwo(bool W,
++                                              int SET_VEX_L,
++                                              int SET_VEX_PP) {
++  // Vex Byte 2,
++  uint8_t vex_prefix = VEX_INIT;
++
++  /** Bit[7] This bits needs to be set to '1' with default value.
++  When using C4H form of VEX prefix, REX.W value is ignored */
++  if (W) {
++    vex_prefix |= SET_VEX_W;
++  }
++  /** Bits[6:3] - 'vvvv' the source or dest register specifier */
++  vex_prefix |= (0x0F << 3);
++  /** Bit[2] - "L" If VEX.L = 1 indicates 256-bit vector operation ,
++  VEX.L = 0 indicates 128 bit vector operation */
++  vex_prefix |= SET_VEX_L;
++
++  // Bits[1:0] -  "pp"
++  if (SET_VEX_PP != SET_VEX_PP_NONE) {
++    vex_prefix |= SET_VEX_PP;
++  }
++  return vex_prefix;
++}
++
+ }  // namespace x86_64
+ }  // namespace art
+diff --git a/compiler/utils/x86_64/assembler_x86_64.h b/compiler/utils/x86_64/assembler_x86_64.h
+index ff13ea3..471b314 100644
+--- a/compiler/utils/x86_64/assembler_x86_64.h
++++ b/compiler/utils/x86_64/assembler_x86_64.h
+@@ -19,6 +19,7 @@
+ 
+ #include <vector>
+ 
++#include "arch/x86_64/instruction_set_features_x86_64.h"
+ #include "base/arena_containers.h"
+ #include "base/array_ref.h"
+ #include "base/bit_utils.h"
+@@ -353,8 +354,12 @@ class NearLabel : private Label {
+ 
+ class X86_64Assembler final : public Assembler {
+  public:
+-  explicit X86_64Assembler(ArenaAllocator* allocator)
+-      : Assembler(allocator), constant_area_(allocator) {}
++  explicit X86_64Assembler(ArenaAllocator* allocator,
++                           const X86_64InstructionSetFeatures* instruction_set_features = nullptr)
++      : Assembler(allocator),
++        constant_area_(allocator),
++        has_AVX_(instruction_set_features != nullptr ? instruction_set_features->HasAVX(): false),
++        has_AVX2_(instruction_set_features != nullptr ? instruction_set_features->HasAVX2() : false) {}
+   virtual ~X86_64Assembler() {}
+ 
+   /*
+@@ -415,6 +420,12 @@ class X86_64Assembler final : public Assembler {
+   void movaps(const Address& dst, XmmRegister src);  // store aligned
+   void movups(const Address& dst, XmmRegister src);  // store unaligned
+ 
++  void vmovaps(XmmRegister dst, XmmRegister src);     // move
++  void vmovaps(XmmRegister dst, const Address& src);  // load aligned
++  void vmovaps(const Address& dst, XmmRegister src);  // store aligned
++  void vmovups(XmmRegister dst, const Address& src);  // load unaligned
++  void vmovups(const Address& dst, XmmRegister src);  // store unaligned
++
+   void movss(XmmRegister dst, const Address& src);
+   void movss(const Address& dst, XmmRegister src);
+   void movss(XmmRegister dst, XmmRegister src);
+@@ -447,6 +458,12 @@ class X86_64Assembler final : public Assembler {
+   void movapd(const Address& dst, XmmRegister src);  // store aligned
+   void movupd(const Address& dst, XmmRegister src);  // store unaligned
+ 
++  void vmovapd(XmmRegister dst, XmmRegister src);     // move
++  void vmovapd(XmmRegister dst, const Address& src);  // load aligned
++  void vmovapd(const Address& dst, XmmRegister src);  // store aligned
++  void vmovupd(XmmRegister dst, const Address& src);  // load unaligned
++  void vmovupd(const Address& dst, XmmRegister src);  // store unaligned
++
+   void movsd(XmmRegister dst, const Address& src);
+   void movsd(const Address& dst, XmmRegister src);
+   void movsd(XmmRegister dst, XmmRegister src);
+@@ -471,6 +488,12 @@ class X86_64Assembler final : public Assembler {
+   void movdqa(const Address& dst, XmmRegister src);  // store aligned
+   void movdqu(const Address& dst, XmmRegister src);  // store unaligned
+ 
++  void vmovdqa(XmmRegister dst, XmmRegister src);     // move
++  void vmovdqa(XmmRegister dst, const Address& src);  // load aligned
++  void vmovdqa(const Address& dst, XmmRegister src);  // store aligned
++  void vmovdqu(XmmRegister dst, const Address& src);  // load unaligned
++  void vmovdqu(const Address& dst, XmmRegister src);  // store unaligned
++
+   void paddb(XmmRegister dst, XmmRegister src);  // no addr variant (for now)
+   void psubb(XmmRegister dst, XmmRegister src);
+ 
+@@ -909,6 +932,8 @@ class X86_64Assembler final : public Assembler {
+     }
+   }
+ 
++  bool CpuHasAVXorAVX2FeatureFlag();
++
+  private:
+   void EmitUint8(uint8_t value);
+   void EmitInt32(int32_t value);
+@@ -956,12 +981,22 @@ class X86_64Assembler final : public Assembler {
+   void EmitOptionalByteRegNormalizingRex32(CpuRegister dst, CpuRegister src);
+   void EmitOptionalByteRegNormalizingRex32(CpuRegister dst, const Operand& operand);
+ 
+-  // Emit a 3 byte VEX Prefix
+-  uint8_t EmitVexByteZero(bool is_two_byte);
+-  uint8_t EmitVexByte1(bool r, bool x, bool b, int mmmmm);
+-  uint8_t EmitVexByte2(bool w , int l , X86_64ManagedRegister operand, int pp);
+-
++  uint8_t EmitVexPrefixByteZero(bool is_twobyte_form);
++  uint8_t EmitVexPrefixByteOne(bool R, bool X, bool B, int SET_VEX_M);
++  uint8_t EmitVexPrefixByteOne(bool R,
++                               X86_64ManagedRegister operand,
++                               int SET_VEX_L,
++                               int SET_VEX_PP);
++  uint8_t EmitVexPrefixByteTwo(bool W,
++                               X86_64ManagedRegister operand,
++                               int SET_VEX_L,
++                               int SET_VEX_PP);
++  uint8_t EmitVexPrefixByteTwo(bool W,
++                               int SET_VEX_L,
++                               int SET_VEX_PP);
+   ConstantArea constant_area_;
++  bool has_AVX_;     // x86 256bit SIMD AVX.
++  bool has_AVX2_;    // x86 256bit SIMD AVX 2.0.
+ 
+   DISALLOW_COPY_AND_ASSIGN(X86_64Assembler);
+ };
+diff --git a/compiler/utils/x86_64/assembler_x86_64_test.cc b/compiler/utils/x86_64/assembler_x86_64_test.cc
+index 461f028..297246e 100644
+--- a/compiler/utils/x86_64/assembler_x86_64_test.cc
++++ b/compiler/utils/x86_64/assembler_x86_64_test.cc
+@@ -339,6 +339,18 @@ class AssemblerX86_64Test : public AssemblerTest<x86_64::X86_64Assembler,
+   std::vector<x86_64::XmmRegister*> fp_registers_;
+ };
+ 
++class AssemblerX86_64AVXTest : public AssemblerX86_64Test {
++ public:
++  AssemblerX86_64AVXTest()
++      : instruction_set_features_(X86_64InstructionSetFeatures::FromVariant("kabylake", nullptr)) {}
++ protected:
++  x86_64::X86_64Assembler* CreateAssembler(ArenaAllocator* allocator) override {
++    return new (allocator) x86_64::X86_64Assembler(allocator, instruction_set_features_.get());
++  }
++ private:
++  std::unique_ptr<const X86_64InstructionSetFeatures> instruction_set_features_;
++};
++
+ //
+ // Test some repeat drivers used in the tests.
+ //
+@@ -1107,22 +1119,43 @@ TEST_F(AssemblerX86_64Test, Movaps) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::movaps, "movaps %{reg2}, %{reg1}"), "movaps");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VMovaps) {
++  DriverStr(RepeatFF(&x86_64::X86_64Assembler::vmovaps, "vmovaps %{reg2}, %{reg1}"), "vmovaps");
++}
++
+ TEST_F(AssemblerX86_64Test, MovapsStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::movaps, "movaps %{reg}, {mem}"), "movaps_s");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VMovapsStore) {
++  DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovaps, "vmovaps %{reg}, {mem}"), "vmovaps_s");
++}
++
+ TEST_F(AssemblerX86_64Test, MovapsLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::movaps, "movaps {mem}, %{reg}"), "movaps_l");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VMovapsLoad) {
++  DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovaps, "vmovaps {mem}, %{reg}"), "vmovaps_l");
++}
++
+ TEST_F(AssemblerX86_64Test, MovupsStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::movups, "movups %{reg}, {mem}"), "movups_s");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VMovupsStore) {
++  DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovups, "vmovups %{reg}, {mem}"), "vmovups_s");
++}
++
+ TEST_F(AssemblerX86_64Test, MovupsLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::movups, "movups {mem}, %{reg}"), "movups_l");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VMovupsLoad) {
++  DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovups, "vmovups {mem}, %{reg}"), "vmovups_l");
++}
++
++
+ TEST_F(AssemblerX86_64Test, Movss) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::movss, "movss %{reg2}, %{reg1}"), "movss");
+ }
+@@ -1131,22 +1164,42 @@ TEST_F(AssemblerX86_64Test, Movapd) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::movapd, "movapd %{reg2}, %{reg1}"), "movapd");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VMovapd) {
++  DriverStr(RepeatFF(&x86_64::X86_64Assembler::vmovapd, "vmovapd %{reg2}, %{reg1}"), "vmovapd");
++}
++
+ TEST_F(AssemblerX86_64Test, MovapdStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::movapd, "movapd %{reg}, {mem}"), "movapd_s");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VMovapdStore) {
++  DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovapd, "vmovapd %{reg}, {mem}"), "vmovapd_s");
++}
++
+ TEST_F(AssemblerX86_64Test, MovapdLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::movapd, "movapd {mem}, %{reg}"), "movapd_l");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VMovapdLoad) {
++  DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovapd, "vmovapd {mem}, %{reg}"), "vmovapd_l");
++}
++
+ TEST_F(AssemblerX86_64Test, MovupdStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::movupd, "movupd %{reg}, {mem}"), "movupd_s");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VMovupdStore) {
++  DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovupd, "vmovupd %{reg}, {mem}"), "vmovupd_s");
++}
++
+ TEST_F(AssemblerX86_64Test, MovupdLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::movupd, "movupd {mem}, %{reg}"), "movupd_l");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VMovupdLoad) {
++  DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovupd, "vmovupd {mem}, %{reg}"), "vmovupd_l");
++}
++
+ TEST_F(AssemblerX86_64Test, Movsd) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::movsd, "movsd %{reg2}, %{reg1}"), "movsd");
+ }
+@@ -1155,22 +1208,42 @@ TEST_F(AssemblerX86_64Test, Movdqa) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::movdqa, "movdqa %{reg2}, %{reg1}"), "movdqa");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VMovdqa) {
++  DriverStr(RepeatFF(&x86_64::X86_64Assembler::vmovdqa, "vmovdqa %{reg2}, %{reg1}"), "vmovdqa");
++}
++
+ TEST_F(AssemblerX86_64Test, MovdqaStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::movdqa, "movdqa %{reg}, {mem}"), "movdqa_s");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VMovdqaStore) {
++  DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovdqa, "vmovdqa %{reg}, {mem}"), "vmovdqa_s");
++}
++
+ TEST_F(AssemblerX86_64Test, MovdqaLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::movdqa, "movdqa {mem}, %{reg}"), "movdqa_l");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VMovdqaLoad) {
++  DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovdqa, "vmovdqa {mem}, %{reg}"), "vmovdqa_l");
++}
++
+ TEST_F(AssemblerX86_64Test, MovdquStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::movdqu, "movdqu %{reg}, {mem}"), "movdqu_s");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VMovdquStore) {
++  DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovdqu, "vmovdqu %{reg}, {mem}"), "vmovdqu_s");
++}
++
+ TEST_F(AssemblerX86_64Test, MovdquLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::movdqu, "movdqu {mem}, %{reg}"), "movdqu_l");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VMovdquLoad) {
++  DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovdqu, "vmovdqu {mem}, %{reg}"), "vmovdqu_l");
++}
++
+ TEST_F(AssemblerX86_64Test, Movd1) {
+   DriverStr(RepeatFR(&x86_64::X86_64Assembler::movd, "movd %{reg2}, %{reg1}"), "movd.1");
+ }
+diff --git a/disassembler/disassembler_x86.cc b/disassembler/disassembler_x86.cc
+index dbdde64..98201f9 100644
+--- a/disassembler/disassembler_x86.cc
++++ b/disassembler/disassembler_x86.cc
+@@ -24,6 +24,16 @@
+ #include "android-base/logging.h"
+ #include "android-base/stringprintf.h"
+ 
++#define TWO_BYTE_VEX    0xC5
++#define THREE_BYTE_VEX  0xC4
++#define VEX_M_0F        0x01
++#define VEX_M_0F_38     0x02
++#define VEX_M_0F_3A     0x03
++#define VEX_PP_NONE     0x00
++#define VEX_PP_66       0x01
++#define VEX_PP_F3       0x02
++#define VEX_PP_F2       0x03
++
+ using android::base::StringPrintf;
+ 
+ namespace art {
+@@ -316,9 +326,11 @@ size_t DisassemblerX86::DumpInstruction(std::ostream& os, const uint8_t* instr)
+   if (rex != 0) {
+     instr++;
+   }
++
+   const char** modrm_opcodes = nullptr;
+   bool has_modrm = false;
+   bool reg_is_opcode = false;
++
+   size_t immediate_bytes = 0;
+   size_t branch_bytes = 0;
+   std::string opcode_tmp;    // Storage to keep StringPrintf result alive.
+@@ -340,6 +352,8 @@ size_t DisassemblerX86::DumpInstruction(std::ostream& os, const uint8_t* instr)
+   bool no_ops = false;
+   RegFile src_reg_file = GPR;
+   RegFile dst_reg_file = GPR;
++
++
+   switch (*instr) {
+ #define DISASSEMBLER_ENTRY(opname, \
+                      rm8_r8, rm32_r32, \
+@@ -381,11 +395,12 @@ DISASSEMBLER_ENTRY(xor,
+   0x32 /* Reg8/RegMem8 */,     0x33 /* Reg32/RegMem32 */,
+   0x34 /* Rax8/imm8 opcode */, 0x35 /* Rax32/imm32 */)
+ DISASSEMBLER_ENTRY(cmp,
+-  0x38 /* RegMem8/Reg8 */,     0x39 /* RegMem32/Reg32 */,
++  0x38 /* RegMem8/Reg8 */,     0x39 /* RegMem/Reg32 */,
+   0x3A /* Reg8/RegMem8 */,     0x3B /* Reg32/RegMem32 */,
+   0x3C /* Rax8/imm8 opcode */, 0x3D /* Rax32/imm32 */)
+ 
+ #undef DISASSEMBLER_ENTRY
++
+   case 0x50: case 0x51: case 0x52: case 0x53: case 0x54: case 0x55: case 0x56: case 0x57:
+     opcode1 = "push";
+     reg_in_opcode = true;
+@@ -1372,6 +1387,7 @@ DISASSEMBLER_ENTRY(cmp,
+     byte_operand = (*instr == 0xC0);
+     break;
+   case 0xC3: opcode1 = "ret"; break;
++
+   case 0xC6:
+     static const char* c6_opcodes[] = {"mov",        "unknown-c6", "unknown-c6",
+                                        "unknown-c6", "unknown-c6", "unknown-c6",
+@@ -1521,6 +1537,7 @@ DISASSEMBLER_ENTRY(cmp,
+         args << ", ";
+       }
+       DumpSegmentOverride(args, prefix[1]);
++
+       args << address;
+     } else {
+       DCHECK(store);
+@@ -1595,7 +1612,7 @@ DISASSEMBLER_ENTRY(cmp,
+      << StringPrintf(": %22s    \t%-7s%s%s%s%s%s ", DumpCodeHex(begin_instr, instr).c_str(),
+                      prefix_str, opcode0, opcode1, opcode2, opcode3, opcode4)
+      << args.str() << '\n';
+-  return instr - begin_instr;
++    return instr - begin_instr;
+ }  // NOLINT(readability/fn_size)
+ 
+ }  // namespace x86
+diff --git a/runtime/arch/x86/instruction_set_features_x86.h b/runtime/arch/x86/instruction_set_features_x86.h
+index 34d908b..bf1b606 100644
+--- a/runtime/arch/x86/instruction_set_features_x86.h
++++ b/runtime/arch/x86/instruction_set_features_x86.h
+@@ -19,6 +19,26 @@
+ 
+ #include "arch/instruction_set_features.h"
+ 
++#define GET_REX_R       0x04
++#define GET_REX_X       0x02
++#define GET_REX_B       0x01
++#define SET_VEX_R       0x80
++#define SET_VEX_X       0x40
++#define SET_VEX_B       0x20
++#define SET_VEX_M_0F    0x01
++#define SET_VEX_M_0F_38 0x02
++#define SET_VEX_M_0F_3A 0x03
++#define SET_VEX_W       0x80
++#define SET_VEX_L_128   0x00
++#define SET_VEL_L_256   0x04
++#define SET_VEX_PP_NONE 0x00
++#define SET_VEX_PP_66   0x01
++#define SET_VEX_PP_F3   0x02
++#define SET_VEX_PP_F2   0x03
++#define TWO_BYTE_VEX    0xC5
++#define THREE_BYTE_VEX  0xC4
++#define VEX_INIT        0x00
++
+ namespace art {
+ 
+ class X86InstructionSetFeatures;
+@@ -69,6 +89,8 @@ class X86InstructionSetFeatures : public InstructionSetFeatures {
+ 
+   bool HasAVX2() const { return has_AVX2_; }
+ 
++  bool HasAVX() const { return has_AVX_; }
++
+  protected:
+   // Parse a string of the form "ssse3" adding these to a new InstructionSetFeatures.
+   std::unique_ptr<const InstructionSetFeatures>
+-- 
+2.7.4
+

--- a/aosp_diff/caas/art/0003-x86-Add-assembler-tests-and-clean-up-style.patch
+++ b/aosp_diff/caas/art/0003-x86-Add-assembler-tests-and-clean-up-style.patch
@@ -1,0 +1,825 @@
+From c4f0bdaec7b11bebc028555c36880b2ff3d34932 Mon Sep 17 00:00:00 2001
+From: Vladimir Marko <vmarko@google.com>
+Date: Wed, 8 May 2019 11:50:58 +0100
+Subject: [PATCH] x86: Add assembler tests and clean up style.
+
+This is a follow-up after
+    https://android-review.googlesource.com/923493
+
+Test: m test-art-host-gtest
+Change-Id: Id287815c8ffc001d7cf7a4838c744620a553f662
+Signed-off-by: bodapati <shalini.salomi.bodapati@intel.com>
+---
+ compiler/utils/x86/assembler_x86.cc            | 76 +++++++++++++-------------
+ compiler/utils/x86/assembler_x86_test.cc       | 60 ++++++++++++++++++++
+ compiler/utils/x86_64/assembler_x86_64.cc      | 66 +++++++++++-----------
+ compiler/utils/x86_64/assembler_x86_64_test.cc | 59 ++++++++++++++++++++
+ 4 files changed, 190 insertions(+), 71 deletions(-)
+
+diff --git a/compiler/utils/x86/assembler_x86.cc b/compiler/utils/x86/assembler_x86.cc
+index 01eb160..bcc197b 100644
+--- a/compiler/utils/x86/assembler_x86.cc
++++ b/compiler/utils/x86/assembler_x86.cc
+@@ -188,7 +188,7 @@ void X86Assembler::movntl(const Address& dst, Register src) {
+ 
+ void X86Assembler::blsi(Register dst, Register src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  uint8_t byte_zero = EmitVexPrefixByteZero(false /*is_two_byte*/);
++  uint8_t byte_zero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ false);
+   uint8_t byte_one  = EmitVexPrefixByteOne(false, false, false, SET_VEX_M_0F_38);
+   uint8_t byte_two  = EmitVexPrefixByteTwo(false,
+                                            X86ManagedRegister::FromCpuRegister(dst),
+@@ -202,7 +202,7 @@ void X86Assembler::blsi(Register dst, Register src) {
+ 
+ void X86Assembler::blsmsk(Register dst, Register src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  uint8_t byte_zero = EmitVexPrefixByteZero(false /*is_two_byte*/);
++  uint8_t byte_zero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ false);
+   uint8_t byte_one = EmitVexPrefixByteOne(false, false, false, SET_VEX_M_0F_38);
+   uint8_t byte_two = EmitVexPrefixByteTwo(false,
+                                          X86ManagedRegister::FromCpuRegister(dst),
+@@ -216,7 +216,7 @@ void X86Assembler::blsmsk(Register dst, Register src) {
+ 
+ void X86Assembler::blsr(Register dst, Register src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  uint8_t byte_zero = EmitVexPrefixByteZero(false /*is_two_byte*/);
++  uint8_t byte_zero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ false);
+   uint8_t byte_one = EmitVexPrefixByteOne(false, false, false,  SET_VEX_M_0F_38);
+   uint8_t byte_two = EmitVexPrefixByteTwo(false,
+                                           X86ManagedRegister::FromCpuRegister(dst),
+@@ -434,11 +434,11 @@ void X86Assembler::vmovaps(XmmRegister dst, XmmRegister src) {
+   DCHECK(CpuHasAVXorAVX2FeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   /**Instruction VEX Prefix*/
+-  uint8_t byte_zero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  uint8_t byte_zero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
+   X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
+   /**a REX prefix is necessary only if an instruction references one of the
+   extended registers or uses a 64-bit operand.*/
+-  uint8_t byte_one = EmitVexPrefixByteOne(/**R = */false,
++  uint8_t byte_one = EmitVexPrefixByteOne(/*R=*/ false,
+                                           vvvv_reg,
+                                           SET_VEX_L_128,
+                                           SET_VEX_PP_NONE);
+@@ -466,11 +466,11 @@ void X86Assembler::vmovaps(XmmRegister dst, const Address& src) {
+   DCHECK(CpuHasAVXorAVX2FeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   /**Instruction VEX Prefix*/
+-  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  uint8_t ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
+   X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
+   /**a REX prefix is necessary only if an instruction references one of the
+   extended registers or uses a 64-bit operand.*/
+-  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++  uint8_t ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
+                                          vvvv_reg,
+                                          SET_VEX_L_128,
+                                          SET_VEX_PP_NONE);
+@@ -498,11 +498,11 @@ void X86Assembler::vmovups(XmmRegister dst, const Address& src) {
+   DCHECK(CpuHasAVXorAVX2FeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   /**Instruction VEX Prefix*/
+-  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  uint8_t ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
+   X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
+   /**a REX prefix is necessary only if an instruction references one of the
+   extended registers or uses a 64-bit operand.*/
+-  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++  uint8_t ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
+                                          vvvv_reg,
+                                          SET_VEX_L_128,
+                                          SET_VEX_PP_NONE);
+@@ -530,11 +530,11 @@ void X86Assembler::vmovaps(const Address& dst, XmmRegister src) {
+   DCHECK(CpuHasAVXorAVX2FeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   /**Instruction VEX Prefix*/
+-  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  uint8_t ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
+   X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
+   /**a REX prefix is necessary only if an instruction references one of the
+   extended registers or uses a 64-bit operand.*/
+-  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++  uint8_t ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
+                                          vvvv_reg,
+                                          SET_VEX_L_128,
+                                          SET_VEX_PP_NONE);
+@@ -562,11 +562,11 @@ void X86Assembler::vmovups(const Address& dst, XmmRegister src) {
+   DCHECK(CpuHasAVXorAVX2FeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   /**Instruction VEX Prefix*/
+-  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  uint8_t ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
+   X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
+   /**a REX prefix is necessary only if an instruction references one of the
+   extended registers or uses a 64-bit operand.*/
+-  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++  uint8_t ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
+                                          vvvv_reg,
+                                          SET_VEX_L_128,
+                                          SET_VEX_PP_NONE);
+@@ -745,11 +745,11 @@ void X86Assembler::vmovapd(XmmRegister dst, XmmRegister src) {
+   DCHECK(CpuHasAVXorAVX2FeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   /**Instruction VEX Prefix*/
+-  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  uint8_t ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
+   X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
+   /**a REX prefix is necessary only if an instruction references one of the
+   extended registers or uses a 64-bit operand.*/
+-  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++  uint8_t ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
+                                          vvvv_reg ,
+                                          SET_VEX_L_128,
+                                          SET_VEX_PP_66);
+@@ -778,11 +778,11 @@ void X86Assembler::vmovapd(XmmRegister dst, const Address& src) {
+   DCHECK(CpuHasAVXorAVX2FeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   /**Instruction VEX Prefix*/
+-  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  uint8_t ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
+   X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
+   /**a REX prefix is necessary only if an instruction references one of the
+   extended registers or uses a 64-bit operand.*/
+-  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++  uint8_t ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
+                                          vvvv_reg,
+                                          SET_VEX_L_128,
+                                          SET_VEX_PP_66);
+@@ -811,11 +811,11 @@ void X86Assembler::vmovupd(XmmRegister dst, const Address& src) {
+   DCHECK(CpuHasAVXorAVX2FeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   /**Instruction VEX Prefix*/
+-  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  uint8_t ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
+   X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
+   /**a REX prefix is necessary only if an instruction references one of the
+   extended registers or uses a 64-bit operand.*/
+-  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++  uint8_t ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
+                                          vvvv_reg,
+                                          SET_VEX_L_128,
+                                          SET_VEX_PP_66);
+@@ -845,11 +845,11 @@ void X86Assembler::vmovapd(const Address& dst, XmmRegister src) {
+   DCHECK(CpuHasAVXorAVX2FeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   /**Instruction VEX Prefix */
+-  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  uint8_t ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
+   X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
+   /**a REX prefix is necessary only if an instruction references one of the
+   extended registers or uses a 64-bit operand.*/
+-  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++  uint8_t ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
+                                          vvvv_reg,
+                                          SET_VEX_L_128,
+                                          SET_VEX_PP_66);
+@@ -878,11 +878,11 @@ void X86Assembler::vmovupd(const Address& dst, XmmRegister src) {
+   DCHECK(CpuHasAVXorAVX2FeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   /**Instruction VEX Prefix */
+-  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  uint8_t ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
+   X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
+   /**a REX prefix is necessary only if an instruction references one of the
+   extended registers or uses a 64-bit operand.**/
+-  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++  uint8_t ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
+                                          vvvv_reg,
+                                          SET_VEX_L_128,
+                                          SET_VEX_PP_66);
+@@ -1085,9 +1085,9 @@ void X86Assembler::vmovdqa(XmmRegister dst, XmmRegister src) {
+   DCHECK(CpuHasAVXorAVX2FeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   /**Instruction VEX Prefix */
+-  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  uint8_t ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
+   X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
+-  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++  uint8_t ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
+                                          vvvv_reg,
+                                          SET_VEX_L_128,
+                                          SET_VEX_PP_66);
+@@ -1116,9 +1116,9 @@ void X86Assembler::vmovdqa(XmmRegister dst, const Address& src) {
+   DCHECK(CpuHasAVXorAVX2FeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   /**Instruction VEX Prefix */
+-  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  uint8_t ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
+   X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
+-  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++  uint8_t ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
+                                          vvvv_reg,
+                                          SET_VEX_L_128,
+                                          SET_VEX_PP_66);
+@@ -1147,9 +1147,9 @@ void X86Assembler::vmovdqu(XmmRegister dst, const Address& src) {
+   DCHECK(CpuHasAVXorAVX2FeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   /**Instruction VEX Prefix */
+-  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  uint8_t ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
+   X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
+-  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++  uint8_t ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
+                                          vvvv_reg,
+                                          SET_VEX_L_128,
+                                          SET_VEX_PP_F3);
+@@ -1178,9 +1178,9 @@ void X86Assembler::vmovdqa(const Address& dst, XmmRegister src) {
+   DCHECK(CpuHasAVXorAVX2FeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   /**Instruction VEX Prefix */
+-  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  uint8_t ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
+   X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
+-  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++  uint8_t ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
+                                          vvvv_reg,
+                                          SET_VEX_L_128,
+                                          SET_VEX_PP_66);
+@@ -1210,9 +1210,9 @@ void X86Assembler::vmovdqu(const Address& dst, XmmRegister src) {
+   DCHECK(CpuHasAVXorAVX2FeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   // Instruction VEX Prefix
+-  uint8_t ByteZero = EmitVexPrefixByteZero(/**is_twobyte_form= */true);
++  uint8_t ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
+   X86ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86();
+-  uint8_t ByteOne = EmitVexPrefixByteOne(/**R = */false,
++  uint8_t ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
+                                          vvvv_reg,
+                                          SET_VEX_L_128,
+                                          SET_VEX_PP_F3);
+@@ -1716,12 +1716,12 @@ void X86Assembler::orps(XmmRegister dst, XmmRegister src) {
+ 
+ void X86Assembler::andn(Register dst, Register src1, Register src2) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  uint8_t byte_zero = EmitVexPrefixByteZero(/**is_twobyte_form= */false);
+-  uint8_t byte_one = EmitVexPrefixByteOne(/**R = */false,
+-                                          /**X = */false,
+-                                          /**B = */false,
++  uint8_t byte_zero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ false);
++  uint8_t byte_one = EmitVexPrefixByteOne(/*R=*/ false,
++                                          /*X=*/ false,
++                                          /*B=*/ false,
+                                           SET_VEX_M_0F_38);
+-  uint8_t byte_two = EmitVexPrefixByteTwo(/**W= */false,
++  uint8_t byte_two = EmitVexPrefixByteTwo(/*W=*/ false,
+                                           X86ManagedRegister::FromCpuRegister(src1),
+                                           SET_VEX_L_128,
+                                           SET_VEX_PP_NONE);
+diff --git a/compiler/utils/x86/assembler_x86_test.cc b/compiler/utils/x86/assembler_x86_test.cc
+index 5197156..ee29482 100644
+--- a/compiler/utils/x86/assembler_x86_test.cc
++++ b/compiler/utils/x86/assembler_x86_test.cc
+@@ -501,6 +501,10 @@ TEST_F(AssemblerX86AVXTest, VMovaps) {
+   DriverStr(RepeatFF(&x86::X86Assembler::vmovaps, "vmovaps %{reg2}, %{reg1}"), "vmovaps");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, Movaps) {
++  DriverStr(RepeatFF(&x86::X86Assembler::movaps, "vmovaps %{reg2}, %{reg1}"), "avx_movaps");
++}
++
+ TEST_F(AssemblerX86Test, MovapsLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::movaps, "movaps {mem}, %{reg}"), "movaps_load");
+ }
+@@ -509,6 +513,10 @@ TEST_F(AssemblerX86AVXTest, VMovapsLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::vmovaps, "vmovaps {mem}, %{reg}"), "vmovaps_load");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, MovapsLoad) {
++  DriverStr(RepeatFA(&x86::X86Assembler::movaps, "vmovaps {mem}, %{reg}"), "avx_movaps_load");
++}
++
+ TEST_F(AssemblerX86Test, MovapsStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::movaps, "movaps %{reg}, {mem}"), "movaps_store");
+ }
+@@ -517,6 +525,10 @@ TEST_F(AssemblerX86AVXTest, VMovapsStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::vmovaps, "vmovaps %{reg}, {mem}"), "vmovaps_store");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, MovapsStore) {
++  DriverStr(RepeatAF(&x86::X86Assembler::movaps, "vmovaps %{reg}, {mem}"), "avx_movaps_store");
++}
++
+ TEST_F(AssemblerX86Test, MovupsLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::movups, "movups {mem}, %{reg}"), "movups_load");
+ }
+@@ -525,6 +537,10 @@ TEST_F(AssemblerX86AVXTest, VMovupsLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::vmovups, "vmovups {mem}, %{reg}"), "vmovups_load");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, MovupsLoad) {
++  DriverStr(RepeatFA(&x86::X86Assembler::movups, "vmovups {mem}, %{reg}"), "avx_movups_load");
++}
++
+ TEST_F(AssemblerX86Test, MovupsStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::movups, "movups %{reg}, {mem}"), "movups_store");
+ }
+@@ -533,6 +549,10 @@ TEST_F(AssemblerX86AVXTest, VMovupsStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::vmovups, "vmovups %{reg}, {mem}"), "vmovups_store");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, MovupsStore) {
++  DriverStr(RepeatAF(&x86::X86Assembler::movups, "vmovups %{reg}, {mem}"), "avx_movups_store");
++}
++
+ TEST_F(AssemblerX86Test, Movapd) {
+   DriverStr(RepeatFF(&x86::X86Assembler::movapd, "movapd %{reg2}, %{reg1}"), "movapd");
+ }
+@@ -541,6 +561,10 @@ TEST_F(AssemblerX86AVXTest, VMovapd) {
+   DriverStr(RepeatFF(&x86::X86Assembler::vmovapd, "vmovapd %{reg2}, %{reg1}"), "vmovapd");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, Movapd) {
++  DriverStr(RepeatFF(&x86::X86Assembler::movapd, "vmovapd %{reg2}, %{reg1}"), "avx_movapd");
++}
++
+ TEST_F(AssemblerX86Test, MovapdLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::movapd, "movapd {mem}, %{reg}"), "movapd_load");
+ }
+@@ -549,6 +573,10 @@ TEST_F(AssemblerX86AVXTest, VMovapdLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::vmovapd, "vmovapd {mem}, %{reg}"), "vmovapd_load");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, MovapdLoad) {
++  DriverStr(RepeatFA(&x86::X86Assembler::movapd, "vmovapd {mem}, %{reg}"), "avx_movapd_load");
++}
++
+ TEST_F(AssemblerX86Test, MovapdStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::movapd, "movapd %{reg}, {mem}"), "movapd_store");
+ }
+@@ -557,6 +585,10 @@ TEST_F(AssemblerX86AVXTest, VMovapdStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::vmovapd, "vmovapd %{reg}, {mem}"), "vmovapd_store");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, MovapdStore) {
++  DriverStr(RepeatAF(&x86::X86Assembler::movapd, "vmovapd %{reg}, {mem}"), "avx_movapd_store");
++}
++
+ TEST_F(AssemblerX86Test, MovupdLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::movupd, "movupd {mem}, %{reg}"), "movupd_load");
+ }
+@@ -565,6 +597,10 @@ TEST_F(AssemblerX86AVXTest, VMovupdLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::vmovupd, "vmovupd {mem}, %{reg}"), "vmovupd_load");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, MovupdLoad) {
++  DriverStr(RepeatFA(&x86::X86Assembler::movupd, "vmovupd {mem}, %{reg}"), "avx_movupd_load");
++}
++
+ TEST_F(AssemblerX86Test, MovupdStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::movupd, "movupd %{reg}, {mem}"), "movupd_store");
+ }
+@@ -573,6 +609,10 @@ TEST_F(AssemblerX86AVXTest, VMovupdStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::vmovupd, "vmovupd %{reg}, {mem}"), "vmovupd_store");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, MovupdStore) {
++  DriverStr(RepeatAF(&x86::X86Assembler::movupd, "vmovupd %{reg}, {mem}"), "avx_movupd_store");
++}
++
+ TEST_F(AssemblerX86Test, Movdqa) {
+   DriverStr(RepeatFF(&x86::X86Assembler::movdqa, "movdqa %{reg2}, %{reg1}"), "movdqa");
+ }
+@@ -581,6 +621,10 @@ TEST_F(AssemblerX86AVXTest, VMovdqa) {
+   DriverStr(RepeatFF(&x86::X86Assembler::vmovdqa, "vmovdqa %{reg2}, %{reg1}"), "vmovdqa");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, Movdqa) {
++  DriverStr(RepeatFF(&x86::X86Assembler::movdqa, "vmovdqa %{reg2}, %{reg1}"), "avx_movdqa");
++}
++
+ TEST_F(AssemblerX86Test, MovdqaLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::movdqa, "movdqa {mem}, %{reg}"), "movdqa_load");
+ }
+@@ -589,6 +633,10 @@ TEST_F(AssemblerX86AVXTest, VMovdqaLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::vmovdqa, "vmovdqa {mem}, %{reg}"), "vmovdqa_load");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, MovdqaLoad) {
++  DriverStr(RepeatFA(&x86::X86Assembler::movdqa, "vmovdqa {mem}, %{reg}"), "avx_movdqa_load");
++}
++
+ TEST_F(AssemblerX86Test, MovdqaStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::movdqa, "movdqa %{reg}, {mem}"), "movdqa_store");
+ }
+@@ -597,6 +645,10 @@ TEST_F(AssemblerX86AVXTest, VMovdqaStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::vmovdqa, "vmovdqa %{reg}, {mem}"), "vmovdqa_store");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, MovdqaStore) {
++  DriverStr(RepeatAF(&x86::X86Assembler::movdqa, "vmovdqa %{reg}, {mem}"), "avx_movdqa_store");
++}
++
+ TEST_F(AssemblerX86Test, MovdquLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::movdqu, "movdqu {mem}, %{reg}"), "movdqu_load");
+ }
+@@ -605,6 +657,10 @@ TEST_F(AssemblerX86AVXTest, VMovdquLoad) {
+   DriverStr(RepeatFA(&x86::X86Assembler::vmovdqu, "vmovdqu {mem}, %{reg}"), "vmovdqu_load");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, MovdquLoad) {
++  DriverStr(RepeatFA(&x86::X86Assembler::movdqu, "vmovdqu {mem}, %{reg}"), "avx_movdqu_load");
++}
++
+ TEST_F(AssemblerX86Test, MovdquStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::movdqu, "movdqu %{reg}, {mem}"), "movdqu_store");
+ }
+@@ -613,6 +669,10 @@ TEST_F(AssemblerX86AVXTest, VMovdquStore) {
+   DriverStr(RepeatAF(&x86::X86Assembler::vmovdqu, "vmovdqu %{reg}, {mem}"), "vmovdqu_store");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, MovdquStore) {
++  DriverStr(RepeatAF(&x86::X86Assembler::movdqu, "vmovdqu %{reg}, {mem}"), "avx_movdqu_store");
++}
++
+ TEST_F(AssemblerX86Test, AddPS) {
+   DriverStr(RepeatFF(&x86::X86Assembler::addps, "addps %{reg2}, %{reg1}"), "addps");
+ }
+diff --git a/compiler/utils/x86_64/assembler_x86_64.cc b/compiler/utils/x86_64/assembler_x86_64.cc
+index c010a68..336ecbf 100644
+--- a/compiler/utils/x86_64/assembler_x86_64.cc
++++ b/compiler/utils/x86_64/assembler_x86_64.cc
+@@ -448,10 +448,10 @@ void X86_64Assembler::vmovaps(XmmRegister dst, XmmRegister src) {
+                                     SET_VEX_PP_NONE);
+   } else {
+     byte_one = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                    /** X= */false,
++                                    /*X=*/ false,
+                                     src.NeedsRex(),
+                                     SET_VEX_M_0F);
+-    byte_two = EmitVexPrefixByteTwo(/**W= */false,
++    byte_two = EmitVexPrefixByteTwo(/*W=*/ false,
+                                     SET_VEX_L_128,
+                                     SET_VEX_PP_NONE);
+   }
+@@ -511,7 +511,7 @@ void X86_64Assembler::vmovaps(XmmRegister dst, const Address& src) {
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+                                    SET_VEX_L_128,
+                                    SET_VEX_PP_NONE);
+   }
+@@ -563,7 +563,7 @@ void X86_64Assembler::vmovups(XmmRegister dst, const Address& src) {
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+                                    SET_VEX_L_128,
+                                    SET_VEX_PP_NONE);
+   }
+@@ -617,7 +617,7 @@ void X86_64Assembler::vmovaps(const Address& dst, XmmRegister src) {
+                                    Rex_x ,
+                                    Rex_b ,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+                                    SET_VEX_L_128,
+                                    SET_VEX_PP_NONE);
+   }
+@@ -670,7 +670,7 @@ void X86_64Assembler::vmovups(const Address& dst, XmmRegister src) {
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+                                    SET_VEX_L_128,
+                                    SET_VEX_PP_NONE);
+   }
+@@ -931,10 +931,10 @@ void X86_64Assembler::vmovapd(XmmRegister dst, XmmRegister src) {
+                                    SET_VEX_PP_66);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /**X = */false ,
++                                   /*X=*/ false ,
+                                    src.NeedsRex(),
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+                                    SET_VEX_L_128,
+                                    SET_VEX_PP_66);
+   }
+@@ -996,7 +996,7 @@ void X86_64Assembler::vmovapd(XmmRegister dst, const Address& src) {
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+                                    SET_VEX_L_128,
+                                    SET_VEX_PP_66);
+   }
+@@ -1050,7 +1050,7 @@ void X86_64Assembler::vmovupd(XmmRegister dst, const Address& src) {
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+                                    SET_VEX_L_128,
+                                    SET_VEX_PP_66);
+   }
+@@ -1102,7 +1102,7 @@ void X86_64Assembler::vmovapd(const Address& dst, XmmRegister src) {
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+                                    SET_VEX_L_128,
+                                    SET_VEX_PP_66);
+   }
+@@ -1156,7 +1156,7 @@ void X86_64Assembler::vmovupd(const Address& dst, XmmRegister src) {
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+                                    SET_VEX_L_128,
+                                    SET_VEX_PP_66);
+   }
+@@ -1357,10 +1357,10 @@ void X86_64Assembler::vmovdqa(XmmRegister dst, XmmRegister src) {
+                                    SET_VEX_PP_66);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /**X = */false,
++                                   /*X=*/ false,
+                                    src.NeedsRex(),
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+                                    SET_VEX_L_128,
+                                    SET_VEX_PP_66);
+   }
+@@ -1422,7 +1422,7 @@ void X86_64Assembler::vmovdqa(XmmRegister dst, const Address& src) {
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+                                    SET_VEX_L_128,
+                                    SET_VEX_PP_66);
+   }
+@@ -1477,7 +1477,7 @@ void X86_64Assembler::vmovdqu(XmmRegister dst, const Address& src) {
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+                                    SET_VEX_L_128,
+                                    SET_VEX_PP_F3);
+   }
+@@ -1530,7 +1530,7 @@ void X86_64Assembler::vmovdqa(const Address& dst, XmmRegister src) {
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+                                    SET_VEX_L_128,
+                                    SET_VEX_PP_66);
+   }
+@@ -1584,7 +1584,7 @@ void X86_64Assembler::vmovdqu(const Address& dst, XmmRegister src) {
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/**W= */false,
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+                                    SET_VEX_L_128,
+                                    SET_VEX_PP_F3);
+   }
+@@ -2174,12 +2174,12 @@ void X86_64Assembler::pand(XmmRegister dst, XmmRegister src) {
+ 
+ void X86_64Assembler::andn(CpuRegister dst, CpuRegister src1, CpuRegister src2) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  uint8_t byte_zero = EmitVexPrefixByteZero(/**is_two_byte= */false);
++  uint8_t byte_zero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ false);
+   uint8_t byte_one = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                          /**X = */false,
++                                          /*X=*/ false,
+                                           src2.NeedsRex(),
+                                           SET_VEX_M_0F_38);
+-  uint8_t byte_two = EmitVexPrefixByteTwo(/**W= */true,
++  uint8_t byte_two = EmitVexPrefixByteTwo(/*W=*/ true,
+                                           X86_64ManagedRegister::FromCpuRegister(src1.AsRegister()),
+                                           SET_VEX_L_128,
+                                           SET_VEX_PP_NONE);
+@@ -3970,12 +3970,12 @@ void X86_64Assembler::setcc(Condition condition, CpuRegister dst) {
+ 
+ void X86_64Assembler::blsi(CpuRegister dst, CpuRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  uint8_t byte_zero = EmitVexPrefixByteZero(/**is_two_byte= */false);
+-  uint8_t byte_one = EmitVexPrefixByteOne(/**R = */false,
+-                                          /**X = */false,
++  uint8_t byte_zero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ false);
++  uint8_t byte_one = EmitVexPrefixByteOne(/*R=*/ false,
++                                          /*X=*/ false,
+                                           src.NeedsRex(),
+                                           SET_VEX_M_0F_38);
+-  uint8_t byte_two = EmitVexPrefixByteTwo(/**W= */true,
++  uint8_t byte_two = EmitVexPrefixByteTwo(/*W=*/true,
+                                           X86_64ManagedRegister::FromCpuRegister(dst.AsRegister()),
+                                           SET_VEX_L_128,
+                                           SET_VEX_PP_NONE);
+@@ -3988,12 +3988,12 @@ void X86_64Assembler::blsi(CpuRegister dst, CpuRegister src) {
+ 
+ void X86_64Assembler::blsmsk(CpuRegister dst, CpuRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  uint8_t byte_zero = EmitVexPrefixByteZero(/**is_two_byte= */false);
+-  uint8_t byte_one = EmitVexPrefixByteOne(/**R = */false,
+-                                          /**X = */false,
++  uint8_t byte_zero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ false);
++  uint8_t byte_one = EmitVexPrefixByteOne(/*R=*/ false,
++                                          /*X=*/ false,
+                                           src.NeedsRex(),
+                                           SET_VEX_M_0F_38);
+-  uint8_t byte_two = EmitVexPrefixByteTwo(/**W= */true,
++  uint8_t byte_two = EmitVexPrefixByteTwo(/*W=*/ true,
+                                           X86_64ManagedRegister::FromCpuRegister(dst.AsRegister()),
+                                           SET_VEX_L_128,
+                                           SET_VEX_PP_NONE);
+@@ -4006,12 +4006,12 @@ void X86_64Assembler::blsmsk(CpuRegister dst, CpuRegister src) {
+ 
+ void X86_64Assembler::blsr(CpuRegister dst, CpuRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  uint8_t byte_zero = EmitVexPrefixByteZero(/**is_two_byte= */false);
+-  uint8_t byte_one = EmitVexPrefixByteOne(/**R = */false,
+-                                          /**X = */false,
++  uint8_t byte_zero = EmitVexPrefixByteZero(/*is_twobyte_form=*/false);
++  uint8_t byte_one = EmitVexPrefixByteOne(/*R=*/ false,
++                                          /*X=*/ false,
+                                           src.NeedsRex(),
+                                           SET_VEX_M_0F_38);
+-  uint8_t byte_two = EmitVexPrefixByteTwo(/**W= */true,
++  uint8_t byte_two = EmitVexPrefixByteTwo(/*W=*/ true,
+                                           X86_64ManagedRegister::FromCpuRegister(dst.AsRegister()),
+                                           SET_VEX_L_128,
+                                           SET_VEX_PP_NONE);
+diff --git a/compiler/utils/x86_64/assembler_x86_64_test.cc b/compiler/utils/x86_64/assembler_x86_64_test.cc
+index 297246e..411c30b 100644
+--- a/compiler/utils/x86_64/assembler_x86_64_test.cc
++++ b/compiler/utils/x86_64/assembler_x86_64_test.cc
+@@ -1123,6 +1123,10 @@ TEST_F(AssemblerX86_64AVXTest, VMovaps) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::vmovaps, "vmovaps %{reg2}, %{reg1}"), "vmovaps");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, Movaps) {
++  DriverStr(RepeatFF(&x86_64::X86_64Assembler::movaps, "vmovaps %{reg2}, %{reg1}"), "avx_movaps");
++}
++
+ TEST_F(AssemblerX86_64Test, MovapsStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::movaps, "movaps %{reg}, {mem}"), "movaps_s");
+ }
+@@ -1131,6 +1135,10 @@ TEST_F(AssemblerX86_64AVXTest, VMovapsStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovaps, "vmovaps %{reg}, {mem}"), "vmovaps_s");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, MovapsStore) {
++  DriverStr(RepeatAF(&x86_64::X86_64Assembler::movaps, "vmovaps %{reg}, {mem}"), "avx_movaps_s");
++}
++
+ TEST_F(AssemblerX86_64Test, MovapsLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::movaps, "movaps {mem}, %{reg}"), "movaps_l");
+ }
+@@ -1139,6 +1147,10 @@ TEST_F(AssemblerX86_64AVXTest, VMovapsLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovaps, "vmovaps {mem}, %{reg}"), "vmovaps_l");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, MovapsLoad) {
++  DriverStr(RepeatFA(&x86_64::X86_64Assembler::movaps, "vmovaps {mem}, %{reg}"), "avx_movaps_l");
++}
++
+ TEST_F(AssemblerX86_64Test, MovupsStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::movups, "movups %{reg}, {mem}"), "movups_s");
+ }
+@@ -1147,6 +1159,10 @@ TEST_F(AssemblerX86_64AVXTest, VMovupsStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovups, "vmovups %{reg}, {mem}"), "vmovups_s");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, MovupsStore) {
++  DriverStr(RepeatAF(&x86_64::X86_64Assembler::movups, "vmovups %{reg}, {mem}"), "avx_movups_s");
++}
++
+ TEST_F(AssemblerX86_64Test, MovupsLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::movups, "movups {mem}, %{reg}"), "movups_l");
+ }
+@@ -1155,6 +1171,9 @@ TEST_F(AssemblerX86_64AVXTest, VMovupsLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovups, "vmovups {mem}, %{reg}"), "vmovups_l");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, MovupsLoad) {
++  DriverStr(RepeatFA(&x86_64::X86_64Assembler::movups, "vmovups {mem}, %{reg}"), "avx_movups_l");
++}
+ 
+ TEST_F(AssemblerX86_64Test, Movss) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::movss, "movss %{reg2}, %{reg1}"), "movss");
+@@ -1168,6 +1187,10 @@ TEST_F(AssemblerX86_64AVXTest, VMovapd) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::vmovapd, "vmovapd %{reg2}, %{reg1}"), "vmovapd");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, Movapd) {
++  DriverStr(RepeatFF(&x86_64::X86_64Assembler::movapd, "vmovapd %{reg2}, %{reg1}"), "avx_movapd");
++}
++
+ TEST_F(AssemblerX86_64Test, MovapdStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::movapd, "movapd %{reg}, {mem}"), "movapd_s");
+ }
+@@ -1176,6 +1199,10 @@ TEST_F(AssemblerX86_64AVXTest, VMovapdStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovapd, "vmovapd %{reg}, {mem}"), "vmovapd_s");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, MovapdStore) {
++  DriverStr(RepeatAF(&x86_64::X86_64Assembler::movapd, "vmovapd %{reg}, {mem}"), "avx_movapd_s");
++}
++
+ TEST_F(AssemblerX86_64Test, MovapdLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::movapd, "movapd {mem}, %{reg}"), "movapd_l");
+ }
+@@ -1184,6 +1211,10 @@ TEST_F(AssemblerX86_64AVXTest, VMovapdLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovapd, "vmovapd {mem}, %{reg}"), "vmovapd_l");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, MovapdLoad) {
++  DriverStr(RepeatFA(&x86_64::X86_64Assembler::movapd, "vmovapd {mem}, %{reg}"), "avx_movapd_l");
++}
++
+ TEST_F(AssemblerX86_64Test, MovupdStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::movupd, "movupd %{reg}, {mem}"), "movupd_s");
+ }
+@@ -1192,6 +1223,10 @@ TEST_F(AssemblerX86_64AVXTest, VMovupdStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovupd, "vmovupd %{reg}, {mem}"), "vmovupd_s");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, MovupdStore) {
++  DriverStr(RepeatAF(&x86_64::X86_64Assembler::movupd, "vmovupd %{reg}, {mem}"), "avx_movupd_s");
++}
++
+ TEST_F(AssemblerX86_64Test, MovupdLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::movupd, "movupd {mem}, %{reg}"), "movupd_l");
+ }
+@@ -1200,6 +1235,10 @@ TEST_F(AssemblerX86_64AVXTest, VMovupdLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovupd, "vmovupd {mem}, %{reg}"), "vmovupd_l");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, MovupdLoad) {
++  DriverStr(RepeatFA(&x86_64::X86_64Assembler::movupd, "vmovupd {mem}, %{reg}"), "avx_movupd_l");
++}
++
+ TEST_F(AssemblerX86_64Test, Movsd) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::movsd, "movsd %{reg2}, %{reg1}"), "movsd");
+ }
+@@ -1212,6 +1251,10 @@ TEST_F(AssemblerX86_64AVXTest, VMovdqa) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::vmovdqa, "vmovdqa %{reg2}, %{reg1}"), "vmovdqa");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, Movdqa) {
++  DriverStr(RepeatFF(&x86_64::X86_64Assembler::movdqa, "vmovdqa %{reg2}, %{reg1}"), "avx_movdqa");
++}
++
+ TEST_F(AssemblerX86_64Test, MovdqaStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::movdqa, "movdqa %{reg}, {mem}"), "movdqa_s");
+ }
+@@ -1220,6 +1263,10 @@ TEST_F(AssemblerX86_64AVXTest, VMovdqaStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovdqa, "vmovdqa %{reg}, {mem}"), "vmovdqa_s");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, MovdqaStore) {
++  DriverStr(RepeatAF(&x86_64::X86_64Assembler::movdqa, "vmovdqa %{reg}, {mem}"), "avx_movdqa_s");
++}
++
+ TEST_F(AssemblerX86_64Test, MovdqaLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::movdqa, "movdqa {mem}, %{reg}"), "movdqa_l");
+ }
+@@ -1228,6 +1275,10 @@ TEST_F(AssemblerX86_64AVXTest, VMovdqaLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovdqa, "vmovdqa {mem}, %{reg}"), "vmovdqa_l");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, MovdqaLoad) {
++  DriverStr(RepeatFA(&x86_64::X86_64Assembler::movdqa, "vmovdqa {mem}, %{reg}"), "avx_movdqa_l");
++}
++
+ TEST_F(AssemblerX86_64Test, MovdquStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::movdqu, "movdqu %{reg}, {mem}"), "movdqu_s");
+ }
+@@ -1236,6 +1287,10 @@ TEST_F(AssemblerX86_64AVXTest, VMovdquStore) {
+   DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovdqu, "vmovdqu %{reg}, {mem}"), "vmovdqu_s");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, MovdquStore) {
++  DriverStr(RepeatAF(&x86_64::X86_64Assembler::movdqu, "vmovdqu %{reg}, {mem}"), "avx_movdqu_s");
++}
++
+ TEST_F(AssemblerX86_64Test, MovdquLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::movdqu, "movdqu {mem}, %{reg}"), "movdqu_l");
+ }
+@@ -1244,6 +1299,10 @@ TEST_F(AssemblerX86_64AVXTest, VMovdquLoad) {
+   DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovdqu, "vmovdqu {mem}, %{reg}"), "vmovdqu_l");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, MovdquLoad) {
++  DriverStr(RepeatFA(&x86_64::X86_64Assembler::movdqu, "vmovdqu {mem}, %{reg}"), "avx_movdqu_l");
++}
++
+ TEST_F(AssemblerX86_64Test, Movd1) {
+   DriverStr(RepeatFR(&x86_64::X86_64Assembler::movd, "movd %{reg2}, %{reg1}"), "movd.1");
+ }
+-- 
+2.7.4
+

--- a/aosp_diff/caas/art/0004-Add-AVX-support-for-packed-add-sub-instructions-on-x.patch
+++ b/aosp_diff/caas/art/0004-Add-AVX-support-for-packed-add-sub-instructions-on-x.patch
@@ -1,0 +1,1496 @@
+From e6cb33a31ee7633da4b2525efb237cdbd00e2b62 Mon Sep 17 00:00:00 2001
+From: Shalini Salomi Bodapati <shalini.salomi.bodapati@intel.com>
+Date: Thu, 30 May 2019 11:00:42 +0530
+Subject: [PATCH] Add AVX support for packed add/sub instructions on x86
+
+Test: ./test.py --host, test-art-host-gtest
+
+Change-Id: I48d05e6f6befd54657d962119a543b27a8a51d71
+Signed-off-by: Shalini Salomi Bodapati <shalini.salomi.bodapati@intel.com>
+---
+ compiler/optimizing/code_generator_vector_x86.cc   | 106 ++++++
+ .../optimizing/code_generator_vector_x86_64.cc     | 106 ++++++
+ compiler/optimizing/loop_optimization.cc           |  29 +-
+ compiler/optimizing/nodes.h                        |   7 +-
+ compiler/optimizing/nodes_vector_x86.h             |  84 +++++
+ compiler/utils/x86/assembler_x86.cc                | 154 +++++++++
+ compiler/utils/x86/assembler_x86.h                 |  17 +
+ compiler/utils/x86/assembler_x86_test.cc           |  50 +++
+ compiler/utils/x86_64/assembler_x86_64.cc          | 359 ++++++++++++++++++++-
+ compiler/utils/x86_64/assembler_x86_64.h           |  17 +
+ compiler/utils/x86_64/assembler_x86_64_test.cc     |  61 ++++
+ 11 files changed, 981 insertions(+), 9 deletions(-)
+ create mode 100644 compiler/optimizing/nodes_vector_x86.h
+
+diff --git a/compiler/optimizing/code_generator_vector_x86.cc b/compiler/optimizing/code_generator_vector_x86.cc
+index 0ee0035..c8964dd 100644
+--- a/compiler/optimizing/code_generator_vector_x86.cc
++++ b/compiler/optimizing/code_generator_vector_x86.cc
+@@ -473,6 +473,70 @@ void InstructionCodeGeneratorX86::VisitVecAdd(HVecAdd* instruction) {
+   }
+ }
+ 
++static void CreateVecTerOpLocations(ArenaAllocator* allocator, HVecOperation* instruction) {
++  LocationSummary* locations = new (allocator) LocationSummary(instruction);
++  switch (instruction->GetPackedType()) {
++    case DataType::Type::kBool:
++    case DataType::Type::kUint8:
++    case DataType::Type::kInt8:
++    case DataType::Type::kUint16:
++    case DataType::Type::kInt16:
++    case DataType::Type::kInt32:
++    case DataType::Type::kInt64:
++    case DataType::Type::kFloat32:
++    case DataType::Type::kFloat64:
++      locations->SetInAt(0, Location::RequiresFpuRegister());
++      locations->SetInAt(1, Location::RequiresFpuRegister());
++      locations->SetOut(Location::RequiresFpuRegister());
++      break;
++    default:
++      LOG(FATAL) << "Unsupported SIMD type";
++      UNREACHABLE();
++  }
++}
++
++void LocationsBuilderX86::VisitVecAvxAdd(HVecAvxAdd* instruction) {
++    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++}
++
++void InstructionCodeGeneratorX86::VisitVecAvxAdd(HVecAvxAdd* instruction) {
++  LocationSummary* locations = instruction->GetLocations();
++  XmmRegister src1 = locations->InAt(0).AsFpuRegister<XmmRegister>();
++  XmmRegister src2 = locations->InAt(1).AsFpuRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  switch (instruction->GetPackedType()) {
++    case DataType::Type::kUint8:
++    case DataType::Type::kInt8:
++      DCHECK_EQ(16u, instruction->GetVectorLength());
++        __ vpaddb(dst, src1, src2);
++      break;
++    case DataType::Type::kUint16:
++    case DataType::Type::kInt16:
++      DCHECK_EQ(8u, instruction->GetVectorLength());
++      __ vpaddw(dst, src1, src2);
++      break;
++    case DataType::Type::kInt32:
++      DCHECK_EQ(4u, instruction->GetVectorLength());
++      __ vpaddd(dst, src1, src2);
++      break;
++    case DataType::Type::kInt64:
++      DCHECK_EQ(2u, instruction->GetVectorLength());
++      __ vpaddq(dst, src1, src2);
++      break;
++    case DataType::Type::kFloat32:
++      DCHECK_EQ(4u, instruction->GetVectorLength());
++      __ vaddps(dst, src1, src2);
++      break;
++    case DataType::Type::kFloat64:
++      DCHECK_EQ(2u, instruction->GetVectorLength());
++      __ vaddpd(dst, src1, src2);
++      break;
++    default:
++      LOG(FATAL) << "Unsupported SIMD type";
++      UNREACHABLE();
++  }
++}
++
+ void LocationsBuilderX86::VisitVecSaturationAdd(HVecSaturationAdd* instruction) {
+   CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+ }
+@@ -574,6 +638,48 @@ void InstructionCodeGeneratorX86::VisitVecSub(HVecSub* instruction) {
+   }
+ }
+ 
++void LocationsBuilderX86::VisitVecAvxSub(HVecAvxSub* instruction) {
++  CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++}
++
++void InstructionCodeGeneratorX86::VisitVecAvxSub(HVecAvxSub* instruction) {
++  LocationSummary* locations = instruction->GetLocations();
++  XmmRegister src1 = locations->InAt(0).AsFpuRegister<XmmRegister>();
++  XmmRegister src2 = locations->InAt(1).AsFpuRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  switch (instruction->GetPackedType()) {
++    case DataType::Type::kUint8:
++    case DataType::Type::kInt8:
++      DCHECK_EQ(16u, instruction->GetVectorLength());
++      __ vpsubb(dst, src1, src2);
++      break;
++    case DataType::Type::kUint16:
++    case DataType::Type::kInt16:
++      DCHECK_EQ(8u, instruction->GetVectorLength());
++      __ vpsubw(dst, src1, src2);
++      break;
++    case DataType::Type::kInt32:
++      DCHECK_EQ(4u, instruction->GetVectorLength());
++      __ vpsubd(dst, src1, src2);
++      break;
++    case DataType::Type::kInt64:
++      DCHECK_EQ(2u, instruction->GetVectorLength());
++      __ vpsubq(dst, src1, src2);
++      break;
++    case DataType::Type::kFloat32:
++      DCHECK_EQ(4u, instruction->GetVectorLength());
++      __ vsubps(dst, src1, src2);
++      break;
++    case DataType::Type::kFloat64:
++      DCHECK_EQ(2u, instruction->GetVectorLength());
++      __ vsubpd(dst, src1, src2);
++      break;
++    default:
++      LOG(FATAL) << "Unsupported SIMD type";
++      UNREACHABLE();
++  }
++}
++
+ void LocationsBuilderX86::VisitVecSaturationSub(HVecSaturationSub* instruction) {
+   CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+ }
+diff --git a/compiler/optimizing/code_generator_vector_x86_64.cc b/compiler/optimizing/code_generator_vector_x86_64.cc
+index 9c28827..c147659 100644
+--- a/compiler/optimizing/code_generator_vector_x86_64.cc
++++ b/compiler/optimizing/code_generator_vector_x86_64.cc
+@@ -414,6 +414,28 @@ static void CreateVecBinOpLocations(ArenaAllocator* allocator, HVecBinaryOperati
+   }
+ }
+ 
++static void CreateVecTerOpLocations(ArenaAllocator* allocator, HVecOperation* instruction) {
++  LocationSummary* locations = new (allocator) LocationSummary(instruction);
++  switch (instruction->GetPackedType()) {
++    case DataType::Type::kBool:
++    case DataType::Type::kUint8:
++    case DataType::Type::kInt8:
++    case DataType::Type::kUint16:
++    case DataType::Type::kInt16:
++    case DataType::Type::kInt32:
++    case DataType::Type::kInt64:
++    case DataType::Type::kFloat32:
++    case DataType::Type::kFloat64:
++      locations->SetInAt(0, Location::RequiresFpuRegister());
++      locations->SetInAt(1, Location::RequiresFpuRegister());
++      locations->SetOut(Location::RequiresFpuRegister());
++      break;
++    default:
++      LOG(FATAL) << "Unsupported SIMD type";
++      UNREACHABLE();
++  }
++}
++
+ void LocationsBuilderX86_64::VisitVecAdd(HVecAdd* instruction) {
+   CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+ }
+@@ -456,6 +478,48 @@ void InstructionCodeGeneratorX86_64::VisitVecAdd(HVecAdd* instruction) {
+   }
+ }
+ 
++void LocationsBuilderX86_64::VisitVecAvxAdd(HVecAvxAdd* instruction) {
++    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++}
++
++void InstructionCodeGeneratorX86_64::VisitVecAvxAdd(HVecAvxAdd* instruction) {
++  LocationSummary* locations = instruction->GetLocations();
++  XmmRegister src1 = locations->InAt(0).AsFpuRegister<XmmRegister>();
++  XmmRegister src2 = locations->InAt(1).AsFpuRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  switch (instruction->GetPackedType()) {
++    case DataType::Type::kUint8:
++    case DataType::Type::kInt8:
++      DCHECK_EQ(16u, instruction->GetVectorLength());
++        __ vpaddb(dst, src1, src2);
++      break;
++    case DataType::Type::kUint16:
++    case DataType::Type::kInt16:
++      DCHECK_EQ(8u, instruction->GetVectorLength());
++      __ vpaddw(dst, src1, src2);
++      break;
++    case DataType::Type::kInt32:
++      DCHECK_EQ(4u, instruction->GetVectorLength());
++      __ vpaddd(dst, src1, src2);
++      break;
++    case DataType::Type::kInt64:
++      DCHECK_EQ(2u, instruction->GetVectorLength());
++      __ vpaddq(dst, src1, src2);
++      break;
++    case DataType::Type::kFloat32:
++      DCHECK_EQ(4u, instruction->GetVectorLength());
++      __ vaddps(dst, src1, src2);
++      break;
++    case DataType::Type::kFloat64:
++      DCHECK_EQ(2u, instruction->GetVectorLength());
++      __ vaddpd(dst, src1, src2);
++      break;
++    default:
++      LOG(FATAL) << "Unsupported SIMD type";
++      UNREACHABLE();
++  }
++}
++
+ void LocationsBuilderX86_64::VisitVecSaturationAdd(HVecSaturationAdd* instruction) {
+   CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+ }
+@@ -557,6 +621,48 @@ void InstructionCodeGeneratorX86_64::VisitVecSub(HVecSub* instruction) {
+   }
+ }
+ 
++void LocationsBuilderX86_64::VisitVecAvxSub(HVecAvxSub* instruction) {
++  CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++}
++
++void InstructionCodeGeneratorX86_64::VisitVecAvxSub(HVecAvxSub* instruction) {
++  LocationSummary* locations = instruction->GetLocations();
++  XmmRegister src1 = locations->InAt(0).AsFpuRegister<XmmRegister>();
++  XmmRegister src2 = locations->InAt(1).AsFpuRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  switch (instruction->GetPackedType()) {
++    case DataType::Type::kUint8:
++    case DataType::Type::kInt8:
++      DCHECK_EQ(16u, instruction->GetVectorLength());
++      __ vpsubb(dst, src1, src2);
++      break;
++    case DataType::Type::kUint16:
++    case DataType::Type::kInt16:
++      DCHECK_EQ(8u, instruction->GetVectorLength());
++      __ vpsubw(dst, src1, src2);
++      break;
++    case DataType::Type::kInt32:
++      DCHECK_EQ(4u, instruction->GetVectorLength());
++      __ vpsubd(dst, src1, src2);
++      break;
++    case DataType::Type::kInt64:
++      DCHECK_EQ(2u, instruction->GetVectorLength());
++      __ vpsubq(dst, src1, src2);
++      break;
++    case DataType::Type::kFloat32:
++      DCHECK_EQ(4u, instruction->GetVectorLength());
++      __ vsubps(dst, src1, src2);
++      break;
++    case DataType::Type::kFloat64:
++      DCHECK_EQ(2u, instruction->GetVectorLength());
++      __ vsubpd(dst, src1, src2);
++      break;
++    default:
++      LOG(FATAL) << "Unsupported SIMD type";
++      UNREACHABLE();
++  }
++}
++
+ void LocationsBuilderX86_64::VisitVecSaturationSub(HVecSaturationSub* instruction) {
+   CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+ }
+diff --git a/compiler/optimizing/loop_optimization.cc b/compiler/optimizing/loop_optimization.cc
+index 6c76ab8..c6e7560 100644
+--- a/compiler/optimizing/loop_optimization.cc
++++ b/compiler/optimizing/loop_optimization.cc
+@@ -351,8 +351,11 @@ static bool HasReductionFormat(HInstruction* reduction, HInstruction* phi) {
+ 
+ // Translates vector operation to reduction kind.
+ static HVecReduce::ReductionKind GetReductionKind(HVecOperation* reduction) {
+-  if (reduction->IsVecAdd() ||
++  if (reduction->IsVecAdd()  ||
+       reduction->IsVecSub() ||
++      #if defined(ART_ENABLE_CODEGEN_x86) || defined(ART_ENABLE_CODEGEN_x86_64)
++      reduction->IsVecAvxSub() || reduction->IsVecAvxAdd() ||
++      #endif
+       reduction->IsVecSADAccumulate() ||
+       reduction->IsVecDotProd()) {
+     return HVecReduce::kSum;
+@@ -1940,10 +1943,34 @@ void HLoopOptimization::GenerateVecOp(HInstruction* org,
+         new (global_allocator_) HVecCnv(global_allocator_, opa, type, vector_length_, dex_pc),
+         new (global_allocator_) HTypeConversion(org_type, opa, dex_pc));
+     case HInstruction::kAdd:
++      #if defined(ART_ENABLE_CODEGEN_x86) || defined(ART_ENABLE_CODEGEN_x86_64)
++      if ((compiler_options_->GetInstructionSet() == InstructionSet::kX86 ||
++           compiler_options_->GetInstructionSet() == InstructionSet::kX86_64) &&
++           compiler_options_->GetInstructionSetFeatures()->AsX86InstructionSetFeatures()
++               ->HasAVX2()) {
++        GENERATE_VEC(
++          new (global_allocator_) HVecAvxAdd(
++                                      global_allocator_, opa, opb, type, vector_length_, dex_pc),
++          new (global_allocator_) HAdd(org_type, opa, opb, dex_pc));
++        UNREACHABLE();  // GENERATE_VEC ends with a "break".
++      }
++      #endif
+       GENERATE_VEC(
+         new (global_allocator_) HVecAdd(global_allocator_, opa, opb, type, vector_length_, dex_pc),
+         new (global_allocator_) HAdd(org_type, opa, opb, dex_pc));
+     case HInstruction::kSub:
++      #if defined(ART_ENABLE_CODEGEN_x86) || defined(ART_ENABLE_CODEGEN_x86_64)
++      if ((compiler_options_->GetInstructionSet() == InstructionSet::kX86 ||
++           compiler_options_->GetInstructionSet() == InstructionSet::kX86_64) &&
++           compiler_options_->GetInstructionSetFeatures()->AsX86InstructionSetFeatures()
++               ->HasAVX2()) {
++        GENERATE_VEC(
++          new (global_allocator_) HVecAvxSub(
++                                      global_allocator_, opa, opb, type, vector_length_, dex_pc),
++          new (global_allocator_) HSub(org_type, opa, opb, dex_pc));
++        UNREACHABLE();  // GENERATE_VEC ends with a "break".
++      }
++      #endif
+       GENERATE_VEC(
+         new (global_allocator_) HVecSub(global_allocator_, opa, opb, type, vector_length_, dex_pc),
+         new (global_allocator_) HSub(org_type, opa, opb, dex_pc));
+diff --git a/compiler/optimizing/nodes.h b/compiler/optimizing/nodes.h
+index fedad0c..8ae9d0b 100644
+--- a/compiler/optimizing/nodes.h
++++ b/compiler/optimizing/nodes.h
+@@ -1520,8 +1520,10 @@ class HLoopInformationOutwardIterator : public ValueObject {
+ 
+ #if defined(ART_ENABLE_CODEGEN_x86) || defined(ART_ENABLE_CODEGEN_x86_64)
+ #define FOR_EACH_CONCRETE_INSTRUCTION_X86_COMMON(M)                     \
+-  M(X86AndNot, Instruction)                                                \
+-  M(X86MaskOrResetLeastSetBit, Instruction)
++  M(X86AndNot, Instruction)                                             \
++  M(X86MaskOrResetLeastSetBit, Instruction)                             \
++  M(VecAvxSub, VecOperation)                                            \
++  M(VecAvxAdd, VecOperation)
+ #else
+ #define FOR_EACH_CONCRETE_INSTRUCTION_X86_COMMON(M)
+ #endif
+@@ -7794,6 +7796,7 @@ class HIntermediateAddress final : public HExpression<2> {
+ #endif
+ #if defined(ART_ENABLE_CODEGEN_x86) || defined(ART_ENABLE_CODEGEN_x86_64)
+ #include "nodes_x86.h"
++#include "nodes_vector_x86.h"
+ #endif
+ 
+ namespace art {
+diff --git a/compiler/optimizing/nodes_vector_x86.h b/compiler/optimizing/nodes_vector_x86.h
+new file mode 100644
+index 0000000..a8f576f
+--- /dev/null
++++ b/compiler/optimizing/nodes_vector_x86.h
+@@ -0,0 +1,84 @@
++/*
++ * Copyright (C) 2018 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++#ifndef ART_COMPILER_OPTIMIZING_NODES_VECTOR_X86_H_
++#define ART_COMPILER_OPTIMIZING_NODES_VECTOR_X86_H_
++
++#include "nodes_vector.h"
++
++namespace art {
++
++class HVecAvxAdd final : public HVecOperation {
++ public:
++  HVecAvxAdd(ArenaAllocator* allocator,
++             HInstruction* src1,
++             HInstruction* src2,
++             DataType::Type packed_type,
++             size_t vector_length,
++             uint32_t dex_pc)
++      : HVecOperation(kVecAvxAdd,
++                      allocator,
++                      packed_type,
++                      SideEffects::None(),
++                      /* number_of_inputs */ 2,
++                      vector_length,
++                      dex_pc) {
++    DCHECK(HasConsistentPackedTypes(src1, packed_type));
++    DCHECK(HasConsistentPackedTypes(src2, packed_type));
++    SetRawInputAt(0, src1);
++    SetRawInputAt(1, src2);
++  }
++
++  bool CanBeMoved() const override { return true; }
++
++  DECLARE_INSTRUCTION(VecAvxAdd);
++
++ protected:
++  DEFAULT_COPY_CONSTRUCTOR(VecAvxAdd);
++};
++
++class HVecAvxSub final : public HVecOperation {
++ public:
++  HVecAvxSub(ArenaAllocator* allocator,
++             HInstruction* src1,
++             HInstruction* src2,
++             DataType::Type packed_type,
++             size_t vector_length,
++             uint32_t dex_pc)
++      : HVecOperation(kVecAvxSub,
++                      allocator,
++                      packed_type,
++                      SideEffects::None(),
++                      /* number_of_inputs */ 2,
++                      vector_length,
++                      dex_pc) {
++    DCHECK(HasConsistentPackedTypes(src1, packed_type));
++    DCHECK(HasConsistentPackedTypes(src2, packed_type));
++    SetRawInputAt(0, src1);
++    SetRawInputAt(1, src2);
++  }
++
++  bool CanBeMoved() const override { return true; }
++
++  DECLARE_INSTRUCTION(VecAvxSub);
++
++ protected:
++  DEFAULT_COPY_CONSTRUCTOR(VecAvxSub);
++};
++
++}  // namespace art
++
++#endif  // ART_COMPILER_OPTIMIZING_NODES_VECTOR_X86_H_
+diff --git a/compiler/utils/x86/assembler_x86.cc b/compiler/utils/x86/assembler_x86.cc
+index bcc197b..3eaf93a 100644
+--- a/compiler/utils/x86/assembler_x86.cc
++++ b/compiler/utils/x86/assembler_x86.cc
+@@ -703,6 +703,20 @@ void X86Assembler::addps(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++void X86Assembler::vaddps(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(add_left),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_NONE);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(0x58);
++  EmitXmmRegisterOperand(dst, add_right);
++}
+ 
+ void X86Assembler::subps(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -711,6 +725,18 @@ void X86Assembler::subps(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++void X86Assembler::vsubps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t byte_zero = 0x00, byte_one = 0x00;
++  byte_zero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  X86ManagedRegister vvvv_reg = X86ManagedRegister::FromXmmRegister(src1);
++  byte_one = EmitVexPrefixByteOne(/*R=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
++  EmitUint8(byte_zero);
++  EmitUint8(byte_one);
++  EmitUint8(0x5C);
++  EmitXmmRegisterOperand(dst, src2);
++}
+ 
+ void X86Assembler::mulps(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1041,6 +1067,21 @@ void X86Assembler::addpd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ 
++void X86Assembler::vaddpd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(add_left),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(0x58);
++  EmitXmmRegisterOperand(dst, add_right);
++}
++
++
+ void X86Assembler::subpd(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+@@ -1050,6 +1091,20 @@ void X86Assembler::subpd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ 
++void X86Assembler::vsubpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form*/ true);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(0x5C);
++  EmitXmmRegisterOperand(dst, src2);
++}
++
+ void X86Assembler::mulpd(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+@@ -1232,6 +1287,18 @@ void X86Assembler::paddb(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++void X86Assembler::vpaddb(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteOne = 0x00, ByteZero = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  X86ManagedRegister vvvv_reg = X86ManagedRegister::FromXmmRegister(add_left);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(0xFC);
++  EmitXmmRegisterOperand(dst, add_right);
++}
+ 
+ void X86Assembler::psubb(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1241,6 +1308,18 @@ void X86Assembler::psubb(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++void X86Assembler::vpsubb(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  X86ManagedRegister vvvv_reg = X86ManagedRegister::FromXmmRegister(add_left);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(0xF8);
++  EmitXmmRegisterOperand(dst, add_right);
++}
+ 
+ void X86Assembler::paddw(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1250,6 +1329,18 @@ void X86Assembler::paddw(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++void X86Assembler::vpaddw(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  X86ManagedRegister vvvv_reg = X86ManagedRegister::FromXmmRegister(add_left);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(0xFD);
++  EmitXmmRegisterOperand(dst, add_right);
++}
+ 
+ void X86Assembler::psubw(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1259,6 +1350,18 @@ void X86Assembler::psubw(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++void X86Assembler::vpsubw(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  X86ManagedRegister vvvv_reg = X86ManagedRegister::FromXmmRegister(add_left);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(0xF9);
++  EmitXmmRegisterOperand(dst, add_right);
++}
+ 
+ void X86Assembler::pmullw(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1277,6 +1380,18 @@ void X86Assembler::paddd(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++void X86Assembler::vpaddd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  X86ManagedRegister vvvv_reg = X86ManagedRegister::FromXmmRegister(add_left);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(0xFE);
++  EmitXmmRegisterOperand(dst, add_right);
++}
+ 
+ void X86Assembler::psubd(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1287,6 +1402,20 @@ void X86Assembler::psubd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ 
++void X86Assembler::vpsubd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  X86ManagedRegister vvvv_reg = X86ManagedRegister::FromXmmRegister(add_left);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(0xFA);
++  EmitXmmRegisterOperand(dst, add_right);
++}
++
++
+ void X86Assembler::pmulld(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+@@ -1305,6 +1434,19 @@ void X86Assembler::paddq(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++void X86Assembler::vpaddq(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  X86ManagedRegister vvvv_reg = X86ManagedRegister::FromXmmRegister(add_left);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(0xD4);
++  EmitXmmRegisterOperand(dst, add_right);
++}
++
+ 
+ void X86Assembler::psubq(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1314,6 +1456,18 @@ void X86Assembler::psubq(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++void X86Assembler::vpsubq(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  X86ManagedRegister vvvv_reg = X86ManagedRegister::FromXmmRegister(add_left);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(0xFB);
++  EmitXmmRegisterOperand(dst, add_right);
++}
+ 
+ void X86Assembler::paddusb(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+diff --git a/compiler/utils/x86/assembler_x86.h b/compiler/utils/x86/assembler_x86.h
+index e84294a..17039f0 100644
+--- a/compiler/utils/x86/assembler_x86.h
++++ b/compiler/utils/x86/assembler_x86.h
+@@ -417,6 +417,11 @@ class X86Assembler final : public Assembler {
+   void mulps(XmmRegister dst, XmmRegister src);
+   void divps(XmmRegister dst, XmmRegister src);
+ 
++  void vaddps(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++  void vsubps(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++  void vsubpd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++  void vaddpd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++
+   void movapd(XmmRegister dst, XmmRegister src);     // move
+   void movapd(XmmRegister dst, const Address& src);  // load aligned
+   void movupd(XmmRegister dst, const Address& src);  // load unaligned
+@@ -465,17 +470,29 @@ class X86Assembler final : public Assembler {
+   void paddb(XmmRegister dst, XmmRegister src);  // no addr variant (for now)
+   void psubb(XmmRegister dst, XmmRegister src);
+ 
++  void vpaddb(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++  void vpaddw(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++
+   void paddw(XmmRegister dst, XmmRegister src);
+   void psubw(XmmRegister dst, XmmRegister src);
+   void pmullw(XmmRegister dst, XmmRegister src);
+ 
++  void vpsubb(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpsubw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpsubd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++
+   void paddd(XmmRegister dst, XmmRegister src);
+   void psubd(XmmRegister dst, XmmRegister src);
+   void pmulld(XmmRegister dst, XmmRegister src);
+ 
++  void vpaddd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++
+   void paddq(XmmRegister dst, XmmRegister src);
+   void psubq(XmmRegister dst, XmmRegister src);
+ 
++  void vpaddq(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++  void vpsubq(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++
+   void paddusb(XmmRegister dst, XmmRegister src);
+   void paddsb(XmmRegister dst, XmmRegister src);
+   void paddusw(XmmRegister dst, XmmRegister src);
+diff --git a/compiler/utils/x86/assembler_x86_test.cc b/compiler/utils/x86/assembler_x86_test.cc
+index ee29482..42ee383 100644
+--- a/compiler/utils/x86/assembler_x86_test.cc
++++ b/compiler/utils/x86/assembler_x86_test.cc
+@@ -677,18 +677,36 @@ TEST_F(AssemblerX86Test, AddPS) {
+   DriverStr(RepeatFF(&x86::X86Assembler::addps, "addps %{reg2}, %{reg1}"), "addps");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VAddps) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vaddps, "vaddps %{reg3}, %{reg2}, %{reg1}"), "vaddps");
++}
++
+ TEST_F(AssemblerX86Test, AddPD) {
+   DriverStr(RepeatFF(&x86::X86Assembler::addpd, "addpd %{reg2}, %{reg1}"), "addpd");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VAddpd) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vaddpd, "vaddpd %{reg3}, %{reg2}, %{reg1}"), "vaddpd");
++}
++
+ TEST_F(AssemblerX86Test, SubPS) {
+   DriverStr(RepeatFF(&x86::X86Assembler::subps, "subps %{reg2}, %{reg1}"), "subps");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VSubps) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vsubps, "vsubps %{reg3},%{reg2}, %{reg1}"), "vsubps");
++}
++
++
+ TEST_F(AssemblerX86Test, SubPD) {
+   DriverStr(RepeatFF(&x86::X86Assembler::subpd, "subpd %{reg2}, %{reg1}"), "subpd");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VSubpd) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vsubpd, "vsubpd %{reg3}, %{reg2}, %{reg1}"), "vsubpd");
++}
++
++
+ TEST_F(AssemblerX86Test, MulPS) {
+   DriverStr(RepeatFF(&x86::X86Assembler::mulps, "mulps %{reg2}, %{reg1}"), "mulps");
+ }
+@@ -709,18 +727,34 @@ TEST_F(AssemblerX86Test, PAddB) {
+   DriverStr(RepeatFF(&x86::X86Assembler::paddb, "paddb %{reg2}, %{reg1}"), "paddb");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VPaddb) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vpaddb, "vpaddb %{reg3}, %{reg2}, %{reg1}"), "vpaddb");
++}
++
+ TEST_F(AssemblerX86Test, PSubB) {
+   DriverStr(RepeatFF(&x86::X86Assembler::psubb, "psubb %{reg2}, %{reg1}"), "psubb");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VPsubb) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vpsubb, "vpsubb %{reg3},%{reg2}, %{reg1}"), "vpsubb");
++}
++
+ TEST_F(AssemblerX86Test, PAddW) {
+   DriverStr(RepeatFF(&x86::X86Assembler::paddw, "paddw %{reg2}, %{reg1}"), "paddw");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VPaddw) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vpaddw, "vpaddw %{reg3}, %{reg2}, %{reg1}"), "vpaddw");
++}
++
+ TEST_F(AssemblerX86Test, PSubW) {
+   DriverStr(RepeatFF(&x86::X86Assembler::psubw, "psubw %{reg2}, %{reg1}"), "psubw");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VPsubw) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vpsubw, "vpsubw %{reg3}, %{reg2}, %{reg1}"), "vpsubw");
++}
++
+ TEST_F(AssemblerX86Test, PMullW) {
+   DriverStr(RepeatFF(&x86::X86Assembler::pmullw, "pmullw %{reg2}, %{reg1}"), "pmullw");
+ }
+@@ -729,10 +763,18 @@ TEST_F(AssemblerX86Test, PAddD) {
+   DriverStr(RepeatFF(&x86::X86Assembler::paddd, "paddd %{reg2}, %{reg1}"), "paddd");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VPaddd) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vpaddd, "vpaddd %{reg3}, %{reg2}, %{reg1}"), "vpaddd");
++}
++
+ TEST_F(AssemblerX86Test, PSubD) {
+   DriverStr(RepeatFF(&x86::X86Assembler::psubd, "psubd %{reg2}, %{reg1}"), "psubd");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VPsubd) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vpsubd, "vpsubd %{reg3}, %{reg2}, %{reg1}"), "vpsubd");
++}
++
+ TEST_F(AssemblerX86Test, PMullD) {
+   DriverStr(RepeatFF(&x86::X86Assembler::pmulld, "pmulld %{reg2}, %{reg1}"), "pmulld");
+ }
+@@ -741,10 +783,18 @@ TEST_F(AssemblerX86Test, PAddQ) {
+   DriverStr(RepeatFF(&x86::X86Assembler::paddq, "paddq %{reg2}, %{reg1}"), "paddq");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VPaddq) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vpaddq, "vpaddq %{reg3}, %{reg2}, %{reg1}"), "vpaddq");
++}
++
+ TEST_F(AssemblerX86Test, PSubQ) {
+   DriverStr(RepeatFF(&x86::X86Assembler::psubq, "psubq %{reg2}, %{reg1}"), "psubq");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VPsubq) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vpsubq, "vpsubq %{reg3}, %{reg2}, %{reg1}"), "vpsubq");
++}
++
+ TEST_F(AssemblerX86Test, PAddUSB) {
+   DriverStr(RepeatFF(&x86::X86Assembler::paddusb, "paddusb %{reg2}, %{reg1}"), "paddusb");
+ }
+diff --git a/compiler/utils/x86_64/assembler_x86_64.cc b/compiler/utils/x86_64/assembler_x86_64.cc
+index 336ecbf..72b7ae0 100644
+--- a/compiler/utils/x86_64/assembler_x86_64.cc
++++ b/compiler/utils/x86_64/assembler_x86_64.cc
+@@ -614,8 +614,8 @@ void X86_64Assembler::vmovaps(const Address& dst, XmmRegister src) {
+                                    SET_VEX_PP_NONE);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
+-                                   Rex_x ,
+-                                   Rex_b ,
++                                   Rex_x,
++                                   Rex_b,
+                                    SET_VEX_M_0F);
+     ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+                                    SET_VEX_L_128,
+@@ -856,6 +856,60 @@ void X86_64Assembler::subps(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++void X86_64Assembler::vaddps(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!add_right.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   add_right.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0x58);
++  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++}
++
++void X86_64Assembler::vsubps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t byte_zero = 0x00, byte_one = 0x00, byte_two = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  byte_zero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg = X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  if (is_twobyte_form) {
++    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
++  } else {
++    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(), /*X=*/ false, src2.NeedsRex(), SET_VEX_M_0F);
++    byte_two = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
++  }
++  EmitUint8(byte_zero);
++  EmitUint8(byte_one);
++  if (!is_twobyte_form) {
++    EmitUint8(byte_two);
++  }
++  EmitUint8(0x5C);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
+ 
+ void X86_64Assembler::mulps(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -931,7 +985,7 @@ void X86_64Assembler::vmovapd(XmmRegister dst, XmmRegister src) {
+                                    SET_VEX_PP_66);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false ,
++                                   /*X=*/ false,
+                                    src.NeedsRex(),
+                                    SET_VEX_M_0F);
+     ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+@@ -1292,6 +1346,35 @@ void X86_64Assembler::addpd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ 
++void X86_64Assembler::vaddpd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!add_right.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   add_right.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0x58);
++  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++}
++
++
+ void X86_64Assembler::subpd(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+@@ -1302,6 +1385,35 @@ void X86_64Assembler::subpd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ 
++void X86_64Assembler::vsubpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0x5C);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
++
+ void X86_64Assembler::mulpd(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+@@ -1609,6 +1721,36 @@ void X86_64Assembler::paddb(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ 
++void X86_64Assembler::vpaddb(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteOne = 0x00, ByteZero = 0x00, ByteTwo = 0x00;
++  bool is_twobyte_form = true;
++  if (add_right.NeedsRex()) {
++    is_twobyte_form = false;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   add_right.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0xFC);
++  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++}
++
++
+ void X86_64Assembler::psubb(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+@@ -1619,6 +1761,36 @@ void X86_64Assembler::psubb(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ 
++void X86_64Assembler::vpsubb(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!add_right.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   add_right.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0xF8);
++  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++}
++
++
+ void X86_64Assembler::paddw(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+@@ -1628,6 +1800,35 @@ void X86_64Assembler::paddw(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++void X86_64Assembler::vpaddw(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!add_right.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   add_right.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0xFD);
++  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++}
++
+ 
+ void X86_64Assembler::psubw(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1638,6 +1839,35 @@ void X86_64Assembler::psubw(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++void X86_64Assembler::vpsubw(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!add_right.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   add_right.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0xF9);
++  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++}
++
+ 
+ void X86_64Assembler::pmullw(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1658,6 +1888,34 @@ void X86_64Assembler::paddd(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++void X86_64Assembler::vpaddd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!add_right.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   add_right.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0xFE);
++  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++}
+ 
+ void X86_64Assembler::psubd(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1690,6 +1948,36 @@ void X86_64Assembler::paddq(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ 
++void X86_64Assembler::vpaddq(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!add_right.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   add_right.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0xD4);
++  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++}
++
++
+ void X86_64Assembler::psubq(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+@@ -1699,6 +1987,35 @@ void X86_64Assembler::psubq(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++void X86_64Assembler::vpsubq(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!add_right.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   add_right.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0xFB);
++  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++}
++
+ 
+ void X86_64Assembler::paddusb(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1760,6 +2077,36 @@ void X86_64Assembler::psubsb(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ 
++void X86_64Assembler::vpsubd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!add_right.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   add_right.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0xFA);
++  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++}
++
++
+ void X86_64Assembler::psubusw(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+@@ -4597,7 +4944,7 @@ uint8_t X86_64Assembler::EmitVexPrefixByteOne(bool R,
+     uint8_t reg = static_cast<uint8_t>(inverted_reg);
+     vex_prefix |= ((reg & 0x0F) << 3);
+   }
+-  /** Bit[2] - "L" If VEX.L = 1 indicates 256-bit vector operation ,
++  /** Bit[2] - "L" If VEX.L = 1 indicates 256-bit vector operation,
+   VEX.L = 0 indicates 128 bit vector operation */
+   vex_prefix |= SET_VEX_L;
+   // Bits[1:0] -  "pp"
+@@ -4629,7 +4976,7 @@ uint8_t X86_64Assembler::EmitVexPrefixByteTwo(bool W,
+     uint8_t reg = static_cast<uint8_t>(inverted_reg);
+     vex_prefix |= ((reg & 0x0F) << 3);
+   }
+-  /** Bit[2] - "L" If VEX.L = 1 indicates 256-bit vector operation ,
++  /** Bit[2] - "L" If VEX.L = 1 indicates 256-bit vector operation,
+   VEX.L = 0 indicates 128 bit vector operation */
+   vex_prefix |= SET_VEX_L;
+   // Bits[1:0] -  "pp"
+@@ -4650,7 +4997,7 @@ uint8_t X86_64Assembler::EmitVexPrefixByteTwo(bool W,
+   }
+   /** Bits[6:3] - 'vvvv' the source or dest register specifier */
+   vex_prefix |= (0x0F << 3);
+-  /** Bit[2] - "L" If VEX.L = 1 indicates 256-bit vector operation ,
++  /** Bit[2] - "L" If VEX.L = 1 indicates 256-bit vector operation,
+   VEX.L = 0 indicates 128 bit vector operation */
+   vex_prefix |= SET_VEX_L;
+ 
+diff --git a/compiler/utils/x86_64/assembler_x86_64.h b/compiler/utils/x86_64/assembler_x86_64.h
+index 471b314..8fc69f6 100644
+--- a/compiler/utils/x86_64/assembler_x86_64.h
++++ b/compiler/utils/x86_64/assembler_x86_64.h
+@@ -452,6 +452,11 @@ class X86_64Assembler final : public Assembler {
+   void mulps(XmmRegister dst, XmmRegister src);
+   void divps(XmmRegister dst, XmmRegister src);
+ 
++  void vaddps(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++  void vsubps(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++  void vsubpd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++  void vaddpd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++
+   void movapd(XmmRegister dst, XmmRegister src);     // move
+   void movapd(XmmRegister dst, const Address& src);  // load aligned
+   void movupd(XmmRegister dst, const Address& src);  // load unaligned
+@@ -497,17 +502,29 @@ class X86_64Assembler final : public Assembler {
+   void paddb(XmmRegister dst, XmmRegister src);  // no addr variant (for now)
+   void psubb(XmmRegister dst, XmmRegister src);
+ 
++  void vpaddb(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++  void vpaddw(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++
+   void paddw(XmmRegister dst, XmmRegister src);
+   void psubw(XmmRegister dst, XmmRegister src);
+   void pmullw(XmmRegister dst, XmmRegister src);
+ 
++  void vpsubb(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpsubw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpsubd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++
+   void paddd(XmmRegister dst, XmmRegister src);
+   void psubd(XmmRegister dst, XmmRegister src);
+   void pmulld(XmmRegister dst, XmmRegister src);
+ 
++  void vpaddd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++
+   void paddq(XmmRegister dst, XmmRegister src);
+   void psubq(XmmRegister dst, XmmRegister src);
+ 
++  void vpaddq(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++  void vpsubq(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++
+   void paddusb(XmmRegister dst, XmmRegister src);
+   void paddsb(XmmRegister dst, XmmRegister src);
+   void paddusw(XmmRegister dst, XmmRegister src);
+diff --git a/compiler/utils/x86_64/assembler_x86_64_test.cc b/compiler/utils/x86_64/assembler_x86_64_test.cc
+index 411c30b..24a6c3c 100644
+--- a/compiler/utils/x86_64/assembler_x86_64_test.cc
++++ b/compiler/utils/x86_64/assembler_x86_64_test.cc
+@@ -1323,10 +1323,20 @@ TEST_F(AssemblerX86_64Test, Addps) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::addps, "addps %{reg2}, %{reg1}"), "addps");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VAddps) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vaddps, "vaddps %{reg3}, %{reg2}, %{reg1}"), "vaddps");
++}
++
+ TEST_F(AssemblerX86_64Test, Addpd) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::addpd, "addpd %{reg2}, %{reg1}"), "addpd");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VAddpd) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vaddpd, "vaddpd %{reg3}, %{reg2}, %{reg1}"), "vaddpd");
++}
++
+ TEST_F(AssemblerX86_64Test, Subss) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::subss, "subss %{reg2}, %{reg1}"), "subss");
+ }
+@@ -1339,10 +1349,20 @@ TEST_F(AssemblerX86_64Test, Subps) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::subps, "subps %{reg2}, %{reg1}"), "subps");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VSubps) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vsubps, "vsubps %{reg3},%{reg2}, %{reg1}"), "vsubps");
++}
++
+ TEST_F(AssemblerX86_64Test, Subpd) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::subpd, "subpd %{reg2}, %{reg1}"), "subpd");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VSubpd) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vsubpd, "vsubpd %{reg3}, %{reg2}, %{reg1}"), "vsubpd");
++}
++
+ TEST_F(AssemblerX86_64Test, Mulss) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::mulss, "mulss %{reg2}, %{reg1}"), "mulss");
+ }
+@@ -1379,14 +1399,35 @@ TEST_F(AssemblerX86_64Test, Paddb) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::paddb, "paddb %{reg2}, %{reg1}"), "paddb");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VPaddb) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vpaddb, "vpaddb %{reg3}, %{reg2}, %{reg1}"), "vpaddb");
++}
++
+ TEST_F(AssemblerX86_64Test, Psubb) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::psubb, "psubb %{reg2}, %{reg1}"), "psubb");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VPsubb) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vpsubb, "vpsubb %{reg3},%{reg2}, %{reg1}"), "vpsubb");
++}
++
+ TEST_F(AssemblerX86_64Test, Paddw) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::paddw, "paddw %{reg2}, %{reg1}"), "paddw");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VPsubw) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vpsubw, "vpsubw %{reg3}, %{reg2}, %{reg1}"), "vpsubw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPaddw) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vpaddw, "vpaddw %{reg3}, %{reg2}, %{reg1}"), "vpaddw");
++}
++
++
+ TEST_F(AssemblerX86_64Test, Psubw) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::psubw, "psubw %{reg2}, %{reg1}"), "psubw");
+ }
+@@ -1399,10 +1440,20 @@ TEST_F(AssemblerX86_64Test, Paddd) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::paddd, "paddd %{reg2}, %{reg1}"), "paddd");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VPaddd) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vpaddd, "vpaddd %{reg3}, %{reg2}, %{reg1}"), "vpaddd");
++}
++
+ TEST_F(AssemblerX86_64Test, Psubd) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::psubd, "psubd %{reg2}, %{reg1}"), "psubd");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VPsubd) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vpsubd, "vpsubd %{reg3}, %{reg2}, %{reg1}"), "vpsubd");
++}
++
+ TEST_F(AssemblerX86_64Test, Pmulld) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::pmulld, "pmulld %{reg2}, %{reg1}"), "pmulld");
+ }
+@@ -1411,10 +1462,20 @@ TEST_F(AssemblerX86_64Test, Paddq) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::paddq, "paddq %{reg2}, %{reg1}"), "paddq");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VPaddq) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vpaddq, "vpaddq %{reg3}, %{reg2}, %{reg1}"), "vpaddq");
++}
++
+ TEST_F(AssemblerX86_64Test, Psubq) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::psubq, "psubq %{reg2}, %{reg1}"), "psubq");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VPsubq) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vpsubq, "vpsubq %{reg3}, %{reg2}, %{reg1}"), "vpsubq");
++}
++
+ TEST_F(AssemblerX86_64Test, Paddusb) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::paddusb, "paddusb %{reg2}, %{reg1}"), "paddusb");
+ }
+-- 
+2.7.4
+

--- a/aosp_diff/caas/art/0005-Add-AVX-support-for-packed-mul-div-instructions.patch
+++ b/aosp_diff/caas/art/0005-Add-AVX-support-for-packed-mul-div-instructions.patch
@@ -1,0 +1,1524 @@
+From db0f343985112f327262471b4c9cc1092f90792a Mon Sep 17 00:00:00 2001
+From: Shalini Salomi Bodapati <shalini.salomi.bodapati@intel.com>
+Date: Wed, 10 Jul 2019 16:09:41 +0530
+Subject: [PATCH] Add AVX support for packed mul/div instructions.
+
+This is a follow up for the below patch:
+https://android-review.googlesource.com/c/platform/build/+/830841
+
+Test: ./test.py --host --64, test-art-host-gtest
+Change-Id: Id2aa473035556ee230e66addeb69707df8530e75
+Signed-off-by: Shalini Salomi Bodapati <shalini.salomi.bodapati@intel.com>
+---
+ compiler/optimizing/code_generator_vector_x86.cc   | 166 +++++++--------------
+ .../optimizing/code_generator_vector_x86_64.cc     | 160 +++++++-------------
+ compiler/optimizing/code_generator_x86.cc          |  13 ++
+ compiler/optimizing/code_generator_x86.h           |   4 +
+ compiler/optimizing/code_generator_x86_64.cc       |  16 ++
+ compiler/optimizing/code_generator_x86_64.h        |   5 +
+ compiler/optimizing/loop_optimization.cc           |  27 ----
+ compiler/optimizing/nodes.h                        |   5 +-
+ compiler/optimizing/nodes_vector_x86.h             |  84 -----------
+ compiler/utils/x86/assembler_x86.cc                |  92 ++++++++++++
+ compiler/utils/x86/assembler_x86.h                 |   8 +
+ compiler/utils/x86/assembler_x86_test.cc           |  48 ++++--
+ compiler/utils/x86_64/assembler_x86_64.cc          | 160 ++++++++++++++++++++
+ compiler/utils/x86_64/assembler_x86_64.h           |   7 +
+ compiler/utils/x86_64/assembler_x86_64_test.cc     |  31 +++-
+ compiler/utils/x86_64/constants_x86_64.h           |   3 +
+ 16 files changed, 477 insertions(+), 352 deletions(-)
+ delete mode 100644 compiler/optimizing/nodes_vector_x86.h
+
+diff --git a/compiler/optimizing/code_generator_vector_x86.cc b/compiler/optimizing/code_generator_vector_x86.cc
+index c8964dd..29a1354 100644
+--- a/compiler/optimizing/code_generator_vector_x86.cc
++++ b/compiler/optimizing/code_generator_vector_x86.cc
+@@ -431,48 +431,6 @@ static void CreateVecBinOpLocations(ArenaAllocator* allocator, HVecBinaryOperati
+   }
+ }
+ 
+-void LocationsBuilderX86::VisitVecAdd(HVecAdd* instruction) {
+-  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+-}
+-
+-void InstructionCodeGeneratorX86::VisitVecAdd(HVecAdd* instruction) {
+-  LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
+-  XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
+-  switch (instruction->GetPackedType()) {
+-    case DataType::Type::kUint8:
+-    case DataType::Type::kInt8:
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+-      __ paddb(dst, src);
+-      break;
+-    case DataType::Type::kUint16:
+-    case DataType::Type::kInt16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+-      __ paddw(dst, src);
+-      break;
+-    case DataType::Type::kInt32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ paddd(dst, src);
+-      break;
+-    case DataType::Type::kInt64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ paddq(dst, src);
+-      break;
+-    case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ addps(dst, src);
+-      break;
+-    case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ addpd(dst, src);
+-      break;
+-    default:
+-      LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+-      UNREACHABLE();
+-  }
+-}
+-
+ static void CreateVecTerOpLocations(ArenaAllocator* allocator, HVecOperation* instruction) {
+   LocationSummary* locations = new (allocator) LocationSummary(instruction);
+   switch (instruction->GetPackedType()) {
+@@ -495,44 +453,50 @@ static void CreateVecTerOpLocations(ArenaAllocator* allocator, HVecOperation* in
+   }
+ }
+ 
+-void LocationsBuilderX86::VisitVecAvxAdd(HVecAvxAdd* instruction) {
++void LocationsBuilderX86::VisitVecAdd(HVecAdd* instruction) {
++  if (CpuHasAvxFeatureFlag()) {
+     CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++  } else {
++    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  }
+ }
+ 
+-void InstructionCodeGeneratorX86::VisitVecAvxAdd(HVecAvxAdd* instruction) {
++void InstructionCodeGeneratorX86::VisitVecAdd(HVecAdd* instruction) {
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister src1 = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister src2 = locations->InAt(1).AsFpuRegister<XmmRegister>();
++  XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
++  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  DCHECK(cpu_has_avx || other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint8:
+     case DataType::Type::kInt8:
+       DCHECK_EQ(16u, instruction->GetVectorLength());
+-        __ vpaddb(dst, src1, src2);
++      cpu_has_avx ? __ vpaddb(dst, other_src, src) : __ paddb(dst, src);
+       break;
+     case DataType::Type::kUint16:
+     case DataType::Type::kInt16:
+       DCHECK_EQ(8u, instruction->GetVectorLength());
+-      __ vpaddw(dst, src1, src2);
++      cpu_has_avx ? __ vpaddw(dst, other_src, src) : __ paddw(dst, src);
+       break;
+     case DataType::Type::kInt32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ vpaddd(dst, src1, src2);
++      cpu_has_avx ?  __ vpaddd(dst, other_src, src) : __ paddd(dst, src);
+       break;
+     case DataType::Type::kInt64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ vpaddq(dst, src1, src2);
++      cpu_has_avx ? __ vpaddq(dst, other_src, src) : __ paddq(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ vaddps(dst, src1, src2);
++      cpu_has_avx ? __ vaddps(dst, other_src, src) : __ addps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ vaddpd(dst, src1, src2);
++      cpu_has_avx ? __ vaddpd(dst, other_src, src) : __ addpd(dst, src);
+       break;
+     default:
+-      LOG(FATAL) << "Unsupported SIMD type";
++      LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+       UNREACHABLE();
+   }
+ }
+@@ -597,40 +561,46 @@ void InstructionCodeGeneratorX86::VisitVecHalvingAdd(HVecHalvingAdd* instruction
+ }
+ 
+ void LocationsBuilderX86::VisitVecSub(HVecSub* instruction) {
+-  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  if (CpuHasAvxFeatureFlag()) {
++    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++  } else {
++    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  }
+ }
+ 
+ void InstructionCodeGeneratorX86::VisitVecSub(HVecSub* instruction) {
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
+   XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
++  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  DCHECK(cpu_has_avx || other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint8:
+     case DataType::Type::kInt8:
+       DCHECK_EQ(16u, instruction->GetVectorLength());
+-      __ psubb(dst, src);
++      cpu_has_avx ? __ vpsubb(dst, other_src, src) : __ psubb(dst, src);
+       break;
+     case DataType::Type::kUint16:
+     case DataType::Type::kInt16:
+       DCHECK_EQ(8u, instruction->GetVectorLength());
+-      __ psubw(dst, src);
++      cpu_has_avx ? __ vpsubw(dst, other_src, src) : __ psubw(dst, src);
+       break;
+     case DataType::Type::kInt32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ psubd(dst, src);
++      cpu_has_avx ?  __ vpsubd(dst, other_src, src) : __ psubd(dst, src);
+       break;
+     case DataType::Type::kInt64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ psubq(dst, src);
++      cpu_has_avx ? __ vpsubq(dst, other_src, src) : __ psubq(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ subps(dst, src);
++      cpu_has_avx ? __ vsubps(dst, other_src, src) : __ subps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ subpd(dst, src);
++      cpu_has_avx ? __ vsubpd(dst, other_src, src) : __ subpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -638,48 +608,6 @@ void InstructionCodeGeneratorX86::VisitVecSub(HVecSub* instruction) {
+   }
+ }
+ 
+-void LocationsBuilderX86::VisitVecAvxSub(HVecAvxSub* instruction) {
+-  CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
+-}
+-
+-void InstructionCodeGeneratorX86::VisitVecAvxSub(HVecAvxSub* instruction) {
+-  LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister src1 = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister src2 = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
+-  switch (instruction->GetPackedType()) {
+-    case DataType::Type::kUint8:
+-    case DataType::Type::kInt8:
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+-      __ vpsubb(dst, src1, src2);
+-      break;
+-    case DataType::Type::kUint16:
+-    case DataType::Type::kInt16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+-      __ vpsubw(dst, src1, src2);
+-      break;
+-    case DataType::Type::kInt32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ vpsubd(dst, src1, src2);
+-      break;
+-    case DataType::Type::kInt64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ vpsubq(dst, src1, src2);
+-      break;
+-    case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ vsubps(dst, src1, src2);
+-      break;
+-    case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ vsubpd(dst, src1, src2);
+-      break;
+-    default:
+-      LOG(FATAL) << "Unsupported SIMD type";
+-      UNREACHABLE();
+-  }
+-}
+-
+ void LocationsBuilderX86::VisitVecSaturationSub(HVecSaturationSub* instruction) {
+   CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+ }
+@@ -713,31 +641,37 @@ void InstructionCodeGeneratorX86::VisitVecSaturationSub(HVecSaturationSub* instr
+ }
+ 
+ void LocationsBuilderX86::VisitVecMul(HVecMul* instruction) {
+-  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  if (CpuHasAvxFeatureFlag()) {
++    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++  } else {
++    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  }
+ }
+ 
+ void InstructionCodeGeneratorX86::VisitVecMul(HVecMul* instruction) {
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
+   XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
++  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  DCHECK(cpu_has_avx || other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint16:
+     case DataType::Type::kInt16:
+       DCHECK_EQ(8u, instruction->GetVectorLength());
+-      __ pmullw(dst, src);
++      cpu_has_avx ? __ vpmullw(dst, other_src, src) : __ pmullw(dst, src);
+       break;
+     case DataType::Type::kInt32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ pmulld(dst, src);
++      cpu_has_avx ? __ vpmulld(dst, other_src, src) : __ pmulld(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ mulps(dst, src);
++      cpu_has_avx ? __ vmulps(dst, other_src, src) : __ mulps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ mulpd(dst, src);
++      cpu_has_avx ? __ vmulpd(dst, other_src, src) : __ mulpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -746,22 +680,28 @@ void InstructionCodeGeneratorX86::VisitVecMul(HVecMul* instruction) {
+ }
+ 
+ void LocationsBuilderX86::VisitVecDiv(HVecDiv* instruction) {
+-  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  if (CpuHasAvxFeatureFlag()) {
++    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++  } else {
++    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  }
+ }
+ 
+ void InstructionCodeGeneratorX86::VisitVecDiv(HVecDiv* instruction) {
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
+   XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
++  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  DCHECK(cpu_has_avx || other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kFloat32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ divps(dst, src);
++      cpu_has_avx ? __ vdivps(dst, other_src, src) : __ divps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ divpd(dst, src);
++      cpu_has_avx ?  __ vdivpd(dst, other_src, src) : __ divpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+diff --git a/compiler/optimizing/code_generator_vector_x86_64.cc b/compiler/optimizing/code_generator_vector_x86_64.cc
+index c147659..f28268b 100644
+--- a/compiler/optimizing/code_generator_vector_x86_64.cc
++++ b/compiler/optimizing/code_generator_vector_x86_64.cc
+@@ -437,40 +437,46 @@ static void CreateVecTerOpLocations(ArenaAllocator* allocator, HVecOperation* in
+ }
+ 
+ void LocationsBuilderX86_64::VisitVecAdd(HVecAdd* instruction) {
+-  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  if (CpuHasAvxFeatureFlag()) {
++    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++  } else {
++    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  }
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecAdd(HVecAdd* instruction) {
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
+   XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
++  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  DCHECK(cpu_has_avx || other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint8:
+     case DataType::Type::kInt8:
+       DCHECK_EQ(16u, instruction->GetVectorLength());
+-      __ paddb(dst, src);
++      cpu_has_avx ? __ vpaddb(dst, other_src, src) : __ paddb(dst, src);
+       break;
+     case DataType::Type::kUint16:
+     case DataType::Type::kInt16:
+       DCHECK_EQ(8u, instruction->GetVectorLength());
+-      __ paddw(dst, src);
++      cpu_has_avx ? __ vpaddw(dst, other_src, src) : __ paddw(dst, src);
+       break;
+     case DataType::Type::kInt32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ paddd(dst, src);
++      cpu_has_avx ? __ vpaddd(dst, other_src, src) : __ paddd(dst, src);
+       break;
+     case DataType::Type::kInt64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ paddq(dst, src);
++      cpu_has_avx ? __ vpaddq(dst, other_src, src) : __ paddq(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ addps(dst, src);
++      cpu_has_avx ? __ vaddps(dst, other_src, src) : __ addps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ addpd(dst, src);
++      cpu_has_avx ? __ vaddpd(dst, other_src, src) : __ addpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -478,48 +484,6 @@ void InstructionCodeGeneratorX86_64::VisitVecAdd(HVecAdd* instruction) {
+   }
+ }
+ 
+-void LocationsBuilderX86_64::VisitVecAvxAdd(HVecAvxAdd* instruction) {
+-    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
+-}
+-
+-void InstructionCodeGeneratorX86_64::VisitVecAvxAdd(HVecAvxAdd* instruction) {
+-  LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister src1 = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister src2 = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
+-  switch (instruction->GetPackedType()) {
+-    case DataType::Type::kUint8:
+-    case DataType::Type::kInt8:
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+-        __ vpaddb(dst, src1, src2);
+-      break;
+-    case DataType::Type::kUint16:
+-    case DataType::Type::kInt16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+-      __ vpaddw(dst, src1, src2);
+-      break;
+-    case DataType::Type::kInt32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ vpaddd(dst, src1, src2);
+-      break;
+-    case DataType::Type::kInt64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ vpaddq(dst, src1, src2);
+-      break;
+-    case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ vaddps(dst, src1, src2);
+-      break;
+-    case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ vaddpd(dst, src1, src2);
+-      break;
+-    default:
+-      LOG(FATAL) << "Unsupported SIMD type";
+-      UNREACHABLE();
+-  }
+-}
+-
+ void LocationsBuilderX86_64::VisitVecSaturationAdd(HVecSaturationAdd* instruction) {
+   CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+ }
+@@ -580,40 +544,46 @@ void InstructionCodeGeneratorX86_64::VisitVecHalvingAdd(HVecHalvingAdd* instruct
+ }
+ 
+ void LocationsBuilderX86_64::VisitVecSub(HVecSub* instruction) {
+-  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  if (CpuHasAvxFeatureFlag()) {
++    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++  } else {
++    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  }
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecSub(HVecSub* instruction) {
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
+   XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
++  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  DCHECK(cpu_has_avx || other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint8:
+     case DataType::Type::kInt8:
+       DCHECK_EQ(16u, instruction->GetVectorLength());
+-      __ psubb(dst, src);
++      cpu_has_avx ? __ vpsubb(dst, other_src, src) : __ psubb(dst, src);
+       break;
+     case DataType::Type::kUint16:
+     case DataType::Type::kInt16:
+       DCHECK_EQ(8u, instruction->GetVectorLength());
+-      __ psubw(dst, src);
++      cpu_has_avx ? __ vpsubw(dst, other_src, src) : __ psubw(dst, src);
+       break;
+     case DataType::Type::kInt32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ psubd(dst, src);
++      cpu_has_avx ? __ vpsubd(dst, other_src, src) : __ psubd(dst, src);
+       break;
+     case DataType::Type::kInt64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ psubq(dst, src);
++      cpu_has_avx ? __ vpsubq(dst, other_src, src) : __ psubq(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ subps(dst, src);
++      cpu_has_avx ? __ vsubps(dst, other_src, src) : __ subps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ subpd(dst, src);
++      cpu_has_avx ? __ vsubpd(dst, other_src, src) : __ subpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -621,48 +591,6 @@ void InstructionCodeGeneratorX86_64::VisitVecSub(HVecSub* instruction) {
+   }
+ }
+ 
+-void LocationsBuilderX86_64::VisitVecAvxSub(HVecAvxSub* instruction) {
+-  CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
+-}
+-
+-void InstructionCodeGeneratorX86_64::VisitVecAvxSub(HVecAvxSub* instruction) {
+-  LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister src1 = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister src2 = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
+-  switch (instruction->GetPackedType()) {
+-    case DataType::Type::kUint8:
+-    case DataType::Type::kInt8:
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+-      __ vpsubb(dst, src1, src2);
+-      break;
+-    case DataType::Type::kUint16:
+-    case DataType::Type::kInt16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+-      __ vpsubw(dst, src1, src2);
+-      break;
+-    case DataType::Type::kInt32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ vpsubd(dst, src1, src2);
+-      break;
+-    case DataType::Type::kInt64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ vpsubq(dst, src1, src2);
+-      break;
+-    case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ vsubps(dst, src1, src2);
+-      break;
+-    case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ vsubpd(dst, src1, src2);
+-      break;
+-    default:
+-      LOG(FATAL) << "Unsupported SIMD type";
+-      UNREACHABLE();
+-  }
+-}
+-
+ void LocationsBuilderX86_64::VisitVecSaturationSub(HVecSaturationSub* instruction) {
+   CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+ }
+@@ -696,31 +624,37 @@ void InstructionCodeGeneratorX86_64::VisitVecSaturationSub(HVecSaturationSub* in
+ }
+ 
+ void LocationsBuilderX86_64::VisitVecMul(HVecMul* instruction) {
+-  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  if (CpuHasAvxFeatureFlag()) {
++    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++  } else {
++    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  }
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecMul(HVecMul* instruction) {
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
+   XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
++  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  DCHECK(cpu_has_avx || other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint16:
+     case DataType::Type::kInt16:
+       DCHECK_EQ(8u, instruction->GetVectorLength());
+-      __ pmullw(dst, src);
++      cpu_has_avx ? __ vpmullw(dst, other_src, src) : __ pmullw(dst, src);
+       break;
+     case DataType::Type::kInt32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ pmulld(dst, src);
++      cpu_has_avx ? __ vpmulld(dst, other_src, src): __ pmulld(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ mulps(dst, src);
++      cpu_has_avx ? __ vmulps(dst, other_src, src) : __ mulps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ mulpd(dst, src);
++      cpu_has_avx ? __ vmulpd(dst, other_src, src) : __ mulpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -729,22 +663,28 @@ void InstructionCodeGeneratorX86_64::VisitVecMul(HVecMul* instruction) {
+ }
+ 
+ void LocationsBuilderX86_64::VisitVecDiv(HVecDiv* instruction) {
+-  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  if (CpuHasAvxFeatureFlag()) {
++    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++  } else {
++    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  }
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecDiv(HVecDiv* instruction) {
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
+   XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
++  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  DCHECK(cpu_has_avx || other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kFloat32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ divps(dst, src);
++      cpu_has_avx ? __ vdivps(dst, other_src, src) : __ divps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ divpd(dst, src);
++      cpu_has_avx ? __ vdivpd(dst, other_src, src) : __ divpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+diff --git a/compiler/optimizing/code_generator_x86.cc b/compiler/optimizing/code_generator_x86.cc
+index ca1723b..c868ecf 100644
+--- a/compiler/optimizing/code_generator_x86.cc
++++ b/compiler/optimizing/code_generator_x86.cc
+@@ -8408,6 +8408,19 @@ void InstructionCodeGeneratorX86::VisitIntermediateAddress(HIntermediateAddress*
+   LOG(FATAL) << "Unreachable";
+ }
+ 
++bool LocationsBuilderX86::CpuHasAvxFeatureFlag() {
++  return codegen_->GetInstructionSetFeatures().HasAVX();
++}
++bool LocationsBuilderX86::CpuHasAvx2FeatureFlag() {
++  return codegen_->GetInstructionSetFeatures().HasAVX2();
++}
++bool InstructionCodeGeneratorX86::CpuHasAvxFeatureFlag() {
++  return codegen_->GetInstructionSetFeatures().HasAVX();
++}
++bool InstructionCodeGeneratorX86::CpuHasAvx2FeatureFlag() {
++  return codegen_->GetInstructionSetFeatures().HasAVX2();
++}
++
+ #undef __
+ 
+ }  // namespace x86
+diff --git a/compiler/optimizing/code_generator_x86.h b/compiler/optimizing/code_generator_x86.h
+index deeef88..2789b25 100644
+--- a/compiler/optimizing/code_generator_x86.h
++++ b/compiler/optimizing/code_generator_x86.h
+@@ -175,6 +175,8 @@ class LocationsBuilderX86 : public HGraphVisitor {
+   void HandleShift(HBinaryOperation* instruction);
+   void HandleFieldSet(HInstruction* instruction, const FieldInfo& field_info);
+   void HandleFieldGet(HInstruction* instruction, const FieldInfo& field_info);
++  bool CpuHasAvxFeatureFlag();
++  bool CpuHasAvx2FeatureFlag();
+ 
+   CodeGeneratorX86* const codegen_;
+   InvokeDexCallingConventionVisitorX86 parameter_visitor_;
+@@ -307,6 +309,8 @@ class InstructionCodeGeneratorX86 : public InstructionCodeGenerator {
+                                    HBasicBlock* default_block);
+ 
+   void GenerateFPCompare(Location lhs, Location rhs, HInstruction* insn, bool is_double);
++  bool CpuHasAvxFeatureFlag();
++  bool CpuHasAvx2FeatureFlag();
+ 
+   X86Assembler* const assembler_;
+   CodeGeneratorX86* const codegen_;
+diff --git a/compiler/optimizing/code_generator_x86_64.cc b/compiler/optimizing/code_generator_x86_64.cc
+index 7c293b8..ecc22d8 100644
+--- a/compiler/optimizing/code_generator_x86_64.cc
++++ b/compiler/optimizing/code_generator_x86_64.cc
+@@ -7650,6 +7650,22 @@ void CodeGeneratorX86_64::EmitJitRootPatches(uint8_t* code, const uint8_t* roots
+   }
+ }
+ 
++bool LocationsBuilderX86_64::CpuHasAvxFeatureFlag() {
++  return codegen_->GetInstructionSetFeatures().HasAVX();
++}
++
++bool LocationsBuilderX86_64::CpuHasAvx2FeatureFlag() {
++  return codegen_->GetInstructionSetFeatures().HasAVX2();
++}
++
++bool InstructionCodeGeneratorX86_64::CpuHasAvxFeatureFlag() {
++  return codegen_->GetInstructionSetFeatures().HasAVX();
++}
++
++bool InstructionCodeGeneratorX86_64::CpuHasAvx2FeatureFlag() {
++  return codegen_->GetInstructionSetFeatures().HasAVX2();
++}
++
+ #undef __
+ 
+ }  // namespace x86_64
+diff --git a/compiler/optimizing/code_generator_x86_64.h b/compiler/optimizing/code_generator_x86_64.h
+index f74e130..be9aea6 100644
+--- a/compiler/optimizing/code_generator_x86_64.h
++++ b/compiler/optimizing/code_generator_x86_64.h
+@@ -177,6 +177,8 @@ class LocationsBuilderX86_64 : public HGraphVisitor {
+   void HandleShift(HBinaryOperation* operation);
+   void HandleFieldSet(HInstruction* instruction, const FieldInfo& field_info);
+   void HandleFieldGet(HInstruction* instruction);
++  bool CpuHasAvxFeatureFlag();
++  bool CpuHasAvx2FeatureFlag();
+ 
+   CodeGeneratorX86_64* const codegen_;
+   InvokeDexCallingConventionVisitorX86_64 parameter_visitor_;
+@@ -287,6 +289,9 @@ class InstructionCodeGeneratorX86_64 : public InstructionCodeGenerator {
+ 
+   void HandleGoto(HInstruction* got, HBasicBlock* successor);
+ 
++  bool CpuHasAvxFeatureFlag();
++  bool CpuHasAvx2FeatureFlag();
++
+   X86_64Assembler* const assembler_;
+   CodeGeneratorX86_64* const codegen_;
+ 
+diff --git a/compiler/optimizing/loop_optimization.cc b/compiler/optimizing/loop_optimization.cc
+index c6e7560..9914127 100644
+--- a/compiler/optimizing/loop_optimization.cc
++++ b/compiler/optimizing/loop_optimization.cc
+@@ -353,9 +353,6 @@ static bool HasReductionFormat(HInstruction* reduction, HInstruction* phi) {
+ static HVecReduce::ReductionKind GetReductionKind(HVecOperation* reduction) {
+   if (reduction->IsVecAdd()  ||
+       reduction->IsVecSub() ||
+-      #if defined(ART_ENABLE_CODEGEN_x86) || defined(ART_ENABLE_CODEGEN_x86_64)
+-      reduction->IsVecAvxSub() || reduction->IsVecAvxAdd() ||
+-      #endif
+       reduction->IsVecSADAccumulate() ||
+       reduction->IsVecDotProd()) {
+     return HVecReduce::kSum;
+@@ -1943,34 +1940,10 @@ void HLoopOptimization::GenerateVecOp(HInstruction* org,
+         new (global_allocator_) HVecCnv(global_allocator_, opa, type, vector_length_, dex_pc),
+         new (global_allocator_) HTypeConversion(org_type, opa, dex_pc));
+     case HInstruction::kAdd:
+-      #if defined(ART_ENABLE_CODEGEN_x86) || defined(ART_ENABLE_CODEGEN_x86_64)
+-      if ((compiler_options_->GetInstructionSet() == InstructionSet::kX86 ||
+-           compiler_options_->GetInstructionSet() == InstructionSet::kX86_64) &&
+-           compiler_options_->GetInstructionSetFeatures()->AsX86InstructionSetFeatures()
+-               ->HasAVX2()) {
+-        GENERATE_VEC(
+-          new (global_allocator_) HVecAvxAdd(
+-                                      global_allocator_, opa, opb, type, vector_length_, dex_pc),
+-          new (global_allocator_) HAdd(org_type, opa, opb, dex_pc));
+-        UNREACHABLE();  // GENERATE_VEC ends with a "break".
+-      }
+-      #endif
+       GENERATE_VEC(
+         new (global_allocator_) HVecAdd(global_allocator_, opa, opb, type, vector_length_, dex_pc),
+         new (global_allocator_) HAdd(org_type, opa, opb, dex_pc));
+     case HInstruction::kSub:
+-      #if defined(ART_ENABLE_CODEGEN_x86) || defined(ART_ENABLE_CODEGEN_x86_64)
+-      if ((compiler_options_->GetInstructionSet() == InstructionSet::kX86 ||
+-           compiler_options_->GetInstructionSet() == InstructionSet::kX86_64) &&
+-           compiler_options_->GetInstructionSetFeatures()->AsX86InstructionSetFeatures()
+-               ->HasAVX2()) {
+-        GENERATE_VEC(
+-          new (global_allocator_) HVecAvxSub(
+-                                      global_allocator_, opa, opb, type, vector_length_, dex_pc),
+-          new (global_allocator_) HSub(org_type, opa, opb, dex_pc));
+-        UNREACHABLE();  // GENERATE_VEC ends with a "break".
+-      }
+-      #endif
+       GENERATE_VEC(
+         new (global_allocator_) HVecSub(global_allocator_, opa, opb, type, vector_length_, dex_pc),
+         new (global_allocator_) HSub(org_type, opa, opb, dex_pc));
+diff --git a/compiler/optimizing/nodes.h b/compiler/optimizing/nodes.h
+index 8ae9d0b..aa090cc 100644
+--- a/compiler/optimizing/nodes.h
++++ b/compiler/optimizing/nodes.h
+@@ -1521,9 +1521,7 @@ class HLoopInformationOutwardIterator : public ValueObject {
+ #if defined(ART_ENABLE_CODEGEN_x86) || defined(ART_ENABLE_CODEGEN_x86_64)
+ #define FOR_EACH_CONCRETE_INSTRUCTION_X86_COMMON(M)                     \
+   M(X86AndNot, Instruction)                                             \
+-  M(X86MaskOrResetLeastSetBit, Instruction)                             \
+-  M(VecAvxSub, VecOperation)                                            \
+-  M(VecAvxAdd, VecOperation)
++  M(X86MaskOrResetLeastSetBit, Instruction)
+ #else
+ #define FOR_EACH_CONCRETE_INSTRUCTION_X86_COMMON(M)
+ #endif
+@@ -7796,7 +7794,6 @@ class HIntermediateAddress final : public HExpression<2> {
+ #endif
+ #if defined(ART_ENABLE_CODEGEN_x86) || defined(ART_ENABLE_CODEGEN_x86_64)
+ #include "nodes_x86.h"
+-#include "nodes_vector_x86.h"
+ #endif
+ 
+ namespace art {
+diff --git a/compiler/optimizing/nodes_vector_x86.h b/compiler/optimizing/nodes_vector_x86.h
+deleted file mode 100644
+index a8f576f..0000000
+--- a/compiler/optimizing/nodes_vector_x86.h
++++ /dev/null
+@@ -1,84 +0,0 @@
+-/*
+- * Copyright (C) 2018 The Android Open Source Project
+- *
+- * Licensed under the Apache License, Version 2.0 (the "License");
+- * you may not use this file except in compliance with the License.
+- * You may obtain a copy of the License at
+- *
+- *      http://www.apache.org/licenses/LICENSE-2.0
+- *
+- * Unless required by applicable law or agreed to in writing, software
+- * distributed under the License is distributed on an "AS IS" BASIS,
+- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+- * See the License for the specific language governing permissions and
+- * limitations under the License.
+- */
+-
+-#ifndef ART_COMPILER_OPTIMIZING_NODES_VECTOR_X86_H_
+-#define ART_COMPILER_OPTIMIZING_NODES_VECTOR_X86_H_
+-
+-#include "nodes_vector.h"
+-
+-namespace art {
+-
+-class HVecAvxAdd final : public HVecOperation {
+- public:
+-  HVecAvxAdd(ArenaAllocator* allocator,
+-             HInstruction* src1,
+-             HInstruction* src2,
+-             DataType::Type packed_type,
+-             size_t vector_length,
+-             uint32_t dex_pc)
+-      : HVecOperation(kVecAvxAdd,
+-                      allocator,
+-                      packed_type,
+-                      SideEffects::None(),
+-                      /* number_of_inputs */ 2,
+-                      vector_length,
+-                      dex_pc) {
+-    DCHECK(HasConsistentPackedTypes(src1, packed_type));
+-    DCHECK(HasConsistentPackedTypes(src2, packed_type));
+-    SetRawInputAt(0, src1);
+-    SetRawInputAt(1, src2);
+-  }
+-
+-  bool CanBeMoved() const override { return true; }
+-
+-  DECLARE_INSTRUCTION(VecAvxAdd);
+-
+- protected:
+-  DEFAULT_COPY_CONSTRUCTOR(VecAvxAdd);
+-};
+-
+-class HVecAvxSub final : public HVecOperation {
+- public:
+-  HVecAvxSub(ArenaAllocator* allocator,
+-             HInstruction* src1,
+-             HInstruction* src2,
+-             DataType::Type packed_type,
+-             size_t vector_length,
+-             uint32_t dex_pc)
+-      : HVecOperation(kVecAvxSub,
+-                      allocator,
+-                      packed_type,
+-                      SideEffects::None(),
+-                      /* number_of_inputs */ 2,
+-                      vector_length,
+-                      dex_pc) {
+-    DCHECK(HasConsistentPackedTypes(src1, packed_type));
+-    DCHECK(HasConsistentPackedTypes(src2, packed_type));
+-    SetRawInputAt(0, src1);
+-    SetRawInputAt(1, src2);
+-  }
+-
+-  bool CanBeMoved() const override { return true; }
+-
+-  DECLARE_INSTRUCTION(VecAvxSub);
+-
+- protected:
+-  DEFAULT_COPY_CONSTRUCTOR(VecAvxSub);
+-};
+-
+-}  // namespace art
+-
+-#endif  // ART_COMPILER_OPTIMIZING_NODES_VECTOR_X86_H_
+diff --git a/compiler/utils/x86/assembler_x86.cc b/compiler/utils/x86/assembler_x86.cc
+index 3eaf93a..84a8564 100644
+--- a/compiler/utils/x86/assembler_x86.cc
++++ b/compiler/utils/x86/assembler_x86.cc
+@@ -745,6 +745,20 @@ void X86Assembler::mulps(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++void X86Assembler::vmulps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_NONE);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(0x59);
++  EmitXmmRegisterOperand(dst, src2);
++}
+ 
+ void X86Assembler::divps(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -754,6 +768,22 @@ void X86Assembler::divps(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ 
++void X86Assembler::vdivps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_NONE);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(0x5E);
++  EmitXmmRegisterOperand(dst, src2);
++}
++
++
+ void X86Assembler::movapd(XmmRegister dst, XmmRegister src) {
+   if (CpuHasAVXorAVX2FeatureFlag()) {
+     vmovapd(dst, src);
+@@ -1113,6 +1143,20 @@ void X86Assembler::mulpd(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++void X86Assembler::vmulpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(0x59);
++  EmitXmmRegisterOperand(dst, src2);
++}
+ 
+ void X86Assembler::divpd(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1122,6 +1166,20 @@ void X86Assembler::divpd(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++void X86Assembler::vdivpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(0x5E);
++  EmitXmmRegisterOperand(dst, src2);
++}
+ 
+ void X86Assembler::movdqa(XmmRegister dst, XmmRegister src) {
+   if (CpuHasAVXorAVX2FeatureFlag()) {
+@@ -1425,6 +1483,40 @@ void X86Assembler::pmulld(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++void X86Assembler::vpmulld(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ false);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 /*X=*/ false,
++                                 /*B=*/ false,
++                                 SET_VEX_M_0F_38);
++  ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(ByteTwo);
++  EmitUint8(0x40);
++  EmitRegisterOperand(dst, src2);
++}
++
++void X86Assembler::vpmullw(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(0xD5);
++  EmitRegisterOperand(dst, src2);
++}
+ 
+ void X86Assembler::paddq(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+diff --git a/compiler/utils/x86/assembler_x86.h b/compiler/utils/x86/assembler_x86.h
+index 17039f0..dce546e 100644
+--- a/compiler/utils/x86/assembler_x86.h
++++ b/compiler/utils/x86/assembler_x86.h
+@@ -417,6 +417,11 @@ class X86Assembler final : public Assembler {
+   void mulps(XmmRegister dst, XmmRegister src);
+   void divps(XmmRegister dst, XmmRegister src);
+ 
++  void vmulps(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vmulpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vdivps(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vdivpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++
+   void vaddps(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
+   void vsubps(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
+   void vsubpd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
+@@ -476,6 +481,7 @@ class X86Assembler final : public Assembler {
+   void paddw(XmmRegister dst, XmmRegister src);
+   void psubw(XmmRegister dst, XmmRegister src);
+   void pmullw(XmmRegister dst, XmmRegister src);
++  void vpmullw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void vpsubb(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+   void vpsubw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+@@ -485,6 +491,8 @@ class X86Assembler final : public Assembler {
+   void psubd(XmmRegister dst, XmmRegister src);
+   void pmulld(XmmRegister dst, XmmRegister src);
+ 
++  void vpmulld(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++
+   void vpaddd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void paddq(XmmRegister dst, XmmRegister src);
+diff --git a/compiler/utils/x86/assembler_x86_test.cc b/compiler/utils/x86/assembler_x86_test.cc
+index 42ee383..bce0346 100644
+--- a/compiler/utils/x86/assembler_x86_test.cc
++++ b/compiler/utils/x86/assembler_x86_test.cc
+@@ -677,7 +677,7 @@ TEST_F(AssemblerX86Test, AddPS) {
+   DriverStr(RepeatFF(&x86::X86Assembler::addps, "addps %{reg2}, %{reg1}"), "addps");
+ }
+ 
+-TEST_F(AssemblerX86AVXTest, VAddps) {
++TEST_F(AssemblerX86AVXTest, VAddPS) {
+   DriverStr(RepeatFFF(&x86::X86Assembler::vaddps, "vaddps %{reg3}, %{reg2}, %{reg1}"), "vaddps");
+ }
+ 
+@@ -693,41 +693,55 @@ TEST_F(AssemblerX86Test, SubPS) {
+   DriverStr(RepeatFF(&x86::X86Assembler::subps, "subps %{reg2}, %{reg1}"), "subps");
+ }
+ 
+-TEST_F(AssemblerX86AVXTest, VSubps) {
++TEST_F(AssemblerX86AVXTest, VSubPS) {
+   DriverStr(RepeatFFF(&x86::X86Assembler::vsubps, "vsubps %{reg3},%{reg2}, %{reg1}"), "vsubps");
+ }
+ 
+-
+ TEST_F(AssemblerX86Test, SubPD) {
+   DriverStr(RepeatFF(&x86::X86Assembler::subpd, "subpd %{reg2}, %{reg1}"), "subpd");
+ }
+ 
+-TEST_F(AssemblerX86AVXTest, VSubpd) {
++TEST_F(AssemblerX86AVXTest, VSubPD) {
+   DriverStr(RepeatFFF(&x86::X86Assembler::vsubpd, "vsubpd %{reg3}, %{reg2}, %{reg1}"), "vsubpd");
+ }
+ 
+-
+ TEST_F(AssemblerX86Test, MulPS) {
+   DriverStr(RepeatFF(&x86::X86Assembler::mulps, "mulps %{reg2}, %{reg1}"), "mulps");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VMulPS) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vmulps, "vmulps %{reg3}, %{reg2}, %{reg1}"), "vmulps");
++}
++
+ TEST_F(AssemblerX86Test, MulPD) {
+   DriverStr(RepeatFF(&x86::X86Assembler::mulpd, "mulpd %{reg2}, %{reg1}"), "mulpd");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VMulPD) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vmulpd, "vmulpd %{reg3}, %{reg2}, %{reg1}"), "vmulpd");
++}
++
+ TEST_F(AssemblerX86Test, DivPS) {
+   DriverStr(RepeatFF(&x86::X86Assembler::divps, "divps %{reg2}, %{reg1}"), "divps");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VDivPS) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vdivps, "vdivps %{reg3}, %{reg2}, %{reg1}"), "vdivps");
++}
++
+ TEST_F(AssemblerX86Test, DivPD) {
+   DriverStr(RepeatFF(&x86::X86Assembler::divpd, "divpd %{reg2}, %{reg1}"), "divpd");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VDivPD) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vdivpd, "vdivpd %{reg3}, %{reg2}, %{reg1}"), "vdivpd");
++}
++
+ TEST_F(AssemblerX86Test, PAddB) {
+   DriverStr(RepeatFF(&x86::X86Assembler::paddb, "paddb %{reg2}, %{reg1}"), "paddb");
+ }
+ 
+-TEST_F(AssemblerX86AVXTest, VPaddb) {
++TEST_F(AssemblerX86AVXTest, VPaddB) {
+   DriverStr(RepeatFFF(&x86::X86Assembler::vpaddb, "vpaddb %{reg3}, %{reg2}, %{reg1}"), "vpaddb");
+ }
+ 
+@@ -735,7 +749,7 @@ TEST_F(AssemblerX86Test, PSubB) {
+   DriverStr(RepeatFF(&x86::X86Assembler::psubb, "psubb %{reg2}, %{reg1}"), "psubb");
+ }
+ 
+-TEST_F(AssemblerX86AVXTest, VPsubb) {
++TEST_F(AssemblerX86AVXTest, VPsubB) {
+   DriverStr(RepeatFFF(&x86::X86Assembler::vpsubb, "vpsubb %{reg3},%{reg2}, %{reg1}"), "vpsubb");
+ }
+ 
+@@ -743,7 +757,7 @@ TEST_F(AssemblerX86Test, PAddW) {
+   DriverStr(RepeatFF(&x86::X86Assembler::paddw, "paddw %{reg2}, %{reg1}"), "paddw");
+ }
+ 
+-TEST_F(AssemblerX86AVXTest, VPaddw) {
++TEST_F(AssemblerX86AVXTest, VPaddW) {
+   DriverStr(RepeatFFF(&x86::X86Assembler::vpaddw, "vpaddw %{reg3}, %{reg2}, %{reg1}"), "vpaddw");
+ }
+ 
+@@ -751,7 +765,7 @@ TEST_F(AssemblerX86Test, PSubW) {
+   DriverStr(RepeatFF(&x86::X86Assembler::psubw, "psubw %{reg2}, %{reg1}"), "psubw");
+ }
+ 
+-TEST_F(AssemblerX86AVXTest, VPsubw) {
++TEST_F(AssemblerX86AVXTest, VPsubW) {
+   DriverStr(RepeatFFF(&x86::X86Assembler::vpsubw, "vpsubw %{reg3}, %{reg2}, %{reg1}"), "vpsubw");
+ }
+ 
+@@ -759,11 +773,15 @@ TEST_F(AssemblerX86Test, PMullW) {
+   DriverStr(RepeatFF(&x86::X86Assembler::pmullw, "pmullw %{reg2}, %{reg1}"), "pmullw");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VPMullW) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vpmullw, "vpmullw %{reg3}, %{reg2}, %{reg1}"), "vpmullw");
++}
++
+ TEST_F(AssemblerX86Test, PAddD) {
+   DriverStr(RepeatFF(&x86::X86Assembler::paddd, "paddd %{reg2}, %{reg1}"), "paddd");
+ }
+ 
+-TEST_F(AssemblerX86AVXTest, VPaddd) {
++TEST_F(AssemblerX86AVXTest, VPaddD) {
+   DriverStr(RepeatFFF(&x86::X86Assembler::vpaddd, "vpaddd %{reg3}, %{reg2}, %{reg1}"), "vpaddd");
+ }
+ 
+@@ -771,7 +789,7 @@ TEST_F(AssemblerX86Test, PSubD) {
+   DriverStr(RepeatFF(&x86::X86Assembler::psubd, "psubd %{reg2}, %{reg1}"), "psubd");
+ }
+ 
+-TEST_F(AssemblerX86AVXTest, VPsubd) {
++TEST_F(AssemblerX86AVXTest, VPsubD) {
+   DriverStr(RepeatFFF(&x86::X86Assembler::vpsubd, "vpsubd %{reg3}, %{reg2}, %{reg1}"), "vpsubd");
+ }
+ 
+@@ -779,11 +797,15 @@ TEST_F(AssemblerX86Test, PMullD) {
+   DriverStr(RepeatFF(&x86::X86Assembler::pmulld, "pmulld %{reg2}, %{reg1}"), "pmulld");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VPMullD) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vpmulld, "vpmulld %{reg3}, %{reg2}, %{reg1}"), "vpmulld");
++}
++
+ TEST_F(AssemblerX86Test, PAddQ) {
+   DriverStr(RepeatFF(&x86::X86Assembler::paddq, "paddq %{reg2}, %{reg1}"), "paddq");
+ }
+ 
+-TEST_F(AssemblerX86AVXTest, VPaddq) {
++TEST_F(AssemblerX86AVXTest, VPaddQ) {
+   DriverStr(RepeatFFF(&x86::X86Assembler::vpaddq, "vpaddq %{reg3}, %{reg2}, %{reg1}"), "vpaddq");
+ }
+ 
+@@ -791,7 +813,7 @@ TEST_F(AssemblerX86Test, PSubQ) {
+   DriverStr(RepeatFF(&x86::X86Assembler::psubq, "psubq %{reg2}, %{reg1}"), "psubq");
+ }
+ 
+-TEST_F(AssemblerX86AVXTest, VPsubq) {
++TEST_F(AssemblerX86AVXTest, VPsubQ) {
+   DriverStr(RepeatFFF(&x86::X86Assembler::vpsubq, "vpsubq %{reg3}, %{reg2}, %{reg1}"), "vpsubq");
+ }
+ 
+diff --git a/compiler/utils/x86_64/assembler_x86_64.cc b/compiler/utils/x86_64/assembler_x86_64.cc
+index 72b7ae0..be8fe59 100644
+--- a/compiler/utils/x86_64/assembler_x86_64.cc
++++ b/compiler/utils/x86_64/assembler_x86_64.cc
+@@ -919,6 +919,34 @@ void X86_64Assembler::mulps(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++void X86_64Assembler::vmulps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0x59);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
+ 
+ void X86_64Assembler::divps(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -928,6 +956,34 @@ void X86_64Assembler::divps(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++void X86_64Assembler::vdivps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0x5E);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
+ 
+ void X86_64Assembler::flds(const Address& src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1423,6 +1479,34 @@ void X86_64Assembler::mulpd(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++void X86_64Assembler::vmulpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0x59);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
+ 
+ void X86_64Assembler::divpd(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1434,6 +1518,36 @@ void X86_64Assembler::divpd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ 
++void X86_64Assembler::vdivpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0x5E);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
++
+ void X86_64Assembler::movdqa(XmmRegister dst, XmmRegister src) {
+   if (CpuHasAVXorAVX2FeatureFlag()) {
+     vmovdqa(dst, src);
+@@ -1878,6 +1992,34 @@ void X86_64Assembler::pmullw(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++void X86_64Assembler::vpmullw(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0xD5);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
+ 
+ void X86_64Assembler::paddd(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1937,6 +2079,24 @@ void X86_64Assembler::pmulld(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++void X86_64Assembler::vpmulld(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form*/ false);
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F_38);
++  ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(ByteTwo);
++  EmitUint8(0x40);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
+ 
+ void X86_64Assembler::paddq(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+diff --git a/compiler/utils/x86_64/assembler_x86_64.h b/compiler/utils/x86_64/assembler_x86_64.h
+index 8fc69f6..100707a 100644
+--- a/compiler/utils/x86_64/assembler_x86_64.h
++++ b/compiler/utils/x86_64/assembler_x86_64.h
+@@ -452,6 +452,11 @@ class X86_64Assembler final : public Assembler {
+   void mulps(XmmRegister dst, XmmRegister src);
+   void divps(XmmRegister dst, XmmRegister src);
+ 
++  void vmulps(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vmulpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vdivps(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vdivpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++
+   void vaddps(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
+   void vsubps(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
+   void vsubpd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
+@@ -508,6 +513,7 @@ class X86_64Assembler final : public Assembler {
+   void paddw(XmmRegister dst, XmmRegister src);
+   void psubw(XmmRegister dst, XmmRegister src);
+   void pmullw(XmmRegister dst, XmmRegister src);
++  void vpmullw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void vpsubb(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+   void vpsubw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+@@ -516,6 +522,7 @@ class X86_64Assembler final : public Assembler {
+   void paddd(XmmRegister dst, XmmRegister src);
+   void psubd(XmmRegister dst, XmmRegister src);
+   void pmulld(XmmRegister dst, XmmRegister src);
++  void vpmulld(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void vpaddd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+diff --git a/compiler/utils/x86_64/assembler_x86_64_test.cc b/compiler/utils/x86_64/assembler_x86_64_test.cc
+index 24a6c3c..3d58a6d 100644
+--- a/compiler/utils/x86_64/assembler_x86_64_test.cc
++++ b/compiler/utils/x86_64/assembler_x86_64_test.cc
+@@ -1375,10 +1375,20 @@ TEST_F(AssemblerX86_64Test, Mulps) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::mulps, "mulps %{reg2}, %{reg1}"), "mulps");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VMulps) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vmulps, "vmulps %{reg3}, %{reg2}, %{reg1}"), "vmulps");
++}
++
+ TEST_F(AssemblerX86_64Test, Mulpd) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::mulpd, "mulpd %{reg2}, %{reg1}"), "mulpd");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VMulpd) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vmulpd, "vmulpd %{reg3}, %{reg2}, %{reg1}"), "vmulpd");
++}
++
+ TEST_F(AssemblerX86_64Test, Divss) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::divss, "divss %{reg2}, %{reg1}"), "divss");
+ }
+@@ -1391,10 +1401,20 @@ TEST_F(AssemblerX86_64Test, Divps) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::divps, "divps %{reg2}, %{reg1}"), "divps");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VDivps) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vdivps, "vdivps %{reg3}, %{reg2}, %{reg1}"), "vdivps");
++}
++
+ TEST_F(AssemblerX86_64Test, Divpd) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::divpd, "divpd %{reg2}, %{reg1}"), "divpd");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VDivpd) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vdivpd, "vdivpd %{reg3}, %{reg2}, %{reg1}"), "vdivpd");
++}
++
+ TEST_F(AssemblerX86_64Test, Paddb) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::paddb, "paddb %{reg2}, %{reg1}"), "paddb");
+ }
+@@ -1427,7 +1447,6 @@ TEST_F(AssemblerX86_64AVXTest, VPaddw) {
+       RepeatFFF(&x86_64::X86_64Assembler::vpaddw, "vpaddw %{reg3}, %{reg2}, %{reg1}"), "vpaddw");
+ }
+ 
+-
+ TEST_F(AssemblerX86_64Test, Psubw) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::psubw, "psubw %{reg2}, %{reg1}"), "psubw");
+ }
+@@ -1436,6 +1455,11 @@ TEST_F(AssemblerX86_64Test, Pmullw) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::pmullw, "pmullw %{reg2}, %{reg1}"), "pmullw");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VPmullw) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vpmullw, "vpmullw %{reg3}, %{reg2}, %{reg1}"), "vpmullw");
++}
++
+ TEST_F(AssemblerX86_64Test, Paddd) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::paddd, "paddd %{reg2}, %{reg1}"), "paddd");
+ }
+@@ -1458,6 +1482,11 @@ TEST_F(AssemblerX86_64Test, Pmulld) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::pmulld, "pmulld %{reg2}, %{reg1}"), "pmulld");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VPmulld) {
++  DriverStr(
++      RepeatFFF(&x86_64::X86_64Assembler::vpmulld, "vpmulld %{reg3}, %{reg2}, %{reg1}"), "vpmulld");
++}
++
+ TEST_F(AssemblerX86_64Test, Paddq) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::paddq, "paddq %{reg2}, %{reg1}"), "paddq");
+ }
+diff --git a/compiler/utils/x86_64/constants_x86_64.h b/compiler/utils/x86_64/constants_x86_64.h
+index b02e246..5335398 100644
+--- a/compiler/utils/x86_64/constants_x86_64.h
++++ b/compiler/utils/x86_64/constants_x86_64.h
+@@ -59,6 +59,9 @@ class XmmRegister {
+   constexpr bool NeedsRex() const {
+     return reg_ > 7;
+   }
++  bool operator==(XmmRegister& other) {
++    return reg_ == other.reg_;
++  }
+  private:
+   const FloatRegister reg_;
+ };
+-- 
+2.7.4
+

--- a/aosp_diff/caas/art/0006-AVX-support-for-bitwise-instructions-Xor-Or-And-Andn.patch
+++ b/aosp_diff/caas/art/0006-AVX-support-for-bitwise-instructions-Xor-Or-And-Andn.patch
@@ -1,0 +1,1328 @@
+From 4ea3712301efe61774f0047856d3f8923788145a Mon Sep 17 00:00:00 2001
+From: Neeraj Solanki <neeraj.solanki@intel.com>
+Date: Mon, 5 Aug 2019 23:16:56 +0530
+Subject: [PATCH] AVX support for bitwise instructions (Xor, Or, And, Andn)
+
+Test: ./test.py --host --64, test-art-host-gtest
+
+Change-Id: Ia8302d12d3ebb8447d73db576fb5b945485c11e1
+Signed-off-by: Neeraj Solanki <neeraj.solanki@intel.com>
+---
+ compiler/optimizing/code_generator_vector_x86.cc   |  70 ++--
+ .../optimizing/code_generator_vector_x86_64.cc     |  70 ++--
+ compiler/utils/x86/assembler_x86.cc                | 244 ++++++++++++++
+ compiler/utils/x86/assembler_x86.h                 |  12 +
+ compiler/utils/x86/assembler_x86_test.cc           |  48 +++
+ compiler/utils/x86_64/assembler_x86_64.cc          | 359 +++++++++++++++++++++
+ compiler/utils/x86_64/assembler_x86_64.h           |  12 +
+ compiler/utils/x86_64/assembler_x86_64_test.cc     |  61 ++++
+ 8 files changed, 832 insertions(+), 44 deletions(-)
+
+diff --git a/compiler/optimizing/code_generator_vector_x86.cc b/compiler/optimizing/code_generator_vector_x86.cc
+index 29a1354..68aef77 100644
+--- a/compiler/optimizing/code_generator_vector_x86.cc
++++ b/compiler/optimizing/code_generator_vector_x86.cc
+@@ -63,9 +63,10 @@ void InstructionCodeGeneratorX86::VisitVecReplicateScalar(HVecReplicateScalar* i
+   LocationSummary* locations = instruction->GetLocations();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
+ 
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   // Shorthand for any type of zero.
+   if (IsZeroBitPattern(instruction->InputAt(0))) {
+-    __ xorps(dst, dst);
++    cpu_has_avx ? __ vxorps(dst, dst, dst) : __ xorps(dst, dst);
+     return;
+   }
+ 
+@@ -808,14 +809,20 @@ void InstructionCodeGeneratorX86::VisitVecMax(HVecMax* instruction) {
+ }
+ 
+ void LocationsBuilderX86::VisitVecAnd(HVecAnd* instruction) {
+-  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  if (CpuHasAvxFeatureFlag()) {
++    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++  } else {
++    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  }
+ }
+ 
+ void InstructionCodeGeneratorX86::VisitVecAnd(HVecAnd* instruction) {
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
++  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+   XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  DCHECK(cpu_has_avx || other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kBool:
+     case DataType::Type::kUint8:
+@@ -826,15 +833,15 @@ void InstructionCodeGeneratorX86::VisitVecAnd(HVecAnd* instruction) {
+     case DataType::Type::kInt64:
+       DCHECK_LE(2u, instruction->GetVectorLength());
+       DCHECK_LE(instruction->GetVectorLength(), 16u);
+-      __ pand(dst, src);
++      cpu_has_avx ? __ vpand(dst, other_src, src) : __ pand(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ andps(dst, src);
++      cpu_has_avx ? __ vandps(dst, other_src, src) : __ andps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ andpd(dst, src);
++      cpu_has_avx ? __ vandpd(dst, other_src, src) : __ andpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -843,14 +850,20 @@ void InstructionCodeGeneratorX86::VisitVecAnd(HVecAnd* instruction) {
+ }
+ 
+ void LocationsBuilderX86::VisitVecAndNot(HVecAndNot* instruction) {
+-  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  if (CpuHasAvxFeatureFlag()) {
++    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++  } else {
++    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  }
+ }
+ 
+ void InstructionCodeGeneratorX86::VisitVecAndNot(HVecAndNot* instruction) {
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
++  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+   XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  DCHECK(cpu_has_avx || other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kBool:
+     case DataType::Type::kUint8:
+@@ -861,15 +874,15 @@ void InstructionCodeGeneratorX86::VisitVecAndNot(HVecAndNot* instruction) {
+     case DataType::Type::kInt64:
+       DCHECK_LE(2u, instruction->GetVectorLength());
+       DCHECK_LE(instruction->GetVectorLength(), 16u);
+-      __ pandn(dst, src);
++      cpu_has_avx ? __ vpandn(dst, other_src, src) : __ pandn(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ andnps(dst, src);
++      cpu_has_avx ? __ vandnps(dst, other_src, src) : __ andnps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ andnpd(dst, src);
++      cpu_has_avx ? __ vandnpd(dst, other_src, src) : __ andnpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -878,14 +891,20 @@ void InstructionCodeGeneratorX86::VisitVecAndNot(HVecAndNot* instruction) {
+ }
+ 
+ void LocationsBuilderX86::VisitVecOr(HVecOr* instruction) {
+-  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  if (CpuHasAvxFeatureFlag()) {
++    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++  } else {
++    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  }
+ }
+ 
+ void InstructionCodeGeneratorX86::VisitVecOr(HVecOr* instruction) {
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
++  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+   XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  DCHECK(cpu_has_avx || other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kBool:
+     case DataType::Type::kUint8:
+@@ -896,15 +915,15 @@ void InstructionCodeGeneratorX86::VisitVecOr(HVecOr* instruction) {
+     case DataType::Type::kInt64:
+       DCHECK_LE(2u, instruction->GetVectorLength());
+       DCHECK_LE(instruction->GetVectorLength(), 16u);
+-      __ por(dst, src);
++      cpu_has_avx ? __ vpor(dst, other_src, src) : __ por(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ orps(dst, src);
++      cpu_has_avx ? __ vorps(dst, other_src, src) : __ orps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ orpd(dst, src);
++      cpu_has_avx ? __ vorpd(dst, other_src, src) : __ orpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -913,14 +932,20 @@ void InstructionCodeGeneratorX86::VisitVecOr(HVecOr* instruction) {
+ }
+ 
+ void LocationsBuilderX86::VisitVecXor(HVecXor* instruction) {
+-  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  if (CpuHasAvxFeatureFlag()) {
++    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++  } else {
++    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  }
+ }
+ 
+ void InstructionCodeGeneratorX86::VisitVecXor(HVecXor* instruction) {
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
++  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+   XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  DCHECK(cpu_has_avx || other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kBool:
+     case DataType::Type::kUint8:
+@@ -931,15 +956,15 @@ void InstructionCodeGeneratorX86::VisitVecXor(HVecXor* instruction) {
+     case DataType::Type::kInt64:
+       DCHECK_LE(2u, instruction->GetVectorLength());
+       DCHECK_LE(instruction->GetVectorLength(), 16u);
+-      __ pxor(dst, src);
++      cpu_has_avx ? __ vpxor(dst, other_src, src) : __ pxor(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ xorps(dst, src);
++      cpu_has_avx ? __ vxorps(dst, other_src, src) : __ xorps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ xorpd(dst, src);
++      cpu_has_avx ? __ vxorpd(dst, other_src, src) : __ xorpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -1092,7 +1117,8 @@ void InstructionCodeGeneratorX86::VisitVecSetScalars(HVecSetScalars* instruction
+   DCHECK_EQ(1u, instruction->InputCount());  // only one input currently implemented
+ 
+   // Zero out all other elements first.
+-  __ xorps(dst, dst);
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
++  cpu_has_avx ? __ vxorps(dst, dst, dst) : __ xorps(dst, dst);
+ 
+   // Shorthand for any type of zero.
+   if (IsZeroBitPattern(instruction->InputAt(0))) {
+diff --git a/compiler/optimizing/code_generator_vector_x86_64.cc b/compiler/optimizing/code_generator_vector_x86_64.cc
+index f28268b..19dfd1d 100644
+--- a/compiler/optimizing/code_generator_vector_x86_64.cc
++++ b/compiler/optimizing/code_generator_vector_x86_64.cc
+@@ -58,9 +58,10 @@ void InstructionCodeGeneratorX86_64::VisitVecReplicateScalar(HVecReplicateScalar
+   LocationSummary* locations = instruction->GetLocations();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
+ 
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   // Shorthand for any type of zero.
+   if (IsZeroBitPattern(instruction->InputAt(0))) {
+-    __ xorps(dst, dst);
++    cpu_has_avx ? __ vxorps(dst, dst, dst) : __ xorps(dst, dst);
+     return;
+   }
+ 
+@@ -791,14 +792,20 @@ void InstructionCodeGeneratorX86_64::VisitVecMax(HVecMax* instruction) {
+ }
+ 
+ void LocationsBuilderX86_64::VisitVecAnd(HVecAnd* instruction) {
+-  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  if (CpuHasAvxFeatureFlag()) {
++    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++  } else {
++    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  }
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecAnd(HVecAnd* instruction) {
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
++  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+   XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  DCHECK(cpu_has_avx || other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kBool:
+     case DataType::Type::kUint8:
+@@ -809,15 +816,15 @@ void InstructionCodeGeneratorX86_64::VisitVecAnd(HVecAnd* instruction) {
+     case DataType::Type::kInt64:
+       DCHECK_LE(2u, instruction->GetVectorLength());
+       DCHECK_LE(instruction->GetVectorLength(), 16u);
+-      __ pand(dst, src);
++      cpu_has_avx ? __ vpand(dst, other_src, src) : __ pand(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ andps(dst, src);
++      cpu_has_avx ? __ vandps(dst, other_src, src) : __ andps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ andpd(dst, src);
++      cpu_has_avx ? __ vandpd(dst, other_src, src) : __ andpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -826,14 +833,20 @@ void InstructionCodeGeneratorX86_64::VisitVecAnd(HVecAnd* instruction) {
+ }
+ 
+ void LocationsBuilderX86_64::VisitVecAndNot(HVecAndNot* instruction) {
+-  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  if (CpuHasAvxFeatureFlag()) {
++    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++  } else {
++    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  }
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecAndNot(HVecAndNot* instruction) {
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
++  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+   XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  DCHECK(cpu_has_avx || other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kBool:
+     case DataType::Type::kUint8:
+@@ -844,15 +857,15 @@ void InstructionCodeGeneratorX86_64::VisitVecAndNot(HVecAndNot* instruction) {
+     case DataType::Type::kInt64:
+       DCHECK_LE(2u, instruction->GetVectorLength());
+       DCHECK_LE(instruction->GetVectorLength(), 16u);
+-      __ pandn(dst, src);
++      cpu_has_avx ? __ vpandn(dst, other_src, src) : __ pandn(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ andnps(dst, src);
++      cpu_has_avx ? __ vandnps(dst, other_src, src) : __ andnps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ andnpd(dst, src);
++      cpu_has_avx ? __ vandnpd(dst, other_src, src) : __ andnpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -861,14 +874,20 @@ void InstructionCodeGeneratorX86_64::VisitVecAndNot(HVecAndNot* instruction) {
+ }
+ 
+ void LocationsBuilderX86_64::VisitVecOr(HVecOr* instruction) {
+-  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  if (CpuHasAvxFeatureFlag()) {
++    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++  } else {
++    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  }
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecOr(HVecOr* instruction) {
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
++  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+   XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  DCHECK(cpu_has_avx || other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kBool:
+     case DataType::Type::kUint8:
+@@ -879,15 +898,15 @@ void InstructionCodeGeneratorX86_64::VisitVecOr(HVecOr* instruction) {
+     case DataType::Type::kInt64:
+       DCHECK_LE(2u, instruction->GetVectorLength());
+       DCHECK_LE(instruction->GetVectorLength(), 16u);
+-      __ por(dst, src);
++      cpu_has_avx ? __ vpor(dst, other_src, src) : __ por(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ orps(dst, src);
++      cpu_has_avx ? __ vorps(dst, other_src, src) : __ orps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ orpd(dst, src);
++      cpu_has_avx ? __ vorpd(dst, other_src, src) : __ orpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -896,14 +915,20 @@ void InstructionCodeGeneratorX86_64::VisitVecOr(HVecOr* instruction) {
+ }
+ 
+ void LocationsBuilderX86_64::VisitVecXor(HVecXor* instruction) {
+-  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  if (CpuHasAvxFeatureFlag()) {
++    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
++  } else {
++    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
++  }
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecXor(HVecXor* instruction) {
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
++  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+   XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+   XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  DCHECK(cpu_has_avx || other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kBool:
+     case DataType::Type::kUint8:
+@@ -914,15 +939,15 @@ void InstructionCodeGeneratorX86_64::VisitVecXor(HVecXor* instruction) {
+     case DataType::Type::kInt64:
+       DCHECK_LE(2u, instruction->GetVectorLength());
+       DCHECK_LE(instruction->GetVectorLength(), 16u);
+-      __ pxor(dst, src);
++      cpu_has_avx ? __ vpxor(dst, other_src, src) : __ pxor(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ xorps(dst, src);
++      cpu_has_avx ? __ vxorps(dst, other_src, src) : __ xorps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ xorpd(dst, src);
++      cpu_has_avx ? __ vxorpd(dst, other_src, src) : __ xorpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -1070,7 +1095,8 @@ void InstructionCodeGeneratorX86_64::VisitVecSetScalars(HVecSetScalars* instruct
+   DCHECK_EQ(1u, instruction->InputCount());  // only one input currently implemented
+ 
+   // Zero out all other elements first.
+-  __ xorps(dst, dst);
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
++  cpu_has_avx ? __ vxorps(dst, dst, dst) : __ xorps(dst, dst);
+ 
+   // Shorthand for any type of zero.
+   if (IsZeroBitPattern(instruction->InputAt(0))) {
+diff --git a/compiler/utils/x86/assembler_x86.cc b/compiler/utils/x86/assembler_x86.cc
+index 84a8564..166aec8 100644
+--- a/compiler/utils/x86/assembler_x86.cc
++++ b/compiler/utils/x86/assembler_x86.cc
+@@ -1872,6 +1872,68 @@ void X86Assembler::pxor(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++/* VEX.128.66.0F.WIG EF /r VPXOR xmm1, xmm2, xmm3/m128 */
++void X86Assembler::vpxor(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  /* Instruction VEX Prefix */
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  /* REX prefix is necessary only if an instruction references one of extended
++  registers or uses a 64-bit operand. */
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0xEF);
++  // Instruction Operands
++  EmitXmmRegisterOperand(dst, src2);
++}
++
++/* VEX.128.0F.WIG 57 /r VXORPS xmm1,xmm2, xmm3/m128 */
++void X86Assembler::vxorps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  /* Instruction VEX Prefix */
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  /* REX prefix is necessary only if an instruction references one of extended
++  registers or uses a 64-bit operand. */
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_NONE);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x57);
++  // Instruction Operands
++  EmitXmmRegisterOperand(dst, src2);
++}
++
++/* VEX.128.66.0F.WIG 57 /r VXORPD xmm1,xmm2, xmm3/m128 */
++void X86Assembler::vxorpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  /* Instruction VEX Prefix */
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  /* REX prefix is necessary only if an instruction references one of extended
++  registers or uses a 64-bit operand. */
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x57);
++  // Instruction Operands
++  EmitXmmRegisterOperand(dst, src2);
++}
+ 
+ void X86Assembler::andpd(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1915,8 +1977,66 @@ void X86Assembler::pand(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++/* VEX.128.66.0F.WIG DB /r VPAND xmm1, xmm2, xmm3/m128 */
++void X86Assembler::vpand(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  /* Instruction VEX Prefix */
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  /* REX prefix is necessary only if an instruction references one of extended
++  registers or uses a 64-bit operand. */
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0xDB);
++  // Instruction Operands
++  EmitXmmRegisterOperand(dst, src2);
++}
+ 
++/* VEX.128.0F 54 /r VANDPS xmm1,xmm2, xmm3/m128 */
++void X86Assembler::vandps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  /* Instruction VEX Prefix */
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_NONE);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x54);
++  // Instruction Operands
++  EmitXmmRegisterOperand(dst, src2);
++}
+ 
++/* VEX.128.66.0F 54 /r VANDPD xmm1, xmm2, xmm3/m128 */
++void X86Assembler::vandpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  /* Instruction VEX Prefix */
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  /* REX prefix is necessary only if an instruction references one of extended
++  registers or uses a 64-bit operand. */
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x54);
++  // Instruction Operands
++  EmitXmmRegisterOperand(dst, src2);
++}
+ 
+ void X86Assembler::andnpd(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1943,6 +2063,68 @@ void X86Assembler::pandn(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++/* VEX.128.66.0F.WIG DF /r VPANDN xmm1, xmm2, xmm3/m128 */
++void X86Assembler::vpandn(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  /* Instruction VEX Prefix */
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  /* REX prefix is necessary only if an instruction references one of extended
++  registers or uses a 64-bit operand. */
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0xDF);
++  // Instruction Operands
++  EmitXmmRegisterOperand(dst, src2);
++}
++
++/* VEX.128.0F 55 /r VANDNPS xmm1, xmm2, xmm3/m128 */
++void X86Assembler::vandnps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  /* Instruction VEX Prefix */
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  /* REX prefix is necessary only if an instruction references one of extended
++  registers or uses a 64-bit operand. */
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_NONE);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x55);
++  // Instruction Operands
++  EmitXmmRegisterOperand(dst, src2);
++}
++
++/* VEX.128.66.0F 55 /r VANDNPD xmm1, xmm2, xmm3/m128 */
++void X86Assembler::vandnpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  /* Instruction VEX Prefix */
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  /* REX prefix is necessary only if an instruction references one of extended
++  registers or uses a 64-bit operand. */
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x55);
++  // Instruction Operands
++  EmitXmmRegisterOperand(dst, src2);
++}
+ 
+ void X86Assembler::orpd(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1987,6 +2169,68 @@ void X86Assembler::por(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst, src);
+ }
+ 
++/* VEX.128.66.0F.WIG EB /r VPOR xmm1, xmm2, xmm3/m128 */
++void X86Assembler::vpor(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  /* Instruction VEX Prefix */
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  /* REX prefix is necessary only if an instruction references one of extended
++  registers or uses a 64-bit operand. */
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0xEB);
++  // Instruction Operands
++  EmitXmmRegisterOperand(dst, src2);
++}
++
++/* VEX.128.0F 56 /r VORPS xmm1,xmm2, xmm3/m128 */
++void X86Assembler::vorps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  /* Instruction VEX Prefix */
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  /* REX prefix is necessary only if an instruction references one of extended
++  registers or uses a 64-bit operand. */
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_NONE);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x56);
++  // Instruction Operands
++  EmitXmmRegisterOperand(dst, src2);
++}
++
++/* VEX.128.66.0F 56 /r VORPD xmm1,xmm2, xmm3/m128 */
++void X86Assembler::vorpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  /* Instruction VEX Prefix */
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ true);
++  /* REX prefix is necessary only if an instruction references one of extended
++  registers or uses a 64-bit operand. */
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false,
++                                 X86ManagedRegister::FromXmmRegister(src1),
++                                 SET_VEX_L_128,
++                                 SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  // Instruction Opcode
++  EmitUint8(0x56);
++  // Instruction Operands
++  EmitXmmRegisterOperand(dst, src2);
++}
+ 
+ void X86Assembler::pavgb(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+diff --git a/compiler/utils/x86/assembler_x86.h b/compiler/utils/x86/assembler_x86.h
+index dce546e..1b6941c 100644
+--- a/compiler/utils/x86/assembler_x86.h
++++ b/compiler/utils/x86/assembler_x86.h
+@@ -545,21 +545,33 @@ class X86Assembler final : public Assembler {
+   void xorps(XmmRegister dst, const Address& src);
+   void xorps(XmmRegister dst, XmmRegister src);
+   void pxor(XmmRegister dst, XmmRegister src);  // no addr variant (for now)
++  void vpxor(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vxorps(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vxorpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void andpd(XmmRegister dst, XmmRegister src);
+   void andpd(XmmRegister dst, const Address& src);
+   void andps(XmmRegister dst, XmmRegister src);
+   void andps(XmmRegister dst, const Address& src);
+   void pand(XmmRegister dst, XmmRegister src);  // no addr variant (for now)
++  void vpand(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vandps(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vandpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void andn(Register dst, Register src1, Register src2);  // no addr variant (for now)
+   void andnpd(XmmRegister dst, XmmRegister src);  // no addr variant (for now)
+   void andnps(XmmRegister dst, XmmRegister src);
+   void pandn(XmmRegister dst, XmmRegister src);
++  void vpandn(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vandnps(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vandnpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void orpd(XmmRegister dst, XmmRegister src);  // no addr variant (for now)
+   void orps(XmmRegister dst, XmmRegister src);
+   void por(XmmRegister dst, XmmRegister src);
++  void vpor(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vorps(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vorpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void pavgb(XmmRegister dst, XmmRegister src);  // no addr variant (for now)
+   void pavgw(XmmRegister dst, XmmRegister src);
+diff --git a/compiler/utils/x86/assembler_x86_test.cc b/compiler/utils/x86/assembler_x86_test.cc
+index bce0346..12d9646 100644
+--- a/compiler/utils/x86/assembler_x86_test.cc
++++ b/compiler/utils/x86/assembler_x86_test.cc
+@@ -861,6 +861,18 @@ TEST_F(AssemblerX86Test, PXor) {
+   DriverStr(RepeatFF(&x86::X86Assembler::pxor, "pxor %{reg2}, %{reg1}"), "pxor");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VPXor) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vpxor, "vpxor %{reg3}, %{reg2}, %{reg1}"), "vpxor");
++}
++
++TEST_F(AssemblerX86AVXTest, VXorPS) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vxorps, "vxorps %{reg3}, %{reg2}, %{reg1}"), "vxorps");
++}
++
++TEST_F(AssemblerX86AVXTest, VXorPD) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vxorpd, "vxorpd %{reg3}, %{reg2}, %{reg1}"), "vxorpd");
++}
++
+ TEST_F(AssemblerX86Test, AndPD) {
+   DriverStr(RepeatFF(&x86::X86Assembler::andpd, "andpd %{reg2}, %{reg1}"), "andpd");
+ }
+@@ -873,6 +885,18 @@ TEST_F(AssemblerX86Test, PAnd) {
+   DriverStr(RepeatFF(&x86::X86Assembler::pand, "pand %{reg2}, %{reg1}"), "pand");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VPAnd) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vpand, "vpand %{reg3}, %{reg2}, %{reg1}"), "vpand");
++}
++
++TEST_F(AssemblerX86AVXTest, VAndPS) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vandps, "vandps %{reg3}, %{reg2}, %{reg1}"), "vandps");
++}
++
++TEST_F(AssemblerX86AVXTest, VAndPD) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vandpd, "vandpd %{reg3}, %{reg2}, %{reg1}"), "vandpd");
++}
++
+ TEST_F(AssemblerX86Test, Andn) {
+   DriverStr(RepeatRRR(&x86::X86Assembler::andn, "andn %{reg3}, %{reg2}, %{reg1}"), "andn");
+ }
+@@ -889,6 +913,18 @@ TEST_F(AssemblerX86Test, PAndn) {
+   DriverStr(RepeatFF(&x86::X86Assembler::pandn, "pandn %{reg2}, %{reg1}"), "pandn");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VPAndn) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vpandn, "vpandn %{reg3}, %{reg2}, %{reg1}"), "vpandn");
++}
++
++TEST_F(AssemblerX86AVXTest, VAndnPS) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vandnps, "vandnps %{reg3}, %{reg2}, %{reg1}"), "vandnps");
++}
++
++TEST_F(AssemblerX86AVXTest, VAndnPD) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vandnpd, "vandnpd %{reg3}, %{reg2}, %{reg1}"), "vandnpd");
++}
++
+ TEST_F(AssemblerX86Test, OrPD) {
+   DriverStr(RepeatFF(&x86::X86Assembler::orpd, "orpd %{reg2}, %{reg1}"), "orpd");
+ }
+@@ -901,6 +937,18 @@ TEST_F(AssemblerX86Test, POr) {
+   DriverStr(RepeatFF(&x86::X86Assembler::por, "por %{reg2}, %{reg1}"), "por");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VPor) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vpor, "vpor %{reg3}, %{reg2}, %{reg1}"), "vpor");
++}
++
++TEST_F(AssemblerX86AVXTest, VorPS) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vorps, "vorps %{reg3}, %{reg2}, %{reg1}"), "vorps");
++}
++
++TEST_F(AssemblerX86AVXTest, VorPD) {
++  DriverStr(RepeatFFF(&x86::X86Assembler::vorpd, "vorpd %{reg3}, %{reg2}, %{reg1}"), "vorpd");
++}
++
+ TEST_F(AssemblerX86Test, PAvgB) {
+   DriverStr(RepeatFF(&x86::X86Assembler::pavgb, "pavgb %{reg2}, %{reg1}"), "pavgb");
+ }
+diff --git a/compiler/utils/x86_64/assembler_x86_64.cc b/compiler/utils/x86_64/assembler_x86_64.cc
+index be8fe59..64246aa 100644
+--- a/compiler/utils/x86_64/assembler_x86_64.cc
++++ b/compiler/utils/x86_64/assembler_x86_64.cc
+@@ -2643,6 +2643,95 @@ void X86_64Assembler::pxor(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++/* VEX.128.66.0F.WIG EF /r VPXOR xmm1, xmm2, xmm3/m128 */
++void X86_64Assembler::vpxor(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0xEF);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
++/* VEX.128.0F.WIG 57 /r VXORPS xmm1,xmm2, xmm3/m128 */
++void X86_64Assembler::vxorps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0x57);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
++/* VEX.128.66.0F.WIG 57 /r VXORPD xmm1,xmm2, xmm3/m128 */
++void X86_64Assembler::vxorpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0x57);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
+ 
+ void X86_64Assembler::andpd(XmmRegister dst, const Address& src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -2679,6 +2768,96 @@ void X86_64Assembler::pand(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++/* VEX.128.66.0F.WIG DB /r VPAND xmm1, xmm2, xmm3/m128 */
++void X86_64Assembler::vpand(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0xDB);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
++/* VEX.128.0F 54 /r VANDPS xmm1,xmm2, xmm3/m128 */
++void X86_64Assembler::vandps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0x54);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
++/* VEX.128.66.0F 54 /r VANDPD xmm1, xmm2, xmm3/m128 */
++void X86_64Assembler::vandpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0x54);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
+ void X86_64Assembler::andn(CpuRegister dst, CpuRegister src1, CpuRegister src2) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   uint8_t byte_zero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ false);
+@@ -2724,6 +2903,96 @@ void X86_64Assembler::pandn(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++/* VEX.128.66.0F.WIG DF /r VPANDN xmm1, xmm2, xmm3/m128 */
++void X86_64Assembler::vpandn(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0xDF);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
++/* VEX.128.0F 55 /r VANDNPS xmm1, xmm2, xmm3/m128 */
++void X86_64Assembler::vandnps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0x55);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
++/* VEX.128.66.0F 55 /r VANDNPD xmm1, xmm2, xmm3/m128 */
++void X86_64Assembler::vandnpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0x55);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
+ void X86_64Assembler::orpd(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+@@ -2750,6 +3019,96 @@ void X86_64Assembler::por(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++/* VEX.128.66.0F.WIG EB /r VPOR xmm1, xmm2, xmm3/m128 */
++void X86_64Assembler::vpor(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0xEB);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
++/* VEX.128.0F 56 /r VORPS xmm1,xmm2, xmm3/m128 */
++void X86_64Assembler::vorps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0x56);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
++/* VEX.128.66.0F 56 /r VORPD xmm1,xmm2, xmm3/m128 */
++void X86_64Assembler::vorpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0x56);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
+ void X86_64Assembler::pavgb(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+diff --git a/compiler/utils/x86_64/assembler_x86_64.h b/compiler/utils/x86_64/assembler_x86_64.h
+index 100707a..15f3ab9 100644
+--- a/compiler/utils/x86_64/assembler_x86_64.h
++++ b/compiler/utils/x86_64/assembler_x86_64.h
+@@ -584,20 +584,32 @@ class X86_64Assembler final : public Assembler {
+   void xorps(XmmRegister dst, const Address& src);
+   void xorps(XmmRegister dst, XmmRegister src);
+   void pxor(XmmRegister dst, XmmRegister src);  // no addr variant (for now)
++  void vpxor(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vxorps(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vxorpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void andpd(XmmRegister dst, const Address& src);
+   void andpd(XmmRegister dst, XmmRegister src);
+   void andps(XmmRegister dst, XmmRegister src);  // no addr variant (for now)
+   void pand(XmmRegister dst, XmmRegister src);
++  void vpand(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vandps(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vandpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void andn(CpuRegister dst, CpuRegister src1, CpuRegister src2);
+   void andnpd(XmmRegister dst, XmmRegister src);  // no addr variant (for now)
+   void andnps(XmmRegister dst, XmmRegister src);
+   void pandn(XmmRegister dst, XmmRegister src);
++  void vpandn(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vandnps(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vandnpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void orpd(XmmRegister dst, XmmRegister src);  // no addr variant (for now)
+   void orps(XmmRegister dst, XmmRegister src);
+   void por(XmmRegister dst, XmmRegister src);
++  void vpor(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vorps(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vorpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void pavgb(XmmRegister dst, XmmRegister src);  // no addr variant (for now)
+   void pavgw(XmmRegister dst, XmmRegister src);
+diff --git a/compiler/utils/x86_64/assembler_x86_64_test.cc b/compiler/utils/x86_64/assembler_x86_64_test.cc
+index 3d58a6d..e3b8390 100644
+--- a/compiler/utils/x86_64/assembler_x86_64_test.cc
++++ b/compiler/utils/x86_64/assembler_x86_64_test.cc
+@@ -1625,6 +1625,21 @@ TEST_F(AssemblerX86_64Test, Pxor) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::pxor, "pxor %{reg2}, %{reg1}"), "pxor");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VPXor) {
++  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vpxor,
++                      "vpxor %{reg3}, %{reg2}, %{reg1}"), "vpxor");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VXorps) {
++  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vxorps,
++                      "vxorps %{reg3}, %{reg2}, %{reg1}"), "vxorps");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VXorpd) {
++  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vxorpd,
++                      "vxorpd %{reg3}, %{reg2}, %{reg1}"), "vxorpd");
++}
++
+ TEST_F(AssemblerX86_64Test, Andps) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::andps, "andps %{reg2}, %{reg1}"), "andps");
+ }
+@@ -1636,6 +1651,22 @@ TEST_F(AssemblerX86_64Test, Andpd) {
+ TEST_F(AssemblerX86_64Test, Pand) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::pand, "pand %{reg2}, %{reg1}"), "pand");
+ }
++
++TEST_F(AssemblerX86_64AVXTest, VPAnd) {
++  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vpand,
++                      "vpand %{reg3}, %{reg2}, %{reg1}"), "vpand");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VAndps) {
++  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vandps,
++                      "vandps %{reg3}, %{reg2}, %{reg1}"), "vandps");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VAndpd) {
++  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vandpd,
++                      "vandpd %{reg3}, %{reg2}, %{reg1}"), "vandpd");
++}
++
+ TEST_F(AssemblerX86_64Test, Andn) {
+   DriverStr(RepeatRRR(&x86_64::X86_64Assembler::andn, "andn %{reg3}, %{reg2}, %{reg1}"), "andn");
+ }
+@@ -1651,6 +1682,21 @@ TEST_F(AssemblerX86_64Test, Pandn) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::pandn, "pandn %{reg2}, %{reg1}"), "pandn");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VPAndn) {
++  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vpandn,
++                      "vpandn %{reg3}, %{reg2}, %{reg1}"), "vpandn");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VAndnps) {
++  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vandnps,
++                      "vandnps %{reg3}, %{reg2}, %{reg1}"), "vandnps");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VAndnpd) {
++  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vandnpd,
++                      "vandnpd %{reg3}, %{reg2}, %{reg1}"), "vandnpd");
++}
++
+ TEST_F(AssemblerX86_64Test, Orps) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::orps, "orps %{reg2}, %{reg1}"), "orps");
+ }
+@@ -1663,6 +1709,21 @@ TEST_F(AssemblerX86_64Test, Por) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::por, "por %{reg2}, %{reg1}"), "por");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VPor) {
++  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vpor,
++                      "vpor %{reg3}, %{reg2}, %{reg1}"), "vpor");
++}
++
++TEST_F(AssemblerX86_64AVXTest, Vorps) {
++  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vorps,
++                      "vorps %{reg3}, %{reg2}, %{reg1}"), "vorps");
++}
++
++TEST_F(AssemblerX86_64AVXTest, Vorpd) {
++  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vorpd,
++                      "vorpd %{reg3}, %{reg2}, %{reg1}"), "vorpd");
++}
++
+ TEST_F(AssemblerX86_64Test, Pavgb) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::pavgb, "pavgb %{reg2}, %{reg1}"), "pavgb");
+ }
+-- 
+2.7.4
+

--- a/aosp_diff/caas/art/0007-Get-ISA-features-from-kabylake-variant.patch
+++ b/aosp_diff/caas/art/0007-Get-ISA-features-from-kabylake-variant.patch
@@ -1,0 +1,44 @@
+From ff68eaceea504c324b02a45240b10ad0e0c62347 Mon Sep 17 00:00:00 2001
+From: bodapati <shalini.salomi.bodapati@intel.com>
+Date: Tue, 5 May 2020 23:30:57 +0530
+Subject: [PATCH] Get ISA features from kabylake variant
+
+Tracked-On: https://jira.devtools.intel.com/browse/OAM-90793
+Change-Id: I1e147d95ab34fe5a161ea1be38d2a37e335fdf8b
+Signed-off-by: bodapati <shalini.salomi.bodapati@intel.com>
+---
+ compiler/utils/x86/assembler_x86.h       | 3 ++-
+ compiler/utils/x86_64/assembler_x86_64.h | 3 ++-
+ 2 files changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/compiler/utils/x86/assembler_x86.h b/compiler/utils/x86/assembler_x86.h
+index 1b6941c..f9e8abe 100644
+--- a/compiler/utils/x86/assembler_x86.h
++++ b/compiler/utils/x86/assembler_x86.h
+@@ -310,7 +310,8 @@ class ConstantArea {
+ class X86Assembler final : public Assembler {
+  public:
+   explicit X86Assembler(ArenaAllocator* allocator,
+-                        const X86InstructionSetFeatures* instruction_set_features = nullptr)
++                        const X86InstructionSetFeatures* instruction_set_features =
++                        X86InstructionSetFeatures::FromVariant("kabylake", nullptr).get())
+                 : Assembler(allocator),
+                   constant_area_(allocator),
+                   has_AVX_(instruction_set_features != nullptr ? instruction_set_features->HasAVX() : false),
+diff --git a/compiler/utils/x86_64/assembler_x86_64.h b/compiler/utils/x86_64/assembler_x86_64.h
+index 15f3ab9..258516a 100644
+--- a/compiler/utils/x86_64/assembler_x86_64.h
++++ b/compiler/utils/x86_64/assembler_x86_64.h
+@@ -355,7 +355,8 @@ class NearLabel : private Label {
+ class X86_64Assembler final : public Assembler {
+  public:
+   explicit X86_64Assembler(ArenaAllocator* allocator,
+-                           const X86_64InstructionSetFeatures* instruction_set_features = nullptr)
++                           const X86_64InstructionSetFeatures* instruction_set_features =
++                           X86_64InstructionSetFeatures::FromVariant("kabylake", nullptr).get())
+       : Assembler(allocator),
+         constant_area_(allocator),
+         has_AVX_(instruction_set_features != nullptr ? instruction_set_features->HasAVX(): false),
+-- 
+2.7.4
+

--- a/aosp_diff/caas/art/0008-Implement-Dot-Product-Vectorization-for-x86.patch
+++ b/aosp_diff/caas/art/0008-Implement-Dot-Product-Vectorization-for-x86.patch
@@ -1,0 +1,414 @@
+From b8c72bd167c916c2e8ea934afdbc93db9ee648f7 Mon Sep 17 00:00:00 2001
+From: Shalini Salomi Bodapati <shalini.salomi.bodapati@intel.com>
+Date: Tue, 15 Oct 2019 15:16:22 +0530
+Subject: [PATCH] Implement Dot Product Vectorization for x86
+
+8% improvement in microbench for integral data types
+
+Test: ./test.py --host --64
+Change-Id: I26b584f29d677283195c69b68650651368c656d1
+Signed-off-by: Shalini Salomi Bodapati <shalini.salomi.bodapati@intel.com>
+---
+ compiler/optimizing/code_generator_vector_x86.cc   | 25 +++++-
+ .../optimizing/code_generator_vector_x86_64.cc     | 25 +++++-
+ compiler/optimizing/loop_optimization.cc           | 12 ++-
+ compiler/utils/x86/assembler_x86.cc                | 14 ++++
+ compiler/utils/x86/assembler_x86.h                 |  1 +
+ compiler/utils/x86/assembler_x86_test.cc           |  5 ++
+ compiler/utils/x86_64/assembler_x86_64.cc          | 33 +++++++-
+ compiler/utils/x86_64/assembler_x86_64.h           |  1 +
+ compiler/utils/x86_64/assembler_x86_64_test.cc     |  5 ++
+ test/684-checker-simd-dotprod/src/Main.java        |  2 +
+ .../src/other/TestFloatDouble.java                 | 93 ++++++++++++++++++++++
+ 11 files changed, 206 insertions(+), 10 deletions(-)
+ create mode 100644 test/684-checker-simd-dotprod/src/other/TestFloatDouble.java
+
+diff --git a/compiler/optimizing/code_generator_vector_x86.cc b/compiler/optimizing/code_generator_vector_x86.cc
+index 68aef77..ace8e7a 100644
+--- a/compiler/optimizing/code_generator_vector_x86.cc
++++ b/compiler/optimizing/code_generator_vector_x86.cc
+@@ -1201,11 +1201,32 @@ void InstructionCodeGeneratorX86::VisitVecSADAccumulate(HVecSADAccumulate* instr
+ }
+ 
+ void LocationsBuilderX86::VisitVecDotProd(HVecDotProd* instruction) {
+-  LOG(FATAL) << "No SIMD for " << instruction->GetId();
++  LocationSummary* locations = new (GetGraph()->GetAllocator()) LocationSummary(instruction);
++  locations->SetInAt(0, Location::RequiresFpuRegister());
++  locations->SetInAt(1, Location::RequiresFpuRegister());
++  locations->SetInAt(2, Location::RequiresFpuRegister());
++  locations->SetOut(Location::SameAsFirstInput());
++  locations->AddTemp(Location::RequiresFpuRegister());
+ }
+ 
+ void InstructionCodeGeneratorX86::VisitVecDotProd(HVecDotProd* instruction) {
+-  LOG(FATAL) << "No SIMD for " << instruction->GetId();
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
++  LocationSummary* locations = instruction->GetLocations();
++  XmmRegister acc = locations->InAt(0).AsFpuRegister<XmmRegister>();
++  XmmRegister left = locations->InAt(1).AsFpuRegister<XmmRegister>();
++  XmmRegister right = locations->InAt(2).AsFpuRegister<XmmRegister>();
++  switch (instruction->GetPackedType()) {
++    case DataType::Type::kInt32: {
++      DCHECK_EQ(4u, instruction->GetVectorLength());
++      XmmRegister tmp = locations->GetTemp(0).AsFpuRegister<XmmRegister>();
++      cpu_has_avx ?  __ vpmaddwd(tmp, left, right) : __ pmaddwd(left, right);
++      cpu_has_avx ?  __ vpaddd(acc, acc, tmp) : __ paddd(acc, left);
++      break;
++    }
++    default:
++      LOG(FATAL) << "Unsupported SIMD Type" << instruction->GetPackedType();
++      UNREACHABLE();
++  }
+ }
+ 
+ // Helper to set up locations for vector memory operations.
+diff --git a/compiler/optimizing/code_generator_vector_x86_64.cc b/compiler/optimizing/code_generator_vector_x86_64.cc
+index 19dfd1d..f68062c 100644
+--- a/compiler/optimizing/code_generator_vector_x86_64.cc
++++ b/compiler/optimizing/code_generator_vector_x86_64.cc
+@@ -1174,11 +1174,32 @@ void InstructionCodeGeneratorX86_64::VisitVecSADAccumulate(HVecSADAccumulate* in
+ }
+ 
+ void LocationsBuilderX86_64::VisitVecDotProd(HVecDotProd* instruction) {
+-  LOG(FATAL) << "No SIMD for " << instruction->GetId();
++  LocationSummary* locations = new (GetGraph()->GetAllocator()) LocationSummary(instruction);
++  locations->SetInAt(0, Location::RequiresFpuRegister());
++  locations->SetInAt(1, Location::RequiresFpuRegister());
++  locations->SetInAt(2, Location::RequiresFpuRegister());
++  locations->SetOut(Location::SameAsFirstInput());
++  locations->AddTemp(Location::RequiresFpuRegister());
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecDotProd(HVecDotProd* instruction) {
+-  LOG(FATAL) << "No SIMD for " << instruction->GetId();
++  bool cpu_has_avx = CpuHasAvxFeatureFlag();
++  LocationSummary* locations = instruction->GetLocations();
++  XmmRegister acc = locations->InAt(0).AsFpuRegister<XmmRegister>();
++  XmmRegister left = locations->InAt(1).AsFpuRegister<XmmRegister>();
++  XmmRegister right = locations->InAt(2).AsFpuRegister<XmmRegister>();
++  switch (instruction->GetPackedType()) {
++    case DataType::Type::kInt32: {
++      DCHECK_EQ(4u, instruction->GetVectorLength());
++      XmmRegister tmp = locations->GetTemp(0).AsFpuRegister<XmmRegister>();
++      cpu_has_avx ?  __ vpmaddwd(tmp, left, right) : __ pmaddwd(left, right);
++      cpu_has_avx ?  __ vpaddd(acc, acc, tmp) : __ paddd(acc, left);
++      break;
++    }
++    default:
++      LOG(FATAL) << "Unsupported SIMD Type" << instruction->GetPackedType();
++      UNREACHABLE();
++  }
+ }
+ 
+ // Helper to set up locations for vector memory operations.
+diff --git a/compiler/optimizing/loop_optimization.cc b/compiler/optimizing/loop_optimization.cc
+index 9914127..cec62ef 100644
+--- a/compiler/optimizing/loop_optimization.cc
++++ b/compiler/optimizing/loop_optimization.cc
+@@ -1613,14 +1613,20 @@ bool HLoopOptimization::TrySetVectorType(DataType::Type type, uint64_t* restrict
+                              kNoDotProd;
+             return TrySetVectorLength(16);
+           case DataType::Type::kUint16:
+-          case DataType::Type::kInt16:
+             *restrictions |= kNoDiv |
+                              kNoAbs |
+                              kNoSignedHAdd |
+                              kNoUnroundedHAdd |
+-                             kNoSAD|
++                             kNoSAD |
+                              kNoDotProd;
+             return TrySetVectorLength(8);
++          case DataType::Type::kInt16:
++            *restrictions |= kNoDiv |
++                             kNoAbs |
++                             kNoSignedHAdd |
++                             kNoUnroundedHAdd |
++                             kNoSAD;
++            return TrySetVectorLength(8);
+           case DataType::Type::kInt32:
+             *restrictions |= kNoDiv | kNoSAD;
+             return TrySetVectorLength(4);
+@@ -2156,7 +2162,7 @@ bool HLoopOptimization::VectorizeDotProdIdiom(LoopNode* node,
+                                               bool generate_code,
+                                               DataType::Type reduction_type,
+                                               uint64_t restrictions) {
+-  if (!instruction->IsAdd() || (reduction_type != DataType::Type::kInt32)) {
++  if (!instruction->IsAdd() || reduction_type != DataType::Type::kInt32) {
+     return false;
+   }
+ 
+diff --git a/compiler/utils/x86/assembler_x86.cc b/compiler/utils/x86/assembler_x86.cc
+index 166aec8..55f7691 100644
+--- a/compiler/utils/x86/assembler_x86.cc
++++ b/compiler/utils/x86/assembler_x86.cc
+@@ -2268,6 +2268,20 @@ void X86Assembler::pmaddwd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ 
++void X86Assembler::vpmaddwd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00;
++  ByteZero = EmitVexPrefixByteZero(/* is_twobyte_form=*/ true);
++  X86ManagedRegister vvvv_reg = X86ManagedRegister::FromXmmRegister(src1);
++  ByteOne = EmitVexPrefixByteOne(/*R=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(0xF5);
++  EmitXmmRegisterOperand(dst, src2);
++}
++
++
+ void X86Assembler::phaddw(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+diff --git a/compiler/utils/x86/assembler_x86.h b/compiler/utils/x86/assembler_x86.h
+index f9e8abe..52556fa 100644
+--- a/compiler/utils/x86/assembler_x86.h
++++ b/compiler/utils/x86/assembler_x86.h
+@@ -578,6 +578,7 @@ class X86Assembler final : public Assembler {
+   void pavgw(XmmRegister dst, XmmRegister src);
+   void psadbw(XmmRegister dst, XmmRegister src);
+   void pmaddwd(XmmRegister dst, XmmRegister src);
++  void vpmaddwd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+   void phaddw(XmmRegister dst, XmmRegister src);
+   void phaddd(XmmRegister dst, XmmRegister src);
+   void haddps(XmmRegister dst, XmmRegister src);
+diff --git a/compiler/utils/x86/assembler_x86_test.cc b/compiler/utils/x86/assembler_x86_test.cc
+index 12d9646..9253730 100644
+--- a/compiler/utils/x86/assembler_x86_test.cc
++++ b/compiler/utils/x86/assembler_x86_test.cc
+@@ -965,6 +965,11 @@ TEST_F(AssemblerX86Test, PMAddWD) {
+   DriverStr(RepeatFF(&x86::X86Assembler::pmaddwd, "pmaddwd %{reg2}, %{reg1}"), "pmaddwd");
+ }
+ 
++TEST_F(AssemblerX86AVXTest, VPMAddWD) {
++  DriverStr(
++      RepeatFFF(&x86::X86Assembler::vpmaddwd, "vpmaddwd %{reg3}, %{reg2}, %{reg1}"), "vpmaddwd");
++}
++
+ TEST_F(AssemblerX86Test, PHAddW) {
+   DriverStr(RepeatFF(&x86::X86Assembler::phaddw, "phaddw %{reg2}, %{reg1}"), "phaddw");
+ }
+diff --git a/compiler/utils/x86_64/assembler_x86_64.cc b/compiler/utils/x86_64/assembler_x86_64.cc
+index 64246aa..2c5dd9e 100644
+--- a/compiler/utils/x86_64/assembler_x86_64.cc
++++ b/compiler/utils/x86_64/assembler_x86_64.cc
+@@ -71,6 +71,7 @@ bool X86_64Assembler::CpuHasAVXorAVX2FeatureFlag() {
+   return false;
+ }
+ 
++
+ void X86_64Assembler::call(CpuRegister reg) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitOptionalRex32(reg);
+@@ -758,7 +759,6 @@ void X86_64Assembler::movd(CpuRegister dst, XmmRegister src, bool is64bit) {
+   EmitOperand(src.LowBits(), Operand(dst));
+ }
+ 
+-
+ void X86_64Assembler::addss(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0xF3);
+@@ -768,7 +768,6 @@ void X86_64Assembler::addss(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
+-
+ void X86_64Assembler::addss(XmmRegister dst, const Address& src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0xF3);
+@@ -2633,7 +2632,6 @@ void X86_64Assembler::xorps(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
+-
+ void X86_64Assembler::pxor(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+@@ -3145,6 +3143,35 @@ void X86_64Assembler::pmaddwd(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++void X86_64Assembler::vpmaddwd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg =
++      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/ false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0xF5);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
+ void X86_64Assembler::phaddw(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+diff --git a/compiler/utils/x86_64/assembler_x86_64.h b/compiler/utils/x86_64/assembler_x86_64.h
+index 258516a..3c5b9c2 100644
+--- a/compiler/utils/x86_64/assembler_x86_64.h
++++ b/compiler/utils/x86_64/assembler_x86_64.h
+@@ -616,6 +616,7 @@ class X86_64Assembler final : public Assembler {
+   void pavgw(XmmRegister dst, XmmRegister src);
+   void psadbw(XmmRegister dst, XmmRegister src);
+   void pmaddwd(XmmRegister dst, XmmRegister src);
++  void vpmaddwd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+   void phaddw(XmmRegister dst, XmmRegister src);
+   void phaddd(XmmRegister dst, XmmRegister src);
+   void haddps(XmmRegister dst, XmmRegister src);
+diff --git a/compiler/utils/x86_64/assembler_x86_64_test.cc b/compiler/utils/x86_64/assembler_x86_64_test.cc
+index e3b8390..3921c4a 100644
+--- a/compiler/utils/x86_64/assembler_x86_64_test.cc
++++ b/compiler/utils/x86_64/assembler_x86_64_test.cc
+@@ -1740,6 +1740,11 @@ TEST_F(AssemblerX86_64Test, Pmaddwd) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::pmaddwd, "pmaddwd %{reg2}, %{reg1}"), "pmadwd");
+ }
+ 
++TEST_F(AssemblerX86_64AVXTest, VPmaddwd) {
++  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vpmaddwd,
++                      "vpmaddwd %{reg3}, %{reg2}, %{reg1}"), "vpmaddwd");
++}
++
+ TEST_F(AssemblerX86_64Test, Phaddw) {
+   DriverStr(RepeatFF(&x86_64::X86_64Assembler::phaddw, "phaddw %{reg2}, %{reg1}"), "phaddw");
+ }
+diff --git a/test/684-checker-simd-dotprod/src/Main.java b/test/684-checker-simd-dotprod/src/Main.java
+index e0c8716..aa03d1e 100644
+--- a/test/684-checker-simd-dotprod/src/Main.java
++++ b/test/684-checker-simd-dotprod/src/Main.java
+@@ -17,6 +17,7 @@
+ import other.TestByte;
+ import other.TestCharShort;
+ import other.TestVarious;
++import other.TestFloatDouble;
+ 
+ /**
+  * Tests for dot product idiom vectorization.
+@@ -26,6 +27,7 @@ public class Main {
+      TestByte.run();
+      TestCharShort.run();
+      TestVarious.run();
++     TestFloatDouble.run();
+      System.out.println("passed");
+   }
+ }
+diff --git a/test/684-checker-simd-dotprod/src/other/TestFloatDouble.java b/test/684-checker-simd-dotprod/src/other/TestFloatDouble.java
+new file mode 100644
+index 0000000..b155ae1
+--- /dev/null
++++ b/test/684-checker-simd-dotprod/src/other/TestFloatDouble.java
+@@ -0,0 +1,93 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++package other;
++
++/**
++ * Tests for dot product idiom vectorization: char and short case.
++ */
++public class TestFloatDouble {
++
++  public static final int ARRAY_SIZE = 1024;
++
++
++  /// CHECK-START-{X86_64}: float other.TestFloatDouble.testDotProdSimpleFloat(float[], float[]) loop_optimization (after)
++  /// CHECK-NOT:                 VecDotProd
++  public static final float testDotProdSimpleFloat(float[] a, float[] b) {
++    float sum = 0;
++    for (int i = 0; i < b.length; i++) {
++      sum += a[i] * b[i];
++    }
++    return sum;
++  }
++
++
++  /// CHECK-START-{X86_64}: double other.TestFloatDouble.testDotProdSimpleDouble(double[], double[]) loop_optimization (after)
++  /// CHECK-NOT:                 VecDotProd
++
++  public static final double testDotProdSimpleDouble(double[] a, double[] b) {
++    double sum = 0;
++    for (int i = 0; i < b.length; i++) {
++      sum += a[i] * b[i];
++    }
++    return sum;
++  }
++
++  private static void expectEquals(float expected, float result) {
++    if (Float.compare(expected, result) != 0) {
++      throw new Error("Expected: " + expected + ", found: " + result);
++    }
++  }
++
++  private static void expectEquals(double expected, double result) {
++    if (Double.compare(expected, result) != 0) {
++      throw new Error("Expected: " + expected + ", found: " + result);
++    }
++  }
++
++  public static void run() {
++    final float MAX_F = Float.MAX_VALUE;
++    final float MIN_F = Float.MIN_VALUE;
++    final double MAX_D = Double.MAX_VALUE;
++    final double MIN_D = Double.MIN_VALUE;
++
++    double[] a = new double[1024];
++    for (int i = 0; i != 1024; ++i) a[i] = MAX_D;
++    double[] b = new double[1024];
++    for (int i = 0; i != 1024; ++i) b[i] = ((i & 1) == 0) ? 1.0 : -1.0;
++    expectEquals(0.0, testDotProdSimpleDouble(a,b));
++
++    float[] f1_1 = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3.33f, 0.125f, 3.0f, 0.25f};
++    float[] f2_1 = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6.125f, 2.25f, 1.213f, 0.5f};
++    expectEquals(24.4415f, testDotProdSimpleFloat(f1_1, f2_1));
++
++    float [] f1_2 = { 0, 0, 0, 0, 0, 0, 0, 0,
++                      0, 0, 0, 0,  0.63671875f, 0.76953125f, 0.22265625f, 1.0f};
++    float [] f2_2 = { 0, 0, 0, 0, 0, 0, 0, 0,
++                      0, 0, 0, 0, MIN_F, MAX_F, MAX_F, MIN_F };
++    expectEquals(3.376239E38f, testDotProdSimpleFloat(f1_2, f2_2));
++
++    float[] f1_3 = { 0xc0000000, 0xc015c28f, 0x411dd42c, 0, 0, 0, 0,
++                     0, 0, 0, 0, 0, 0, 0, MIN_F, MIN_F };
++    float[] f2_3 = { 0x3f4c779a, 0x408820c5, 0, 0, 0, 0, 0,
++                     0, 0, 0, 0, 0, 0x00000000, 0, MAX_F, MAX_F };
++    expectEquals(-2.30124471E18f, testDotProdSimpleFloat(f1_3, f2_3));
++  }
++
++  public static void main(String[] args) {
++    run();
++  }
++}
+-- 
+2.7.4
+

--- a/aosp_diff/caas/art/0009-Supported-AVX-AVX2-in-art-interpreter.patch
+++ b/aosp_diff/caas/art/0009-Supported-AVX-AVX2-in-art-interpreter.patch
@@ -1,0 +1,131 @@
+From b160d9dee1eb65c00be3a21771e69d96deb89a7b Mon Sep 17 00:00:00 2001
+From: jaishank <jaishankar.rajendran@intel.com>
+Date: Tue, 11 Jun 2019 16:47:45 +0530
+Subject: [PATCH] Supported AVX/AVX2 in art-interpreter
+
+Performance Impact:
+10-12% Warm Launch Time Performance Improvement in YouTube App
+
+Test: run-test gtest
+
+Change-Id: I103147982a89dd6fc1ef1a271310de5c1804de21
+Signed-off-by: jaishank <jaishankar.rajendran@intel.com>
+---
+ runtime/Android.bp                                | 12 ++++++++++++
+ runtime/interpreter/mterp/x86/floating_point.S    | 14 ++++++++++++++
+ runtime/interpreter/mterp/x86_64/floating_point.S | 14 ++++++++++++++
+ 3 files changed, 40 insertions(+)
+
+diff --git a/runtime/Android.bp b/runtime/Android.bp
+index 7bf662c..e4fcb40 100644
+--- a/runtime/Android.bp
++++ b/runtime/Android.bp
+@@ -287,6 +287,12 @@ libart_cc_defaults {
+                 "arch/x86/thread_x86.cc",
+                 "arch/x86/fault_handler_x86.cc",
+             ],
++            avx: {
++                asflags: ["-DMTERP_USE_AVX"],
++            },
++            avx2: {
++                asflags: ["-DMTERP_USE_AVX"],
++            },
+         },
+         x86_64: {
+             srcs: [
+@@ -303,6 +309,12 @@ libart_cc_defaults {
+                 "monitor_pool.cc",
+                 "arch/x86/fault_handler_x86.cc",
+             ],
++            avx: {
++                asflags: ["-DMTERP_USE_AVX"],
++            },
++            avx2: {
++                asflags: ["-DMTERP_USE_AVX"],
++            },
+         },
+         mips: {
+             srcs: [
+diff --git a/runtime/interpreter/mterp/x86/floating_point.S b/runtime/interpreter/mterp/x86/floating_point.S
+index bc7c59d..0b3c06c 100644
+--- a/runtime/interpreter/mterp/x86/floating_point.S
++++ b/runtime/interpreter/mterp/x86/floating_point.S
+@@ -56,10 +56,17 @@
+     movzbl  2(rPC), %ecx                    # ecx <- BB
+     movzbl  3(rPC), %eax                    # eax <- CC
+     GET_VREG_XMM${suff} %xmm0, %ecx         # %xmm0 <- 1st src
++#ifdef MTERP_USE_AVX
++    v${instr}${suff} VREG_ADDRESS(%eax), %xmm0, %xmm0
++    SET_VREG_XMM${suff} %xmm0, rINST        # vAA <- %xmm0
++    vpxor    %xmm0, %xmm0, %xmm0
++    vmovs${suff}   %xmm0, VREG_REF_ADDRESS(rINST) # clear ref
++#else
+     ${instr}${suff} VREG_ADDRESS(%eax), %xmm0
+     SET_VREG_XMM${suff} %xmm0, rINST        # vAA <- %xmm0
+     pxor    %xmm0, %xmm0
+     movs${suff}   %xmm0, VREG_REF_ADDRESS(rINST) # clear ref
++#endif
+     ADVANCE_PC_FETCH_AND_GOTO_NEXT 2
+ 
+ %def sseBinop2Addr(instr="", suff=""):
+@@ -67,10 +74,17 @@
+     andl    $$0xf, %ecx                     # ecx <- A
+     GET_VREG_XMM${suff} %xmm0, %ecx         # %xmm0 <- 1st src
+     sarl    $$4, rINST                      # rINST<- B
++#ifdef MTERP_USE_AVX
++    v${instr}${suff} VREG_ADDRESS(rINST), %xmm0, %xmm0
++    SET_VREG_XMM${suff} %xmm0, %ecx         # vAA<- %xmm0
++    vpxor    %xmm0, %xmm0, %xmm0
++    vmovs${suff} %xmm0, VREG_REF_ADDRESS(rINST)  # clear ref
++#else
+     ${instr}${suff} VREG_ADDRESS(rINST), %xmm0
+     SET_VREG_XMM${suff} %xmm0, %ecx         # vAA<- %xmm0
+     pxor    %xmm0, %xmm0
+     movs${suff} %xmm0, VREG_REF_ADDRESS(rINST)  # clear ref
++#endif
+     ADVANCE_PC_FETCH_AND_GOTO_NEXT 1
+ 
+ %def op_add_double():
+diff --git a/runtime/interpreter/mterp/x86_64/floating_point.S b/runtime/interpreter/mterp/x86_64/floating_point.S
+index 7fcb742..599b3f4 100644
+--- a/runtime/interpreter/mterp/x86_64/floating_point.S
++++ b/runtime/interpreter/mterp/x86_64/floating_point.S
+@@ -56,10 +56,17 @@
+     movzbq  2(rPC), %rcx                    # ecx <- BB
+     movzbq  3(rPC), %rax                    # eax <- CC
+     GET_VREG_XMM${suff} %xmm0, %rcx         # %xmm0 <- 1st src
++#ifdef MTERP_USE_AVX
++    v${instr}${suff} VREG_ADDRESS(%rax), %xmm0, %xmm0
++    SET_VREG_XMM${suff} %xmm0, rINSTq       # vAA <- %xmm0
++    vpxor    %xmm0, %xmm0, %xmm0
++    vmovs${suff}   %xmm0, VREG_REF_ADDRESS(rINSTq) # clear ref
++#else
+     ${instr}${suff} VREG_ADDRESS(%rax), %xmm0
+     SET_VREG_XMM${suff} %xmm0, rINSTq       # vAA <- %xmm0
+     pxor    %xmm0, %xmm0
+     movs${suff}   %xmm0, VREG_REF_ADDRESS(rINSTq) # clear ref
++#endif
+     ADVANCE_PC_FETCH_AND_GOTO_NEXT 2
+ 
+ %def sseBinop2Addr(instr="", suff=""):
+@@ -67,10 +74,17 @@
+     andl    $$0xf, %ecx                     # ecx <- A
+     GET_VREG_XMM${suff} %xmm0, %rcx         # %xmm0 <- 1st src
+     sarl    $$4, rINST                      # rINST<- B
++#ifdef MTERP_USE_AVX
++    v${instr}${suff} VREG_ADDRESS(rINSTq), %xmm0, %xmm0
++    SET_VREG_XMM${suff} %xmm0, %rcx         # vAA <- %xmm0
++    vpxor    %xmm0, %xmm0, %xmm0
++    vmovs${suff} %xmm0, VREG_REF_ADDRESS(rINSTq)  # clear ref
++#else
+     ${instr}${suff} VREG_ADDRESS(rINSTq), %xmm0
+     SET_VREG_XMM${suff} %xmm0, %rcx         # vAA <- %xmm0
+     pxor    %xmm0, %xmm0
+     movs${suff} %xmm0, VREG_REF_ADDRESS(rINSTq)  # clear ref
++#endif
+     ADVANCE_PC_FETCH_AND_GOTO_NEXT 1
+ 
+ %def op_add_double():
+-- 
+2.7.4
+


### PR DESCRIPTION
1. Add Fma and AVX2 in libart
2. Support AVX/AVX2 mov instruction
3. Support AVX/AVX2 for packed add/sub instructions
4. Support AVX/AVX2 for packed mul/div instructions
5. Support AVX/AVX2 for bitwise opeations
6. Get Instruction set features form kabylake variant
7. Implement Dot Product Vectorization for x86
8. Add AVX2/FMA Intrinsics in art interpreter

Tracked-On: https://jira.devtools.intel.com/browse/OAM-90793
Signef-off-by: bodapati <shalini.salomi.bodapati@intel.com>