### PR TITLE
Force set file contexts of ipc for every boot

### DIFF
--- a/android/cic/system/core/0015-Restore-rootfs-context-for-SELinux-enabling.patch
+++ b/android/cic/system/core/0015-Restore-rootfs-context-for-SELinux-enabling.patch
@@ -1,4 +1,4 @@
-From 018aa19c25c3f1d033b652d12f6244785c68f607 Mon Sep 17 00:00:00 2001
+From 24e79b953c75bd936fa7258a575c7b3b8c0e049b Mon Sep 17 00:00:00 2001
 From: Joe Zheng <joe.zheng@intel.com>
 Date: Wed, 17 Jul 2019 13:13:03 +0800
 Subject: [PATCH] Restore rootfs context for SELinux enabling
@@ -17,10 +17,10 @@ Tracked-On: ACP-649
  1 file changed, 9 insertions(+)
 
 diff --git a/init/init.cpp b/init/init.cpp
-index dfff85fe7..d491119bc 100644
+index 4fe115e92..73d4711b0 100644
 --- a/init/init.cpp
 +++ b/init/init.cpp
-@@ -627,6 +627,15 @@ int main(int argc, char** argv) {
+@@ -622,6 +622,15 @@ int main(int argc, char** argv) {
          SelinuxSetupKernelLogging();
          SelinuxInitialize();
  
@@ -29,7 +29,7 @@ index dfff85fe7..d491119bc 100644
 +        // so that is the reason we need to restorecon here
 +        LOG(INFO) << "Running restorecon for rootfs...";
 +        selinux_android_restorecon("/", SELINUX_ANDROID_RESTORECON_RECURSE);
-+        selinux_android_restorecon("/ipc", SELINUX_ANDROID_RESTORECON_RECURSE|SELINUX_ANDROID_RESTORECON_CROSS_FILESYSTEMS);
++        selinux_android_restorecon("/ipc", SELINUX_ANDROID_RESTORECON_RECURSE|SELINUX_ANDROID_RESTORECON_CROSS_FILESYSTEMS|SELINUX_ANDROID_RESTORECON_FORCE);
 +        selinux_android_restorecon("/proc/cmdline", 0);
 +        LOG(INFO) << "Running restorecon for rootfs done";
 +
@@ -37,5 +37,5 @@ index dfff85fe7..d491119bc 100644
          // that the SELinux policy has been loaded.
          if (selinux_android_restorecon("/init", 0) == -1) {
 -- 
-2.21.0
+2.20.1
 


### PR DESCRIPTION
The /ipc dir is shared by host and cic, host or android-entry
may create some config files under /ipc before selinux rules
are loaded, these files won't be labeled correctly. We need to
force set the file contexts of ipc for every boot, or restorecon
may check the extended attr of ipc and skip the file contexts set
operation if it find ipc was ever set previously. This may leave
the files created by host/aic-manager/android-entry unlabeled.

Tracked-On: OAM-91327
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>