### PR TITLE
Integrate security patch for CVE-2020-9589

### DIFF
--- a/aosp_diff/preliminary/external/dng_sdk/0001-Targeted-minimal-fix-for-security-issue-in-CVE-2020-.patch
+++ b/aosp_diff/preliminary/external/dng_sdk/0001-Targeted-minimal-fix-for-security-issue-in-CVE-2020-.patch
@@ -1,0 +1,40 @@
+From 2e8f1f0dc5ca3db8a7035938752dd230608e17ab Mon Sep 17 00:00:00 2001
+From: Z Stern <zalman@google.com>
+Date: Tue, 12 May 2020 13:32:09 -0700
+Subject: [PATCH] Targeted minimal fix for security issue in CVE-2020-9589.
+
+Bug: 156261521
+Test: If0722deb96def186fcd0a2d97e57647a1b5987f8
+
+Change-Id: I380c158e465a995a5b0f88021cbf10bbf050db00
+Merged-In: I380c158e465a995a5b0f88021cbf10bbf050db00
+(cherry picked from commit 8051967ac143c7e07ee636315cee8b56874e22c3)
+---
+ source/dng_lossless_jpeg.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git source/dng_lossless_jpeg.cpp source/dng_lossless_jpeg.cpp
+index e3b0576..9d0d01a 100644
+--- source/dng_lossless_jpeg.cpp
++++ source/dng_lossless_jpeg.cpp
+@@ -2277,7 +2277,7 @@ void dng_lossless_decoder::DecodeImage ()
+ 	
+ 	#if qSupportHasselblad_3FR
+ 	
+-	if (info.Ss == 8)
++	if (info.Ss == 8 && (numCOL & 1) == 0)
+ 		{
+ 		
+ 		fHasselblad3FR = true;
+@@ -2412,7 +2412,7 @@ void dng_lossless_decoder::DecodeImage ()
+         // For the rest of the column on this row, predictor
+         // calculations are based on PSV. 
+ 
+-     	if (compsInScan == 2 && info.Ss == 1)
++     	if (compsInScan == 2 && info.Ss == 1 && numCOL > 1)
+     		{
+     		
+     		// This is the combination used by both the Canon and Kodak raw formats. 
+-- 
+2.7.4
+


### PR DESCRIPTION
Integrate a CVE security patch 

Integrate security patch: Targeted minimal fix for security issue in CVE-2020-9589.
Bug 156261521

Tracked-On : [OAM-91943](https://jira.devtools.intel.com/browse/OAM-91943) 
Signed-off-by: svenate <salini.venate@intel.com>