### PR TITLE
drm/i915/gt: Schedule request retirement for gen10+

### DIFF
--- a/bsp_diff/caas/kernel/lts2019-chromium/09_0009-drm-i915-gt-Schedule-request-retirement-for-gen10.patch
+++ b/bsp_diff/caas/kernel/lts2019-chromium/09_0009-drm-i915-gt-Schedule-request-retirement-for-gen10.patch
@@ -1,0 +1,47 @@
+From 1a011a3f0d9608a820441905304b684257d936d4 Mon Sep 17 00:00:00 2001
+From: Shaofeng Tang <shaofeng.tang@intel.com>
+Date: Thu, 27 Aug 2020 19:44:00 +0800
+Subject: [PATCH] drm/i915/gt: Schedule request retirement for gen10+
+
+In CML, "Schedule request retirement when timeline idles" might
+introduce random drm init failure during reboot. This change is
+to enable schedule request retirement on Gen10+
+
+Tracked-On: OAM-91972
+Signed-off-by: Romli, Khairul Anuar <khairul.anuar.romli@intel.com>
+Signed-off-by: Junxiao Chang <junxiao.chang@intel.com>
+Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>
+---
+ drivers/gpu/drm/i915/gt/intel_lrc.c | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/gt/intel_lrc.c b/drivers/gpu/drm/i915/gt/intel_lrc.c
+index 51b02ef..b953e37 100644
+--- a/drivers/gpu/drm/i915/gt/intel_lrc.c
++++ b/drivers/gpu/drm/i915/gt/intel_lrc.c
+@@ -1272,13 +1272,15 @@ __execlists_schedule_out(struct i915_request *rq,
+ 	 * refrain from doing non-trivial work here.
+ 	 */
+ 
+-	/*
+-	 * If we have just completed this context, the engine may now be
+-	 * idle and we want to re-enter powersaving.
+-	 */
+-	if (list_is_last(&rq->link, &ce->timeline->requests) &&
+-	    i915_request_completed(rq))
+-		intel_engine_add_retire(engine, ce->timeline);
++	if (INTEL_GEN(engine->i915) >= 10) {
++		/*
++		 * If we have just completed this context, the engine
++		 * may now be idle and we want to re-enter powersaving.
++		 */
++		if (list_is_last(&rq->link, &ce->timeline->requests) &&
++		    i915_request_completed(rq))
++			intel_engine_add_retire(engine, ce->timeline);
++	}
+ 
+ 	intel_engine_context_out(engine);
+ 	execlists_context_status_change(rq, INTEL_CONTEXT_SCHEDULE_OUT);
+-- 
+2.9.2
+


### PR DESCRIPTION
In CML, "Schedule request retirement when timeline idles" might
introduce random drm init failure during reboot. This change is
to enable schedule request retirement on Gen10+

Tracked-On: OAM-91972
Signed-off-by: Romli, Khairul Anuar <khairul.anuar.romli@intel.com>
Signed-off-by: Junxiao Chang <junxiao.chang@intel.com>
Signed-off-by: Shaofeng Tang <shaofeng.tang@intel.com>