### PR TITLE
uvc: Add GET_DEF probe quirk for C922

### DIFF
--- a/bsp_diff/caas/kernel/lts2019-chromium/11_0011-uvc-Add-UVC-GET_DEF-probe-quirk-for-C922-camera.patch
+++ b/bsp_diff/caas/kernel/lts2019-chromium/11_0011-uvc-Add-UVC-GET_DEF-probe-quirk-for-C922-camera.patch
@@ -1,0 +1,40 @@
+From f94cec79544768f80a3541302af23af82a83c239 Mon Sep 17 00:00:00 2001
+From: saranya <saranya.gopal@intel.com>
+Date: Thu, 4 Jun 2020 14:17:06 +0530
+Subject: [PATCH] uvc: Add UVC GET_DEF probe quirk for C922 camera
+
+In some of the C922 camera devices, we find that
+GET_DEF request is not implemented for video probe
+and commit controls. These cameras crash when this
+request is received. Hence, add this quirk for C922
+cameras.
+
+Tracked-On: OAM-91289
+Signed-off-by: saranya <saranya.gopal@intel.com>
+---
+ drivers/media/usb/uvc/uvc_driver.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
+index 99883550375e..59fa4b0f50b4 100644
+--- a/drivers/media/usb/uvc/uvc_driver.c
++++ b/drivers/media/usb/uvc/uvc_driver.c
+@@ -2526,6 +2526,15 @@ static const struct usb_device_id uvc_ids[] = {
+ 	  .bInterfaceSubClass	= 1,
+ 	  .bInterfaceProtocol	= 0,
+ 	  .driver_info		= UVC_INFO_QUIRK(UVC_QUIRK_RESTORE_CTRLS_ON_INIT) },
++	/* Logitech HD Pro Webcam C922 */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x046d,
++	  .idProduct		= 0x085c,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= (kernel_ulong_t)&uvc_quirk_probe_def },
+ 	/* Chicony CNF7129 (Asus EEE 100HE) */
+ 	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
+ 				| USB_DEVICE_ID_MATCH_INT_INFO,
+-- 
+2.21.0
+

--- a/bsp_diff/caas/kernel/lts2019-yocto/11_0011-uvc-Add-UVC-GET_DEF-probe-quirk-for-C922-camera.patch
+++ b/bsp_diff/caas/kernel/lts2019-yocto/11_0011-uvc-Add-UVC-GET_DEF-probe-quirk-for-C922-camera.patch
@@ -1,0 +1,40 @@
+From f94cec79544768f80a3541302af23af82a83c239 Mon Sep 17 00:00:00 2001
+From: saranya <saranya.gopal@intel.com>
+Date: Thu, 4 Jun 2020 14:17:06 +0530
+Subject: [PATCH] uvc: Add UVC GET_DEF probe quirk for C922 camera
+
+In some of the C922 camera devices, we find that
+GET_DEF request is not implemented for video probe
+and commit controls. These cameras crash when this
+request is received. Hence, add this quirk for C922
+cameras.
+
+Tracked-On: OAM-91289
+Signed-off-by: saranya <saranya.gopal@intel.com>
+---
+ drivers/media/usb/uvc/uvc_driver.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/drivers/media/usb/uvc/uvc_driver.c b/drivers/media/usb/uvc/uvc_driver.c
+index 99883550375e..59fa4b0f50b4 100644
+--- a/drivers/media/usb/uvc/uvc_driver.c
++++ b/drivers/media/usb/uvc/uvc_driver.c
+@@ -2526,6 +2526,15 @@ static const struct usb_device_id uvc_ids[] = {
+ 	  .bInterfaceSubClass	= 1,
+ 	  .bInterfaceProtocol	= 0,
+ 	  .driver_info		= UVC_INFO_QUIRK(UVC_QUIRK_RESTORE_CTRLS_ON_INIT) },
++	/* Logitech HD Pro Webcam C922 */
++	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
++				| USB_DEVICE_ID_MATCH_INT_INFO,
++	  .idVendor		= 0x046d,
++	  .idProduct		= 0x085c,
++	  .bInterfaceClass	= USB_CLASS_VIDEO,
++	  .bInterfaceSubClass	= 1,
++	  .bInterfaceProtocol	= 0,
++	  .driver_info		= (kernel_ulong_t)&uvc_quirk_probe_def },
+ 	/* Chicony CNF7129 (Asus EEE 100HE) */
+ 	{ .match_flags		= USB_DEVICE_ID_MATCH_DEVICE
+ 				| USB_DEVICE_ID_MATCH_INT_INFO,
+-- 
+2.21.0
+


### PR DESCRIPTION
Some camera devices will not have GET_DEF
request implemented for video probe and commit
controls. These devices may crash if they receive
GET_DEF request. So, add a quirk to avoid GET_DEF
request for these devices.

Tracked-On: OAM-91289
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>