### PR TITLE
Fix for WiFi status is enabled default.

### DIFF
--- a/android/cic/frameworks/base/0006-Fix-for-WiFi-status-is-enabled-default.patch
+++ b/android/cic/frameworks/base/0006-Fix-for-WiFi-status-is-enabled-default.patch
@@ -1,0 +1,35 @@
+From 0f10ce6a1eb2de84e469119147d58c46c071d3a1 Mon Sep 17 00:00:00 2001
+From: Raveendra Babu Chennakesavulu <raveendra.babu.chennakesavulu@intel.com>
+Date: Mon, 29 Jun 2020 03:24:04 +0530
+Subject: [PATCH] Fix for WiFi status is enabled default.
+
+On very first boot, though wlan is down wifi status in Settings app showing
+as enabled.
+
+Tracked-On: OAM-91559
+Signed-off-by: Raveendra Babu Chennakesavulu
+                        <raveendra.babu.chennakesavulu@intel.com>
+
+Change-Id: Ic0fe3bef88908a35bbaec050ad2a9a659a7db904
+
+diff --git a/wifi/java/android/net/wifi/WifiManager.java b/wifi/java/android/net/wifi/WifiManager.java
+index 50274bfd7fc..69bb9fc856f 100644
+--- a/wifi/java/android/net/wifi/WifiManager.java
++++ b/wifi/java/android/net/wifi/WifiManager.java
+@@ -1859,8 +1859,11 @@ public class WifiManager {
+      * @see #isWifiEnabled()
+      */
+     public int getWifiState() {
+-        Log.e(TAG, "[AIC] **getWifiState** use fake Wifi info");
+-        return WIFI_STATE_ENABLED;
++        try {
++            return mService.getWifiEnabledState();
++        } catch (RemoteException e) {
++            throw e.rethrowFromSystemServer();
++        }
+     }
+
+     /**
+--
+2.17.1
+

--- a/android/cic_dev/frameworks/base/0006-Fix-for-WiFi-status-is-enabled-default.patch
+++ b/android/cic_dev/frameworks/base/0006-Fix-for-WiFi-status-is-enabled-default.patch
@@ -1,0 +1,35 @@
+From 0f10ce6a1eb2de84e469119147d58c46c071d3a1 Mon Sep 17 00:00:00 2001
+From: Raveendra Babu Chennakesavulu <raveendra.babu.chennakesavulu@intel.com>
+Date: Mon, 29 Jun 2020 03:24:04 +0530
+Subject: [PATCH] Fix for WiFi status is enabled default.
+
+On very first boot, though wlan is down wifi status in Settings app showing
+as enabled.
+
+Tracked-On: OAM-91559
+Signed-off-by: Raveendra Babu Chennakesavulu
+                        <raveendra.babu.chennakesavulu@intel.com>
+
+Change-Id: Ic0fe3bef88908a35bbaec050ad2a9a659a7db904
+
+diff --git a/wifi/java/android/net/wifi/WifiManager.java b/wifi/java/android/net/wifi/WifiManager.java
+index 50274bfd7fc..69bb9fc856f 100644
+--- a/wifi/java/android/net/wifi/WifiManager.java
++++ b/wifi/java/android/net/wifi/WifiManager.java
+@@ -1859,8 +1859,11 @@ public class WifiManager {
+      * @see #isWifiEnabled()
+      */
+     public int getWifiState() {
+-        Log.e(TAG, "[AIC] **getWifiState** use fake Wifi info");
+-        return WIFI_STATE_ENABLED;
++        try {
++            return mService.getWifiEnabledState();
++        } catch (RemoteException e) {
++            throw e.rethrowFromSystemServer();
++        }
+     }
+
+     /**
+--
+2.17.1
+


### PR DESCRIPTION
On very first boot, though wlan is down wifi status in Settings app showing
as enabled.

Tracked-On: OAM-91559
Signed-off-by: Raveendra Babu Chennakesavulu
                        <raveendra.babu.chennakesavulu@intel.com>