### PR TITLE
 Fix for FakeWiFi information populated in UI.

### DIFF
--- a/android/cic/frameworks/base/0006-Fix-for-FakeWiFi-information-populated-in-UI.patch
+++ b/android/cic/frameworks/base/0006-Fix-for-FakeWiFi-information-populated-in-UI.patch
@@ -1,0 +1,95 @@
+From 45b1ba2fe366dae7126f8880dd4fb9789fc0f493 Mon Sep 17 00:00:00 2001
+From: Raveendra Babu Chennakesavulu <raveendra.babu.chennakesavulu@intel.com>
+Date: Mon, 29 Jun 2020 03:24:04 +0530
+Subject: [PATCH] Fix for FakeWiFi information populated in UI.
+
+On very first boot, though wlan is down wifi status in Settings
+app showing as enabled, fix is provided to display the right
+information.
+
+Hardcoded WiFi MAC is shown in UI incase of wifi passthrough,
+changing it to actual physical MAC address.
+
+Change-Id: Ic0fe3bef88908a35bbaec050ad2a9a659a7db904
+Tracked-On: OAM-91559
+Signed-off-by: Raveendra Babu Chennakesavulu
+                        <raveendra.babu.chennakesavulu@intel.com>
+
+diff --git a/wifi/java/android/net/wifi/WifiManager.java b/wifi/java/android/net/wifi/WifiManager.java
+index 50274bfd7fc..47365cb9bb6 100644
+--- a/wifi/java/android/net/wifi/WifiManager.java
++++ b/wifi/java/android/net/wifi/WifiManager.java
+@@ -68,6 +68,8 @@ import java.util.Collections;
+ import java.util.List;
+ import java.util.concurrent.CountDownLatch;
+ 
++import java.io.File;
++
+ /**
+  * This class provides the primary API for managing all aspects of Wi-Fi
+  * connectivity.
+@@ -1656,6 +1658,20 @@ public class WifiManager {
+         return null;
+     }
+ 
++    private boolean isWlanNetdevAvailable() {
++        final File f_wlan = new File("/sys/class/net/wlan0");
++        boolean status = false ;
++
++        if (f_wlan.exists()) {
++            status = true;
++            Log.e(TAG, "/sys/class/net/wlan0 file exists status : " + status);
++        } else {
++            Log.e(TAG, "/sys/class/net/wlan0 file doesn't exists status : " + status);
++        }
++
++        return status;
++    }
++
+     /**
+      * Return dynamic information about the current Wi-Fi connection, if any is active.
+      * <p>
+@@ -1667,8 +1683,20 @@ public class WifiManager {
+      * @return the Wi-Fi information, contained in {@link WifiInfo}.
+      */
+     public WifiInfo getConnectionInfo() {
+-        Log.e(TAG, "[AIC] **getConnectionInfo** use fake Wifi info");
+-        return generateFakeWifiInfo();
++        try {
++
++            if (isWlanNetdevAvailable())  {
++                Log.e(TAG, " WiFi ConnectionInfo: " +
++                        mService.getConnectionInfo(mContext.getOpPackageName()));
++                return mService.getConnectionInfo(mContext.getOpPackageName());
++            } else {
++                Log.e(TAG, "[AIC] **getConnectionInfo** use fake Wifi info " +
++                        generateFakeWifiInfo());
++                return generateFakeWifiInfo();
++            }
++        } catch (RemoteException e) {
++            throw e.rethrowFromSystemServer();
++        }
+     }
+ 
+     private InetAddress getInet4AddressFromEth() {
+@@ -1859,8 +1887,15 @@ public class WifiManager {
+      * @see #isWifiEnabled()
+      */
+     public int getWifiState() {
+-        Log.e(TAG, "[AIC] **getWifiState** use fake Wifi info");
+-        return WIFI_STATE_ENABLED;
++        try {
++            if (isWlanNetdevAvailable()) {
++                return mService.getWifiEnabledState();
++            } else {
++                return WIFI_STATE_ENABLED;
++            }
++        } catch (RemoteException e) {
++            throw e.rethrowFromSystemServer();
++        }
+     }
+ 
+     /**
+-- 
+2.17.1
+

--- a/android/cic_dev/frameworks/base/0006-Fix-for-FakeWiFi-information-populated-in-UI.patch
+++ b/android/cic_dev/frameworks/base/0006-Fix-for-FakeWiFi-information-populated-in-UI.patch
@@ -1,0 +1,95 @@
+From 45b1ba2fe366dae7126f8880dd4fb9789fc0f493 Mon Sep 17 00:00:00 2001
+From: Raveendra Babu Chennakesavulu <raveendra.babu.chennakesavulu@intel.com>
+Date: Mon, 29 Jun 2020 03:24:04 +0530
+Subject: [PATCH] Fix for FakeWiFi information populated in UI.
+
+On very first boot, though wlan is down wifi status in Settings
+app showing as enabled, fix is provided to display the right
+information.
+
+Hardcoded WiFi MAC is shown in UI incase of wifi passthrough,
+changing it to actual physical MAC address.
+
+Change-Id: Ic0fe3bef88908a35bbaec050ad2a9a659a7db904
+Tracked-On: OAM-91559
+Signed-off-by: Raveendra Babu Chennakesavulu
+                        <raveendra.babu.chennakesavulu@intel.com>
+
+diff --git a/wifi/java/android/net/wifi/WifiManager.java b/wifi/java/android/net/wifi/WifiManager.java
+index 50274bfd7fc..47365cb9bb6 100644
+--- a/wifi/java/android/net/wifi/WifiManager.java
++++ b/wifi/java/android/net/wifi/WifiManager.java
+@@ -68,6 +68,8 @@ import java.util.Collections;
+ import java.util.List;
+ import java.util.concurrent.CountDownLatch;
+ 
++import java.io.File;
++
+ /**
+  * This class provides the primary API for managing all aspects of Wi-Fi
+  * connectivity.
+@@ -1656,6 +1658,20 @@ public class WifiManager {
+         return null;
+     }
+ 
++    private boolean isWlanNetdevAvailable() {
++        final File f_wlan = new File("/sys/class/net/wlan0");
++        boolean status = false ;
++
++        if (f_wlan.exists()) {
++            status = true;
++            Log.e(TAG, "/sys/class/net/wlan0 file exists status : " + status);
++        } else {
++            Log.e(TAG, "/sys/class/net/wlan0 file doesn't exists status : " + status);
++        }
++
++        return status;
++    }
++
+     /**
+      * Return dynamic information about the current Wi-Fi connection, if any is active.
+      * <p>
+@@ -1667,8 +1683,20 @@ public class WifiManager {
+      * @return the Wi-Fi information, contained in {@link WifiInfo}.
+      */
+     public WifiInfo getConnectionInfo() {
+-        Log.e(TAG, "[AIC] **getConnectionInfo** use fake Wifi info");
+-        return generateFakeWifiInfo();
++        try {
++
++            if (isWlanNetdevAvailable())  {
++                Log.e(TAG, " WiFi ConnectionInfo: " +
++                        mService.getConnectionInfo(mContext.getOpPackageName()));
++                return mService.getConnectionInfo(mContext.getOpPackageName());
++            } else {
++                Log.e(TAG, "[AIC] **getConnectionInfo** use fake Wifi info " +
++                        generateFakeWifiInfo());
++                return generateFakeWifiInfo();
++            }
++        } catch (RemoteException e) {
++            throw e.rethrowFromSystemServer();
++        }
+     }
+ 
+     private InetAddress getInet4AddressFromEth() {
+@@ -1859,8 +1887,15 @@ public class WifiManager {
+      * @see #isWifiEnabled()
+      */
+     public int getWifiState() {
+-        Log.e(TAG, "[AIC] **getWifiState** use fake Wifi info");
+-        return WIFI_STATE_ENABLED;
++        try {
++            if (isWlanNetdevAvailable()) {
++                return mService.getWifiEnabledState();
++            } else {
++                return WIFI_STATE_ENABLED;
++            }
++        } catch (RemoteException e) {
++            throw e.rethrowFromSystemServer();
++        }
+     }
+ 
+     /**
+-- 
+2.17.1
+


### PR DESCRIPTION
On very first boot, though wlan is down wifi status in Settings app showing
as enabled, fix is provided to display the right information.

Hardcoded WiFi MAC is shown in UI, changing it to actual physical MAC
address.

Tracked-On: OAM-91559
Signed-off-by: Raveendra Babu Chennakesavulu
                        <raveendra.babu.chennakesavulu@intel.com>