### PR TITLE
camera port patch WA forcing the MaxBytesPerPixel

### DIFF
--- a/aosp_diff/caas/hardware/interfaces/0003-WA-forcing-the-MaxBytesPerPixel-to-3.patch
+++ b/aosp_diff/caas/hardware/interfaces/0003-WA-forcing-the-MaxBytesPerPixel-to-3.patch
@@ -1,0 +1,25 @@
+From 3d809ab7e8b884183941849097d481ef9d1c5d93 Mon Sep 17 00:00:00 2001
+From: kbillore <kaushal.billore@intel.com>
+Date: Tue, 29 Sep 2020 10:11:33 +0530
+Subject: [PATCH] camera port patches
+
+---
+ .../include/ext_device_v3_4_impl/ExternalCameraDeviceSession.h  | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/camera/device/3.4/default/include/ext_device_v3_4_impl/ExternalCameraDeviceSession.h b/camera/device/3.4/default/include/ext_device_v3_4_impl/ExternalCameraDeviceSession.h
+index 180f0c155..7a190574d 100644
+--- a/camera/device/3.4/default/include/ext_device_v3_4_impl/ExternalCameraDeviceSession.h
++++ b/camera/device/3.4/default/include/ext_device_v3_4_impl/ExternalCameraDeviceSession.h
+@@ -109,7 +109,7 @@ struct ExternalCameraDeviceSession : public virtual RefBase,
+ 
+     static const int kMaxProcessedStream = 2;
+     static const int kMaxStallStream = 1;
+-    static const uint32_t kMaxBytesPerPixel = 2;
++    static const uint32_t kMaxBytesPerPixel = 3;
+ 
+     class OutputThread : public android::Thread {
+     public:
+-- 
+2.17.1
+


### PR DESCRIPTION
WA: forcing the MaxBytesPerPixel to 3

Tracked-On: OAM-93130
Signed-off-by: Shiva Kumara <shiva.kumara.rudrappa@intel.com>
Signed-off-by: kbillore <kaushal.billore@intel.com>