### PR TITLE
Fixed the Invalid Pamameter issue when cat memtrack sysfs files

### DIFF
--- a/host/kernel/lts2019-chromium/0001-drm-i915-Sysfs-interface-to-get-GFX-shmem-usage.patch
+++ b/host/kernel/lts2019-chromium/0001-drm-i915-Sysfs-interface-to-get-GFX-shmem-usage.patch
@@ -1,4 +1,4 @@
-From a4bc7f6c692ac4e2a4a18b8d5a89b08ad211ac4f Mon Sep 17 00:00:00 2001
+From 6c7c99ca47c34c1dfa5b1a5ecea8ff7ef5c4b886 Mon Sep 17 00:00:00 2001
 From: Wan Shuang <shuang.wan@intel.com>
 Date: Fri, 15 May 2020 03:31:03 +0800
 Subject: [PATCH] drm/i915: Sysfs interface to get GFX shmem usage
@@ -56,12 +56,12 @@ Signed-off-by: Wan Shuang <shuang.wan@intel.com>
  drivers/gpu/drm/i915/gem/i915_gem_shmem.c     |  24 +-
  drivers/gpu/drm/i915/i915_drv.c               |  12 +-
  drivers/gpu/drm/i915/i915_drv.h               |  31 +
- drivers/gpu/drm/i915/i915_gem.c               | 901 +++++++++++++++++-
+ drivers/gpu/drm/i915/i915_gem.c               | 898 +++++++++++++++++-
  drivers/gpu/drm/i915/i915_gpu_error.c         |  38 +-
  drivers/gpu/drm/i915/i915_gpu_error.h         |  15 +-
  drivers/gpu/drm/i915/i915_sysfs.c             | 325 ++++++-
  drivers/gpu/drm/i915/i915_sysfs.h             |   7 +
- 15 files changed, 1409 insertions(+), 28 deletions(-)
+ 15 files changed, 1406 insertions(+), 28 deletions(-)
 
 diff --git a/drivers/gpu/drm/drm_file.c b/drivers/gpu/drm/drm_file.c
 index 6940812a97d7..ceda2059d938 100644
@@ -404,7 +404,7 @@ index 5d6be9575ba9..e9610bfe12e6 100644
  
  /* i915_cmd_parser.c */
 diff --git a/drivers/gpu/drm/i915/i915_gem.c b/drivers/gpu/drm/i915/i915_gem.c
-index 5f68542ad63f..4c503643ccd3 100644
+index 5f68542ad63f..8c008f3cdc24 100644
 --- a/drivers/gpu/drm/i915/i915_gem.c
 +++ b/drivers/gpu/drm/i915/i915_gem.c
 @@ -38,6 +38,13 @@
@@ -421,7 +421,7 @@ index 5f68542ad63f..4c503643ccd3 100644
  #include "display/intel_display.h"
  #include "display/intel_frontbuffer.h"
  
-@@ -58,22 +65,852 @@
+@@ -58,22 +65,849 @@
  #include "i915_scatterlist.h"
  #include "i915_trace.h"
  #include "i915_vgpu.h"
@@ -837,9 +837,6 @@ index 5f68542ad63f..4c503643ccd3 100644
 +
 +	list_for_each_entry (pid_info_entry, &obj->pid_info, head)
 +		obj_shared_count++;
-+
-+	if (WARN_ON(obj_shared_count == 0))
-+		return -EINVAL;
 +
 +	return obj_shared_count;
 +}
@@ -1282,7 +1279,7 @@ index 5f68542ad63f..4c503643ccd3 100644
  {
  	drm_mm_remove_node(node);
  }
-@@ -1728,6 +2565,11 @@ void i915_gem_release(struct drm_device *dev, struct drm_file *file)
+@@ -1728,6 +2562,11 @@ void i915_gem_release(struct drm_device *dev, struct drm_file *file)
  	struct drm_i915_file_private *file_priv = file->driver_priv;
  	struct i915_request *request;
  
@@ -1294,7 +1291,7 @@ index 5f68542ad63f..4c503643ccd3 100644
  	/* Clean up our request list when the client is going away, so that
  	 * later retire_requests won't dereference our soon-to-be-gone
  	 * file_priv.
-@@ -1753,15 +2595,58 @@ int i915_gem_open(struct drm_i915_private *i915, struct drm_file *file)
+@@ -1753,15 +2592,58 @@ int i915_gem_open(struct drm_i915_private *i915, struct drm_file *file)
  	file_priv->dev_priv = i915;
  	file_priv->file = file;
  

--- a/host/kernel/lts2019-yocto/0001-drm-i915-Sysfs-interface-to-get-GFX-shmem-usage.patch
+++ b/host/kernel/lts2019-yocto/0001-drm-i915-Sysfs-interface-to-get-GFX-shmem-usage.patch
@@ -1,4 +1,4 @@
-From 1528720468897b58580b95466997143a1a578ba2 Mon Sep 17 00:00:00 2001
+From 9c2aa0c616a040e67468232cea0ef30d467160dc Mon Sep 17 00:00:00 2001
 From: Wan Shuang <shuang.wan@intel.com>
 Date: Sat, 16 May 2020 22:14:15 +0800
 Subject: [PATCH] drm/i915: Sysfs interface to get GFX shmem usage
@@ -56,12 +56,12 @@ Signed-off-by: Wan Shuang <shuang.wan@intel.com>
  drivers/gpu/drm/i915/gem/i915_gem_shmem.c     |  24 +-
  drivers/gpu/drm/i915/i915_drv.c               |  11 +-
  drivers/gpu/drm/i915/i915_drv.h               |  31 +
- drivers/gpu/drm/i915/i915_gem.c               | 895 +++++++++++++++++-
+ drivers/gpu/drm/i915/i915_gem.c               | 892 +++++++++++++++++-
  drivers/gpu/drm/i915/i915_gpu_error.c         |  38 +-
  drivers/gpu/drm/i915/i915_gpu_error.h         |  15 +-
  drivers/gpu/drm/i915/i915_sysfs.c             | 325 ++++++-
  drivers/gpu/drm/i915/i915_sysfs.h             |   7 +
- 15 files changed, 1406 insertions(+), 24 deletions(-)
+ 15 files changed, 1403 insertions(+), 24 deletions(-)
 
 diff --git a/drivers/gpu/drm/drm_file.c b/drivers/gpu/drm/drm_file.c
 index ea34bc991858..e3afe2907730 100644
@@ -405,7 +405,7 @@ index ca42b1090f2f..fd39cbeea15d 100644
  
  /* i915_cmd_parser.c */
 diff --git a/drivers/gpu/drm/i915/i915_gem.c b/drivers/gpu/drm/i915/i915_gem.c
-index 0ff2e2b52565..e811601d4cef 100644
+index 0ff2e2b52565..14aab2d34230 100644
 --- a/drivers/gpu/drm/i915/i915_gem.c
 +++ b/drivers/gpu/drm/i915/i915_gem.c
 @@ -38,6 +38,13 @@
@@ -422,7 +422,7 @@ index 0ff2e2b52565..e811601d4cef 100644
  #include "display/intel_display.h"
  #include "display/intel_frontbuffer.h"
  
-@@ -59,11 +66,833 @@
+@@ -59,11 +66,830 @@
  #include "i915_scatterlist.h"
  #include "i915_trace.h"
  #include "i915_vgpu.h"
@@ -837,9 +837,6 @@ index 0ff2e2b52565..e811601d4cef 100644
 +
 +	list_for_each_entry (pid_info_entry, &obj->pid_info, head)
 +		obj_shared_count++;
-+
-+	if (WARN_ON(obj_shared_count == 0))
-+		return -EINVAL;
 +
 +	return obj_shared_count;
 +}
@@ -1258,7 +1255,7 @@ index 0ff2e2b52565..e811601d4cef 100644
  {
  	int err;
  
-@@ -82,8 +911,18 @@ insert_mappable_node(struct i915_ggtt *ggtt, struct drm_mm_node *node, u32 size)
+@@ -82,8 +908,18 @@ insert_mappable_node(struct i915_ggtt *ggtt, struct drm_mm_node *node, u32 size)
  	return err;
  }
  
@@ -1279,7 +1276,7 @@ index 0ff2e2b52565..e811601d4cef 100644
  {
  	mutex_lock(&ggtt->vm.mutex);
  	drm_mm_remove_node(node);
-@@ -1470,6 +2309,11 @@ void i915_gem_release(struct drm_device *dev, struct drm_file *file)
+@@ -1470,6 +2306,11 @@ void i915_gem_release(struct drm_device *dev, struct drm_file *file)
  	struct drm_i915_file_private *file_priv = file->driver_priv;
  	struct i915_request *request;
  
@@ -1291,7 +1288,7 @@ index 0ff2e2b52565..e811601d4cef 100644
  	/* Clean up our request list when the client is going away, so that
  	 * later retire_requests won't dereference our soon-to-be-gone
  	 * file_priv.
-@@ -1495,15 +2339,58 @@ int i915_gem_open(struct drm_i915_private *i915, struct drm_file *file)
+@@ -1495,15 +2336,58 @@ int i915_gem_open(struct drm_i915_private *i915, struct drm_file *file)
  	file_priv->dev_priv = i915;
  	file_priv->file = file;
  


### PR DESCRIPTION
obj_shared_count == 0 shouldn't lead into syscall exception.
Just skip this false exception fixed the issue.

Tracked-On: OAM-90959
Signed-off-by: Wan Shuang <shuang.wan@intel.com>