### PR TITLE
porting camera framework patch from android 10 to android 11

### DIFF
--- a/aosp_diff/caas/frameworks/av/0002-camera-fix-crash-while-disconnect-USB-camera.patch
+++ b/aosp_diff/caas/frameworks/av/0002-camera-fix-crash-while-disconnect-USB-camera.patch
@@ -1,0 +1,26 @@
+From 8efb896a004d1bfb1d9c4861de6b3b3df0cd0b43 Mon Sep 17 00:00:00 2001
+From: kbillore <kaushal.billore@intel.com>
+Date: Thu, 24 Sep 2020 19:48:50 +0530
+Subject: [PATCH] camera fix crash while disconnect USB camera
+
+---
+ services/camera/libcameraservice/CameraService.cpp | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/services/camera/libcameraservice/CameraService.cpp b/services/camera/libcameraservice/CameraService.cpp
+index af1e01d8e1..a5ee26e30a 100644
+--- a/services/camera/libcameraservice/CameraService.cpp
++++ b/services/camera/libcameraservice/CameraService.cpp
+@@ -493,9 +493,6 @@ void CameraService::disconnectClient(const String8& id, sp<BasicClient> clientTo
+         ALOGI("%s: Client for camera ID %s evicted due to device status change from HAL",
+                 __FUNCTION__, id.string());
+         // Notify the client of disconnection
+-        clientToDisconnect->notifyError(
+-                hardware::camera2::ICameraDeviceCallbacks::ERROR_CAMERA_DISCONNECTED,
+-                CaptureResultExtras{});
+         clientToDisconnect->disconnect();
+     }
+ }
+-- 
+2.17.1
+


### PR DESCRIPTION
camera framework patches was missing in android 11

Solution: ported the camera framework patches

Tracked-On: OAM-93078
Signed-off-by: Shiva Kumara shiva.kumara.rudrappa@intel.com
Signed-off-by: kbillore <kaushal.billore@intel.com>