### PR TITLE
system: core: adb: Adding adb over DbC TTY Support

### DIFF
--- a/aosp_diff/caas/system/core/03_system-core-adb-Adding-adb-over-DbC-TTY-Support.patch
+++ b/aosp_diff/caas/system/core/03_system-core-adb-Adding-adb-over-DbC-TTY-Support.patch
@@ -1,0 +1,77 @@
+From f3e2543c3698edee3cf30409d97508b301cfb141 Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Tue, 9 Jun 2020 12:01:47 +0530
+Subject: [PATCH] system: core: adb: Adding adb over DbC TTY Support
+
+Adding the adb over DbC TTY support for CML and EHL platform.
+Removing ADB over DbC RAW support for CML and EHL.
+
+Tracked-On: OAM-91335
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+---
+ adb/adb.h                 |  2 +-
+ adb/daemon/usb_legacy.cpp | 23 +++++++++++++++++++++++
+ 2 files changed, 24 insertions(+), 1 deletion(-)
+
+diff --git a/adb/adb.h b/adb/adb.h
+index a7009d2a7..a016b82ca 100644
+--- a/adb/adb.h
++++ b/adb/adb.h
+@@ -224,7 +224,7 @@ extern const char* adb_device_banner;
+ #define USB_FFS_ADB_EP0 USB_FFS_ADB_EP(ep0)
+ #define USB_FFS_ADB_OUT USB_FFS_ADB_EP(ep1)
+ #define USB_FFS_ADB_IN USB_FFS_ADB_EP(ep2)
+-#define USB_DBC_ADB_PATH  "/dev/dbc_raw0"
++#define USB_DBC_ADB_PATH  "/dev/ttyDBC0"
+ #endif
+ 
+ enum class HostRequestResult {
+diff --git a/adb/daemon/usb_legacy.cpp b/adb/daemon/usb_legacy.cpp
+index 7afdb3c2c..a52bf7197 100644
+--- a/adb/daemon/usb_legacy.cpp
++++ b/adb/daemon/usb_legacy.cpp
+@@ -27,6 +27,7 @@
+ #include <sys/mman.h>
+ #include <sys/types.h>
+ #include <unistd.h>
++#include <termios.h>
+ 
+ #include <linux/usb/ch9.h>
+ #include <linux/usb/functionfs.h>
+@@ -281,11 +282,33 @@ static void usb_ffs_close(usb_handle* h) {
+ bool init_dbc_raw(struct usb_handle* h) {
+     LOG(INFO) << "init_dbc_raw called\n";
+ 
++    struct termios SerialPortSettings;
++
+     h->bulk_out.reset(adb_open(USB_DBC_ADB_PATH, O_RDWR));
+     if (h->bulk_out < 0) {
+         D("[ %s: cannot open bulk-out ep: errno=%d ]", USB_DBC_ADB_PATH, errno);
+         goto err;
+     }
++
++    tcgetattr(h->bulk_out.get(), &SerialPortSettings);
++
++    cfsetispeed(&SerialPortSettings,B9600);
++    cfsetospeed(&SerialPortSettings,B9600);
++
++    SerialPortSettings.c_cflag &= ~PARENB;
++    SerialPortSettings.c_cflag &= ~CSTOPB;
++    SerialPortSettings.c_cflag &= ~CSIZE;
++    SerialPortSettings.c_cflag &= CS8;
++    SerialPortSettings.c_cflag &= ~CRTSCTS;
++    SerialPortSettings.c_cflag &= CREAD | CLOCAL;
++    SerialPortSettings.c_lflag &= ~(ICANON | ECHO | IEXTEN | ISIG);
++    SerialPortSettings.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
++    SerialPortSettings.c_oflag &= ~OPOST;
++    SerialPortSettings.c_cc[VMIN] = 10;
++    SerialPortSettings.c_cc[VTIME] = 10;
++
++    tcsetattr(h->bulk_out.get(), TCSANOW, &SerialPortSettings);
++
+     h->bulk_in.reset(h->bulk_out.get());
+     h->control.reset(h->bulk_out.get());
+ 
+-- 
+2.24.1
+


### PR DESCRIPTION
Adding the adb over DbC TTY support for CML and EHL platform.
Removing ADB over DbC RAW support for CML and EHL.

Tracked-On: OAM-91335
Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>