### PR TITLE
Changes to update ethernet proxy settings from Settings UI

### DIFF
--- a/aosp_diff/caas/frameworks/opt/net/ethernet/01_0001-Toggle-interface-state-after-proxt-settings-change.patch
+++ b/aosp_diff/caas/frameworks/opt/net/ethernet/01_0001-Toggle-interface-state-after-proxt-settings-change.patch
@@ -1,0 +1,31 @@
+From 81b14caacf6708baf9ba2bce74250d3a6a14e90f Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Wed, 3 Jun 2020 23:06:37 +0530
+Subject: [PATCH] Toggle interface state after proxt settings change
+
+Toggle interface state after proxt settings change to
+make sure proxy is used.
+
+Tracked-On: OAM-91281
+Signed-off-by: Raveendra Babu Chennakesavulu
+                        <raveendra.babu.chennakesavulu@intel.com>
+---
+ java/com/android/server/ethernet/EthernetNetworkFactory.java | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/java/com/android/server/ethernet/EthernetNetworkFactory.java b/java/com/android/server/ethernet/EthernetNetworkFactory.java
+index b8ed845..15ded00 100644
+--- a/java/com/android/server/ethernet/EthernetNetworkFactory.java
++++ b/java/com/android/server/ethernet/EthernetNetworkFactory.java
+@@ -377,6 +377,8 @@ public class EthernetNetworkFactory extends NetworkFactory {
+ 
+         void setIpConfig(IpConfiguration ipConfig) {
+             this.mIpConfig = ipConfig;
++            updateLinkState(false);
++            updateLinkState(true);
+         }
+ 
+         boolean statisified(NetworkCapabilities requestedCapabilities) {
+-- 
+2.17.1
+

--- a/aosp_diff/caas/packages/apps/Settings/01_0001-Add-settings-screen-to-set-ethernet-proxy-host-and-p.patch
+++ b/aosp_diff/caas/packages/apps/Settings/01_0001-Add-settings-screen-to-set-ethernet-proxy-host-and-p.patch
@@ -1,0 +1,628 @@
+From da668d29388befba06708725fea2fb5bfb9dd1a0 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Tue, 2 Jun 2020 22:23:51 +0530
+Subject: [PATCH] Add settings screen to set ethernet proxy host and port
+
+Ethernet Settings screen provided under Network & Internet
+options for setting proxy host and port.
+
+Change-Id: I880bcd2eeaaeb191e8b3e8c300ec2e85d5e5d0e0
+Tracked-On: OAM-91281
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ AndroidManifest.xml                           |  18 ++
+ res/values/strings.xml                        |   3 +
+ res/xml/ethernet_proxy_settings.xml           |  41 ++++
+ res/xml/network_and_internet_and_ethernet.xml | 108 ++++++++++
+ .../network_and_internet_and_ethernet_v2.xml  | 115 +++++++++++
+ src/com/android/settings/Settings.java        |   1 +
+ .../core/gateway/SettingsGateway.java         |   2 +
+ .../settings/network/EthernetSettings.java    | 184 ++++++++++++++++++
+ .../network/NetworkDashboardFragment.java     |  23 ++-
+ 9 files changed, 491 insertions(+), 4 deletions(-)
+ create mode 100644 res/xml/ethernet_proxy_settings.xml
+ create mode 100644 res/xml/network_and_internet_and_ethernet.xml
+ create mode 100644 res/xml/network_and_internet_and_ethernet_v2.xml
+ create mode 100644 src/com/android/settings/network/EthernetSettings.java
+
+diff --git a/AndroidManifest.xml b/AndroidManifest.xml
+index 86cb3f2c5d..79377772d6 100644
+--- a/AndroidManifest.xml
++++ b/AndroidManifest.xml
+@@ -1920,6 +1920,24 @@
+                        android:value="com.android.settings.network.ApnEditor" />
+         </activity>
+ 
++        <activity android:name="Settings$EthernetSettingsActivity"
++                android:label="@string/ethernet_settings"
++                android:configChanges="orientation|keyboardHidden|screenSize" >
++            <intent-filter>
++                <action android:name="android.intent.action.VIEW" />
++                <action android:name="android.intent.action.EDIT" />
++                <category android:name="android.intent.category.DEFAULT" />
++            </intent-filter>
++            <intent-filter>
++                <action android:name="android.intent.action.MAIN" />
++                <category android:name="android.intent.category.DEFAULT" />
++            </intent-filter>
++            <meta-data android:name="com.android.settings.PRIMARY_PROFILE_CONTROLLED"
++                android:value="true" />
++            <meta-data android:name="com.android.settings.FRAGMENT_CLASS"
++                       android:value="com.android.settings.network.EthernetSettings" />
++        </activity>
++
+         <activity
+             android:name="Settings$DevelopmentSettingsDashboardActivity"
+             android:label="@string/development_settings_title"
+diff --git a/res/values/strings.xml b/res/values/strings.xml
+index f8f696f91e..2f63945f7c 100644
+--- a/res/values/strings.xml
++++ b/res/values/strings.xml
+@@ -11435,4 +11435,7 @@
+     <!-- Subtext for showing the option of RTT setting. [CHAR LIMIT=NONE] -->
+     <string name="rtt_settings_always_visible"></string>
+ 
++    <!-- Used in the 1st-level settings screen to go to the 2nd-level settings screen  [CHAR LIMIT=20]-->
++    <string name="ethernet_proxy_settings" translatable="false">Ethernet Proxy Settings</string>
++    <string name="ethernet_settings" translatable="false">Ethernet</string>
+ </resources>
+diff --git a/res/xml/ethernet_proxy_settings.xml b/res/xml/ethernet_proxy_settings.xml
+new file mode 100644
+index 0000000000..7ae6eab942
+--- /dev/null
++++ b/res/xml/ethernet_proxy_settings.xml
+@@ -0,0 +1,41 @@
++<?xml version="1.0" encoding="utf-8"?>
++<!--
++  Copyright (C) 2017 The Android Open Source Project
++
++  Licensed under the Apache License, Version 2.0 (the "License");
++  you may not use this file except in compliance with the License.
++  You may obtain a copy of the License at
++
++       http://www.apache.org/licenses/LICENSE-2.0
++
++  Unless required by applicable law or agreed to in writing, software
++  distributed under the License is distributed on an "AS IS" BASIS,
++  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++  See the License for the specific language governing permissions and
++  limitations under the License.
++  -->
++
++<PreferenceScreen
++    xmlns:android="http://schemas.android.com/apk/res/android"
++    android:title="@string/ethernet_proxy_settings"
++    android:key="ethernet_proxy">
++
++    <EditTextPreference
++        android:key="proxy"
++	android:title="@string/proxy_settings_title"
++        android:dialogTitle="@string/proxy_settings_title"
++        android:singleLine="true"
++        android:inputType="textUri"
++        android:persistent="false"
++        />
++
++    <EditTextPreference
++        android:key="port"
++	android:title="@string/proxy_port_label"
++        android:dialogTitle="@string/proxy_port_label"
++        android:singleLine="true"
++        android:inputType="number"
++        android:persistent="false"
++        />
++
++</PreferenceScreen>
+diff --git a/res/xml/network_and_internet_and_ethernet.xml b/res/xml/network_and_internet_and_ethernet.xml
+new file mode 100644
+index 0000000000..3ae675dcf3
+--- /dev/null
++++ b/res/xml/network_and_internet_and_ethernet.xml
+@@ -0,0 +1,108 @@
++<?xml version="1.0" encoding="utf-8"?>
++<!-- Copyright (C) 2016 The Android Open Source Project
++
++     Licensed under the Apache License, Version 2.0 (the "License");
++     you may not use this file except in compliance with the License.
++     You may obtain a copy of the License at
++
++          http://www.apache.org/licenses/LICENSE-2.0
++
++     Unless required by applicable law or agreed to in writing, software
++     distributed under the License is distributed on an "AS IS" BASIS,
++     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++     See the License for the specific language governing permissions and
++     limitations under the License.
++-->
++
++<PreferenceScreen
++    xmlns:android="http://schemas.android.com/apk/res/android"
++    xmlns:settings="http://schemas.android.com/apk/res-auto"
++    android:key="network_and_internet_screen"
++    android:title="@string/network_dashboard_title"
++    settings:initialExpandedChildrenCount="5">
++
++    <com.android.settings.widget.MasterSwitchPreference
++        android:fragment="com.android.settings.wifi.WifiSettings"
++        android:key="toggle_wifi"
++        android:title="@string/wifi_settings"
++        android:summary="@string/summary_placeholder"
++        android:icon="@drawable/ic_settings_wireless"
++        android:order="-30">
++        <intent
++            android:action="android.settings.WIFI_SETTINGS"
++            android:targetClass="Settings$WifiSettingsActivity" />
++    </com.android.settings.widget.MasterSwitchPreference>
++
++    <com.android.settingslib.RestrictedPreference
++        android:key="mobile_network_settings"
++        android:title="@string/network_settings_title"
++        android:summary="@string/summary_placeholder"
++        android:icon="@drawable/ic_network_cell"
++        android:order="-15"
++        settings:keywords="@string/keywords_more_mobile_networks"
++        settings:userRestriction="no_config_mobile_networks"
++        settings:useAdminDisabledSummary="true">
++        <intent
++            android:action="android.intent.action.MAIN"
++            android:targetPackage="com.android.phone"
++            android:targetClass="com.android.phone.MobileNetworkSettings" />
++    </com.android.settingslib.RestrictedPreference>
++
++    <com.android.settingslib.RestrictedPreference
++        android:fragment="com.android.settings.TetherSettings"
++        android:key="tether_settings"
++        android:title="@string/tether_settings_title_all"
++        android:icon="@drawable/ic_wifi_tethering"
++        android:order="-5"
++        android:summary="@string/summary_placeholder"
++        settings:keywords="@string/keywords_hotspot_tethering"
++        settings:userRestriction="no_config_tethering"
++        settings:useAdminDisabledSummary="true" />
++
++    <com.android.settingslib.RestrictedPreference
++        android:key="manage_mobile_plan"
++        android:title="@string/manage_mobile_plan_title"
++        android:persistent="false"
++        android:order="0"
++        settings:userRestriction="no_config_mobile_networks"
++        settings:useAdminDisabledSummary="true" />
++
++    <com.android.settingslib.RestrictedSwitchPreference
++        android:key="airplane_mode"
++        android:title="@string/airplane_mode"
++        android:icon="@drawable/ic_airplanemode_active"
++        android:disableDependentsState="true"
++        android:order="5"
++        settings:controller="com.android.settings.network.AirplaneModePreferenceController"
++        settings:platform_slice="true"
++        settings:userRestriction="no_airplane_mode"/>
++
++    <Preference
++        android:fragment="com.android.settings.ProxySelector"
++        android:key="proxy_settings"
++        android:title="@string/proxy_settings_title" />
++
++    <com.android.settingslib.RestrictedPreference
++        android:fragment="com.android.settings.vpn2.VpnSettings"
++        android:key="vpn_settings"
++        android:title="@string/vpn_settings_title"
++        android:icon="@drawable/ic_vpn_key"
++        android:order="10"
++        android:summary="@string/summary_placeholder"
++        settings:userRestriction="no_config_vpn"
++        settings:useAdminDisabledSummary="true" />
++
++    <com.android.settings.network.PrivateDnsModeDialogPreference
++        android:key="private_dns_settings"
++        android:title="@string/select_private_dns_configuration_title"
++        android:order="15"
++        android:dialogTitle="@string/select_private_dns_configuration_dialog_title"
++        android:dialogLayout="@layout/private_dns_mode_dialog"
++        android:positiveButtonText="@string/save"
++        android:negativeButtonText="@android:string/cancel" />
++
++    <PreferenceScreen
++        android:fragment="com.android.settings.network.EthernetSettings"
++        android:key="ethernet_settings"
++	android:title="@string/ethernet_settings" />
++</PreferenceScreen>
+diff --git a/res/xml/network_and_internet_and_ethernet_v2.xml b/res/xml/network_and_internet_and_ethernet_v2.xml
+new file mode 100644
+index 0000000000..efe143430b
+--- /dev/null
++++ b/res/xml/network_and_internet_and_ethernet_v2.xml
+@@ -0,0 +1,115 @@
++<?xml version="1.0" encoding="utf-8"?>
++<!-- Copyright (C) 2018 The Android Open Source Project
++
++     Licensed under the Apache License, Version 2.0 (the "License");
++     you may not use this file except in compliance with the License.
++     You may obtain a copy of the License at
++
++          http://www.apache.org/licenses/LICENSE-2.0
++
++     Unless required by applicable law or agreed to in writing, software
++     distributed under the License is distributed on an "AS IS" BASIS,
++     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++     See the License for the specific language governing permissions and
++     limitations under the License.
++-->
++
++<PreferenceScreen
++    xmlns:android="http://schemas.android.com/apk/res/android"
++    xmlns:settings="http://schemas.android.com/apk/res-auto"
++    android:key="network_and_internet_screen"
++    android:title="@string/network_dashboard_title"
++    settings:initialExpandedChildrenCount="5">
++
++    <PreferenceCategory
++        android:key="multi_network_header"
++        android:title="@string/summary_placeholder"
++        android:layout="@layout/preference_category_no_label"
++        settings:allowDividerBelow="true"
++        android:order="-40"
++        settings:controller="com.android.settings.network.MultiNetworkHeaderController"/>
++
++    <com.android.settings.widget.MasterSwitchPreference
++        android:fragment="com.android.settings.wifi.WifiSettings"
++        android:key="toggle_wifi"
++        android:title="@string/wifi_settings"
++        android:summary="@string/summary_placeholder"
++        android:icon="@drawable/ic_settings_wireless"
++        android:order="-30"
++        settings:allowDividerAbove="true">
++        <intent
++            android:action="android.settings.WIFI_SETTINGS"
++            android:targetClass="Settings$WifiSettingsActivity" />
++    </com.android.settings.widget.MasterSwitchPreference>
++
++    <com.android.settings.widget.AddPreference
++        android:key="mobile_network_list"
++        android:title="@string/network_settings_title"
++        android:summary="@string/summary_placeholder"
++        android:icon="@drawable/ic_network_cell"
++        android:order="-15"
++        settings:keywords="@string/keywords_more_mobile_networks"
++        settings:userRestriction="no_config_mobile_networks"
++        settings:useAdminDisabledSummary="true" />
++
++    <com.android.settingslib.RestrictedSwitchPreference
++        android:key="airplane_mode"
++        android:title="@string/airplane_mode"
++        android:icon="@drawable/ic_airplanemode_active"
++        android:disableDependentsState="true"
++        android:order="-5"
++        settings:controller="com.android.settings.network.AirplaneModePreferenceController"
++        settings:platform_slice="true"
++        settings:userRestriction="no_airplane_mode"/>
++
++    <com.android.settingslib.RestrictedPreference
++        android:key="manage_mobile_plan"
++        android:title="@string/manage_mobile_plan_title"
++        android:persistent="false"
++        android:order="0"
++        settings:userRestriction="no_config_mobile_networks"
++        settings:useAdminDisabledSummary="true" />
++
++    <com.android.settingslib.RestrictedPreference
++        android:fragment="com.android.settings.TetherSettings"
++        android:key="tether_settings"
++        android:title="@string/tether_settings_title_all"
++        android:icon="@drawable/ic_wifi_tethering"
++        android:order="5"
++        android:summary="@string/summary_placeholder"
++        settings:keywords="@string/keywords_hotspot_tethering"
++        settings:userRestriction="no_config_tethering"
++        settings:useAdminDisabledSummary="true" />
++
++    <com.android.settings.datausage.DataSaverPreference
++        android:key="restrict_background_parent_entry"
++        android:title="@string/data_saver_title"
++        android:icon="@drawable/ic_settings_data_usage"
++        android:order="10"
++        android:fragment="com.android.settings.datausage.DataSaverSummary"/>
++
++    <com.android.settingslib.RestrictedPreference
++        android:fragment="com.android.settings.vpn2.VpnSettings"
++        android:key="vpn_settings"
++        android:title="@string/vpn_settings_title"
++        android:icon="@drawable/ic_vpn_key"
++        android:order="15"
++        android:summary="@string/summary_placeholder"
++        settings:userRestriction="no_config_vpn"
++        settings:useAdminDisabledSummary="true" />
++
++    <com.android.settings.network.PrivateDnsModeDialogPreference
++        android:key="private_dns_settings"
++        android:title="@string/select_private_dns_configuration_title"
++        android:order="20"
++        android:dialogTitle="@string/select_private_dns_configuration_dialog_title"
++        android:dialogLayout="@layout/private_dns_mode_dialog"
++        android:positiveButtonText="@string/save"
++        android:negativeButtonText="@android:string/cancel" />
++
++    <PreferenceScreen
++        android:fragment="com.android.settings.network.EthernetSettings"
++        android:key="ethernet_settings"
++        android:title="@string/ethernet_settings" />
++
++</PreferenceScreen>
+diff --git a/src/com/android/settings/Settings.java b/src/com/android/settings/Settings.java
+index e63edd79c0..326572c79a 100644
+--- a/src/com/android/settings/Settings.java
++++ b/src/com/android/settings/Settings.java
+@@ -43,6 +43,7 @@ public class Settings extends SettingsActivity {
+     public static class PrivateVolumeSettingsActivity extends SettingsActivity { /* empty */ }
+     public static class PublicVolumeSettingsActivity extends SettingsActivity { /* empty */ }
+     public static class WifiSettingsActivity extends SettingsActivity { /* empty */ }
++    public static class EthernetSettingsActivity extends SettingsActivity { /* empty */ }
+     public static class WifiP2pSettingsActivity extends SettingsActivity { /* empty */ }
+     public static class AvailableVirtualKeyboardActivity extends SettingsActivity { /* empty */ }
+     public static class KeyboardLayoutPickerActivity extends SettingsActivity { /* empty */ }
+diff --git a/src/com/android/settings/core/gateway/SettingsGateway.java b/src/com/android/settings/core/gateway/SettingsGateway.java
+index fd036976e5..c2e84113a6 100644
+--- a/src/com/android/settings/core/gateway/SettingsGateway.java
++++ b/src/com/android/settings/core/gateway/SettingsGateway.java
+@@ -101,6 +101,7 @@ import com.android.settings.location.LocationSettings;
+ import com.android.settings.location.ScanningSettings;
+ import com.android.settings.network.ApnEditor;
+ import com.android.settings.network.ApnSettings;
++import com.android.settings.network.EthernetSettings;
+ import com.android.settings.network.MobileNetworkListFragment;
+ import com.android.settings.network.NetworkDashboardFragment;
+ import com.android.settings.nfc.AndroidBeam;
+@@ -240,6 +241,7 @@ public class SettingsGateway {
+             ChannelNotificationSettings.class.getName(),
+             ApnSettings.class.getName(),
+             ApnEditor.class.getName(),
++            EthernetSettings.class.getName(),
+             WifiCallingSettings.class.getName(),
+             ZenModeScheduleRuleSettings.class.getName(),
+             ZenModeEventRuleSettings.class.getName(),
+diff --git a/src/com/android/settings/network/EthernetSettings.java b/src/com/android/settings/network/EthernetSettings.java
+new file mode 100644
+index 0000000000..0e6ad62959
+--- /dev/null
++++ b/src/com/android/settings/network/EthernetSettings.java
+@@ -0,0 +1,184 @@
++/*
++ * Copyright (C) 2006 The Android Open Source Project
++ * Copyright (C) 2020 Intel Corporation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++package com.android.settings.network;
++
++import android.app.Dialog;
++import android.content.Context;
++import android.net.EthernetManager;
++import android.net.ProxyInfo;
++import android.net.IpConfiguration;
++import android.net.IpConfiguration.ProxySettings;
++import android.net.Uri;
++import android.os.Bundle;
++import android.os.PersistableBundle;
++import android.text.TextUtils;
++import android.util.Log;
++import android.view.KeyEvent;
++import android.view.Menu;
++import android.view.MenuInflater;
++import android.view.MenuItem;
++import android.view.View;
++import android.view.View.OnKeyListener;
++
++import androidx.preference.EditTextPreference;
++import androidx.preference.Preference;
++import androidx.preference.Preference.OnPreferenceChangeListener;
++
++import com.android.internal.logging.nano.MetricsProto.MetricsEvent;
++import com.android.settings.R;
++import com.android.settings.SettingsPreferenceFragment;
++
++public class EthernetSettings extends SettingsPreferenceFragment
++        implements OnPreferenceChangeListener, OnKeyListener {
++
++    private static final String TAG = "EthernetSettings";
++
++    private EditTextPreference mProxyPreference;
++    private EditTextPreference mPortPreference;
++
++    private String mProxyHost = "";
++    private int mProxyPort = -1;
++
++    private EthernetManager mEthernetManager;
++    private IpConfiguration mIpConfiguration;
++    private String mInterfaceName;
++
++    private final static String KEY_PROXY = "proxy";
++    private final static String KEY_PORT = "port";
++
++    private static final int MENU_SAVE = Menu.FIRST;
++    private static final int MENU_CANCEL = Menu.FIRST + 1;
++
++    @Override
++    public void onCreate(Bundle icicle) {
++        super.onCreate(icicle);
++
++        addPreferencesFromResource(R.xml.ethernet_proxy_settings);
++
++	mProxyPreference = (EditTextPreference) findPreference("proxy");
++        mPortPreference = (EditTextPreference) findPreference("port");
++
++        for (int i = 0; i < getPreferenceScreen().getPreferenceCount(); i++) {
++            getPreferenceScreen().getPreference(i).setOnPreferenceChangeListener(this);
++        }
++        mEthernetManager = (EthernetManager) getSystemService(Context.ETHERNET_SERVICE);
++
++        String[] ifaces = mEthernetManager.getAvailableInterfaces();
++        if (ifaces.length > 0) {
++            mInterfaceName = ifaces[0];
++            mIpConfiguration = mEthernetManager.getConfiguration(mInterfaceName);
++        }
++        Log.d(TAG, "Interface Name: " + mInterfaceName);
++        if (mIpConfiguration != null & mIpConfiguration.httpProxy != null) {
++            mProxyHost = mIpConfiguration.httpProxy.getHost();
++            mProxyPort = mIpConfiguration.httpProxy.getPort();
++            if (mProxyHost != null && !mProxyHost.equals("")) {
++                mProxyPreference.setText(mProxyHost);
++            }
++            if (mProxyPort > -1) {
++                mPortPreference.setText(String.valueOf(mProxyPort));
++            }
++	}
++    }
++
++    @Override
++    public int getMetricsCategory() {
++        return MetricsEvent.VIEW_UNKNOWN;
++    }
++
++    public void configureProxy() {
++        if (!mProxyHost.equals("") && mProxyPort > -1) {
++            mIpConfiguration.setProxySettings(ProxySettings.STATIC);
++            ProxyInfo mHttpProxy = new ProxyInfo(mProxyHost, mProxyPort, null);
++            mIpConfiguration.setHttpProxy(mHttpProxy);
++            mEthernetManager.setConfiguration(mInterfaceName, mIpConfiguration);
++
++            Log.d(TAG, "IpConfiguration being updated: " + mIpConfiguration.toString());
++        }
++    }
++
++    public boolean onPreferenceChange(Preference preference, Object newValue) {
++        String key = preference.getKey();
++        if (KEY_PROXY.equals(key)) {
++	    if (newValue != null) {
++	        mProxyHost = String.valueOf(newValue);
++                Log.d(TAG, "ProxyHost: " + mProxyHost);
++	        preference.setSummary(mProxyHost);
++            }
++        } else if (KEY_PORT.equals(key)) {
++	    if (newValue != null) {
++                String port = String.valueOf(newValue);
++                try {
++	            mProxyPort = Integer.parseInt(port);
++                } catch (NumberFormatException ex) {
++                    Log.e(TAG, "Exception in port: " + ex);
++		    mProxyPort = -1;
++                }
++                Log.d(TAG, "Port: " + port);
++	        preference.setSummary(port);
++            }
++        }
++        return true;
++    }
++
++    @Override
++    public boolean onKey(View v, int keyCode, KeyEvent event) {
++        if (event.getAction() != KeyEvent.ACTION_DOWN) return false;
++        switch (keyCode) {
++            case KeyEvent.KEYCODE_BACK: {
++		configureProxy();
++                finish();
++                return true;
++            }
++        }
++        return false;
++    }
++
++    @Override
++    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
++        super.onCreateOptionsMenu(menu, inflater);
++
++	menu.add(0, MENU_SAVE, 0, R.string.menu_save)
++            .setIcon(android.R.drawable.ic_menu_save);
++        menu.add(0, MENU_CANCEL, 0, R.string.menu_cancel)
++            .setIcon(android.R.drawable.ic_menu_close_clear_cancel);
++    }
++
++    @Override
++    public boolean onOptionsItemSelected(MenuItem item) {
++        switch (item.getItemId()) {
++            case MENU_SAVE:
++		configureProxy();
++		finish();
++                return true;
++            case MENU_CANCEL:
++                finish();
++                return true;
++            default:
++                return super.onOptionsItemSelected(item);
++        }
++    }
++
++    @Override
++    public void onViewCreated(View view, Bundle savedInstanceState) {
++        super.onViewCreated(view, savedInstanceState);
++        view.setOnKeyListener(this);
++        view.setFocusableInTouchMode(true);
++        view.requestFocus();
++    }
++}
+diff --git a/src/com/android/settings/network/NetworkDashboardFragment.java b/src/com/android/settings/network/NetworkDashboardFragment.java
+index 8c686a54aa..e4480ab10c 100644
+--- a/src/com/android/settings/network/NetworkDashboardFragment.java
++++ b/src/com/android/settings/network/NetworkDashboardFragment.java
+@@ -20,6 +20,7 @@ import static com.android.settings.network.MobilePlanPreferenceController.MANAGE
+ import android.app.Dialog;
+ import android.app.settings.SettingsEnums;
+ import android.content.Context;
++import android.os.SystemProperties;
+ import android.provider.SearchIndexableResource;
+ import android.util.Log;
+ 
+@@ -60,10 +61,17 @@ public class NetworkDashboardFragment extends DashboardFragment implements
+ 
+     @Override
+     protected int getPreferenceScreenResId() {
++        String build = SystemProperties.get("ro.build.type", "user");
+         if (FeatureFlagPersistent.isEnabled(getContext(), FeatureFlags.NETWORK_INTERNET_V2)) {
+-            return R.xml.network_and_internet_v2;
++            if (build.equals("userdebug") || build.equals("eng"))
++                return R.xml.network_and_internet_and_ethernet_v2;
++            else 
++                return R.xml.network_and_internet_v2;
+         } else {
+-            return R.xml.network_and_internet;
++            if (build.equals("userdebug") || build.equals("eng"))
++                return R.xml.network_and_internet_and_ethernet;
++            else 
++                return R.xml.network_and_internet;
+         }
+     }
+ 
+@@ -168,11 +176,18 @@ public class NetworkDashboardFragment extends DashboardFragment implements
+                 public List<SearchIndexableResource> getXmlResourcesToIndex(
+                         Context context, boolean enabled) {
+                     final SearchIndexableResource sir = new SearchIndexableResource(context);
++                    final String build = SystemProperties.get("ro.build.type", "user");
+                     if (FeatureFlagPersistent.isEnabled(context,
+                             FeatureFlags.NETWORK_INTERNET_V2)) {
+-                        sir.xmlResId = R.xml.network_and_internet_v2;
++                        if (build.equals("userdebug") || build.equals("eng"))
++                            sir.xmlResId = R.xml.network_and_internet_and_ethernet_v2;
++                        else 
++                            sir.xmlResId = R.xml.network_and_internet_v2;
+                     } else {
+-                        sir.xmlResId = R.xml.network_and_internet;
++                        if (build.equals("userdebug") || build.equals("eng"))
++                            sir.xmlResId = R.xml.network_and_internet_and_ethernet;
++                        else
++                            sir.xmlResId = R.xml.network_and_internet;
+                     }
+                     return Arrays.asList(sir);
+                 }
+-- 
+2.17.1
+


### PR DESCRIPTION
Changes include
- Added ethernet proxy settings screen under
Network & Internet settings.
- Toggle inteface state for proxy settings to take effect.

Tracked-On: OAM-91281
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>