### PR TITLE
Add usb printer support

### DIFF
--- a/aosp_diff/caas/system/core/01_1-Add-support-for-creation-of-usb-pri.patch
+++ b/aosp_diff/caas/system/core/01_1-Add-support-for-creation-of-usb-pri.patch
@@ -1,0 +1,46 @@
+From 8f4cca64bf2117f4f62667ce6603db028fb5f740 Mon Sep 17 00:00:00 2001
+From: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+Date: Mon, 24 Feb 2020 11:49:20 +0530
+Subject: [PATCH] Add support for creation of usb printer in android
+
+These changes will allow creation of dev node for usb printer
+connected to android devices
+
+Change-Id: I2c676a924fd703135bfc1b0bbf244a37bb9f8a24
+Tracked-On: None
+Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+---
+ init/devices.cpp   | 4 ++++
+ rootdir/ueventd.rc | 1 +
+ 2 files changed, 5 insertions(+)
+
+diff --git a/init/devices.cpp b/init/devices.cpp
+index 9fbec641b..07adfb80c 100644
+--- a/init/devices.cpp
++++ b/init/devices.cpp
+@@ -492,6 +492,10 @@ void DeviceHandler::HandleUevent(const Uevent& uevent) {
+             int device_id = uevent.minor % 128 + 1;
+             devpath = StringPrintf("/dev/bus/usb/%03d/%03d", bus_id, device_id);
+         }
++    } else if (uevent.subsystem == "usbmisc") {
++        if (!uevent.device_name.empty()) {
++            devpath = "/dev/" + uevent.device_name;
++        }
+     } else if (StartsWith(uevent.subsystem, "usb")) {
+         // ignore other USB events
+         return;
+diff --git a/rootdir/ueventd.rc b/rootdir/ueventd.rc
+index 9c2cdf27f..45ab2ca59 100644
+--- a/rootdir/ueventd.rc
++++ b/rootdir/ueventd.rc
+@@ -37,6 +37,7 @@ subsystem sound
+ /dev/binder               0666   root       root
+ /dev/hwbinder             0666   root       root
+ /dev/vndbinder            0666   root       root
++/dev/usb/lp*		   0666	  root       root
+ 
+ /dev/pmsg0                0222   root       log
+ 
+-- 
+2.21.0
+


### PR DESCRIPTION
This patch enabled the node access for USB Printer.

Tracked-On: OAM-92969
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>