### PR TITLE
Disable avx avx2 avx512 flags by default

### DIFF
--- a/aosp_diff/caas/build/soong/0001-Disabled-avx-avx2-avx512-compiler-flags-by-default.patch
+++ b/aosp_diff/caas/build/soong/0001-Disabled-avx-avx2-avx512-compiler-flags-by-default.patch
@@ -1,0 +1,94 @@
+From 007c2fa3ba340843597f188d840cc0300cab03f7 Mon Sep 17 00:00:00 2001
+From: Shalini Salomi Bodapati <shalini.salomi.bodapati@intel.com>
+Date: Fri, 15 May 2020 02:19:11 +0530
+Subject: [PATCH] Disabled avx avx2 avx512 compiler flags by default.
+
+Library components can enable the flags based on performance impact
+
+Tracked-On: https://jira.devtools.intel.com/browse/OAM-91583
+Signed-off-by: Shalini Salomi Bodapati <shalini.salomi.bodapati@intel.com>
+---
+ cc/config/x86_64_device.go | 14 +++++++-------
+ cc/config/x86_device.go    | 20 ++++++++++----------
+ 2 files changed, 17 insertions(+), 17 deletions(-)
+
+diff --git a/cc/config/x86_64_device.go b/cc/config/x86_64_device.go
+index e1d418b..d076842 100644
+--- a/cc/config/x86_64_device.go
++++ b/cc/config/x86_64_device.go
+@@ -48,17 +48,15 @@ var (
+ 		"ivybridge": []string{
+ 			"-march=core-avx-i",
+ 		},
+-                "kabylake": []string{
+-                       "-march=core-avx2",
+-                },
+ 		"sandybridge": []string{
+ 			"-march=corei7",
+ 		},
+ 		"silvermont": []string{
+ 			"-march=slm",
+ 		},
++                "kabylake": []string{
++                },
+ 		"skylake": []string{
+-			"-march=skylake",
+ 		},
+ 		"stoneyridge": []string{
+ 			"-march=bdver4",
+@@ -71,9 +69,11 @@ var (
+ 		"sse4_1": []string{"-msse4.1"},
+ 		"sse4_2": []string{"-msse4.2"},
+ 		"popcnt": []string{"-mpopcnt"},
+-		"avx":    []string{"-mavx"},
+-		"avx2":   []string{"-mavx2"},
+-		"avx512": []string{"-mavx512"},
++                // Not all cases there is performance gain by enabling avx flags.
++                // Individual modules need to enable it
++		//"avx":    []string{"-mavx"},
++		//"avx2":   []string{"-mavx2"},
++		//"avx512": []string{"-mavx512"},
+ 		"aes_ni": []string{"-maes"},
+ 	}
+ )
+diff --git a/cc/config/x86_device.go b/cc/config/x86_device.go
+index 31f0e9d..59089ed 100644
+--- a/cc/config/x86_device.go
++++ b/cc/config/x86_device.go
+@@ -71,14 +71,12 @@ var (
+ 			"-march=slm",
+ 			"-mfpmath=sse",
+ 		},
+-                "kabylake": []string{
+-			"-march=core-avx2",
+-			"-mfpmath=sse",
+-		},
+-		"skylake": []string{
+-			"-march=skylake",
+-			"-mfpmath=sse",
+-		},
++                "kabylake":[]string{
++                       "-mfpmath=sse",
++                },
++                "skylake": []string{
++                        "-mfpmath=sse",
++               },
+ 		"stoneyridge": []string{
+ 			"-march=bdver4",
+ 			"-mfpmath=sse",
+@@ -90,8 +88,10 @@ var (
+ 		"sse4":   []string{"-msse4"},
+ 		"sse4_1": []string{"-msse4.1"},
+ 		"sse4_2": []string{"-msse4.2"},
+-		"avx":    []string{"-mavx"},
+-		"avx2":   []string{"-mavx2"},
++                // Not all cases there is performance gain by enabling avx flags.
++                // Individual modules need to enable it
++		//"avx":    []string{"-mavx"},
++		//"avx2":   []string{"-mavx2"},
+ 		"aes_ni": []string{"-maes"},
+ 	}
+ )
+-- 
+2.7.4
+


### PR DESCRIPTION
Not all cases there is benefit by enabling avx flags.
Hence, individual components need to enable it based on
performance gain

Tracked-On: OAM-91583
Signed-off-by: bodapati <shalini.salomi.bodapati@intel.com>