### PR TITLE
Handle simultaneous HDMI & WiredHeadphone events

### DIFF
--- a/aosp_diff/caas/frameworks/base/03_0001-Handle-simultaneous-HDMI-WiredHeadphone-events.patch
+++ b/aosp_diff/caas/frameworks/base/03_0001-Handle-simultaneous-HDMI-WiredHeadphone-events.patch
@@ -1,25 +1,28 @@
-From d23e19d5af342e930f6ea7da07343da27f6ce50a Mon Sep 17 00:00:00 2001
-From: "M, Kumar K" <kumar.k.m@intel.com>
-Date: Wed, 18 Sep 2019 12:16:57 +0530
-Subject: [PATCH] Handle HDMI audio device in framework
+From 573c82ea591b910ccc4b68a0f04f441426a9c2e7 Mon Sep 17 00:00:00 2001
+From: akodanka <anoob.anto.kodankandath@intel.com>
+Date: Wed, 24 Jun 2020 13:12:52 +0530
+Subject: [PATCH] Handle simultaneous HDMI & WiredHeadphone events
 
-Handle HDMI device in wired acc manager and default policy.
+Wired Headset sets these 2 bits in the device when connected:
+SW_HEADPHONE_INSERT_BIT & SW_MICROPHONE_INSERT_BIT
+Additionally, if HDMI device is connected, it sets the
+SW_LINEOUT_INSERT_BIT event too.
+The combination of these 3 bits has to be handled correctly.
 
-Change-Id: Icf1bf6846e6108c9af36ed9332456531a9761106
-Tracked-On: OAM-90930
-Signed-off-by: M, Kumar K <kumar.k.m@intel.com>
+Tracked-On: OAM-91511
+Signed-off-by: akodanka <anoob.anto.kodankandath@intel.com>
 ---
- .../java/com/android/server/WiredAccessoryManager.java    | 8 ++++++--
- 1 file changed, 6 insertions(+), 2 deletions(-)
+ .../com/android/server/WiredAccessoryManager.java    | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
  mode change 100644 => 100755 services/core/java/com/android/server/WiredAccessoryManager.java
 
 diff --git a/services/core/java/com/android/server/WiredAccessoryManager.java b/services/core/java/com/android/server/WiredAccessoryManager.java
 old mode 100644
 new mode 100755
-index 8e5c73bfc02..e993522c340
+index 8e5c73bfc02..3a9e4d46d4e
 --- a/services/core/java/com/android/server/WiredAccessoryManager.java
 +++ b/services/core/java/com/android/server/WiredAccessoryManager.java
-@@ -167,6 +167,10 @@ final class WiredAccessoryManager implements WiredAccessoryCallbacks {
+@@ -167,6 +167,14 @@ final class WiredAccessoryManager implements WiredAccessoryCallbacks {
                      headset = BIT_HEADSET;
                      break;
  
@@ -27,10 +30,14 @@ index 8e5c73bfc02..e993522c340
 +                    headset = BIT_HEADSET;
 +                    break;
 +
++                case SW_HEADPHONE_INSERT_BIT | SW_LINEOUT_INSERT_BIT | SW_MICROPHONE_INSERT_BIT:
++                    headset = BIT_HEADSET;
++                    break;
++
                  default:
                      headset = 0;
                      break;
-@@ -404,11 +408,11 @@ final class WiredAccessoryManager implements WiredAccessoryCallbacks {
+@@ -404,11 +412,11 @@ final class WiredAccessoryManager implements WiredAccessoryCallbacks {
              //
              // If the kernel does not have an "hdmi_audio" switch, just fall back on the older
              // "hdmi" switch instead.


### PR DESCRIPTION
Wired Headset sets these 2 bits in the device when connected:
SW_HEADPHONE_INSERT_BIT & SW_MICROPHONE_INSERT_BIT
Additionally, if HDMI device is connected, it sets the
SW_LINEOUT_INSERT_BIT event too.
The combination of these 3 bits has to be handled correctly.

Tracked-On: OAM-91511
Signed-off-by: akodanka <anoob.anto.kodankandath@intel.com>