### PR TITLE
bsp_diff for 9p: freezing aborts when use wait_event_killable()

### DIFF
--- a/bsp_diff/caas/kernel/lts2019-chromium/10_0010-9p-freezing-aborts-when-use-wait_event_killable.patch
+++ b/bsp_diff/caas/kernel/lts2019-chromium/10_0010-9p-freezing-aborts-when-use-wait_event_killable.patch
@@ -1,0 +1,40 @@
+From d24497918c5bd64041684472e0bee75a7da8d652 Mon Sep 17 00:00:00 2001
+From: Kaushlendra Kumar <kaushalendra.kumar@intel.com>
+Date: Tue, 6 Oct 2020 14:46:37 +0530
+Subject: [PATCH] 9p: freezing aborts when use wait_event_killable()
+
+Freezing of process abort when a client is waiting uninterruptibly
+for a response. This happens when system is entering to suspend and
+trying to freeze all the processes and at that moment freezing aborts
+which leads to suspend failure. So instead of wait_event_killable()
+use wait_event_freezable()
+
+Signed-off-by: Kaushlendra Kumar <kaushalendra.kumar@intel.com>
+---
+ net/9p/client.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/net/9p/client.c b/net/9p/client.c
+index 09f1ec589b80..a5ce640eeee5 100644
+--- a/net/9p/client.c
++++ b/net/9p/client.c
+@@ -11,6 +11,7 @@
+ #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+ 
+ #include <linux/module.h>
++#include <linux/freezer.h>
+ #include <linux/errno.h>
+ #include <linux/fs.h>
+ #include <linux/poll.h>
+@@ -754,7 +755,7 @@ p9_client_rpc(struct p9_client *c, int8_t type, const char *fmt, ...)
+ 	}
+ again:
+ 	/* Wait for the response */
+-	err = wait_event_killable(req->wq, req->status >= REQ_STATUS_RCVD);
++	err = wait_event_freezable(req->wq, req->status >= REQ_STATUS_RCVD);
+ 
+ 	/*
+ 	 * Make sure our req is coherent with regard to updates in other
+-- 
+2.28.0
+


### PR DESCRIPTION
Freezing of processes abort when a client is waiting uninterruptibly
for a response. Instead use wait_event_freezable() to fix it.

Tracked-On: OAM-94084
Signed-off-by: Shwetha B <shwetha.b@intel.com>
Signed-off-by: Kaushlendra Kumar <kaushlendra.kumar@intel.com>