### PR TITLE
Rebase AOSP libdrm diff

### DIFF
--- a/aosp_diff/cic/external/libdrm/0001-use-private-libdrm-instead-of-external-libdrm.patch
+++ b/aosp_diff/cic/external/libdrm/0001-use-private-libdrm-instead-of-external-libdrm.patch
@@ -1,18 +1,22 @@
-From 4f29f007daeac434b3c8dbc234a1d2e0c200ac1c Mon Sep 17 00:00:00 2001
+From 5a04f7d40192a1ae0c5dba364f6f1641601619e1 Mon Sep 17 00:00:00 2001
 From: yifang ma <yifangx.ma@intel.com>
 Date: Tue, 3 Dec 2019 15:51:42 +0800
 Subject: [PATCH] use private libdrm instead of external libdrm
 
-Rename lib names to libxxx_orig, so that we use libdrm-intel instead of external libdrm,
-and bunches of libdrm_pri renaming patches could be removed.
+Rename lib names to libxxx_orig, so that we use
+libdrm-intel instead of external libdrm, and
+bunches of libdrm_pri renaming patches could
+be removed.
 
 Tracked-On: OAM-88717
 Signed-off-by: yifang ma <yifangx.ma@intel.com>
+Signed-off-by: Chenglei Ren <chenglei.ren@intel.com>
 ---
  Android.bp                        |  8 ++++----
  Android.sources.bp                |  2 +-
  amdgpu/Android.bp                 |  8 ++++----
  amdgpu/Android.sources.bp         |  2 +-
+ data/Android.bp                   |  2 +-
  etnaviv/Android.bp                |  8 ++++----
  etnaviv/Android.sources.bp        |  2 +-
  freedreno/Android.bp              |  8 ++++----
@@ -24,7 +28,9 @@ Signed-off-by: yifang ma <yifangx.ma@intel.com>
  nouveau/Android.bp                |  8 ++++----
  nouveau/Android.sources.bp        |  2 +-
  omap/Android.bp                   |  4 ++--
+ omap/Android.sources.bp           |  2 +-
  radeon/Android.bp                 |  4 ++--
+ radeon/Android.sources.bp         |  2 +-
  tegra/Android.bp                  |  4 ++--
  tests/Android.bp                  |  2 +-
  tests/modetest/Android.bp         | 10 +++++-----
@@ -32,10 +38,10 @@ Signed-off-by: yifang ma <yifangx.ma@intel.com>
  tests/proptest/Android.bp         |  6 +++---
  tests/util/Android.bp             | 12 ++++++------
  tests/util/Android.sources.bp     |  2 +-
- 23 files changed, 66 insertions(+), 66 deletions(-)
+ 26 files changed, 69 insertions(+), 69 deletions(-)
 
 diff --git a/Android.bp b/Android.bp
-index 6fe434c..a075d8e 100644
+index 6fe434c6ee66..a075d8e55ee1 100644
 --- a/Android.bp
 +++ b/Android.bp
 @@ -25,7 +25,7 @@ subdirs = ["*"]
@@ -64,7 +70,7 @@ index 6fe434c..a075d8e 100644
  
      export_include_dirs: ["include/drm", "android"],
 diff --git a/Android.sources.bp b/Android.sources.bp
-index 73356dd..1e4f801 100644
+index 73356dd80a37..1e4f8013ed4c 100644
 --- a/Android.sources.bp
 +++ b/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -77,7 +83,7 @@ index 73356dd..1e4f801 100644
          "xf86drm.c",
          "xf86drmHash.c",
 diff --git a/amdgpu/Android.bp b/amdgpu/Android.bp
-index 976f03e..e999eda 100644
+index 976f03e9d617..e999edae900e 100644
 --- a/amdgpu/Android.bp
 +++ b/amdgpu/Android.bp
 @@ -1,16 +1,16 @@
@@ -102,7 +108,7 @@ index 976f03e..e999eda 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/amdgpu/Android.sources.bp b/amdgpu/Android.sources.bp
-index be85283..653ef89 100644
+index ed85682aaa2f..62952f95cce1 100644
 --- a/amdgpu/Android.sources.bp
 +++ b/amdgpu/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -114,8 +120,19 @@ index be85283..653ef89 100644
      srcs: [
  	"amdgpu_asic_id.c",
          "amdgpu_bo.c",
+diff --git a/data/Android.bp b/data/Android.bp
+index 47f64371a4ca..a83777fdcb07 100644
+--- a/data/Android.bp
++++ b/data/Android.bp
+@@ -1,5 +1,5 @@
+ prebuilt_etc {
+-    name: "amdgpu.ids",
++    name: "amdgpu.ids_orig",
+     proprietary: true,
+     sub_dir: "hwdata",
+     src: "amdgpu.ids",
 diff --git a/etnaviv/Android.bp b/etnaviv/Android.bp
-index 21deda9..fdddc65 100644
+index 21deda99900d..fdddc6532120 100644
 --- a/etnaviv/Android.bp
 +++ b/etnaviv/Android.bp
 @@ -1,11 +1,11 @@
@@ -135,7 +152,7 @@ index 21deda9..fdddc65 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/etnaviv/Android.sources.bp b/etnaviv/Android.sources.bp
-index aa82890..aaed155 100644
+index aa8289009b93..aaed1558f329 100644
 --- a/etnaviv/Android.sources.bp
 +++ b/etnaviv/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -148,7 +165,7 @@ index aa82890..aaed155 100644
          "etnaviv_device.c",
          "etnaviv_gpu.c",
 diff --git a/freedreno/Android.bp b/freedreno/Android.bp
-index 9fca9b1..3d20772 100644
+index 9fca9b1260d6..3d20772e5338 100644
 --- a/freedreno/Android.bp
 +++ b/freedreno/Android.bp
 @@ -1,11 +1,11 @@
@@ -168,7 +185,7 @@ index 9fca9b1..3d20772 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/freedreno/Android.sources.bp b/freedreno/Android.sources.bp
-index 3c1ca31..808608c 100644
+index 3c1ca316a5c9..808608c50bf0 100644
 --- a/freedreno/Android.sources.bp
 +++ b/freedreno/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -181,7 +198,7 @@ index 3c1ca31..808608c 100644
          "freedreno_device.c",
          "freedreno_pipe.c",
 diff --git a/intel/Android.bp b/intel/Android.bp
-index 22713ac..05aba7f 100644
+index 22713acc8405..05aba7f77f72 100644
 --- a/intel/Android.bp
 +++ b/intel/Android.bp
 @@ -24,13 +24,13 @@
@@ -203,7 +220,7 @@ index 22713ac..05aba7f 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/intel/Android.sources.bp b/intel/Android.sources.bp
-index 46e0328..e968e2e 100644
+index 459c070fa580..a6e789ab7f4d 100644
 --- a/intel/Android.sources.bp
 +++ b/intel/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -216,7 +233,7 @@ index 46e0328..e968e2e 100644
          "intel_bufmgr.c",
          "intel_bufmgr_fake.c",
 diff --git a/libkms/Android.bp b/libkms/Android.bp
-index b09dbf4..6521911 100644
+index b09dbf42f885..65219110f123 100644
 --- a/libkms/Android.bp
 +++ b/libkms/Android.bp
 @@ -1,15 +1,15 @@
@@ -244,7 +261,7 @@ index b09dbf4..6521911 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/libkms/Android.sources.bp b/libkms/Android.sources.bp
-index 5582f23..3addc57 100644
+index 5582f2356cae..3addc57dd1bb 100644
 --- a/libkms/Android.sources.bp
 +++ b/libkms/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -290,7 +307,7 @@ index 5582f23..3addc57 100644
          "radeon.c",
      ],
 diff --git a/nouveau/Android.bp b/nouveau/Android.bp
-index 12c37e3..a8a504d 100644
+index 12c37e3dc29b..a8a504dcbc56 100644
 --- a/nouveau/Android.bp
 +++ b/nouveau/Android.bp
 @@ -1,11 +1,11 @@
@@ -310,7 +327,7 @@ index 12c37e3..a8a504d 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/nouveau/Android.sources.bp b/nouveau/Android.sources.bp
-index 5ecdb53..72012e5 100644
+index 5ecdb53c80a8..72012e55d652 100644
 --- a/nouveau/Android.sources.bp
 +++ b/nouveau/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -323,7 +340,7 @@ index 5ecdb53..72012e5 100644
          "nouveau.c",
          "pushbuf.c",
 diff --git a/omap/Android.bp b/omap/Android.bp
-index 05ca7d2..9c06cb4 100644
+index 05ca7d2db79b..9c06cb4e8fa3 100644
 --- a/omap/Android.bp
 +++ b/omap/Android.bp
 @@ -1,12 +1,12 @@
@@ -341,8 +358,21 @@ index 05ca7d2..9c06cb4 100644
 -    shared_libs: ["libdrm"],
 +    shared_libs: ["libdrm_orig"],
  }
+diff --git a/omap/Android.sources.bp b/omap/Android.sources.bp
+index 3c7da94a4b18..2491fa9a35c9 100644
+--- a/omap/Android.sources.bp
++++ b/omap/Android.sources.bp
+@@ -1,7 +1,7 @@
+ // Autogenerated with Android.sources.bp.mk
+ 
+ cc_defaults {
+-    name: "libdrm_omap_sources",
++    name: "libdrm_omap_sources_orig",
+     srcs: [
+ 	"omap_drm.c",
+     ],
 diff --git a/radeon/Android.bp b/radeon/Android.bp
-index 9d0a09e..f2bd52e 100644
+index 9d0a09ec718a..f2bd52e9779a 100644
 --- a/radeon/Android.bp
 +++ b/radeon/Android.bp
 @@ -1,11 +1,11 @@
@@ -359,8 +389,21 @@ index 9d0a09e..f2bd52e 100644
 -    shared_libs: ["libdrm"],
 +    shared_libs: ["libdrm_orig"],
  }
+diff --git a/radeon/Android.sources.bp b/radeon/Android.sources.bp
+index 820ac4d6d4ed..3d004f02003f 100644
+--- a/radeon/Android.sources.bp
++++ b/radeon/Android.sources.bp
+@@ -1,7 +1,7 @@
+ // Autogenerated with Android.sources.bp.mk
+ 
+ cc_defaults {
+-    name: "libdrm_radeon_sources",
++    name: "libdrm_radeon_sources_orig",
+     srcs: [
+         "radeon_bo_gem.c",
+         "radeon_cs_gem.c",
 diff --git a/tegra/Android.bp b/tegra/Android.bp
-index 33eaf6c..3839ebd 100644
+index 33eaf6c50eb5..3839ebde8039 100644
 --- a/tegra/Android.bp
 +++ b/tegra/Android.bp
 @@ -1,7 +1,7 @@
@@ -374,7 +417,7 @@ index 33eaf6c..3839ebd 100644
      srcs: ["tegra.c"],
  
 diff --git a/tests/Android.bp b/tests/Android.bp
-index cdc6c2c..696bcac 100644
+index cdc6c2cf350f..696bcac4f7f7 100644
 --- a/tests/Android.bp
 +++ b/tests/Android.bp
 @@ -1,6 +1,6 @@
@@ -386,7 +429,7 @@ index cdc6c2c..696bcac 100644
      export_include_dirs: ["."],
  }
 diff --git a/tests/modetest/Android.bp b/tests/modetest/Android.bp
-index ca811fe..791f9a2 100644
+index ca811fee05e9..791f9a21f256 100644
 --- a/tests/modetest/Android.bp
 +++ b/tests/modetest/Android.bp
 @@ -1,12 +1,12 @@
@@ -408,7 +451,7 @@ index ca811fe..791f9a2 100644
 +    static_libs: ["libdrm_util_orig"],
  }
 diff --git a/tests/modetest/Android.sources.bp b/tests/modetest/Android.sources.bp
-index c6aca2e..e510bfe 100644
+index c6aca2ef757e..e510bfe84b7b 100644
 --- a/tests/modetest/Android.sources.bp
 +++ b/tests/modetest/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -421,7 +464,7 @@ index c6aca2e..e510bfe 100644
          "buffers.c",
          "cursor.c",
 diff --git a/tests/proptest/Android.bp b/tests/proptest/Android.bp
-index 28c87e9..89affae 100644
+index 28c87e91040a..89affae20b2a 100644
 --- a/tests/proptest/Android.bp
 +++ b/tests/proptest/Android.bp
 @@ -1,8 +1,8 @@
@@ -437,7 +480,7 @@ index 28c87e9..89affae 100644
 +    static_libs: ["libdrm_util_orig"],
  }
 diff --git a/tests/util/Android.bp b/tests/util/Android.bp
-index 36d1820..4aac168 100644
+index 36d18206d6bb..4aac168f49cc 100644
 --- a/tests/util/Android.bp
 +++ b/tests/util/Android.bp
 @@ -24,12 +24,12 @@
@@ -460,7 +503,7 @@ index 36d1820..4aac168 100644
 +    export_header_lib_headers: ["libdrm_test_headers_orig"],
  }
 diff --git a/tests/util/Android.sources.bp b/tests/util/Android.sources.bp
-index 529e112..c9a6f1a 100644
+index 529e1124ed9f..c9a6f1a06ee1 100644
 --- a/tests/util/Android.sources.bp
 +++ b/tests/util/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -473,5 +516,5 @@ index 529e112..c9a6f1a 100644
          "format.c",
          "kms.c",
 -- 
-2.7.4
+2.17.1
 

--- a/aosp_diff/preliminary/external/libdrm/0001-use-private-libdrm-instead-of-external-libdrm.patch
+++ b/aosp_diff/preliminary/external/libdrm/0001-use-private-libdrm-instead-of-external-libdrm.patch
@@ -1,18 +1,22 @@
-From 4f29f007daeac434b3c8dbc234a1d2e0c200ac1c Mon Sep 17 00:00:00 2001
+From 5a04f7d40192a1ae0c5dba364f6f1641601619e1 Mon Sep 17 00:00:00 2001
 From: yifang ma <yifangx.ma@intel.com>
 Date: Tue, 3 Dec 2019 15:51:42 +0800
 Subject: [PATCH] use private libdrm instead of external libdrm
 
-Rename lib names to libxxx_orig, so that we use libdrm-intel instead of external libdrm,
-and bunches of libdrm_pri renaming patches could be removed.
+Rename lib names to libxxx_orig, so that we use
+libdrm-intel instead of external libdrm, and
+bunches of libdrm_pri renaming patches could
+be removed.
 
 Tracked-On: OAM-88717
 Signed-off-by: yifang ma <yifangx.ma@intel.com>
+Signed-off-by: Chenglei Ren <chenglei.ren@intel.com>
 ---
  Android.bp                        |  8 ++++----
  Android.sources.bp                |  2 +-
  amdgpu/Android.bp                 |  8 ++++----
  amdgpu/Android.sources.bp         |  2 +-
+ data/Android.bp                   |  2 +-
  etnaviv/Android.bp                |  8 ++++----
  etnaviv/Android.sources.bp        |  2 +-
  freedreno/Android.bp              |  8 ++++----
@@ -24,7 +28,9 @@ Signed-off-by: yifang ma <yifangx.ma@intel.com>
  nouveau/Android.bp                |  8 ++++----
  nouveau/Android.sources.bp        |  2 +-
  omap/Android.bp                   |  4 ++--
+ omap/Android.sources.bp           |  2 +-
  radeon/Android.bp                 |  4 ++--
+ radeon/Android.sources.bp         |  2 +-
  tegra/Android.bp                  |  4 ++--
  tests/Android.bp                  |  2 +-
  tests/modetest/Android.bp         | 10 +++++-----
@@ -32,10 +38,10 @@ Signed-off-by: yifang ma <yifangx.ma@intel.com>
  tests/proptest/Android.bp         |  6 +++---
  tests/util/Android.bp             | 12 ++++++------
  tests/util/Android.sources.bp     |  2 +-
- 23 files changed, 66 insertions(+), 66 deletions(-)
+ 26 files changed, 69 insertions(+), 69 deletions(-)
 
 diff --git a/Android.bp b/Android.bp
-index 6fe434c..a075d8e 100644
+index 6fe434c6ee66..a075d8e55ee1 100644
 --- a/Android.bp
 +++ b/Android.bp
 @@ -25,7 +25,7 @@ subdirs = ["*"]
@@ -64,7 +70,7 @@ index 6fe434c..a075d8e 100644
  
      export_include_dirs: ["include/drm", "android"],
 diff --git a/Android.sources.bp b/Android.sources.bp
-index 73356dd..1e4f801 100644
+index 73356dd80a37..1e4f8013ed4c 100644
 --- a/Android.sources.bp
 +++ b/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -77,7 +83,7 @@ index 73356dd..1e4f801 100644
          "xf86drm.c",
          "xf86drmHash.c",
 diff --git a/amdgpu/Android.bp b/amdgpu/Android.bp
-index 976f03e..e999eda 100644
+index 976f03e9d617..e999edae900e 100644
 --- a/amdgpu/Android.bp
 +++ b/amdgpu/Android.bp
 @@ -1,16 +1,16 @@
@@ -102,7 +108,7 @@ index 976f03e..e999eda 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/amdgpu/Android.sources.bp b/amdgpu/Android.sources.bp
-index be85283..653ef89 100644
+index ed85682aaa2f..62952f95cce1 100644
 --- a/amdgpu/Android.sources.bp
 +++ b/amdgpu/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -114,8 +120,19 @@ index be85283..653ef89 100644
      srcs: [
  	"amdgpu_asic_id.c",
          "amdgpu_bo.c",
+diff --git a/data/Android.bp b/data/Android.bp
+index 47f64371a4ca..a83777fdcb07 100644
+--- a/data/Android.bp
++++ b/data/Android.bp
+@@ -1,5 +1,5 @@
+ prebuilt_etc {
+-    name: "amdgpu.ids",
++    name: "amdgpu.ids_orig",
+     proprietary: true,
+     sub_dir: "hwdata",
+     src: "amdgpu.ids",
 diff --git a/etnaviv/Android.bp b/etnaviv/Android.bp
-index 21deda9..fdddc65 100644
+index 21deda99900d..fdddc6532120 100644
 --- a/etnaviv/Android.bp
 +++ b/etnaviv/Android.bp
 @@ -1,11 +1,11 @@
@@ -135,7 +152,7 @@ index 21deda9..fdddc65 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/etnaviv/Android.sources.bp b/etnaviv/Android.sources.bp
-index aa82890..aaed155 100644
+index aa8289009b93..aaed1558f329 100644
 --- a/etnaviv/Android.sources.bp
 +++ b/etnaviv/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -148,7 +165,7 @@ index aa82890..aaed155 100644
          "etnaviv_device.c",
          "etnaviv_gpu.c",
 diff --git a/freedreno/Android.bp b/freedreno/Android.bp
-index 9fca9b1..3d20772 100644
+index 9fca9b1260d6..3d20772e5338 100644
 --- a/freedreno/Android.bp
 +++ b/freedreno/Android.bp
 @@ -1,11 +1,11 @@
@@ -168,7 +185,7 @@ index 9fca9b1..3d20772 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/freedreno/Android.sources.bp b/freedreno/Android.sources.bp
-index 3c1ca31..808608c 100644
+index 3c1ca316a5c9..808608c50bf0 100644
 --- a/freedreno/Android.sources.bp
 +++ b/freedreno/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -181,7 +198,7 @@ index 3c1ca31..808608c 100644
          "freedreno_device.c",
          "freedreno_pipe.c",
 diff --git a/intel/Android.bp b/intel/Android.bp
-index 22713ac..05aba7f 100644
+index 22713acc8405..05aba7f77f72 100644
 --- a/intel/Android.bp
 +++ b/intel/Android.bp
 @@ -24,13 +24,13 @@
@@ -203,7 +220,7 @@ index 22713ac..05aba7f 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/intel/Android.sources.bp b/intel/Android.sources.bp
-index 46e0328..e968e2e 100644
+index 459c070fa580..a6e789ab7f4d 100644
 --- a/intel/Android.sources.bp
 +++ b/intel/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -216,7 +233,7 @@ index 46e0328..e968e2e 100644
          "intel_bufmgr.c",
          "intel_bufmgr_fake.c",
 diff --git a/libkms/Android.bp b/libkms/Android.bp
-index b09dbf4..6521911 100644
+index b09dbf42f885..65219110f123 100644
 --- a/libkms/Android.bp
 +++ b/libkms/Android.bp
 @@ -1,15 +1,15 @@
@@ -244,7 +261,7 @@ index b09dbf4..6521911 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/libkms/Android.sources.bp b/libkms/Android.sources.bp
-index 5582f23..3addc57 100644
+index 5582f2356cae..3addc57dd1bb 100644
 --- a/libkms/Android.sources.bp
 +++ b/libkms/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -290,7 +307,7 @@ index 5582f23..3addc57 100644
          "radeon.c",
      ],
 diff --git a/nouveau/Android.bp b/nouveau/Android.bp
-index 12c37e3..a8a504d 100644
+index 12c37e3dc29b..a8a504dcbc56 100644
 --- a/nouveau/Android.bp
 +++ b/nouveau/Android.bp
 @@ -1,11 +1,11 @@
@@ -310,7 +327,7 @@ index 12c37e3..a8a504d 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/nouveau/Android.sources.bp b/nouveau/Android.sources.bp
-index 5ecdb53..72012e5 100644
+index 5ecdb53c80a8..72012e55d652 100644
 --- a/nouveau/Android.sources.bp
 +++ b/nouveau/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -323,7 +340,7 @@ index 5ecdb53..72012e5 100644
          "nouveau.c",
          "pushbuf.c",
 diff --git a/omap/Android.bp b/omap/Android.bp
-index 05ca7d2..9c06cb4 100644
+index 05ca7d2db79b..9c06cb4e8fa3 100644
 --- a/omap/Android.bp
 +++ b/omap/Android.bp
 @@ -1,12 +1,12 @@
@@ -341,8 +358,21 @@ index 05ca7d2..9c06cb4 100644
 -    shared_libs: ["libdrm"],
 +    shared_libs: ["libdrm_orig"],
  }
+diff --git a/omap/Android.sources.bp b/omap/Android.sources.bp
+index 3c7da94a4b18..2491fa9a35c9 100644
+--- a/omap/Android.sources.bp
++++ b/omap/Android.sources.bp
+@@ -1,7 +1,7 @@
+ // Autogenerated with Android.sources.bp.mk
+ 
+ cc_defaults {
+-    name: "libdrm_omap_sources",
++    name: "libdrm_omap_sources_orig",
+     srcs: [
+ 	"omap_drm.c",
+     ],
 diff --git a/radeon/Android.bp b/radeon/Android.bp
-index 9d0a09e..f2bd52e 100644
+index 9d0a09ec718a..f2bd52e9779a 100644
 --- a/radeon/Android.bp
 +++ b/radeon/Android.bp
 @@ -1,11 +1,11 @@
@@ -359,8 +389,21 @@ index 9d0a09e..f2bd52e 100644
 -    shared_libs: ["libdrm"],
 +    shared_libs: ["libdrm_orig"],
  }
+diff --git a/radeon/Android.sources.bp b/radeon/Android.sources.bp
+index 820ac4d6d4ed..3d004f02003f 100644
+--- a/radeon/Android.sources.bp
++++ b/radeon/Android.sources.bp
+@@ -1,7 +1,7 @@
+ // Autogenerated with Android.sources.bp.mk
+ 
+ cc_defaults {
+-    name: "libdrm_radeon_sources",
++    name: "libdrm_radeon_sources_orig",
+     srcs: [
+         "radeon_bo_gem.c",
+         "radeon_cs_gem.c",
 diff --git a/tegra/Android.bp b/tegra/Android.bp
-index 33eaf6c..3839ebd 100644
+index 33eaf6c50eb5..3839ebde8039 100644
 --- a/tegra/Android.bp
 +++ b/tegra/Android.bp
 @@ -1,7 +1,7 @@
@@ -374,7 +417,7 @@ index 33eaf6c..3839ebd 100644
      srcs: ["tegra.c"],
  
 diff --git a/tests/Android.bp b/tests/Android.bp
-index cdc6c2c..696bcac 100644
+index cdc6c2cf350f..696bcac4f7f7 100644
 --- a/tests/Android.bp
 +++ b/tests/Android.bp
 @@ -1,6 +1,6 @@
@@ -386,7 +429,7 @@ index cdc6c2c..696bcac 100644
      export_include_dirs: ["."],
  }
 diff --git a/tests/modetest/Android.bp b/tests/modetest/Android.bp
-index ca811fe..791f9a2 100644
+index ca811fee05e9..791f9a21f256 100644
 --- a/tests/modetest/Android.bp
 +++ b/tests/modetest/Android.bp
 @@ -1,12 +1,12 @@
@@ -408,7 +451,7 @@ index ca811fe..791f9a2 100644
 +    static_libs: ["libdrm_util_orig"],
  }
 diff --git a/tests/modetest/Android.sources.bp b/tests/modetest/Android.sources.bp
-index c6aca2e..e510bfe 100644
+index c6aca2ef757e..e510bfe84b7b 100644
 --- a/tests/modetest/Android.sources.bp
 +++ b/tests/modetest/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -421,7 +464,7 @@ index c6aca2e..e510bfe 100644
          "buffers.c",
          "cursor.c",
 diff --git a/tests/proptest/Android.bp b/tests/proptest/Android.bp
-index 28c87e9..89affae 100644
+index 28c87e91040a..89affae20b2a 100644
 --- a/tests/proptest/Android.bp
 +++ b/tests/proptest/Android.bp
 @@ -1,8 +1,8 @@
@@ -437,7 +480,7 @@ index 28c87e9..89affae 100644
 +    static_libs: ["libdrm_util_orig"],
  }
 diff --git a/tests/util/Android.bp b/tests/util/Android.bp
-index 36d1820..4aac168 100644
+index 36d18206d6bb..4aac168f49cc 100644
 --- a/tests/util/Android.bp
 +++ b/tests/util/Android.bp
 @@ -24,12 +24,12 @@
@@ -460,7 +503,7 @@ index 36d1820..4aac168 100644
 +    export_header_lib_headers: ["libdrm_test_headers_orig"],
  }
 diff --git a/tests/util/Android.sources.bp b/tests/util/Android.sources.bp
-index 529e112..c9a6f1a 100644
+index 529e1124ed9f..c9a6f1a06ee1 100644
 --- a/tests/util/Android.sources.bp
 +++ b/tests/util/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -473,5 +516,5 @@ index 529e112..c9a6f1a 100644
          "format.c",
          "kms.c",
 -- 
-2.7.4
+2.17.1
 


### PR DESCRIPTION
As we have one round of IA libdrm rebase work. We
need rebase the AOSP libdrm diff patch. This could
help fix the Android building issue.

Tracked-On: OAM-92079
Signed-off-by: Chenglei Ren <chenglei.ren@intel.com>