### PR TITLE
Add a item in get_param IOCTL for chromium kernel GVT active

### DIFF
--- a/bsp_diff/caas/kernel/lts2019-chromium/08_0008-Add-a-item-in-get_param-IOCTL-for-chromium-kernel-GV.patch
+++ b/bsp_diff/caas/kernel/lts2019-chromium/08_0008-Add-a-item-in-get_param-IOCTL-for-chromium-kernel-GV.patch
@@ -1,4 +1,4 @@
-From ec4a1cf81932df9e9ca4d1a9b88490f183d4080e Mon Sep 17 00:00:00 2001
+From 363099a7a0e2a0981b85ce90d86b5b6dd7a56150 Mon Sep 17 00:00:00 2001
 From: Shaofeng Tang <shaofeng.tang@intel.com>
 Date: Fri, 5 Jun 2020 13:26:51 +0800
 Subject: [PATCH] Add a item in get_param IOCTL for chromium kernel GVT active
@@ -13,17 +13,17 @@ Tracked-On: OAM-91324
 Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>
 ---
  drivers/gpu/drm/i915/i915_getparam.c | 3 +++
- include/uapi/drm/i915_drm.h          | 3 +++
+ include/uapi/drm/i915_drm.h          | 2 ++
  tools/include/uapi/drm/i915_drm.h    | 3 +++
- 3 files changed, 9 insertions(+)
+ 3 files changed, 8 insertions(+)
 
 diff --git a/drivers/gpu/drm/i915/i915_getparam.c b/drivers/gpu/drm/i915/i915_getparam.c
-index 9f1517a..e0e7a2c 100644
+index 54fce81d5724..c7641f6a01ad 100644
 --- a/drivers/gpu/drm/i915/i915_getparam.c
 +++ b/drivers/gpu/drm/i915/i915_getparam.c
-@@ -156,6 +156,9 @@ int i915_getparam_ioctl(struct drm_device *dev, void *data,
- 	case I915_PARAM_MMAP_GTT_COHERENT:
- 		value = INTEL_INFO(i915)->has_coherent_ggtt;
+@@ -161,6 +161,9 @@ int i915_getparam_ioctl(struct drm_device *dev, void *data,
+ 	case I915_PARAM_PERF_REVISION:
+ 		value = i915_perf_ioctl_version();
  		break;
 +	case I915_PARAM_IS_GVT:
 +		value = intel_vgpu_active(i915);
@@ -32,24 +32,23 @@ index 9f1517a..e0e7a2c 100644
  		DRM_DEBUG("Unknown parameter %d\n", param->param);
  		return -EINVAL;
 diff --git a/include/uapi/drm/i915_drm.h b/include/uapi/drm/i915_drm.h
-index 30c5421..77421ff 100644
+index 829c0a48577f..3cf7974f300a 100644
 --- a/include/uapi/drm/i915_drm.h
 +++ b/include/uapi/drm/i915_drm.h
-@@ -611,6 +611,9 @@ enum drm_i915_pmu_engine_sample {
-  * See I915_EXEC_FENCE_OUT and I915_EXEC_FENCE_SUBMIT.
+@@ -619,6 +619,8 @@ typedef struct drm_i915_irq_wait {
   */
- #define I915_PARAM_HAS_EXEC_SUBMIT_FENCE 53
-+
+ #define I915_PARAM_PERF_REVISION	54
+ 
 +#define I915_PARAM_IS_GVT	55
 +
  /* Must be kept compact -- no holes and well documented */
  
  typedef struct drm_i915_getparam {
 diff --git a/tools/include/uapi/drm/i915_drm.h b/tools/include/uapi/drm/i915_drm.h
-index 469dc51..8b584e3 100644
+index 469dc512cca3..8b584e3daf51 100644
 --- a/tools/include/uapi/drm/i915_drm.h
 +++ b/tools/include/uapi/drm/i915_drm.h
-@@ -611,6 +611,9 @@ enum drm_i915_pmu_engine_sample {
+@@ -611,6 +611,9 @@ typedef struct drm_i915_irq_wait {
   * See I915_EXEC_FENCE_OUT and I915_EXEC_FENCE_SUBMIT.
   */
  #define I915_PARAM_HAS_EXEC_SUBMIT_FENCE 53
@@ -60,5 +59,5 @@ index 469dc51..8b584e3 100644
  
  typedef struct drm_i915_getparam {
 -- 
-1.9.1
+2.17.1
 


### PR DESCRIPTION
When GVT in chromium kernel is active, return true.
    that is:
    GVT-g --- true
    GVT-d --- false
    native --- false

Tracked-On: OAM-OAM-91479
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>
Signed-off-by: Muhammad Aksar <muhammad.aksar@intel.com>