### PR TITLE
ueventd: add rw attribe for block device /dev/block/vdc

### DIFF
--- a/aosp_diff/caas/system/core/03_ueventd-add-rw-attribe-for-block-device-dev-block-vd.patch
+++ b/aosp_diff/caas/system/core/03_ueventd-add-rw-attribe-for-block-device-dev-block-vd.patch
@@ -1,0 +1,27 @@
+From f2dbe3e353faebd9bb3678836f817001db2dce36 Mon Sep 17 00:00:00 2001
+From: "JianFeng,Zhou" <jianfeng.zhou@intel.com>
+Date: Fri, 24 Apr 2020 16:14:12 +0800
+Subject: [PATCH] ueventd: add rw attribe for block device /dev/block/vdc
+
+Tracked-On: OAM-91579
+Signed-off-by: JianFeng,Zhou <jianfeng.zhou@intel.com>
+---
+ rootdir/ueventd.rc | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/rootdir/ueventd.rc b/rootdir/ueventd.rc
+index 09e5ed5..036eec4 100644
+--- a/rootdir/ueventd.rc
++++ b/rootdir/ueventd.rc
+@@ -41,6 +41,8 @@ subsystem sound
+ 
+ /dev/pmsg0                0222   root       log
+ 
++/dev/block/vdc            0666   root root
++
+ # kms driver for drm based gpu
+ /dev/dri/*                0666   root       graphics
+ 
+-- 
+2.7.4
+


### PR DESCRIPTION
/dev/block/vdc is mounted as persistent partition, rw attribute is necessary

Tracked-On: OAM-91579
Signed-off-by: JianFeng,Zhou <jianfeng.zhou@intel.com>