### PR TITLE
iwlwifi: Vendor command support in iwlwifi driver

### DIFF
--- a/bsp_diff/caas/kernel/lts2019-chromium/10_0010-iwlwifi-Vendor-command-support-in-iwlwifi-driver.patch
+++ b/bsp_diff/caas/kernel/lts2019-chromium/10_0010-iwlwifi-Vendor-command-support-in-iwlwifi-driver.patch
@@ -1,0 +1,338 @@
+From ee0edbc0e317697a0f50abf640ee45b6b346ea78 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Fri, 25 Sep 2020 09:30:40 +0530
+Subject: [PATCH] iwlwifi: Vendor command support in iwlwifi driver
+
+Adding vendor command support for querying driver & firmware
+version.
+
+Tracked-On: OAM-94267
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Signed-off-by: Amrita Raju <amrita.raju@intel.com>
+---
+ .../wireless/intel/iwlwifi/iwl-vendor-cmd.h   |  96 +++++++++++
+ .../net/wireless/intel/iwlwifi/mvm/Makefile   |   1 +
+ .../net/wireless/intel/iwlwifi/mvm/mac80211.c |   2 +
+ drivers/net/wireless/intel/iwlwifi/mvm/mvm.h  |   2 +
+ .../wireless/intel/iwlwifi/mvm/vendor-cmd.c   | 161 ++++++++++++++++++
+ 5 files changed, 262 insertions(+)
+ create mode 100644 drivers/net/wireless/intel/iwlwifi/iwl-vendor-cmd.h
+ create mode 100644 drivers/net/wireless/intel/iwlwifi/mvm/vendor-cmd.c
+
+diff --git a/drivers/net/wireless/intel/iwlwifi/iwl-vendor-cmd.h b/drivers/net/wireless/intel/iwlwifi/iwl-vendor-cmd.h
+new file mode 100644
+index 000000000000..554d706d9b26
+--- /dev/null
++++ b/drivers/net/wireless/intel/iwlwifi/iwl-vendor-cmd.h
+@@ -0,0 +1,96 @@
++/******************************************************************************
++ *
++ * This file is provided under a dual BSD/GPLv2 license.  When using or
++ * redistributing this file, you may do so under either license.
++ *
++ * GPL LICENSE SUMMARY
++ *
++ * Copyright(c) 2012 - 2014 Intel Corporation. All rights reserved.
++ * Copyright(c) 2013 - 2015 Intel Mobile Communications GmbH
++ * Copyright(c) 2016 - 2017 Intel Deutschland GmbH
++ * Copyright(c) 2018 Intel Corporation
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of version 2 of the GNU General Public License as
++ * published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope that it will be useful, but
++ * WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * General Public License for more details.
++ *
++ * The full GNU General Public License is included in this distribution
++ * in the file called COPYING.
++ *
++ * Contact Information:
++ *  Intel Linux Wireless <linuxwifi@intel.com>
++ * Intel Corporation, 5200 N.E. Elam Young Parkway, Hillsboro, OR 97124-6497
++ *
++ * BSD LICENSE
++ *
++ * Copyright(c) 2012 - 2014 Intel Corporation. All rights reserved.
++ * Copyright(c) 2013 - 2015 Intel Mobile Communications GmbH
++ * Copyright(c) 2016 - 2017 Intel Deutschland GmbH
++ * Copyright(c) 2018 Intel Corporation
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *
++ *  * Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ *  * Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in
++ *    the documentation and/or other materials provided with the
++ *    distribution.
++ *  * Neither the name Intel Corporation nor the names of its
++ *    contributors may be used to endorse or promote products derived
++ *    from this software without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
++ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
++ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
++ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
++ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
++ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++ *
++ *****************************************************************************/
++#ifndef __VENDOR_CMD_H__
++#define __VENDOR_CMD_H__
++
++#define INTEL_OUI	0x001735
++
++/**
++ * enum iwl_mvm_vendor_cmd - supported vendor commands
++ * @IWL_MVM_VENDOR_CMD_GET_FW_VERSION:
++ * @IWL_MVM_VENDOR_CMD_GET_DRV_VERSION:
++ */
++
++enum iwl_mvm_vendor_cmd {
++	IWL_MVM_VENDOR_CMD_GET_FW_VERSION			= 0x00,
++	IWL_MVM_VENDOR_CMD_GET_DRV_VERSION			= 0x01,
++};
++
++/**
++ * enum iwl_mvm_vendor_attr - attributes used in vendor commands
++ * @__IWL_MVM_VENDOR_ATTR_INVALID: attribute 0 is invalid
++ * @IWL_MVM_VENDOR_ATTR_DRV_VER: string attribute
++ * @IWL_MVM_VENDOR_ATTR_FW_VER: string attribute
++ * @NUM_IWL_MVM_VENDOR_ATTR: number of vendor attributes
++ * @MAX_IWL_MVM_VENDOR_ATTR: highest vendor attribute number
++ */
++enum iwl_mvm_vendor_attr {
++	__IWL_MVM_VENDOR_ATTR_INVALID,
++	IWL_MVM_VENDOR_ATTR_FW_VER,
++	IWL_MVM_VENDOR_ATTR_DRV_VER,
++
++	NUM_IWL_MVM_VENDOR_ATTR,
++	MAX_IWL_MVM_VENDOR_ATTR = NUM_IWL_MVM_VENDOR_ATTR - 1,
++};
++#endif /* __VENDOR_CMD_H__ */
+diff --git a/drivers/net/wireless/intel/iwlwifi/mvm/Makefile b/drivers/net/wireless/intel/iwlwifi/mvm/Makefile
+index dd268c4bd371..8e6de89a19e1 100644
+--- a/drivers/net/wireless/intel/iwlwifi/mvm/Makefile
++++ b/drivers/net/wireless/intel/iwlwifi/mvm/Makefile
+@@ -8,6 +8,7 @@ iwlmvm-y += tt.o offloading.o tdls.o
+ iwlmvm-y += ftm-responder.o ftm-initiator.o
+ iwlmvm-$(CONFIG_IWLWIFI_DEBUGFS) += debugfs.o debugfs-vif.o
+ iwlmvm-$(CONFIG_IWLWIFI_LEDS) += led.o
++iwlmvm-y += vendor-cmd.o
+ iwlmvm-$(CONFIG_PM) += d3.o
+ 
+ ccflags-y += -I $(srctree)/$(src)/../
+diff --git a/drivers/net/wireless/intel/iwlwifi/mvm/mac80211.c b/drivers/net/wireless/intel/iwlwifi/mvm/mac80211.c
+index ed92a8e8cd51..e01e563a457f 100644
+--- a/drivers/net/wireless/intel/iwlwifi/mvm/mac80211.c
++++ b/drivers/net/wireless/intel/iwlwifi/mvm/mac80211.c
+@@ -733,6 +733,8 @@ int iwl_mvm_mac_setup_register(struct iwl_mvm *mvm)
+ 		wiphy_ext_feature_set(hw->wiphy,
+ 				      NL80211_EXT_FEATURE_MU_MIMO_AIR_SNIFFER);
+ 
++	iwl_mvm_set_wiphy_vendor_commands(hw->wiphy);
++
+ 	ret = ieee80211_register_hw(mvm->hw);
+ 	if (ret) {
+ 		iwl_mvm_leds_exit(mvm);
+diff --git a/drivers/net/wireless/intel/iwlwifi/mvm/mvm.h b/drivers/net/wireless/intel/iwlwifi/mvm/mvm.h
+index 5f1ecbb6fb71..fcd813e94a19 100644
+--- a/drivers/net/wireless/intel/iwlwifi/mvm/mvm.h
++++ b/drivers/net/wireless/intel/iwlwifi/mvm/mvm.h
+@@ -83,6 +83,7 @@
+ #include "sta.h"
+ #include "fw-api.h"
+ #include "constants.h"
++#include "iwl-vendor-cmd.h"
+ #include "fw/runtime.h"
+ #include "fw/dbg.h"
+ #include "fw/acpi.h"
+@@ -2045,6 +2046,7 @@ void iwl_mvm_reorder_timer_expired(struct timer_list *t);
+ struct ieee80211_vif *iwl_mvm_get_bss_vif(struct iwl_mvm *mvm);
+ bool iwl_mvm_is_vif_assoc(struct iwl_mvm *mvm);
+ 
++void iwl_mvm_set_wiphy_vendor_commands(struct wiphy *wiphy);
+ #define MVM_TCM_PERIOD_MSEC 500
+ #define MVM_TCM_PERIOD (HZ * MVM_TCM_PERIOD_MSEC / 1000)
+ #define MVM_LL_PERIOD (10 * HZ)
+diff --git a/drivers/net/wireless/intel/iwlwifi/mvm/vendor-cmd.c b/drivers/net/wireless/intel/iwlwifi/mvm/vendor-cmd.c
+new file mode 100644
+index 000000000000..8e884e5831a8
+--- /dev/null
++++ b/drivers/net/wireless/intel/iwlwifi/mvm/vendor-cmd.c
+@@ -0,0 +1,161 @@
++/******************************************************************************
++ *
++ * This file is provided under a dual BSD/GPLv2 license.  When using or
++ * redistributing this file, you may do so under either license.
++ *
++ * GPL LICENSE SUMMARY
++ *
++ * Copyright(c) 2012 - 2014 Intel Corporation. All rights reserved.
++ * Copyright(c) 2013 - 2015 Intel Mobile Communications GmbH
++ * Copyright(c) 2016 - 2017 Intel Deutschland GmbH
++ * Copyright(c) 2018        Intel Corporation
++ * Copyright (C) 2019 Intel Corporation
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of version 2 of the GNU General Public License as
++ * published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope that it will be useful, but
++ * WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * General Public License for more details.
++ *
++ * The full GNU General Public License is included in this distribution
++ * in the file called COPYING.
++ *
++ * Contact Information:
++ *  Intel Linux Wireless <linuxwifi@intel.com>
++ * Intel Corporation, 5200 N.E. Elam Young Parkway, Hillsboro, OR 97124-6497
++ *
++ * BSD LICENSE
++ *
++ * Copyright(c) 2012 - 2014 Intel Corporation. All rights reserved.
++ * Copyright(c) 2013 - 2015 Intel Mobile Communications GmbH
++ * Copyright(c) 2016 - 2017 Intel Deutschland GmbH
++ * Copyright(c) 2018        Intel Corporation
++ * Copyright (C) 2019 Intel Corporation
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *
++ *  * Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ *  * Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in
++ *    the documentation and/or other materials provided with the
++ *    distribution.
++ *  * Neither the name Intel Corporation nor the names of its
++ *    contributors may be used to endorse or promote products derived
++ *    from this software without specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
++ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
++ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
++ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
++ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
++ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
++ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++ *
++ *****************************************************************************/
++#include <linux/etherdevice.h>
++#include <linux/utsname.h>
++#include <linux/version.h>
++#include <net/mac80211.h>
++#include <net/netlink.h>
++#include "mvm.h"
++
++#include "iwl-vendor-cmd.h"
++
++#include "iwl-io.h"
++#include "iwl-prph.h"
++
++static const struct nla_policy
++iwl_mvm_vendor_attr_policy[NUM_IWL_MVM_VENDOR_ATTR] = {
++	[IWL_MVM_VENDOR_ATTR_FW_VER] = { .type = NLA_STRING, .len = 50 },
++	[IWL_MVM_VENDOR_ATTR_DRV_VER] = { .type = NLA_STRING, .len = 50 },
++};
++
++static int iwl_mvm_vendor_get_fw_version(struct wiphy *wiphy,
++				   struct wireless_dev *wdev,
++				   const void *data, int data_len)
++{
++	int err = 0;
++	struct sk_buff *skb;
++	struct ieee80211_hw *hw = wiphy_to_ieee80211_hw(wiphy);
++	struct iwl_mvm *mvm = IWL_MAC80211_GET_MVM(hw);
++	const struct iwl_fw *fw = mvm->fw;
++
++	skb = cfg80211_vendor_cmd_alloc_reply_skb(wiphy, sizeof(fw->fw_version));
++        if (!skb)
++                return -ENOMEM;
++        if (nla_put_string(skb, IWL_MVM_VENDOR_ATTR_FW_VER, fw->fw_version)) {
++                kfree_skb(skb);
++                return -ENOBUFS;
++	}
++
++	return cfg80211_vendor_cmd_reply(skb);
++}
++
++static int iwl_mvm_vendor_get_drv_version(struct wiphy *wiphy,
++				   struct wireless_dev *wdev,
++				   const void *data, int data_len)
++{
++	int err = 0;
++	struct sk_buff *skb;
++	struct ieee80211_hw *hw = wiphy_to_ieee80211_hw(wiphy);
++	struct iwl_mvm *mvm = IWL_MAC80211_GET_MVM(hw);
++	const struct iwl_fw *fw = mvm->fw;
++
++	skb = cfg80211_vendor_cmd_alloc_reply_skb(wiphy, sizeof(utsname()->release));
++        if (!skb)
++                return -ENOMEM;
++        if (nla_put_string(skb, IWL_MVM_VENDOR_ATTR_DRV_VER, utsname()->release)) {
++                kfree_skb(skb);
++                return -ENOBUFS;
++	}
++
++	return cfg80211_vendor_cmd_reply(skb);
++}
++
++static const struct wiphy_vendor_command iwl_mvm_vendor_commands[] = {
++	{
++		.info = {
++			.vendor_id = INTEL_OUI,
++			.subcmd = IWL_MVM_VENDOR_CMD_GET_FW_VERSION,
++		},
++		.flags = WIPHY_VENDOR_CMD_NEED_NETDEV |
++			 WIPHY_VENDOR_CMD_NEED_RUNNING,
++		.doit = iwl_mvm_vendor_get_fw_version,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
++		.policy = iwl_mvm_vendor_attr_policy,
++		.maxattr = MAX_IWL_MVM_VENDOR_ATTR,
++#endif
++	},
++	{
++		.info = {
++			.vendor_id = INTEL_OUI,
++			.subcmd = IWL_MVM_VENDOR_CMD_GET_DRV_VERSION,
++		},
++		.flags = WIPHY_VENDOR_CMD_NEED_NETDEV |
++			 WIPHY_VENDOR_CMD_NEED_RUNNING,
++		.doit = iwl_mvm_vendor_get_drv_version,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
++		.policy = iwl_mvm_vendor_attr_policy,
++		.maxattr = MAX_IWL_MVM_VENDOR_ATTR,
++#endif
++	},
++};
++
++void iwl_mvm_set_wiphy_vendor_commands(struct wiphy *wiphy)
++{
++	wiphy->vendor_commands = iwl_mvm_vendor_commands;
++	wiphy->n_vendor_commands = ARRAY_SIZE(iwl_mvm_vendor_commands);
++	wiphy->vendor_events = NULL;;
++	wiphy->n_vendor_events = 0;
++}
+-- 
+2.17.1
+


### PR DESCRIPTION
Adding vendor command support for querying driver & firmware
version.

Tracked-On: OAM-94267
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
Signed-off-by: Amrita Raju <amrita.raju@intel.com>