### PR TITLE
Fix signapk.jar not found in RELEASE_BUILD=true

### DIFF
--- a/aosp_diff/caas/build/make/0003-Fix-signapk.jar-path-for-RELEASE_BUILD-true-case.patch
+++ b/aosp_diff/caas/build/make/0003-Fix-signapk.jar-path-for-RELEASE_BUILD-true-case.patch
@@ -1,0 +1,34 @@
+From 7289608cee0cd5edaf7a9a9a0eeb9e99f0b81748 Mon Sep 17 00:00:00 2001
+From: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+Date: Mon, 28 Sep 2020 20:39:45 +0530
+Subject: [PATCH] Fix signapk.jar path for RELEASE_BUILD=true case
+
+This patch fixes the issue with signapk.jar path.
+This path was set to the script directory but needed to be
+set to the output directory.
+Without this if code built with RELEASE_BUILD=true will fail.
+As the cass-sign****.zip will not be generated and signapk.jar
+will not be found.
+
+Tracked-On: OAM-92994
+Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+---
+ tools/releasetools/common.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/releasetools/common.py b/tools/releasetools/common.py
+index ae7da2fb6..8726609f4 100644
+--- a/tools/releasetools/common.py
++++ b/tools/releasetools/common.py
+@@ -62,7 +62,7 @@ class Options(object):
+           'Warning: releasetools script should be invoked as hermetic Python '
+           'executable -- build and run `{}` directly.'.format(script_name[:-3]),
+           file=sys.stderr)
+-    self.search_path = os.path.realpath(os.path.join(os.path.dirname(exec_path), '..'))
++    self.search_path = os.path.realpath(os.path.join(os.path.dirname(exec_path), '../../../../out/host/linux-x86'))
+ 
+     self.signapk_path = "framework/signapk.jar"  # Relative to search_path
+     self.signapk_shared_library_path = "lib64"   # Relative to search_path
+-- 
+2.21.0
+


### PR DESCRIPTION
When built with RELEASE_BUILD=true option builder tries to
call the signapk.jar file to generate the caas-sign***.zip file.
This signapk path is not set properly in Android 11.
The path is set relative to the script directory but it should
be relative to the output directory.
This patch fixes this issue and sets the path properly.

Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>