### PR TITLE
adb: dbc: tty: device offline issue

### DIFF
--- a/aosp_diff/caas/frameworks/base/04_0001-adb-dbc-tty-device-offline-issue.patch
+++ b/aosp_diff/caas/frameworks/base/04_0001-adb-dbc-tty-device-offline-issue.patch
@@ -1,0 +1,52 @@
+From eff53f32d14388dc48e1faed748ec958067e01b3 Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Wed, 17 Jun 2020 14:09:26 +0530
+Subject: [PATCH] adb: dbc: tty: device offline issue
+
+Restarting the adb daemon when DbC device move to the dbc
+state configured from dbc state enable.
+To do so added DEVPATH variable which match to the DbC TTY
+DEVPATH uevent.
+
+Tracked-On: OAM-91445
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+---
+ .../usb/java/com/android/server/usb/UsbDeviceManager.java | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/services/usb/java/com/android/server/usb/UsbDeviceManager.java b/services/usb/java/com/android/server/usb/UsbDeviceManager.java
+index 460ec5e8fc7..edac60ee8fa 100644
+--- a/services/usb/java/com/android/server/usb/UsbDeviceManager.java
++++ b/services/usb/java/com/android/server/usb/UsbDeviceManager.java
+@@ -128,7 +128,7 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
+     private static final String NORMAL_BOOT = "normal";
+ 
+     private static final String USB_DBC_STATE_MATCH =
+-            "SUBSYSTEM=pci";
++            "DEVPATH=/devices/virtual/tty/ttyDBC0";
+     private static final String USB_STATE_MATCH =
+             "DEVPATH=/devices/virtual/android_usb/android0";
+     private static final String ACCESSORY_START_MATCH =
+@@ -218,6 +218,10 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
+             if (DEBUG) Slog.v(TAG, "USB UEVENT: " + event.toString());
+ 
+             String state = event.get("USB_STATE");
++
++            if (state == null)
++                state = event.get("ACTION");
++
+             String accessory = event.get("ACCESSORY");
+             if (state != null) {
+                 mHandler.updateState(state);
+@@ -573,7 +577,7 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
+             } else if ("CONFIGURED".equals(state)) {
+                 connected = 1;
+                 configured = 1;
+-            } else if ("DBCCONNECTED".equals(state)) {
++            } else if ("add".equals(state)) {
+                 connected = 2;
+                 configured = 1;
+             } else {
+-- 
+2.24.1
+


### PR DESCRIPTION
Restarting the adb daemon when DbC device move to the dbc
state configured from dbc state enable.

Tracked-On: OAM-91445
Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>