### PR TITLE
Add lz4 and kernel toolchain to path

### DIFF
--- a/aosp_diff/caas/prebuilts/clang/host/linux-x86/01_0001-Update-llvm-to-latest-toolchain-binaries.patch
+++ b/aosp_diff/caas/prebuilts/clang/host/linux-x86/01_0001-Update-llvm-to-latest-toolchain-binaries.patch
@@ -1,0 +1,306 @@
+From 485cb409882b1712e0e2683fe948e465d6913828 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Mon, 12 Oct 2020 23:11:22 +0530
+Subject: [PATCH] Update llvm to latest toolchain binaries
+
+With this patch, llvm binaries are symbolic linked to
+llvm binaries under clang r383902b bin folder.
+
+Tracked-On: OAM-94248
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ llvm-binutils-stable/ld.lld          | 1 +
+ llvm-binutils-stable/ld64.lld        | 1 +
+ llvm-binutils-stable/lld             | 1 +
+ llvm-binutils-stable/lld-link        | 1 +
+ llvm-binutils-stable/lldb            | 1 +
+ llvm-binutils-stable/lldb-argdumper  | 1 +
+ llvm-binutils-stable/llvm-addr2line  | 2 +-
+ llvm-binutils-stable/llvm-ar         | 2 +-
+ llvm-binutils-stable/llvm-as         | 2 +-
+ llvm-binutils-stable/llvm-cfi-verify | 1 +
+ llvm-binutils-stable/llvm-config     | 1 +
+ llvm-binutils-stable/llvm-cov        | 2 +-
+ llvm-binutils-stable/llvm-dis        | 2 +-
+ llvm-binutils-stable/llvm-dwarfdump  | 2 +-
+ llvm-binutils-stable/llvm-lib        | 1 +
+ llvm-binutils-stable/llvm-link       | 2 +-
+ llvm-binutils-stable/llvm-modextract | 2 +-
+ llvm-binutils-stable/llvm-nm         | 2 +-
+ llvm-binutils-stable/llvm-objcopy    | 2 +-
+ llvm-binutils-stable/llvm-objdump    | 2 +-
+ llvm-binutils-stable/llvm-profdata   | 2 +-
+ llvm-binutils-stable/llvm-ranlib     | 2 +-
+ llvm-binutils-stable/llvm-rc         | 1 +
+ llvm-binutils-stable/llvm-readelf    | 2 +-
+ llvm-binutils-stable/llvm-readobj    | 2 +-
+ llvm-binutils-stable/llvm-size       | 2 +-
+ llvm-binutils-stable/llvm-strings    | 2 +-
+ llvm-binutils-stable/llvm-strip      | 2 +-
+ llvm-binutils-stable/llvm-symbolizer | 2 +-
+ 29 files changed, 29 insertions(+), 19 deletions(-)
+ create mode 120000 llvm-binutils-stable/ld.lld
+ create mode 120000 llvm-binutils-stable/ld64.lld
+ create mode 120000 llvm-binutils-stable/lld
+ create mode 120000 llvm-binutils-stable/lld-link
+ create mode 120000 llvm-binutils-stable/lldb
+ create mode 120000 llvm-binutils-stable/lldb-argdumper
+ create mode 120000 llvm-binutils-stable/llvm-cfi-verify
+ create mode 120000 llvm-binutils-stable/llvm-config
+ create mode 120000 llvm-binutils-stable/llvm-lib
+ create mode 120000 llvm-binutils-stable/llvm-rc
+
+diff --git a/llvm-binutils-stable/ld.lld b/llvm-binutils-stable/ld.lld
+new file mode 120000
+index 0000000..18770da
+--- /dev/null
++++ b/llvm-binutils-stable/ld.lld
+@@ -0,0 +1 @@
++../clang-r383902b/bin/lld
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/ld64.lld b/llvm-binutils-stable/ld64.lld
+new file mode 120000
+index 0000000..18770da
+--- /dev/null
++++ b/llvm-binutils-stable/ld64.lld
+@@ -0,0 +1 @@
++../clang-r383902b/bin/lld
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/lld b/llvm-binutils-stable/lld
+new file mode 120000
+index 0000000..18770da
+--- /dev/null
++++ b/llvm-binutils-stable/lld
+@@ -0,0 +1 @@
++../clang-r383902b/bin/lld
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/lld-link b/llvm-binutils-stable/lld-link
+new file mode 120000
+index 0000000..18770da
+--- /dev/null
++++ b/llvm-binutils-stable/lld-link
+@@ -0,0 +1 @@
++../clang-r383902b/bin/lld
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/lldb b/llvm-binutils-stable/lldb
+new file mode 120000
+index 0000000..f780224
+--- /dev/null
++++ b/llvm-binutils-stable/lldb
+@@ -0,0 +1 @@
++../clang-r383902b/bin/lldb
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/lldb-argdumper b/llvm-binutils-stable/lldb-argdumper
+new file mode 120000
+index 0000000..cb64261
+--- /dev/null
++++ b/llvm-binutils-stable/lldb-argdumper
+@@ -0,0 +1 @@
++../clang-r383902b/bin/lldb-argdumper
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-addr2line b/llvm-binutils-stable/llvm-addr2line
+index cc882ee..7999234 120000
+--- a/llvm-binutils-stable/llvm-addr2line
++++ b/llvm-binutils-stable/llvm-addr2line
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-addr2line
+\ No newline at end of file
++../clang-r383902b/bin/llvm-addr2line
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-ar b/llvm-binutils-stable/llvm-ar
+index 036ef83..d842234 120000
+--- a/llvm-binutils-stable/llvm-ar
++++ b/llvm-binutils-stable/llvm-ar
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-ar
+\ No newline at end of file
++../clang-r383902b/bin/llvm-ar
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-as b/llvm-binutils-stable/llvm-as
+index 8231c4d..7b57450 120000
+--- a/llvm-binutils-stable/llvm-as
++++ b/llvm-binutils-stable/llvm-as
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-as
+\ No newline at end of file
++../clang-r383902b/bin/llvm-as
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-cfi-verify b/llvm-binutils-stable/llvm-cfi-verify
+new file mode 120000
+index 0000000..b125918
+--- /dev/null
++++ b/llvm-binutils-stable/llvm-cfi-verify
+@@ -0,0 +1 @@
++../clang-r383902b/bin/llvm-cfi-verify
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-config b/llvm-binutils-stable/llvm-config
+new file mode 120000
+index 0000000..b27509b
+--- /dev/null
++++ b/llvm-binutils-stable/llvm-config
+@@ -0,0 +1 @@
++../clang-r383902b/bin/llvm-config
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-cov b/llvm-binutils-stable/llvm-cov
+index 1f407ad..a8c19df 120000
+--- a/llvm-binutils-stable/llvm-cov
++++ b/llvm-binutils-stable/llvm-cov
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-cov
+\ No newline at end of file
++../clang-r383902b/bin/llvm-cov
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-dis b/llvm-binutils-stable/llvm-dis
+index 0523b12..dc1e8ac 120000
+--- a/llvm-binutils-stable/llvm-dis
++++ b/llvm-binutils-stable/llvm-dis
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-dis
+\ No newline at end of file
++../clang-r383902b/bin/llvm-dis
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-dwarfdump b/llvm-binutils-stable/llvm-dwarfdump
+index 7972750..f245e20 120000
+--- a/llvm-binutils-stable/llvm-dwarfdump
++++ b/llvm-binutils-stable/llvm-dwarfdump
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-dwarfdump
+\ No newline at end of file
++../clang-r383902b/bin/llvm-dwarfdump
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-lib b/llvm-binutils-stable/llvm-lib
+new file mode 120000
+index 0000000..7d374a4
+--- /dev/null
++++ b/llvm-binutils-stable/llvm-lib
+@@ -0,0 +1 @@
++../clang-r383902b/bin/llvm-lib
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-link b/llvm-binutils-stable/llvm-link
+index ad60d10..e8dd2f2 120000
+--- a/llvm-binutils-stable/llvm-link
++++ b/llvm-binutils-stable/llvm-link
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-link
+\ No newline at end of file
++../clang-r383902b/bin/llvm-link
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-modextract b/llvm-binutils-stable/llvm-modextract
+index e046813..b805f94 120000
+--- a/llvm-binutils-stable/llvm-modextract
++++ b/llvm-binutils-stable/llvm-modextract
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-modextract
+\ No newline at end of file
++../clang-r383902b/bin/llvm-modextract
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-nm b/llvm-binutils-stable/llvm-nm
+index d79bd23..32ee82d 120000
+--- a/llvm-binutils-stable/llvm-nm
++++ b/llvm-binutils-stable/llvm-nm
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-nm
+\ No newline at end of file
++../clang-r383902b/bin/llvm-nm
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-objcopy b/llvm-binutils-stable/llvm-objcopy
+index 03a009a..7d94573 120000
+--- a/llvm-binutils-stable/llvm-objcopy
++++ b/llvm-binutils-stable/llvm-objcopy
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-objcopy
+\ No newline at end of file
++../clang-r383902b/bin/llvm-objcopy
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-objdump b/llvm-binutils-stable/llvm-objdump
+index 8182cb3..90bc4fd 120000
+--- a/llvm-binutils-stable/llvm-objdump
++++ b/llvm-binutils-stable/llvm-objdump
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-objdump
+\ No newline at end of file
++../clang-r383902b/bin/llvm-objdump
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-profdata b/llvm-binutils-stable/llvm-profdata
+index f0d22c2..0a2c661 120000
+--- a/llvm-binutils-stable/llvm-profdata
++++ b/llvm-binutils-stable/llvm-profdata
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-profdata
+\ No newline at end of file
++../clang-r383902b/bin/llvm-profdata
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-ranlib b/llvm-binutils-stable/llvm-ranlib
+index 398f5a7..f353ef0 120000
+--- a/llvm-binutils-stable/llvm-ranlib
++++ b/llvm-binutils-stable/llvm-ranlib
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-ranlib
+\ No newline at end of file
++../clang-r383902b/bin/llvm-ranlib
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-rc b/llvm-binutils-stable/llvm-rc
+new file mode 120000
+index 0000000..f48c0ab
+--- /dev/null
++++ b/llvm-binutils-stable/llvm-rc
+@@ -0,0 +1 @@
++../clang-r383902b/bin/llvm-rc
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-readelf b/llvm-binutils-stable/llvm-readelf
+index 3815f4f..ce67a17 120000
+--- a/llvm-binutils-stable/llvm-readelf
++++ b/llvm-binutils-stable/llvm-readelf
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-readelf
+\ No newline at end of file
++../clang-r383902b/bin/llvm-readelf
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-readobj b/llvm-binutils-stable/llvm-readobj
+index 5bf5991..6dfe2af 120000
+--- a/llvm-binutils-stable/llvm-readobj
++++ b/llvm-binutils-stable/llvm-readobj
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-readobj
+\ No newline at end of file
++../clang-r383902b/bin/llvm-readobj
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-size b/llvm-binutils-stable/llvm-size
+index 828d638..91456f9 120000
+--- a/llvm-binutils-stable/llvm-size
++++ b/llvm-binutils-stable/llvm-size
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-size
+\ No newline at end of file
++../clang-r383902b/bin/llvm-size
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-strings b/llvm-binutils-stable/llvm-strings
+index cd73aaa..9261d33 120000
+--- a/llvm-binutils-stable/llvm-strings
++++ b/llvm-binutils-stable/llvm-strings
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-strings
+\ No newline at end of file
++../clang-r383902b/bin/llvm-strings
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-strip b/llvm-binutils-stable/llvm-strip
+index 0ec6b77..1813a64 120000
+--- a/llvm-binutils-stable/llvm-strip
++++ b/llvm-binutils-stable/llvm-strip
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-strip
+\ No newline at end of file
++../clang-r383902b/bin/llvm-strip
+\ No newline at end of file
+diff --git a/llvm-binutils-stable/llvm-symbolizer b/llvm-binutils-stable/llvm-symbolizer
+index 9e4f3ac..c1a993a 120000
+--- a/llvm-binutils-stable/llvm-symbolizer
++++ b/llvm-binutils-stable/llvm-symbolizer
+@@ -1 +1 @@
+-../clang-r383902/bin/llvm-symbolizer
+\ No newline at end of file
++../clang-r383902b/bin/llvm-symbolizer
+\ No newline at end of file
+-- 
+2.17.1
+


### PR DESCRIPTION
When LTO, CFI is enabled in kernel, error is seen
due to toolchain path not present in path variable.

Added LZ4 and prebuilt toolchain path to path variable.

Tracked-On: OAM-94248
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>