### PR TITLE
Disable ICMP redirects

### DIFF
--- a/android/common/system/netd/0002-Ensure-icmp-redirects-are-always-ignored.patch
+++ b/android/common/system/netd/0002-Ensure-icmp-redirects-are-always-ignored.patch
@@ -1,0 +1,109 @@
+From ce36af79ec9525da09c3c15723682f1b84f4cd13 Mon Sep 17 00:00:00 2001
+From: Hugo Benichi <hugobenichi@google.com>
+Date: Tue, 22 May 2018 08:48:40 +0900
+Subject: [PATCH] Ensure icmp redirects are always ignored
+
+A side effect of disabling the ip forwarding sysconf on all
+interfaces is to re-enable the ICMP redirects sysconf on all
+interfaces.
+
+This patch ensures that ICMP redirects stays turned off when disabling
+ip forwarding in TetherController.
+
+Accepting ICMP redirects can allow an attacker to inject malicious
+routes into a host and it is therefore desirable to always reject them.
+
+Bug: 62387578
+Bug: 77541904
+Test: manual
+Change-Id: I1f9a950eebf2f65d047f33145feee40d3ab34bd9
+---
+ server/InterfaceController.cpp | 16 ++++++++++++++--
+ server/InterfaceController.h   |  1 +
+ server/TetherController.cpp    | 10 +++++++++-
+ 3 files changed, 24 insertions(+), 3 deletions(-)
+
+diff --git server/InterfaceController.cpp server/InterfaceController.cpp
+index c0210d7b..2f2b3149 100644
+--- server/InterfaceController.cpp
++++ server/InterfaceController.cpp
+@@ -54,10 +54,10 @@ using android::netdutils::toString;
+ 
+ namespace {
+ 
++const char ipv4_proc_path[] = "/proc/sys/net/ipv4/conf";
+ const char ipv6_proc_path[] = "/proc/sys/net/ipv6/conf";
+ 
+ const char ipv4_neigh_conf_dir[] = "/proc/sys/net/ipv4/neigh";
+-
+ const char ipv6_neigh_conf_dir[] = "/proc/sys/net/ipv6/neigh";
+ 
+ const char proc_net_path[] = "/proc/sys/net";
+@@ -245,8 +245,11 @@ void InterfaceController::initializeAll() {
+     setBaseReachableTimeMs(15 * 1000);
+ 
+     // When sending traffic via a given interface use only addresses configured
+-       // on that interface as possible source addresses.
++    // on that interface as possible source addresses.
+     setIPv6UseOutgoingInterfaceAddrsOnly("1");
++
++    // Ensure that ICMP redirects are rejected globally on all interfaces.
++    disableIcmpRedirects();
+ }
+ 
+ int InterfaceController::setEnableIPv6(const char *interface, const int on) {
+@@ -358,6 +361,15 @@ int InterfaceController::delAddress(const char *interface,
+     return ifc_del_address(interface, addrString, prefixLength);
+ }
+ 
++int InterfaceController::disableIcmpRedirects() {
++    int rv = 0;
++    rv |= writeValueToPath(ipv4_proc_path, "all", "accept_redirects", "0");
++    rv |= writeValueToPath(ipv6_proc_path, "all", "accept_redirects", "0");
++    setOnAllInterfaces(ipv4_proc_path, "accept_redirects", "0");
++    setOnAllInterfaces(ipv6_proc_path, "accept_redirects", "0");
++    return rv;
++}
++
+ int InterfaceController::getParameter(
+         const char *family, const char *which, const char *interface, const char *parameter,
+         std::string *value) {
+diff --git server/InterfaceController.h server/InterfaceController.h
+index cd6f0eb2..f97547f9 100644
+--- server/InterfaceController.h
++++ server/InterfaceController.h
+@@ -43,6 +43,7 @@ public:
+     static int setMtu(const char *interface, const char *mtu);
+     static int addAddress(const char *interface, const char *addrString, int prefixLength);
+     static int delAddress(const char *interface, const char *addrString, int prefixLength);
++    static int disableIcmpRedirects();
+ 
+     // Read and write values in files of the form:
+     //     /proc/sys/net/<family>/<which>/<interface>/<parameter>
+diff --git server/TetherController.cpp server/TetherController.cpp
+index 6e805f56..af8f3e17 100644
+--- server/TetherController.cpp
++++ server/TetherController.cpp
+@@ -143,10 +143,18 @@ TetherController::~TetherController() {
+ 
+ bool TetherController::setIpFwdEnabled() {
+     bool success = true;
+-    const char* value = mForwardingRequests.empty() ? "0" : "1";
++    bool disable = mForwardingRequests.empty();
++    const char* value = disable ? "0" : "1";
+     ALOGD("Setting IP forward enable = %s", value);
+     success &= writeToFile(IPV4_FORWARDING_PROC_FILE, value);
+     success &= writeToFile(IPV6_FORWARDING_PROC_FILE, value);
++    if (disable) {
++        // Turning off the forwarding sysconf in the kernel has the side effect
++        // of turning on ICMP redirect, which is a security hazard.
++        // Turn ICMP redirect back off immediately.
++        int rv = InterfaceController::disableIcmpRedirects();
++        success &= (rv == 0);
++    }
+     return success;
+ }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
Even though ICMP redirects are disabled in init.rc, redirects
gets enabled.

ICMP redirects are getting enabled on ipv_forward disable.

Fix the issue by making sure ICMP redirects are disabled
on IP forward disable too.

Tracked-On: OAM-90968
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>