### PR TITLE
Grant CAP_KILL capability to zygote

### DIFF
--- a/android/cic/system/core/0018-Let-some-core-services-run-as-system-user.patch
+++ b/android/cic/system/core/0018-Let-some-core-services-run-as-system-user.patch
@@ -1,4 +1,4 @@
-From 3ac848557af57bd29bc9c920671cf9c8a5624fe0 Mon Sep 17 00:00:00 2001
+From 6f8bbfb7181d5d9fee591ec6aeb555d06e9bec74 Mon Sep 17 00:00:00 2001
 From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
 Date: Thu, 30 Apr 2020 14:28:26 +0800
 Subject: [PATCH] Let some core services run as system user
@@ -354,26 +354,26 @@ index b9464e7fd..68cc79798 100644
      seclabel u:r:ueventd:s0
      shutdown critical
 diff --git a/rootdir/init.zygote32.rc b/rootdir/init.zygote32.rc
-index ac87979ec..e61477ee6 100644
+index ac87979ec..c158ba3ea 100644
 --- a/rootdir/init.zygote32.rc
 +++ b/rootdir/init.zygote32.rc
 @@ -1,7 +1,7 @@
  service zygote /system/bin/app_process -Xzygote /system/bin --zygote --start-system-server
      class main
-+    capabilities DAC_READ_SEARCH DAC_OVERRIDE SETGID SETUID FOWNER CHOWN SETPCAP SYS_ADMIN SYS_NICE SYS_TIME NET_ADMIN WAKE_ALARM NET_RAW NET_BIND_SERVICE
++    capabilities DAC_READ_SEARCH DAC_OVERRIDE SETGID SETUID FOWNER CHOWN SETPCAP SYS_ADMIN SYS_NICE SYS_TIME NET_ADMIN WAKE_ALARM NET_RAW NET_BIND_SERVICE KILL
      priority -20
 -    user root
      group root readproc reserved_disk
      socket zygote stream 660 root system
      onrestart write /sys/android_power/request_state wake
 diff --git a/rootdir/init.zygote64_32.rc b/rootdir/init.zygote64_32.rc
-index 7ddd52ee5..3c1790b45 100644
+index 7ddd52ee5..d13871ec8 100644
 --- a/rootdir/init.zygote64_32.rc
 +++ b/rootdir/init.zygote64_32.rc
 @@ -1,7 +1,7 @@
  service zygote /system/bin/app_process64 -Xzygote /system/bin --zygote --start-system-server --socket-name=zygote
      class main
-+    capabilities DAC_READ_SEARCH DAC_OVERRIDE SETGID SETUID FOWNER CHOWN SETPCAP SYS_ADMIN SYS_NICE SYS_TIME NET_ADMIN WAKE_ALARM NET_RAW NET_BIND_SERVICE
++    capabilities DAC_READ_SEARCH DAC_OVERRIDE SETGID SETUID FOWNER CHOWN SETPCAP SYS_ADMIN SYS_NICE SYS_TIME NET_ADMIN WAKE_ALARM NET_RAW NET_BIND_SERVICE KILL
      priority -20
 -    user root
      group root readproc reserved_disk
@@ -383,7 +383,7 @@ index 7ddd52ee5..3c1790b45 100644
  
  service zygote_secondary /system/bin/app_process32 -Xzygote /system/bin --zygote --socket-name=zygote_secondary --enable-lazy-preload
      class main
-+    capabilities DAC_READ_SEARCH DAC_OVERRIDE SETGID SETUID FOWNER CHOWN SETPCAP SYS_ADMIN SYS_NICE SYS_TIME NET_ADMIN WAKE_ALARM NET_RAW NET_BIND_SERVICE
++    capabilities DAC_READ_SEARCH DAC_OVERRIDE SETGID SETUID FOWNER CHOWN SETPCAP SYS_ADMIN SYS_NICE SYS_TIME NET_ADMIN WAKE_ALARM NET_RAW NET_BIND_SERVICE KILL
      priority -20
 -    user root
      group root readproc reserved_disk


### PR DESCRIPTION
Grant CAP_KILL capability to zygote, or uiautomator cannot
work normally.

Tracked-On: OAM-91952
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>