### PR TITLE
aosp_diff: Add support for sdcard and USB disk

### DIFF
--- a/aosp_diff/caas/system/vold/0001-PATCH-WA-CIV-Vold-SD-and-USB-handling-for-CIV.patch
+++ b/aosp_diff/caas/system/vold/0001-PATCH-WA-CIV-Vold-SD-and-USB-handling-for-CIV.patch
@@ -1,0 +1,45 @@
+From c9a54f0af3bcb2d36c4907e94244dbe3ac2e781a Mon Sep 17 00:00:00 2001
+From: Salih <muhammadhx.salih@intel.com>
+Date: Fri, 25 Sep 2020 09:44:59 +0530
+Subject: [PATCH] [CIV] Vold: SD and USB handling for CIV
+
+SD card is enabled through the hdd emulation.
+This patch adds support for sd card and usb disk
+to co-exist.
+
+Signed-off-by: Salih <muhammadhx.salih@intel.com>
+Signed-off-by: N,Shyjumon <shyjumon.n@intel.com>
+Change-Id: I25391fc616656a56da41243207713ced01693110
+---
+ VolumeManager.cpp | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/VolumeManager.cpp b/VolumeManager.cpp
+index a5435739..95fef487 100644
+--- a/VolumeManager.cpp
++++ b/VolumeManager.cpp
+@@ -105,6 +105,7 @@ static const std::string kEmptyString("");
+ static const unsigned int kSizeVirtualDisk = 536870912;
+ 
+ static const unsigned int kMajorBlockMmc = 179;
++static const unsigned int kMajorBlockMmcCIV = 8;       //FIXME: Hack for CIV in IA Arch with KVM
+ 
+ using ScanProcCallback = bool(*)(uid_t uid, pid_t pid, int nsFd, const char* name, void* params);
+ 
+@@ -237,7 +238,12 @@ void VolumeManager::handleBlockEvent(NetlinkEvent* evt) {
+                     if (major == kMajorBlockMmc || IsVirtioBlkDevice(major)) {
+                         flags |= android::vold::Disk::Flags::kSd;
+                     } else {
+-                        flags |= android::vold::Disk::Flags::kUsb;
++			// FIXME: In CIV KVM SD card is virtualized through hdd now,
++			// kMajorBlockMmcCIV and below block need to be  removed.
++			if (major == kMajorBlockMmcCIV && source->getNickname() == "sdcard1")
++				flags |= android::vold::Disk::Flags::kSd;
++			else
++				flags |= android::vold::Disk::Flags::kUsb;
+                     }
+ 
+                     auto disk =
+-- 
+2.17.1
+


### PR DESCRIPTION
This patch adds support in vold for co-existence of
sdcard and USB drive.

Tracked-On: OAM-93067
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>