### PR TITLE
Add QEMU patch for GVT-g

### DIFF
--- a/host/qemu/Disable-EDID-auto-generation-in-QEMU.patch
+++ b/host/qemu/Disable-EDID-auto-generation-in-QEMU.patch
@@ -1,0 +1,47 @@
+diff -uprN qemu-4.2.0/hw/vfio/display.c qemu-4.2.0_fix/hw/vfio/display.c
+--- qemu-4.2.0/hw/vfio/display.c	2019-12-13 02:20:47.000000000 +0800
++++ qemu-4.2.0_fix/hw/vfio/display.c	2020-05-09 00:33:30.360150136 +0800
+@@ -26,6 +26,10 @@
+ # define DRM_PLANE_TYPE_CURSOR  2
+ #endif
+ 
++#ifndef DISABLE_EDID_AUTO_GENERATION
++#define DISABLE_EDID_AUTO_GENERATION
++#endif
++
+ #define pread_field(_fd, _reg, _ptr, _fld)                              \
+     (sizeof(_ptr->_fld) !=                                              \
+      pread(_fd, &(_ptr->_fld), sizeof(_ptr->_fld),                      \
+@@ -113,6 +117,10 @@ static int vfio_display_edid_ui_info(voi
+     VFIOPCIDevice *vdev = opaque;
+     VFIODisplay *dpy = vdev->dpy;
+ 
++    #if defined(DISABLE_EDID_AUTO_GENERATION)
++    return 0;
++    #endif
++
+     if (!dpy->edid_regs) {
+         return 0;
+     }
+@@ -132,6 +140,10 @@ static void vfio_display_edid_init(VFIOP
+     int fd = vdev->vbasedev.fd;
+     int ret;
+ 
++    #if defined(DISABLE_EDID_AUTO_GENERATION)
++    return;
++    #endif
++    
+     ret = vfio_get_dev_region_info(&vdev->vbasedev,
+                                    VFIO_REGION_TYPE_GFX,
+                                    VFIO_REGION_SUBTYPE_GFX_EDID,
+@@ -180,6 +192,10 @@ err:
+ 
+ static void vfio_display_edid_exit(VFIODisplay *dpy)
+ {
++    #if defined(DISABLE_EDID_AUTO_GENERATION)
++    return;
++    #endif
++
+     if (!dpy->edid_regs) {
+         return;
+     }


### PR DESCRIPTION
To fix refresh-rate issue, disable EDID auto generation in QEMU
Put the patch here.

Tracked-On: OAM-90886
Signed-off-by: Lu Yang A <yang.a.lu@intel.com>