### PR TITLE
Handle USB_HEADSET device type to fix no audio on video recording

### DIFF
--- a/bsp_diff/caas/vendor/intel/external/apps/01_0001-Handle-USB_HEADSET-device-type-to-fix-no-audio-on-vi.patch
+++ b/bsp_diff/caas/vendor/intel/external/apps/01_0001-Handle-USB_HEADSET-device-type-to-fix-no-audio-on-vi.patch
@@ -1,0 +1,39 @@
+From 5a0477dcdcfa0692305f581908437d37967ed2bd Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Fri, 19 Jun 2020 22:27:55 +0530
+Subject: [PATCH] Handle USB_HEADSET device type to fix no audio on video
+ recording
+
+When video recording is started with USB headset detected, audio
+device doesn't return USB_DEVICE instead it returns USB_HEADSET.
+So, preferred audio device is not set resulting in audio not
+recorded on video recording.
+
+Fix the issue by setting preferred device for device type
+USB_HEADSET.
+
+Tracked-On: OAM-91435
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ .../java/com/intel/multicamera/VideoRecord.java              | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/camera/MultiCameraApplication/java/com/intel/multicamera/VideoRecord.java b/camera/MultiCameraApplication/java/com/intel/multicamera/VideoRecord.java
+index 9da5b26..d7c46f2 100644
+--- a/camera/MultiCameraApplication/java/com/intel/multicamera/VideoRecord.java
++++ b/camera/MultiCameraApplication/java/com/intel/multicamera/VideoRecord.java
+@@ -438,6 +438,11 @@ public class VideoRecord implements MediaRecorder.OnErrorListener, MediaRecorder
+                     mAudioManager.getDevices(AudioManager.GET_DEVICES_INPUTS);
+             for (AudioDeviceInfo audioDeviceInfo : deviceList) {
+                 if (audioDeviceInfo.getType() == AudioDeviceInfo.TYPE_USB_DEVICE) {
++                    Log.d(TAG, "Setting preferred device to TYPE_USB_DEVICE");
++                    mMediaRecorder.setPreferredDevice(audioDeviceInfo);
++                    break;
++                } else if (audioDeviceInfo.getType() == AudioDeviceInfo.TYPE_USB_HEADSET) {
++                    Log.d(TAG, "Setting preferred device to TYPE_USB_HEADSET");
+                     mMediaRecorder.setPreferredDevice(audioDeviceInfo);
+                     break;
+                 }
+-- 
+2.17.1
+


### PR DESCRIPTION
When video recording is started with USB headset detected, audio
device doesn't return USB_DEVICE instead it returns USB_HEADSET.
So, preferred audio device is not set resulting in audio not
recorded on video recording.

Fix the issue by setting preferred device for device type
USB_HEADSET.

Tracked-On: OAM-91435
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>