### PR TITLE
Add DRM_FORMAT_ABGR8888 format for virtio on Android

### DIFF
--- a/bsp_diff/caas/kernel/lts2019-chromium/04_0004-Add-AB24-support-for-virtio-on-Android.patch
+++ b/bsp_diff/caas/kernel/lts2019-chromium/04_0004-Add-AB24-support-for-virtio-on-Android.patch
@@ -1,0 +1,69 @@
+From 9ba90e0f161c7e29a899849ec8aa926cf3ed4bee Mon Sep 17 00:00:00 2001
+From: renchenglei <chenglei.ren@intel.com>
+Date: Fri, 8 May 2020 19:43:21 +0800
+Subject: [PATCH] Add AB24 support for virtio on Android
+
+---
+ drivers/gpu/drm/virtio/virtgpu_display.c | 3 ++-
+ drivers/gpu/drm/virtio/virtgpu_plane.c   | 4 ++++
+ include/drm/drm_fourcc.h                 | 2 ++
+ 3 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/virtio/virtgpu_display.c b/drivers/gpu/drm/virtio/virtgpu_display.c
+index e622485ae826..cb8f14b4c9da 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_display.c
++++ b/drivers/gpu/drm/virtio/virtgpu_display.c
+@@ -299,7 +299,8 @@ virtio_gpu_user_framebuffer_create(struct drm_device *dev,
+ 	int ret;
+ 
+ 	if (mode_cmd->pixel_format != DRM_FORMAT_HOST_XRGB8888 &&
+-	    mode_cmd->pixel_format != DRM_FORMAT_HOST_ARGB8888)
++	    mode_cmd->pixel_format != DRM_FORMAT_HOST_ARGB8888 &&
++	    mode_cmd->pixel_format != DRM_FORMAT_HOST_ABGR8888)
+ 		return ERR_PTR(-ENOENT);
+ 
+ 	/* lookup object associated with res handle */
+diff --git a/drivers/gpu/drm/virtio/virtgpu_plane.c b/drivers/gpu/drm/virtio/virtgpu_plane.c
+index a492ac3f4a7e..f01e8156e600 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_plane.c
++++ b/drivers/gpu/drm/virtio/virtgpu_plane.c
+@@ -31,6 +31,7 @@
+ 
+ static const uint32_t virtio_gpu_formats[] = {
+ 	DRM_FORMAT_HOST_XRGB8888,
++	DRM_FORMAT_HOST_ABGR8888,
+ };
+ 
+ static const uint32_t virtio_gpu_cursor_formats[] = {
+@@ -54,6 +55,9 @@ uint32_t virtio_gpu_translate_format(uint32_t drm_fourcc)
+ 	case DRM_FORMAT_BGRA8888:
+ 		format = VIRTIO_GPU_FORMAT_A8R8G8B8_UNORM;
+ 		break;
++	case DRM_FORMAT_ABGR8888:
++                format = VIRTIO_GPU_FORMAT_A8B8G8R8_UNORM;
++                break;
+ 	default:
+ 		/*
+ 		 * This should not happen, we handle everything listed
+diff --git a/include/drm/drm_fourcc.h b/include/drm/drm_fourcc.h
+index 306d1efeb5e0..103994e71352 100644
+--- a/include/drm/drm_fourcc.h
++++ b/include/drm/drm_fourcc.h
+@@ -40,11 +40,13 @@
+ 				       DRM_FORMAT_BIG_ENDIAN)
+ # define DRM_FORMAT_HOST_XRGB8888     DRM_FORMAT_BGRX8888
+ # define DRM_FORMAT_HOST_ARGB8888     DRM_FORMAT_BGRA8888
++# define DRM_FORMAT_HOST_ABGR8888     DRM_FORMAT_ABGR8888
+ #else
+ # define DRM_FORMAT_HOST_XRGB1555     DRM_FORMAT_XRGB1555
+ # define DRM_FORMAT_HOST_RGB565       DRM_FORMAT_RGB565
+ # define DRM_FORMAT_HOST_XRGB8888     DRM_FORMAT_XRGB8888
+ # define DRM_FORMAT_HOST_ARGB8888     DRM_FORMAT_ARGB8888
++# define DRM_FORMAT_HOST_ABGR8888     DRM_FORMAT_ABGR8888
+ #endif
+ 
+ struct drm_device;
+-- 
+2.26.2
+
+

--- a/bsp_diff/caas/kernel/lts2019-yocto/05_0005-Add-AB24-support-for-virtio-on-Android.patch
+++ b/bsp_diff/caas/kernel/lts2019-yocto/05_0005-Add-AB24-support-for-virtio-on-Android.patch
@@ -1,0 +1,69 @@
+From 9ba90e0f161c7e29a899849ec8aa926cf3ed4bee Mon Sep 17 00:00:00 2001
+From: renchenglei <chenglei.ren@intel.com>
+Date: Fri, 8 May 2020 19:43:21 +0800
+Subject: [PATCH] Add AB24 support for virtio on Android
+
+---
+ drivers/gpu/drm/virtio/virtgpu_display.c | 3 ++-
+ drivers/gpu/drm/virtio/virtgpu_plane.c   | 4 ++++
+ include/drm/drm_fourcc.h                 | 2 ++
+ 3 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/virtio/virtgpu_display.c b/drivers/gpu/drm/virtio/virtgpu_display.c
+index e622485ae826..cb8f14b4c9da 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_display.c
++++ b/drivers/gpu/drm/virtio/virtgpu_display.c
+@@ -299,7 +299,8 @@ virtio_gpu_user_framebuffer_create(struct drm_device *dev,
+ 	int ret;
+ 
+ 	if (mode_cmd->pixel_format != DRM_FORMAT_HOST_XRGB8888 &&
+-	    mode_cmd->pixel_format != DRM_FORMAT_HOST_ARGB8888)
++	    mode_cmd->pixel_format != DRM_FORMAT_HOST_ARGB8888 &&
++	    mode_cmd->pixel_format != DRM_FORMAT_HOST_ABGR8888)
+ 		return ERR_PTR(-ENOENT);
+ 
+ 	/* lookup object associated with res handle */
+diff --git a/drivers/gpu/drm/virtio/virtgpu_plane.c b/drivers/gpu/drm/virtio/virtgpu_plane.c
+index a492ac3f4a7e..f01e8156e600 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_plane.c
++++ b/drivers/gpu/drm/virtio/virtgpu_plane.c
+@@ -31,6 +31,7 @@
+ 
+ static const uint32_t virtio_gpu_formats[] = {
+ 	DRM_FORMAT_HOST_XRGB8888,
++	DRM_FORMAT_HOST_ABGR8888,
+ };
+ 
+ static const uint32_t virtio_gpu_cursor_formats[] = {
+@@ -54,6 +55,9 @@ uint32_t virtio_gpu_translate_format(uint32_t drm_fourcc)
+ 	case DRM_FORMAT_BGRA8888:
+ 		format = VIRTIO_GPU_FORMAT_A8R8G8B8_UNORM;
+ 		break;
++	case DRM_FORMAT_ABGR8888:
++                format = VIRTIO_GPU_FORMAT_A8B8G8R8_UNORM;
++                break;
+ 	default:
+ 		/*
+ 		 * This should not happen, we handle everything listed
+diff --git a/include/drm/drm_fourcc.h b/include/drm/drm_fourcc.h
+index 306d1efeb5e0..103994e71352 100644
+--- a/include/drm/drm_fourcc.h
++++ b/include/drm/drm_fourcc.h
+@@ -40,11 +40,13 @@
+ 				       DRM_FORMAT_BIG_ENDIAN)
+ # define DRM_FORMAT_HOST_XRGB8888     DRM_FORMAT_BGRX8888
+ # define DRM_FORMAT_HOST_ARGB8888     DRM_FORMAT_BGRA8888
++# define DRM_FORMAT_HOST_ABGR8888     DRM_FORMAT_ABGR8888
+ #else
+ # define DRM_FORMAT_HOST_XRGB1555     DRM_FORMAT_XRGB1555
+ # define DRM_FORMAT_HOST_RGB565       DRM_FORMAT_RGB565
+ # define DRM_FORMAT_HOST_XRGB8888     DRM_FORMAT_XRGB8888
+ # define DRM_FORMAT_HOST_ARGB8888     DRM_FORMAT_ARGB8888
++# define DRM_FORMAT_HOST_ABGR8888     DRM_FORMAT_ABGR8888
+ #endif
+ 
+ struct drm_device;
+-- 
+2.26.2
+
+


### PR DESCRIPTION
On Android, the format of Virtio is DRM_FORMAT_ABGR8888, so
we add the kernel format support.

With this patch applied both ADDFB and ADDFB2 ioctls work
correctly in the virtio-gpu.ko driver

Tracked-On: OAM-92985
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>