### PR TITLE
Add HDA HDMI support for EHL

### DIFF
--- a/bsp_diff/caas/kernel/lts2019-yocto/11_0011-Fix-HDMI-audio-for-EHL.patch
+++ b/bsp_diff/caas/kernel/lts2019-yocto/11_0011-Fix-HDMI-audio-for-EHL.patch
@@ -1,0 +1,31 @@
+From d233c4941630af0ec2e14be7c2a693e9c9ce3087 Mon Sep 17 00:00:00 2001
+From: Libin Yang <libin.yang@linux.intel.com>
+Date: Thu, 9 Apr 2020 13:58:17 -0500
+Subject: [PATCH] ALSA: hda: Add ElkhartLake HDMI codec vid
+
+Add HDMI codec vid for the Intel ElkhartLake platform
+
+Signed-off-by: Libin Yang <libin.yang@linux.intel.com>
+Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>
+Reviewed-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>
+Reviewed-by: Guennadi Liakhovetski <guennadi.liakhovetski@linux.intel.com>
+Reviewed-by: Bard Liao <yung-chuan.liao@linux.intel.com>
+Acked-by: Takashi Iwai <tiwai@suse.de>
+Link: https://lore.kernel.org/r/20200409185827.16255-4-pierre-louis.bossart@linux.intel.com
+Signed-off-by: Mark Brown <broonie@kernel.org>
+---
+ sound/pci/hda/patch_hdmi.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/sound/pci/hda/patch_hdmi.c b/sound/pci/hda/patch_hdmi.c
+index bb287a916dae0..403baca89452a 100644
+--- a/sound/pci/hda/patch_hdmi.c
++++ b/sound/pci/hda/patch_hdmi.c
+@@ -4156,6 +4156,7 @@ HDA_CODEC_ENTRY(0x8086280d, "Geminilake HDMI",	patch_i915_glk_hdmi),
+ HDA_CODEC_ENTRY(0x8086280f, "Icelake HDMI",	patch_i915_icl_hdmi),
+ HDA_CODEC_ENTRY(0x80862812, "Tigerlake HDMI",	patch_i915_tgl_hdmi),
+ HDA_CODEC_ENTRY(0x8086281a, "Jasperlake HDMI",	patch_i915_icl_hdmi),
++HDA_CODEC_ENTRY(0x8086281b, "Elkhartlake HDMI",	patch_i915_icl_hdmi),
+ HDA_CODEC_ENTRY(0x80862880, "CedarTrail HDMI",	patch_generic_hdmi),
+ HDA_CODEC_ENTRY(0x80862882, "Valleyview2 HDMI",	patch_i915_byt_hdmi),
+ HDA_CODEC_ENTRY(0x80862883, "Braswell HDMI",	patch_i915_byt_hdmi),


### PR DESCRIPTION
Back ported patch from:
https://github.com/thesofproject/linux/commit/d233c4941630af0ec2e14be7c2a693e9c9ce3087

Tracked-On: OAM-91411
Signed-off-by: gkdeepa <g.k.deepa@intel.com>