### PR TITLE
aosp_diff: Add Intel healthloop

### DIFF
--- a/aosp_diff/caas/hardware/interfaces/05_0005-health-Health-HAL-needs-Intel-healthloop.patch
+++ b/aosp_diff/caas/hardware/interfaces/05_0005-health-Health-HAL-needs-Intel-healthloop.patch
@@ -1,0 +1,31 @@
+From b7e7290ad82b8b175b7efed5938b2ed34d880eb1 Mon Sep 17 00:00:00 2001
+From: saranya <saranya.gopal@intel.com>
+Date: Thu, 1 Oct 2020 11:05:53 +0530
+Subject: [PATCH] health: Health HAL needs Intel healthloop
+
+This is to add Intel healthloop for health service.
+Other than this dependency, AOSP health service itself is
+sufficient.
+
+Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>
+Change-Id: Iccb90c515bee855e07c9c3291616cd6533dc4b22
+---
+ health/2.1/default/Android.bp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/health/2.1/default/Android.bp b/health/2.1/default/Android.bp
+index 3649853a3..f894bdc15 100644
+--- a/health/2.1/default/Android.bp
++++ b/health/2.1/default/Android.bp
+@@ -29,7 +29,7 @@ cc_defaults {
+     static_libs: [
+         "android.hardware.health@1.0-convert",
+         "libbatterymonitor",
+-        "libhealthloop",
++        "libhealthloop.intel",
+         "libhealth2impl",
+     ],
+ }
+-- 
+2.17.1
+


### PR DESCRIPTION
This patch adds Intel healthloop to health service 2.1

Tracked-On: OAM-92794
Signed-off-by: Saranya Gopal <saranya.gopal@intel.com>