### PR TITLE
WA patch to enable adb in android user build.

### DIFF
--- a/aosp_diff/caas/system/core/02_1-WA-to-make-USB-Debugging-work-in-case-of-User-Build.patch
+++ b/aosp_diff/caas/system/core/02_1-WA-to-make-USB-Debugging-work-in-case-of-User-Build.patch
@@ -1,0 +1,31 @@
+From c949e1799088a81975cc2e94907e1172f1edb95c Mon Sep 17 00:00:00 2001
+From: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+Date: Tue, 13 Oct 2020 14:55:53 +0530
+Subject: [PATCH] WA to make USB Debugging work in case of User Build
+
+This patch makes adb work in case of user build by
+bypassing authentication.
+As of now authentication is failing so adb enable is failing.
+
+Tracked-On: NA
+Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+---
+ adb/daemon/auth.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/adb/daemon/auth.cpp b/adb/daemon/auth.cpp
+index 1a1e4ad62..cbf4360ec 100644
+--- a/adb/daemon/auth.cpp
++++ b/adb/daemon/auth.cpp
+@@ -63,7 +63,7 @@ static struct adisconnect adb_disconnect = {adb_disconnected, nullptr};
+ static android::base::NoDestructor<std::map<uint32_t, weak_ptr<atransport>>> transports;
+ static uint32_t transport_auth_id = 0;
+ 
+-bool auth_required = true;
++bool auth_required = false;
+ 
+ static void* transport_to_callback_arg(atransport* transport) {
+     uint32_t id = transport_auth_id++;
+-- 
+2.21.0
+


### PR DESCRIPTION
This patch enables the adb in user build of android
by bypassing the authentication mechanism.

Tracked-On: OAM-93155
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>