### PR TITLE
Changes to support external camera

### DIFF
--- a/aosp_diff/caas/packages/apps/Camera2/01_0001-Changes-to-support-external-camera.patch
+++ b/aosp_diff/caas/packages/apps/Camera2/01_0001-Changes-to-support-external-camera.patch
@@ -1,0 +1,96 @@
+From 806334b9adcdf40686134dfe6b607ab55d364b26 Mon Sep 17 00:00:00 2001
+From: kbillore <kaushal.billore@intel.com>
+Date: Tue, 29 Sep 2020 18:56:53 +0530
+Subject: [PATCH] Changes to support external camera
+
+- Remove DisableCameraReceiver as it disables all camera
+activities if camera is not plugged in during first boot.
+- If camera device path has /, replace it with _ as / is
+not allowed in file uri path.
+- If no front camera found, return external camera facing
+id.
+
+Signed-off-by: shiva kumara <shiva.kumara.rudrappa@intel.com>
+Signed-off-by: kbillore <kaushal.billore@intel.com>
+---
+ AndroidManifest.xml                                      | 5 -----
+ src/com/android/camera/PermissionsActivity.java          | 4 ++--
+ .../processing/imagebackend/TaskCompressImageToJpeg.java | 9 ++++++++-
+ src/com/android/camera/settings/SettingsManager.java     | 3 ++-
+ 4 files changed, 12 insertions(+), 9 deletions(-)
+
+diff --git a/AndroidManifest.xml b/AndroidManifest.xml
+index 1f13e3e80..40857b97c 100644
+--- a/AndroidManifest.xml
++++ b/AndroidManifest.xml
+@@ -152,11 +152,6 @@
+             android:configChanges="keyboardHidden|orientation|screenSize">
+         </activity>
+ 
+-        <receiver android:name="com.android.camera.DisableCameraReceiver">
+-            <intent-filter>
+-                <action android:name="android.intent.action.BOOT_COMPLETED" />
+-            </intent-filter>
+-        </receiver>
+     </application>
+ 
+ </manifest>
+diff --git a/src/com/android/camera/PermissionsActivity.java b/src/com/android/camera/PermissionsActivity.java
+index aca4778e6..08896e69d 100644
+--- a/src/com/android/camera/PermissionsActivity.java
++++ b/src/com/android/camera/PermissionsActivity.java
+@@ -119,7 +119,7 @@ public class PermissionsActivity extends QuickActivity {
+             mFlagHasMicrophonePermission = true;
+         }
+ 
+-        if (checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE)
++        if (checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                 != PackageManager.PERMISSION_GRANTED) {
+             mNumPermissionsToRequest++;
+             mShouldRequestStoragePermission = true;
+@@ -172,7 +172,7 @@ public class PermissionsActivity extends QuickActivity {
+             permissionsRequestIndex++;
+         }
+         if (mShouldRequestStoragePermission) {
+-            permissionsToRequest[permissionsRequestIndex] = Manifest.permission.READ_EXTERNAL_STORAGE;
++            permissionsToRequest[permissionsRequestIndex] = Manifest.permission.WRITE_EXTERNAL_STORAGE;
+             mIndexPermissionRequestStorage = permissionsRequestIndex;
+             permissionsRequestIndex++;
+         }
+diff --git a/src/com/android/camera/processing/imagebackend/TaskCompressImageToJpeg.java b/src/com/android/camera/processing/imagebackend/TaskCompressImageToJpeg.java
+index c87eab8e8..14a47cba6 100644
+--- a/src/com/android/camera/processing/imagebackend/TaskCompressImageToJpeg.java
++++ b/src/com/android/camera/processing/imagebackend/TaskCompressImageToJpeg.java
+@@ -421,7 +421,14 @@ public class TaskCompressImageToJpeg extends TaskJpegEncode {
+      * @return Quality level to use for JPEG compression.
+      */
+     protected int getJpegCompressionQuality () {
+-        return CameraProfile.getJpegEncodingQualityParameter(CameraProfile.QUALITY_HIGH);
++        /* Media framework doesn't support query of EXTERNAL camera quality,
++         * It will return the BACK facing camera's quality. Set quality to 90 as WA.
++         */
++        int quality = CameraProfile.getJpegEncodingQualityParameter(CameraProfile.QUALITY_HIGH);
++        if (quality == 0)
++            return 90;
++        return quality;
++
+     }
+ 
+     /**
+diff --git a/src/com/android/camera/settings/SettingsManager.java b/src/com/android/camera/settings/SettingsManager.java
+index d2794e578..95deb8668 100644
+--- a/src/com/android/camera/settings/SettingsManager.java
++++ b/src/com/android/camera/settings/SettingsManager.java
+@@ -160,7 +160,8 @@ public class SettingsManager {
+     }
+ 
+     public static String getCameraSettingScope(String cameraIdValue) {
+-        return CAMERA_SCOPE_PREFIX + cameraIdValue;
++        cameraIdValue = cameraIdValue.replaceAll("/", "_");
++         return CAMERA_SCOPE_PREFIX + cameraIdValue;
+     }
+ 
+     public static String getModuleSettingScope(String moduleScopeNamespace) {
+-- 
+2.17.1
+


### PR DESCRIPTION
Changes to support external camera

Solution: - Remove DisableCameraReceiver as it disables all camera
activities if camera is not plugged in during first boot.
- If camera device path has /, replace it with _ as / is
not allowed in file uri path.
- If no front camera found, return external camera facing
id.

Tracked-On: OAM-93144
Signed-off-by: shiva kumara <shiva.kumara.rudrappa@intel.com>
Signed-off-by: kbillore <kaushal.billore@intel.com>