### PR TITLE
Add a item in get_param IOCTL for chromium kernel GVT active

### DIFF
--- a/bsp_diff/caas/kernel/lts2019-chromium/12_0001-Add-a-item-in-get_param-IOCTL-for-chromium-kernel-GV.patch
+++ b/bsp_diff/caas/kernel/lts2019-chromium/12_0001-Add-a-item-in-get_param-IOCTL-for-chromium-kernel-GV.patch
@@ -1,0 +1,64 @@
+From ec4a1cf81932df9e9ca4d1a9b88490f183d4080e Mon Sep 17 00:00:00 2001
+From: Shaofeng Tang <shaofeng.tang@intel.com>
+Date: Fri, 5 Jun 2020 13:26:51 +0800
+Subject: [PATCH] Add a item in get_param IOCTL for chromium kernel GVT active
+
+When GVT in chromium kernel is active, return true.
+that is:
+GVT-g --- true
+GVT-d --- false
+native --- false
+
+Tracked-On: OAM-91324
+Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>
+---
+ drivers/gpu/drm/i915/i915_getparam.c | 3 +++
+ include/uapi/drm/i915_drm.h          | 3 +++
+ tools/include/uapi/drm/i915_drm.h    | 3 +++
+ 3 files changed, 9 insertions(+)
+
+diff --git a/drivers/gpu/drm/i915/i915_getparam.c b/drivers/gpu/drm/i915/i915_getparam.c
+index 9f1517a..e0e7a2c 100644
+--- a/drivers/gpu/drm/i915/i915_getparam.c
++++ b/drivers/gpu/drm/i915/i915_getparam.c
+@@ -156,6 +156,9 @@ int i915_getparam_ioctl(struct drm_device *dev, void *data,
+ 	case I915_PARAM_MMAP_GTT_COHERENT:
+ 		value = INTEL_INFO(i915)->has_coherent_ggtt;
+ 		break;
++	case I915_PARAM_IS_GVT:
++		value = intel_vgpu_active(i915);
++		break;
+ 	default:
+ 		DRM_DEBUG("Unknown parameter %d\n", param->param);
+ 		return -EINVAL;
+diff --git a/include/uapi/drm/i915_drm.h b/include/uapi/drm/i915_drm.h
+index 30c5421..77421ff 100644
+--- a/include/uapi/drm/i915_drm.h
++++ b/include/uapi/drm/i915_drm.h
+@@ -611,6 +611,9 @@ enum drm_i915_pmu_engine_sample {
+  * See I915_EXEC_FENCE_OUT and I915_EXEC_FENCE_SUBMIT.
+  */
+ #define I915_PARAM_HAS_EXEC_SUBMIT_FENCE 53
++
++#define I915_PARAM_IS_GVT	55
++
+ /* Must be kept compact -- no holes and well documented */
+ 
+ typedef struct drm_i915_getparam {
+diff --git a/tools/include/uapi/drm/i915_drm.h b/tools/include/uapi/drm/i915_drm.h
+index 469dc51..8b584e3 100644
+--- a/tools/include/uapi/drm/i915_drm.h
++++ b/tools/include/uapi/drm/i915_drm.h
+@@ -611,6 +611,9 @@ enum drm_i915_pmu_engine_sample {
+  * See I915_EXEC_FENCE_OUT and I915_EXEC_FENCE_SUBMIT.
+  */
+ #define I915_PARAM_HAS_EXEC_SUBMIT_FENCE 53
++
++#define I915_PARAM_IS_GVT	55
++
+ /* Must be kept compact -- no holes and well documented */
+ 
+ typedef struct drm_i915_getparam {
+-- 
+1.9.1
+


### PR DESCRIPTION
When GVT in chromium kernel is active, return true.
that is:
GVT-g --- true
GVT-d --- false
native --- false

Tracked-On: OAM-90744
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>