### PR TITLE
CiV: HOST kernel: Add KVM patch which support wait-for-SIPI and SIPI-VMExit

### DIFF
--- a/host/kernel/lts2019-chromium/0001-BACKPORT-v5.4-KVM-VMX-Consume-pending-LAPIC-INIT-event-when-exit-o.patch
+++ b/host/kernel/lts2019-chromium/0001-BACKPORT-v5.4-KVM-VMX-Consume-pending-LAPIC-INIT-event-when-exit-o.patch
@@ -1,0 +1,49 @@
+From 4c24581c73ad3d1b6ca179ca65eed38b6ac41898 Mon Sep 17 00:00:00 2001
+From: Liran Alon <liran.alon@oracle.com>
+Date: Mon, 11 Nov 2019 14:16:05 +0200
+Subject: [PATCH 1/2] KVM: VMX: Consume pending LAPIC INIT event when exit on
+ INIT_SIGNAL
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Intel SDM section 25.2 OTHER CAUSES OF VM EXITS specifies the following
+on INIT signals: "Such exits do not modify register state or clear pending
+events as they would outside of VMX operation."
+
+When commit 4b9852f4f389 ("KVM: x86: Fix INIT signal handling in various CPU states")
+was applied, I interepted above Intel SDM statement such that
+INIT_SIGNAL exit don’t consume the LAPIC INIT pending event.
+
+However, when Nadav Amit run matching kvm-unit-test on a bare-metal
+machine, it turned out my interpetation was wrong. i.e. INIT_SIGNAL
+exit does consume the LAPIC INIT pending event.
+(See: https://www.spinics.net/lists/kvm/msg196757.html)
+
+Therefore, fix KVM code to behave as observed on bare-metal.
+
+Fixes: 4b9852f4f389 ("KVM: x86: Fix INIT signal handling in various CPU states")
+Reported-by: Nadav Amit <nadav.amit@gmail.com>
+Reviewed-by: Mihai Carabas <mihai.carabas@oracle.com>
+Reviewed-by: Joao Martins <joao.m.martins@oracle.com>
+Signed-off-by: Liran Alon <liran.alon@oracle.com>
+Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>
+---
+ arch/x86/kvm/vmx/nested.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/x86/kvm/vmx/nested.c b/arch/x86/kvm/vmx/nested.c
+index a460ddf04d60..461981cf6dac 100644
+--- a/arch/x86/kvm/vmx/nested.c
++++ b/arch/x86/kvm/vmx/nested.c
+@@ -3472,6 +3472,7 @@ static int vmx_check_nested_events(struct kvm_vcpu *vcpu)
+ 		test_bit(KVM_APIC_INIT, &apic->pending_events)) {
+ 		if (block_nested_events)
+ 			return -EBUSY;
++		clear_bit(KVM_APIC_INIT, &apic->pending_events);
+ 		nested_vmx_vmexit(vcpu, EXIT_REASON_INIT_SIGNAL, 0, 0);
+ 		return 0;
+ 	}
+-- 
+2.25.1
+

--- a/host/kernel/lts2019-chromium/0002-BACKPORT-v5.4-KVM-x86-emulate-wait-for-SIPI-and-SIPI-VMExit.patch
+++ b/host/kernel/lts2019-chromium/0002-BACKPORT-v5.4-KVM-x86-emulate-wait-for-SIPI-and-SIPI-VMExit.patch
@@ -1,0 +1,186 @@
+From 4023b3385de2f39d7c87b67b06e2dc966ac3cdc5 Mon Sep 17 00:00:00 2001
+From: Yadong Qi <yadong.qi@intel.com>
+Date: Thu, 3 Sep 2020 16:20:10 +0800
+Subject: [PATCH 2/2] KVM: x86: emulate wait-for-SIPI and SIPI-VMExit
+
+Background: We have a lightweight HV, it needs INIT-VMExit and
+SIPI-VMExit to wake-up APs for guests since it do not monitoring
+the Local APIC. But currently virtual wait-for-SIPI(WFS) state
+is not supported in KVM, so when running on top of KVM, the L1
+HV cannot receive the INIT-VMExit and SIPI-VMExit which cause
+the L2 guest cannot wake up the APs.
+
+This patch is incomplete, it emulated wait-for-SIPI state by halt
+the vCPU and emulated SIPI-VMExit to L1 when trapped SIPI signal
+from L2. I am posting it RFC to gauge whether or not upstream
+KVM is interested in emulating wait-for-SIPI state before
+investing the time to finish the full support.
+
+According to Intel SDM Chapter 25.2 Other Causes of VM Exits,
+SIPIs cause VM exits when a logical processor is in
+wait-for-SIPI state.
+
+In this patch:
+    1. introduce SIPI exit reason,
+    2. introduce wait-for-SIPI state for nVMX,
+    3. advertise wait-for-SIPI support to guest.
+
+When L1 hypervisor do not trap Local APIC, L0 need to emulate
+INIT-VMExit and SIPI-VMExit to L1 to emulate INIT-SIPI-SIPI for
+L2.
+L2 guest would be traped by L0 Hypervisor(KVM), L0 should emulate
+the INIT-SIPI-SIPI vmexit to L1 hypervisor to set proper state for
+L2's vcpu state.
+
+Handle procdure:
+Source vCPU:
+    L2 write LAPIC.ICR(INIT).
+    L0 trap LAPIC.ICR write(INIT): inject a latched INIT event to target
+       vCPU.
+Target vCPU:
+    L0 emulate an INIT VMExit to L1 if is guest mode.
+    L1 set guest VMCS, guest_activity_state=WAIT_SIPI, vmresume.
+    L0 halt vCPU if (vmcs12.guest_activity_state == WAIT_SIPI).
+
+Source vCPU:
+    L2 write LAPIC.ICR(SIPI).
+    L0 trap LAPIC.ICR write(INIT): inject a latched SIPI event to traget
+       vCPU.
+Target vCPU:
+    L0 emulate an SIPI VMExit to L1 if (vmcs12.guest_activity_state ==
+       WAIT_SIPI).
+    L1 set CS:IP, guest_activity_state=ACTIVE, vmresume
+    L0 resume to L2
+    L2 start-up
+
+Signed-off-by: Yadong Qi <yadong.qi@intel.com>
+---
+ arch/x86/include/asm/vmx.h      |  1 +
+ arch/x86/include/uapi/asm/vmx.h |  2 ++
+ arch/x86/kvm/lapic.c            |  5 +++--
+ arch/x86/kvm/vmx/nested.c       | 24 ++++++++++++++++++++----
+ 4 files changed, 26 insertions(+), 6 deletions(-)
+
+diff --git a/arch/x86/include/asm/vmx.h b/arch/x86/include/asm/vmx.h
+index 1835767aa335..0b51f769becc 100644
+--- a/arch/x86/include/asm/vmx.h
++++ b/arch/x86/include/asm/vmx.h
+@@ -110,6 +110,7 @@
+ #define VMX_MISC_PREEMPTION_TIMER_RATE_MASK	0x0000001f
+ #define VMX_MISC_SAVE_EFER_LMA			0x00000020
+ #define VMX_MISC_ACTIVITY_HLT			0x00000040
++#define VMX_MISC_ACTIVITY_WAIT_SIPI		0x00000100
+ #define VMX_MISC_ZERO_LEN_INS			0x40000000
+ #define VMX_MISC_MSR_LIST_MULTIPLIER		512
+ 
+diff --git a/arch/x86/include/uapi/asm/vmx.h b/arch/x86/include/uapi/asm/vmx.h
+index 3eb8411ab60e..daa0c7e71784 100644
+--- a/arch/x86/include/uapi/asm/vmx.h
++++ b/arch/x86/include/uapi/asm/vmx.h
+@@ -32,6 +32,7 @@
+ #define EXIT_REASON_EXTERNAL_INTERRUPT  1
+ #define EXIT_REASON_TRIPLE_FAULT        2
+ #define EXIT_REASON_INIT_SIGNAL			3
++#define EXIT_REASON_SIPI_SIGNAL         4
+ 
+ #define EXIT_REASON_PENDING_INTERRUPT   7
+ #define EXIT_REASON_NMI_WINDOW          8
+@@ -94,6 +95,7 @@
+ 	{ EXIT_REASON_EXTERNAL_INTERRUPT,    "EXTERNAL_INTERRUPT" }, \
+ 	{ EXIT_REASON_TRIPLE_FAULT,          "TRIPLE_FAULT" }, \
+ 	{ EXIT_REASON_INIT_SIGNAL,           "INIT_SIGNAL" }, \
++	{ EXIT_REASON_SIPI_SIGNAL,           "SIPI_SIGNAL" }, \
+ 	{ EXIT_REASON_PENDING_INTERRUPT,     "PENDING_INTERRUPT" }, \
+ 	{ EXIT_REASON_NMI_WINDOW,            "NMI_WINDOW" }, \
+ 	{ EXIT_REASON_TASK_SWITCH,           "TASK_SWITCH" }, \
+diff --git a/arch/x86/kvm/lapic.c b/arch/x86/kvm/lapic.c
+index 6920f1d3b66f..ff8382853c64 100644
+--- a/arch/x86/kvm/lapic.c
++++ b/arch/x86/kvm/lapic.c
+@@ -2707,7 +2707,7 @@ void kvm_apic_accept_events(struct kvm_vcpu *vcpu)
+ 
+ 	/*
+ 	 * INITs are latched while CPU is in specific states
+-	 * (SMM, VMX non-root mode, SVM with GIF=0).
++	 * (SMM, SVM with GIF=0).
+ 	 * Because a CPU cannot be in these states immediately
+ 	 * after it has processed an INIT signal (and thus in
+ 	 * KVM_MP_STATE_INIT_RECEIVED state), just eat SIPIs
+@@ -2715,7 +2715,8 @@ void kvm_apic_accept_events(struct kvm_vcpu *vcpu)
+ 	 */
+ 	if (is_smm(vcpu) || kvm_x86_ops->apic_init_signal_blocked(vcpu)) {
+ 		WARN_ON_ONCE(vcpu->arch.mp_state == KVM_MP_STATE_INIT_RECEIVED);
+-		if (test_bit(KVM_APIC_SIPI, &apic->pending_events))
++		if (test_bit(KVM_APIC_SIPI, &apic->pending_events) &&
++		    !is_guest_mode(vcpu))
+ 			clear_bit(KVM_APIC_SIPI, &apic->pending_events);
+ 		return;
+ 	}
+diff --git a/arch/x86/kvm/vmx/nested.c b/arch/x86/kvm/vmx/nested.c
+index 461981cf6dac..830e99224b81 100644
+--- a/arch/x86/kvm/vmx/nested.c
++++ b/arch/x86/kvm/vmx/nested.c
+@@ -2763,7 +2763,8 @@ static int nested_vmx_check_vmcs_link_ptr(struct kvm_vcpu *vcpu,
+ static int nested_check_guest_non_reg_state(struct vmcs12 *vmcs12)
+ {
+ 	if (CC(vmcs12->guest_activity_state != GUEST_ACTIVITY_ACTIVE &&
+-	       vmcs12->guest_activity_state != GUEST_ACTIVITY_HLT))
++	       vmcs12->guest_activity_state != GUEST_ACTIVITY_HLT &&
++	       vmcs12->guest_activity_state != GUEST_ACTIVITY_WAIT_SIPI))
+ 		return -EINVAL;
+ 
+ 	return 0;
+@@ -3282,7 +3283,8 @@ static int nested_vmx_run(struct kvm_vcpu *vcpu, bool launch)
+ 	 * awakened by event injection or by an NMI-window VM-exit or
+ 	 * by an interrupt-window VM-exit, halt the vcpu.
+ 	 */
+-	if ((vmcs12->guest_activity_state == GUEST_ACTIVITY_HLT) &&
++	if (((vmcs12->guest_activity_state == GUEST_ACTIVITY_HLT) ||
++	    (vmcs12->guest_activity_state == GUEST_ACTIVITY_WAIT_SIPI)) &&
+ 	    !(vmcs12->vm_entry_intr_info_field & INTR_INFO_VALID_MASK) &&
+ 	    !(vmcs12->cpu_based_vm_exec_control & CPU_BASED_VIRTUAL_NMI_PENDING) &&
+ 	    !((vmcs12->cpu_based_vm_exec_control & CPU_BASED_VIRTUAL_INTR_PENDING) &&
+@@ -3467,16 +3469,29 @@ static int vmx_check_nested_events(struct kvm_vcpu *vcpu)
+ 	bool block_nested_events =
+ 	    vmx->nested.nested_run_pending || kvm_event_needs_reinjection(vcpu);
+ 	struct kvm_lapic *apic = vcpu->arch.apic;
++	struct vmcs12 *vmcs12 = get_vmcs12(vcpu);
+ 
+ 	if (lapic_in_kernel(vcpu) &&
+ 		test_bit(KVM_APIC_INIT, &apic->pending_events)) {
+ 		if (block_nested_events)
+ 			return -EBUSY;
+ 		clear_bit(KVM_APIC_INIT, &apic->pending_events);
+-		nested_vmx_vmexit(vcpu, EXIT_REASON_INIT_SIGNAL, 0, 0);
++		if (vmcs12->guest_activity_state != GUEST_ACTIVITY_WAIT_SIPI)
++			nested_vmx_vmexit(vcpu, EXIT_REASON_INIT_SIGNAL, 0, 0);
+ 		return 0;
+ 	}
+ 
++	if (lapic_in_kernel(vcpu) &&
++	    test_bit(KVM_APIC_SIPI, &apic->pending_events)) {
++		if (block_nested_events)
++			return -EBUSY;
++
++		clear_bit(KVM_APIC_SIPI, &apic->pending_events);
++		if (vmcs12->guest_activity_state == GUEST_ACTIVITY_WAIT_SIPI)
++			nested_vmx_vmexit(vcpu, EXIT_REASON_SIPI_SIGNAL, 0,
++						apic->sipi_vector & 0xFFUL);
++	}
++
+ 	if (vcpu->arch.exception.pending &&
+ 		nested_vmx_check_exception(vcpu, &exit_qual)) {
+ 		if (block_nested_events)
+@@ -5984,7 +5999,8 @@ void nested_vmx_setup_ctls_msrs(struct nested_vmx_msrs *msrs, u32 ept_caps)
+ 	msrs->misc_low |=
+ 		MSR_IA32_VMX_MISC_VMWRITE_SHADOW_RO_FIELDS |
+ 		VMX_MISC_EMULATED_PREEMPTION_TIMER_RATE |
+-		VMX_MISC_ACTIVITY_HLT;
++		VMX_MISC_ACTIVITY_HLT |
++		VMX_MISC_ACTIVITY_WAIT_SIPI;
+ 	msrs->misc_high = 0;
+ 
+ 	/*
+-- 
+2.25.1
+

--- a/host/kernel/lts2019-yocto/0001-BACKPORT-v5.4-KVM-VMX-Consume-pending-LAPIC-INIT-event-when-exit-o.patch
+++ b/host/kernel/lts2019-yocto/0001-BACKPORT-v5.4-KVM-VMX-Consume-pending-LAPIC-INIT-event-when-exit-o.patch
@@ -1,0 +1,49 @@
+From 4c24581c73ad3d1b6ca179ca65eed38b6ac41898 Mon Sep 17 00:00:00 2001
+From: Liran Alon <liran.alon@oracle.com>
+Date: Mon, 11 Nov 2019 14:16:05 +0200
+Subject: [PATCH 1/2] KVM: VMX: Consume pending LAPIC INIT event when exit on
+ INIT_SIGNAL
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Intel SDM section 25.2 OTHER CAUSES OF VM EXITS specifies the following
+on INIT signals: "Such exits do not modify register state or clear pending
+events as they would outside of VMX operation."
+
+When commit 4b9852f4f389 ("KVM: x86: Fix INIT signal handling in various CPU states")
+was applied, I interepted above Intel SDM statement such that
+INIT_SIGNAL exit don’t consume the LAPIC INIT pending event.
+
+However, when Nadav Amit run matching kvm-unit-test on a bare-metal
+machine, it turned out my interpetation was wrong. i.e. INIT_SIGNAL
+exit does consume the LAPIC INIT pending event.
+(See: https://www.spinics.net/lists/kvm/msg196757.html)
+
+Therefore, fix KVM code to behave as observed on bare-metal.
+
+Fixes: 4b9852f4f389 ("KVM: x86: Fix INIT signal handling in various CPU states")
+Reported-by: Nadav Amit <nadav.amit@gmail.com>
+Reviewed-by: Mihai Carabas <mihai.carabas@oracle.com>
+Reviewed-by: Joao Martins <joao.m.martins@oracle.com>
+Signed-off-by: Liran Alon <liran.alon@oracle.com>
+Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>
+---
+ arch/x86/kvm/vmx/nested.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/x86/kvm/vmx/nested.c b/arch/x86/kvm/vmx/nested.c
+index a460ddf04d60..461981cf6dac 100644
+--- a/arch/x86/kvm/vmx/nested.c
++++ b/arch/x86/kvm/vmx/nested.c
+@@ -3472,6 +3472,7 @@ static int vmx_check_nested_events(struct kvm_vcpu *vcpu)
+ 		test_bit(KVM_APIC_INIT, &apic->pending_events)) {
+ 		if (block_nested_events)
+ 			return -EBUSY;
++		clear_bit(KVM_APIC_INIT, &apic->pending_events);
+ 		nested_vmx_vmexit(vcpu, EXIT_REASON_INIT_SIGNAL, 0, 0);
+ 		return 0;
+ 	}
+-- 
+2.25.1
+

--- a/host/kernel/lts2019-yocto/0002-BACKPORT-v5.4-KVM-x86-emulate-wait-for-SIPI-and-SIPI-VMExit.patch
+++ b/host/kernel/lts2019-yocto/0002-BACKPORT-v5.4-KVM-x86-emulate-wait-for-SIPI-and-SIPI-VMExit.patch
@@ -1,0 +1,186 @@
+From 4023b3385de2f39d7c87b67b06e2dc966ac3cdc5 Mon Sep 17 00:00:00 2001
+From: Yadong Qi <yadong.qi@intel.com>
+Date: Thu, 3 Sep 2020 16:20:10 +0800
+Subject: [PATCH 2/2] KVM: x86: emulate wait-for-SIPI and SIPI-VMExit
+
+Background: We have a lightweight HV, it needs INIT-VMExit and
+SIPI-VMExit to wake-up APs for guests since it do not monitoring
+the Local APIC. But currently virtual wait-for-SIPI(WFS) state
+is not supported in KVM, so when running on top of KVM, the L1
+HV cannot receive the INIT-VMExit and SIPI-VMExit which cause
+the L2 guest cannot wake up the APs.
+
+This patch is incomplete, it emulated wait-for-SIPI state by halt
+the vCPU and emulated SIPI-VMExit to L1 when trapped SIPI signal
+from L2. I am posting it RFC to gauge whether or not upstream
+KVM is interested in emulating wait-for-SIPI state before
+investing the time to finish the full support.
+
+According to Intel SDM Chapter 25.2 Other Causes of VM Exits,
+SIPIs cause VM exits when a logical processor is in
+wait-for-SIPI state.
+
+In this patch:
+    1. introduce SIPI exit reason,
+    2. introduce wait-for-SIPI state for nVMX,
+    3. advertise wait-for-SIPI support to guest.
+
+When L1 hypervisor do not trap Local APIC, L0 need to emulate
+INIT-VMExit and SIPI-VMExit to L1 to emulate INIT-SIPI-SIPI for
+L2.
+L2 guest would be traped by L0 Hypervisor(KVM), L0 should emulate
+the INIT-SIPI-SIPI vmexit to L1 hypervisor to set proper state for
+L2's vcpu state.
+
+Handle procdure:
+Source vCPU:
+    L2 write LAPIC.ICR(INIT).
+    L0 trap LAPIC.ICR write(INIT): inject a latched INIT event to target
+       vCPU.
+Target vCPU:
+    L0 emulate an INIT VMExit to L1 if is guest mode.
+    L1 set guest VMCS, guest_activity_state=WAIT_SIPI, vmresume.
+    L0 halt vCPU if (vmcs12.guest_activity_state == WAIT_SIPI).
+
+Source vCPU:
+    L2 write LAPIC.ICR(SIPI).
+    L0 trap LAPIC.ICR write(INIT): inject a latched SIPI event to traget
+       vCPU.
+Target vCPU:
+    L0 emulate an SIPI VMExit to L1 if (vmcs12.guest_activity_state ==
+       WAIT_SIPI).
+    L1 set CS:IP, guest_activity_state=ACTIVE, vmresume
+    L0 resume to L2
+    L2 start-up
+
+Signed-off-by: Yadong Qi <yadong.qi@intel.com>
+---
+ arch/x86/include/asm/vmx.h      |  1 +
+ arch/x86/include/uapi/asm/vmx.h |  2 ++
+ arch/x86/kvm/lapic.c            |  5 +++--
+ arch/x86/kvm/vmx/nested.c       | 24 ++++++++++++++++++++----
+ 4 files changed, 26 insertions(+), 6 deletions(-)
+
+diff --git a/arch/x86/include/asm/vmx.h b/arch/x86/include/asm/vmx.h
+index 1835767aa335..0b51f769becc 100644
+--- a/arch/x86/include/asm/vmx.h
++++ b/arch/x86/include/asm/vmx.h
+@@ -110,6 +110,7 @@
+ #define VMX_MISC_PREEMPTION_TIMER_RATE_MASK	0x0000001f
+ #define VMX_MISC_SAVE_EFER_LMA			0x00000020
+ #define VMX_MISC_ACTIVITY_HLT			0x00000040
++#define VMX_MISC_ACTIVITY_WAIT_SIPI		0x00000100
+ #define VMX_MISC_ZERO_LEN_INS			0x40000000
+ #define VMX_MISC_MSR_LIST_MULTIPLIER		512
+ 
+diff --git a/arch/x86/include/uapi/asm/vmx.h b/arch/x86/include/uapi/asm/vmx.h
+index 3eb8411ab60e..daa0c7e71784 100644
+--- a/arch/x86/include/uapi/asm/vmx.h
++++ b/arch/x86/include/uapi/asm/vmx.h
+@@ -32,6 +32,7 @@
+ #define EXIT_REASON_EXTERNAL_INTERRUPT  1
+ #define EXIT_REASON_TRIPLE_FAULT        2
+ #define EXIT_REASON_INIT_SIGNAL			3
++#define EXIT_REASON_SIPI_SIGNAL         4
+ 
+ #define EXIT_REASON_PENDING_INTERRUPT   7
+ #define EXIT_REASON_NMI_WINDOW          8
+@@ -94,6 +95,7 @@
+ 	{ EXIT_REASON_EXTERNAL_INTERRUPT,    "EXTERNAL_INTERRUPT" }, \
+ 	{ EXIT_REASON_TRIPLE_FAULT,          "TRIPLE_FAULT" }, \
+ 	{ EXIT_REASON_INIT_SIGNAL,           "INIT_SIGNAL" }, \
++	{ EXIT_REASON_SIPI_SIGNAL,           "SIPI_SIGNAL" }, \
+ 	{ EXIT_REASON_PENDING_INTERRUPT,     "PENDING_INTERRUPT" }, \
+ 	{ EXIT_REASON_NMI_WINDOW,            "NMI_WINDOW" }, \
+ 	{ EXIT_REASON_TASK_SWITCH,           "TASK_SWITCH" }, \
+diff --git a/arch/x86/kvm/lapic.c b/arch/x86/kvm/lapic.c
+index 6920f1d3b66f..ff8382853c64 100644
+--- a/arch/x86/kvm/lapic.c
++++ b/arch/x86/kvm/lapic.c
+@@ -2707,7 +2707,7 @@ void kvm_apic_accept_events(struct kvm_vcpu *vcpu)
+ 
+ 	/*
+ 	 * INITs are latched while CPU is in specific states
+-	 * (SMM, VMX non-root mode, SVM with GIF=0).
++	 * (SMM, SVM with GIF=0).
+ 	 * Because a CPU cannot be in these states immediately
+ 	 * after it has processed an INIT signal (and thus in
+ 	 * KVM_MP_STATE_INIT_RECEIVED state), just eat SIPIs
+@@ -2715,7 +2715,8 @@ void kvm_apic_accept_events(struct kvm_vcpu *vcpu)
+ 	 */
+ 	if (is_smm(vcpu) || kvm_x86_ops->apic_init_signal_blocked(vcpu)) {
+ 		WARN_ON_ONCE(vcpu->arch.mp_state == KVM_MP_STATE_INIT_RECEIVED);
+-		if (test_bit(KVM_APIC_SIPI, &apic->pending_events))
++		if (test_bit(KVM_APIC_SIPI, &apic->pending_events) &&
++		    !is_guest_mode(vcpu))
+ 			clear_bit(KVM_APIC_SIPI, &apic->pending_events);
+ 		return;
+ 	}
+diff --git a/arch/x86/kvm/vmx/nested.c b/arch/x86/kvm/vmx/nested.c
+index 461981cf6dac..830e99224b81 100644
+--- a/arch/x86/kvm/vmx/nested.c
++++ b/arch/x86/kvm/vmx/nested.c
+@@ -2763,7 +2763,8 @@ static int nested_vmx_check_vmcs_link_ptr(struct kvm_vcpu *vcpu,
+ static int nested_check_guest_non_reg_state(struct vmcs12 *vmcs12)
+ {
+ 	if (CC(vmcs12->guest_activity_state != GUEST_ACTIVITY_ACTIVE &&
+-	       vmcs12->guest_activity_state != GUEST_ACTIVITY_HLT))
++	       vmcs12->guest_activity_state != GUEST_ACTIVITY_HLT &&
++	       vmcs12->guest_activity_state != GUEST_ACTIVITY_WAIT_SIPI))
+ 		return -EINVAL;
+ 
+ 	return 0;
+@@ -3282,7 +3283,8 @@ static int nested_vmx_run(struct kvm_vcpu *vcpu, bool launch)
+ 	 * awakened by event injection or by an NMI-window VM-exit or
+ 	 * by an interrupt-window VM-exit, halt the vcpu.
+ 	 */
+-	if ((vmcs12->guest_activity_state == GUEST_ACTIVITY_HLT) &&
++	if (((vmcs12->guest_activity_state == GUEST_ACTIVITY_HLT) ||
++	    (vmcs12->guest_activity_state == GUEST_ACTIVITY_WAIT_SIPI)) &&
+ 	    !(vmcs12->vm_entry_intr_info_field & INTR_INFO_VALID_MASK) &&
+ 	    !(vmcs12->cpu_based_vm_exec_control & CPU_BASED_VIRTUAL_NMI_PENDING) &&
+ 	    !((vmcs12->cpu_based_vm_exec_control & CPU_BASED_VIRTUAL_INTR_PENDING) &&
+@@ -3467,16 +3469,29 @@ static int vmx_check_nested_events(struct kvm_vcpu *vcpu)
+ 	bool block_nested_events =
+ 	    vmx->nested.nested_run_pending || kvm_event_needs_reinjection(vcpu);
+ 	struct kvm_lapic *apic = vcpu->arch.apic;
++	struct vmcs12 *vmcs12 = get_vmcs12(vcpu);
+ 
+ 	if (lapic_in_kernel(vcpu) &&
+ 		test_bit(KVM_APIC_INIT, &apic->pending_events)) {
+ 		if (block_nested_events)
+ 			return -EBUSY;
+ 		clear_bit(KVM_APIC_INIT, &apic->pending_events);
+-		nested_vmx_vmexit(vcpu, EXIT_REASON_INIT_SIGNAL, 0, 0);
++		if (vmcs12->guest_activity_state != GUEST_ACTIVITY_WAIT_SIPI)
++			nested_vmx_vmexit(vcpu, EXIT_REASON_INIT_SIGNAL, 0, 0);
+ 		return 0;
+ 	}
+ 
++	if (lapic_in_kernel(vcpu) &&
++	    test_bit(KVM_APIC_SIPI, &apic->pending_events)) {
++		if (block_nested_events)
++			return -EBUSY;
++
++		clear_bit(KVM_APIC_SIPI, &apic->pending_events);
++		if (vmcs12->guest_activity_state == GUEST_ACTIVITY_WAIT_SIPI)
++			nested_vmx_vmexit(vcpu, EXIT_REASON_SIPI_SIGNAL, 0,
++						apic->sipi_vector & 0xFFUL);
++	}
++
+ 	if (vcpu->arch.exception.pending &&
+ 		nested_vmx_check_exception(vcpu, &exit_qual)) {
+ 		if (block_nested_events)
+@@ -5984,7 +5999,8 @@ void nested_vmx_setup_ctls_msrs(struct nested_vmx_msrs *msrs, u32 ept_caps)
+ 	msrs->misc_low |=
+ 		MSR_IA32_VMX_MISC_VMWRITE_SHADOW_RO_FIELDS |
+ 		VMX_MISC_EMULATED_PREEMPTION_TIMER_RATE |
+-		VMX_MISC_ACTIVITY_HLT;
++		VMX_MISC_ACTIVITY_HLT |
++		VMX_MISC_ACTIVITY_WAIT_SIPI;
+ 	msrs->misc_high = 0;
+ 
+ 	/*
+-- 
+2.25.1
+


### PR DESCRIPTION
Add KVM patches which support wait-for-SIPI and SIPI-VMExit.
The patches are backported from:
    https://patchwork.kernel.org/patch/11781275
    https://patchwork.kernel.org/patch/11236869

Tracked-On: OAM-92942
Signed-off-by: Yadong Qi <yadong.qi@intel.com>