### PR TITLE
Implement/Port AVX2 optimizations to Bionic module.

### DIFF
--- a/aosp_diff/preliminary/bionic/03_0003-Make-avx-enablement-of-math-func-march-independent.patch
+++ b/aosp_diff/preliminary/bionic/03_0003-Make-avx-enablement-of-math-func-march-independent.patch
@@ -1,0 +1,5901 @@
+From 9ae3680662708b06a70bd1f077a2065c4168994e Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Thu, 24 Sep 2020 12:10:08 +0530
+Subject: Modify the patch enabling avx implementation for math
+  funcs so that it is march independent
+
+Tracked-On:
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ libm/Android.bp                               |  248 ++--
+ libm/x86_64/atan_avx2.S                       |  198 ---
+ libm/x86_64/atan_cout_avx2.S                  |  859 -------------
+ libm/x86_64/atan_data_avx2.S                  | 1102 -----------------
+ libm/x86_64/atanf_avx2.S                      |  220 ----
+ libm/x86_64/atanf_cout_avx2.S                 |  865 -------------
+ libm/x86_64/atanf_data_avx2.S                 |  814 ------------
+ libm/x86_64/dynamic_function_dispatch.cpp     |  175 +++
+ libm/x86_64/{ => generic}/ceil.S              |    5 +-
+ libm/x86_64/{ => generic}/ceilf.S             |    4 +-
+ libm/x86_64/generic/cosf.c                    |   19 +
+ libm/x86_64/{ => generic}/e_acos.S            |    0
+ libm/x86_64/{ => generic}/e_asin.S            |    0
+ libm/x86_64/{ => generic}/e_atan2.S           |    0
+ libm/x86_64/{ => generic}/e_cosh.S            |    0
+ libm/x86_64/{ => generic}/e_hypot.S           |    4 +-
+ libm/x86_64/{ => generic}/e_log10.S           |    4 +-
+ libm/x86_64/generic/e_log10f.c                |   19 +
+ libm/x86_64/{ => generic}/e_sinh.S            |    4 +-
+ libm/x86_64/generic/e_sinhf.c                 |   19 +
+ libm/x86_64/generic/expf.c                    |   19 +
+ libm/x86_64/{ => generic}/floor.S             |    4 +-
+ libm/x86_64/{ => generic}/floorf.S            |    4 +-
+ libm/x86_64/{ => generic}/lrint.S             |    0
+ libm/x86_64/{ => generic}/lrintf.S            |    0
+ libm/x86_64/{ => generic}/rint.S              |    4 +-
+ libm/x86_64/{ => generic}/rintf.S             |    4 +-
+ libm/x86_64/{ => generic}/s_atan.S            |    0
+ libm/x86_64/{ => generic}/s_cbrt.S            |    4 +-
+ libm/x86_64/generic/s_cbrtf.c                 |   19 +
+ libm/x86_64/{ => generic}/s_cos.S             |    4 +-
+ libm/x86_64/{ => generic}/s_expm1.S           |    0
+ libm/x86_64/{ => generic}/s_log1p.S           |    4 +-
+ libm/x86_64/generic/s_log1pf.c                |   19 +
+ libm/x86_64/{ => generic}/s_sin.S             |    4 +-
+ libm/x86_64/{ => generic}/s_tan.S             |    0
+ libm/x86_64/{ => generic}/s_tanh.S            |    0
+ libm/x86_64/generic/sinf.c                    |   19 +
+ libm/x86_64/{ => generic}/sqrt.S              |    0
+ libm/x86_64/{ => generic}/sqrtf.S             |    0
+ libm/x86_64/{ => generic}/trunc.S             |    0
+ libm/x86_64/{ => generic}/truncf.S            |    0
+ libm/x86_64/{ => kabylake}/cbrt_avx2.S        |    4 +-
+ libm/x86_64/{ => kabylake}/cbrt_cout_avx2.S   |    0
+ libm/x86_64/{ => kabylake}/cbrt_data_avx2.S   |    0
+ libm/x86_64/{ => kabylake}/cbrtf_avx2.S       |    4 +-
+ libm/x86_64/{ => kabylake}/cbrtf_cout_avx2.S  |    0
+ libm/x86_64/{ => kabylake}/cbrtf_data_avx2.S  |    0
+ libm/x86_64/{ => kabylake}/ceil_avx2.S        |    4 +-
+ libm/x86_64/{ => kabylake}/ceilf_avx2.S       |    4 +-
+ libm/x86_64/{ => kabylake}/cos_avx2.S         |    4 +-
+ libm/x86_64/{ => kabylake}/cos_cout_avx2.S    |    0
+ libm/x86_64/{ => kabylake}/cos_data_avx2.S    |    0
+ libm/x86_64/{ => kabylake}/cosf_avx2.S        |    4 +-
+ libm/x86_64/{ => kabylake}/cosf_cout_avx2.S   |    0
+ libm/x86_64/{ => kabylake}/cosf_data_avx2.S   |    0
+ libm/x86_64/{ => kabylake}/exp_cout_avx2.S    |    0
+ libm/x86_64/{ => kabylake}/exp_data_avx2.S    |    0
+ libm/x86_64/{ => kabylake}/expf_avx2.S        |    4 +-
+ libm/x86_64/{ => kabylake}/floor_avx2.S       |    4 +-
+ libm/x86_64/{ => kabylake}/floorf_avx2.S      |    4 +-
+ libm/x86_64/{ => kabylake}/hypot_avx2.S       |    4 +-
+ libm/x86_64/{ => kabylake}/hypot_cout_avx2.S  |    0
+ libm/x86_64/{ => kabylake}/hypot_data_avx2.S  |    0
+ libm/x86_64/{ => kabylake}/log10_avx2.S       |    4 +-
+ libm/x86_64/{ => kabylake}/log10_cout_avx2.S  |    0
+ libm/x86_64/{ => kabylake}/log10_data_avx2.S  |    0
+ libm/x86_64/{ => kabylake}/log10f_avx2.S      |    4 +-
+ libm/x86_64/{ => kabylake}/log10f_cout_avx2.S |    0
+ libm/x86_64/{ => kabylake}/log10f_data_avx2.S |    0
+ libm/x86_64/{ => kabylake}/log1p_avx2.S       |    4 +-
+ libm/x86_64/{ => kabylake}/log1p_cout_avx2.S  |    0
+ libm/x86_64/{ => kabylake}/log1p_data_avx2.S  |    0
+ libm/x86_64/{ => kabylake}/log1pf_avx2.S      |    4 +-
+ libm/x86_64/{ => kabylake}/log1pf_cout_avx2.S |    0
+ libm/x86_64/{ => kabylake}/log1pf_data_avx2.S |    0
+ libm/x86_64/{ => kabylake}/rint_avx2.S        |    4 +-
+ libm/x86_64/{ => kabylake}/rintf_avx2.S       |    4 +-
+ libm/x86_64/{ => kabylake}/sin_avx2.S         |    4 +-
+ libm/x86_64/{ => kabylake}/sin_cout_avx2.S    |    0
+ libm/x86_64/{ => kabylake}/sin_data_avx2.S    |    0
+ libm/x86_64/{ => kabylake}/sinf_avx2.S        |    4 +-
+ libm/x86_64/{ => kabylake}/sinf_cout_avx2.S   |    0
+ libm/x86_64/{ => kabylake}/sinf_data_avx2.S   |    0
+ libm/x86_64/{ => kabylake}/sinh_avx2.S        |    4 +-
+ libm/x86_64/{ => kabylake}/sinh_cout_avx2.S   |    0
+ libm/x86_64/{ => kabylake}/sinh_data_avx2.S   |    0
+ libm/x86_64/{ => kabylake}/sinhf_avx2.S       |    4 +-
+ libm/x86_64/{ => kabylake}/sinhf_cout_avx2.S  |    0
+ libm/x86_64/{ => kabylake}/sinhf_data_avx2.S  |    0
+ libm/x86_64/static_function_dispatch.S        |   55 +
+ 91 files changed, 545 insertions(+), 4257 deletions(-)
+ delete mode 100644 libm/x86_64/atan_avx2.S
+ delete mode 100644 libm/x86_64/atan_cout_avx2.S
+ delete mode 100644 libm/x86_64/atan_data_avx2.S
+ delete mode 100644 libm/x86_64/atanf_avx2.S
+ delete mode 100644 libm/x86_64/atanf_cout_avx2.S
+ delete mode 100644 libm/x86_64/atanf_data_avx2.S
+ create mode 100644 libm/x86_64/dynamic_function_dispatch.cpp
+ rename libm/x86_64/{ => generic}/ceil.S (97%)
+ rename libm/x86_64/{ => generic}/ceilf.S (97%)
+ create mode 100644 libm/x86_64/generic/cosf.c
+ rename libm/x86_64/{ => generic}/e_acos.S (100%)
+ rename libm/x86_64/{ => generic}/e_asin.S (100%)
+ rename libm/x86_64/{ => generic}/e_atan2.S (100%)
+ rename libm/x86_64/{ => generic}/e_cosh.S (100%)
+ rename libm/x86_64/{ => generic}/e_hypot.S (99%)
+ rename libm/x86_64/{ => generic}/e_log10.S (99%)
+ create mode 100644 libm/x86_64/generic/e_log10f.c
+ rename libm/x86_64/{ => generic}/e_sinh.S (99%)
+ create mode 100644 libm/x86_64/generic/e_sinhf.c
+ create mode 100644 libm/x86_64/generic/expf.c
+ rename libm/x86_64/{ => generic}/floor.S (97%)
+ rename libm/x86_64/{ => generic}/floorf.S (97%)
+ rename libm/x86_64/{ => generic}/lrint.S (100%)
+ rename libm/x86_64/{ => generic}/lrintf.S (100%)
+ rename libm/x86_64/{ => generic}/rint.S (97%)
+ rename libm/x86_64/{ => generic}/rintf.S (97%)
+ rename libm/x86_64/{ => generic}/s_atan.S (100%)
+ rename libm/x86_64/{ => generic}/s_cbrt.S (99%)
+ create mode 100644 libm/x86_64/generic/s_cbrtf.c
+ rename libm/x86_64/{ => generic}/s_cos.S (99%)
+ rename libm/x86_64/{ => generic}/s_expm1.S (100%)
+ rename libm/x86_64/{ => generic}/s_log1p.S (99%)
+ create mode 100644 libm/x86_64/generic/s_log1pf.c
+ rename libm/x86_64/{ => generic}/s_sin.S (99%)
+ rename libm/x86_64/{ => generic}/s_tan.S (100%)
+ rename libm/x86_64/{ => generic}/s_tanh.S (100%)
+ create mode 100644 libm/x86_64/generic/sinf.c
+ rename libm/x86_64/{ => generic}/sqrt.S (100%)
+ rename libm/x86_64/{ => generic}/sqrtf.S (100%)
+ rename libm/x86_64/{ => generic}/trunc.S (100%)
+ rename libm/x86_64/{ => generic}/truncf.S (100%)
+ rename libm/x86_64/{ => kabylake}/cbrt_avx2.S (99%)
+ rename libm/x86_64/{ => kabylake}/cbrt_cout_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/cbrt_data_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/cbrtf_avx2.S (99%)
+ rename libm/x86_64/{ => kabylake}/cbrtf_cout_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/cbrtf_data_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/ceil_avx2.S (97%)
+ rename libm/x86_64/{ => kabylake}/ceilf_avx2.S (97%)
+ rename libm/x86_64/{ => kabylake}/cos_avx2.S (99%)
+ rename libm/x86_64/{ => kabylake}/cos_cout_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/cos_data_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/cosf_avx2.S (99%)
+ rename libm/x86_64/{ => kabylake}/cosf_cout_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/cosf_data_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/exp_cout_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/exp_data_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/expf_avx2.S (99%)
+ rename libm/x86_64/{ => kabylake}/floor_avx2.S (97%)
+ rename libm/x86_64/{ => kabylake}/floorf_avx2.S (97%)
+ rename libm/x86_64/{ => kabylake}/hypot_avx2.S (99%)
+ rename libm/x86_64/{ => kabylake}/hypot_cout_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/hypot_data_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/log10_avx2.S (99%)
+ rename libm/x86_64/{ => kabylake}/log10_cout_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/log10_data_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/log10f_avx2.S (99%)
+ rename libm/x86_64/{ => kabylake}/log10f_cout_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/log10f_data_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/log1p_avx2.S (99%)
+ rename libm/x86_64/{ => kabylake}/log1p_cout_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/log1p_data_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/log1pf_avx2.S (99%)
+ rename libm/x86_64/{ => kabylake}/log1pf_cout_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/log1pf_data_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/rint_avx2.S (97%)
+ rename libm/x86_64/{ => kabylake}/rintf_avx2.S (97%)
+ rename libm/x86_64/{ => kabylake}/sin_avx2.S (99%)
+ rename libm/x86_64/{ => kabylake}/sin_cout_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/sin_data_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/sinf_avx2.S (99%)
+ rename libm/x86_64/{ => kabylake}/sinf_cout_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/sinf_data_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/sinh_avx2.S (99%)
+ rename libm/x86_64/{ => kabylake}/sinh_cout_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/sinh_data_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/sinhf_avx2.S (99%)
+ rename libm/x86_64/{ => kabylake}/sinhf_cout_avx2.S (100%)
+ rename libm/x86_64/{ => kabylake}/sinhf_data_avx2.S (100%)
+ create mode 100644 libm/x86_64/static_function_dispatch.S
+
+diff --git a/libm/Android.bp b/libm/Android.bp
+index 65d8d5756..0891ed698 100644
+--- a/libm/Android.bp
++++ b/libm/Android.bp
+@@ -394,33 +394,91 @@ cc_library {
+         x86_64: {
+             srcs: [
+                 "amd64/fenv.c",
+-                "x86_64/ceil.S",
+-                "x86_64/ceilf.S",
+-                "x86_64/floor.S",
+-                "x86_64/floorf.S",
+-                "x86_64/rint.S",
+-                "x86_64/rintf.S",
+-                "x86_64/sqrt.S",
+-                "x86_64/sqrtf.S",
+-                "x86_64/trunc.S",
+-                "x86_64/truncf.S",
+-                "x86_64/e_acos.S",
+-                "x86_64/e_asin.S",
+-                "x86_64/e_atan2.S",
+-                "x86_64/e_cosh.S",
+-                "x86_64/e_hypot.S",
+-                "x86_64/e_log10.S",
+-                "x86_64/e_sinh.S",
+-                "x86_64/lrint.S",
+-                "x86_64/lrintf.S",
+-                "x86_64/s_atan.S",
+-                "x86_64/s_cbrt.S",
+-                "x86_64/s_cos.S",
+-                "x86_64/s_expm1.S",
+-                "x86_64/s_log1p.S",
+-                "x86_64/s_sin.S",
+-                "x86_64/s_tanh.S",
+-                "x86_64/s_tan.S",
++                "x86_64/generic/ceil.S",
++                "x86_64/generic/ceilf.S",
++                "x86_64/generic/floor.S",
++                "x86_64/generic/floorf.S",
++                "x86_64/generic/rint.S",
++                "x86_64/generic/rintf.S",
++                "x86_64/generic/sqrt.S",
++                "x86_64/generic/sqrtf.S",
++                "x86_64/generic/trunc.S",
++                "x86_64/generic/truncf.S",
++                "x86_64/generic/e_acos.S",
++                "x86_64/generic/e_asin.S",
++                "x86_64/generic/e_atan2.S",
++                "x86_64/generic/e_cosh.S",
++                "x86_64/generic/e_hypot.S",
++                "x86_64/generic/e_log10.S",
++                "x86_64/generic/e_sinh.S",
++                "x86_64/generic/lrint.S",
++                "x86_64/generic/lrintf.S",
++                "x86_64/generic/s_atan.S",
++                "x86_64/generic/s_cbrt.S",
++                "x86_64/generic/s_cos.S",
++                "x86_64/generic/s_expm1.S",
++                "x86_64/generic/s_log1p.S",
++                "x86_64/generic/s_sin.S",
++                "x86_64/generic/s_tanh.S",
++                "x86_64/generic/s_tan.S",
++               
++                "x86_64/generic/e_log10f.c", 
++                "x86_64/generic/s_log1pf.c", 
++                "x86_64/generic/s_cbrtf.c", 
++                "x86_64/generic/e_sinhf.c",
++                "x86_64/generic/sinf.c",
++                "x86_64/generic/cosf.c",
++                "x86_64/generic/expf.c",
++ 
++                //avx2 functions
++                "x86_64/kabylake/ceil_avx2.S",
++                "x86_64/kabylake/ceilf_avx2.S",
++                "x86_64/kabylake/floor_avx2.S",
++                "x86_64/kabylake/floorf_avx2.S",
++                "x86_64/kabylake/rint_avx2.S",
++                "x86_64/kabylake/rintf_avx2.S",
++                "x86_64/kabylake/hypot_data_avx2.S",
++                "x86_64/kabylake/hypot_cout_avx2.S",
++                "x86_64/kabylake/hypot_avx2.S",
++                "x86_64/kabylake/cbrt_data_avx2.S",
++                "x86_64/kabylake/cbrt_cout_avx2.S",
++                "x86_64/kabylake/cbrt_avx2.S", 
++                "x86_64/kabylake/cbrtf_data_avx2.S",
++                "x86_64/kabylake/cbrtf_cout_avx2.S",
++                "x86_64/kabylake/cbrtf_avx2.S", 
++                "x86_64/kabylake/log10_data_avx2.S",
++                "x86_64/kabylake/log10_cout_avx2.S", 
++                "x86_64/kabylake/log10_avx2.S",
++                "x86_64/kabylake/log10f_data_avx2.S",
++                "x86_64/kabylake/log10f_cout_avx2.S", 
++                "x86_64/kabylake/log10f_avx2.S",
++                "x86_64/kabylake/log1p_data_avx2.S",
++                "x86_64/kabylake/log1p_cout_avx2.S", 
++                "x86_64/kabylake/log1p_avx2.S",
++                "x86_64/kabylake/log1pf_data_avx2.S",
++                "x86_64/kabylake/log1pf_cout_avx2.S", 
++                "x86_64/kabylake/log1pf_avx2.S",
++                "x86_64/kabylake/sinh_data_avx2.S",
++                "x86_64/kabylake/sinh_cout_avx2.S",
++                "x86_64/kabylake/sinh_avx2.S",
++                "x86_64/kabylake/sinhf_data_avx2.S",
++                "x86_64/kabylake/sinhf_cout_avx2.S",
++                "x86_64/kabylake/sinhf_avx2.S",
++                "x86_64/kabylake/sin_data_avx2.S",
++                "x86_64/kabylake/sin_cout_avx2.S",
++                "x86_64/kabylake/sin_avx2.S",
++                "x86_64/kabylake/sinf_data_avx2.S",
++                "x86_64/kabylake/sinf_cout_avx2.S",
++                "x86_64/kabylake/sinf_avx2.S",
++                "x86_64/kabylake/cos_data_avx2.S",
++                "x86_64/kabylake/cos_cout_avx2.S",
++                "x86_64/kabylake/cos_avx2.S",
++                "x86_64/kabylake/cosf_data_avx2.S",
++                "x86_64/kabylake/cosf_cout_avx2.S",
++                "x86_64/kabylake/cosf_avx2.S",
++                "x86_64/kabylake/exp_data_avx2.S",
++                "x86_64/kabylake/exp_cout_avx2.S",
++                "x86_64/kabylake/expf_avx2.S",
+             ],
+             exclude_srcs: [
+                 "upstream-freebsd/lib/msun/src/e_acos.c",
+@@ -429,11 +487,14 @@ cc_library {
+                 "upstream-freebsd/lib/msun/src/e_cosh.c",
+                 "upstream-freebsd/lib/msun/src/e_hypot.c",
+                 "upstream-freebsd/lib/msun/src/e_log10.c",
++                "upstream-freebsd/lib/msun/src/e_log10f.c",
+                 "upstream-freebsd/lib/msun/src/e_sinh.c",
++                "upstream-freebsd/lib/msun/src/e_sinhf.c",
+                 "upstream-freebsd/lib/msun/src/e_sqrt.c",
+                 "upstream-freebsd/lib/msun/src/e_sqrtf.c",
+                 "upstream-freebsd/lib/msun/src/s_atan.c",
+                 "upstream-freebsd/lib/msun/src/s_cbrt.c",
++                "upstream-freebsd/lib/msun/src/s_cbrtf.c",
+                 "upstream-freebsd/lib/msun/src/s_ceil.c",
+                 "upstream-freebsd/lib/msun/src/s_ceilf.c",
+                 "upstream-freebsd/lib/msun/src/s_cos.c",
+@@ -441,6 +502,7 @@ cc_library {
+                 "upstream-freebsd/lib/msun/src/s_floor.c",
+                 "upstream-freebsd/lib/msun/src/s_floorf.c",
+                 "upstream-freebsd/lib/msun/src/s_log1p.c",
++                "upstream-freebsd/lib/msun/src/s_log1pf.c",
+                 "upstream-freebsd/lib/msun/src/s_llrint.c",
+                 "upstream-freebsd/lib/msun/src/s_llrintf.c",
+                 "upstream-freebsd/lib/msun/src/s_lrint.c",
+@@ -453,115 +515,15 @@ cc_library {
+                 "upstream-freebsd/lib/msun/src/s_trunc.c",
+                 "upstream-freebsd/lib/msun/src/s_truncf.c",
+             ],
+-            avx2: {
+-                           srcs: [
+-                               "x86_64/ceil_avx2.S",
+-                               "x86_64/ceilf_avx2.S",
+-                               "x86_64/floor_avx2.S",
+-                               "x86_64/floorf_avx2.S",
+-                               "x86_64/rint_avx2.S",
+-                               "x86_64/rintf_avx2.S",
+-                               "x86_64/exp_data_avx2.S",
+-                               "x86_64/exp_cout_avx2.S",
+-                               "x86_64/expf_avx2.S",
+-
+-                               "x86_64/hypot_data_avx2.S",
+-                               "x86_64/hypot_cout_avx2.S",
+-                               "x86_64/hypot_avx2.S",
+-
+-                               "x86_64/log10_data_avx2.S",
+-                               "x86_64/log10_cout_avx2.S",
+-                               "x86_64/log10_avx2.S",
+-                               "x86_64/log10f_data_avx2.S",
+-                               "x86_64/log10f_cout_avx2.S",
+-                               "x86_64/log10f_avx2.S",
+-
+-                               "x86_64/sinhf_data_avx2.S",
+-                               "x86_64/sinhf_cout_avx2.S",
+-                               "x86_64/sinhf_avx2.S",
+-                               "x86_64/sinh_data_avx2.S",
+-                               "x86_64/sinh_cout_avx2.S",
+-                               "x86_64/sinh_avx2.S",
+-
+-                               //"x86_64/atan_data_avx2.S",
+-                               //"x86_64/atan_cout_avx2.S",
+-                               //"x86_64/atan_avx2.S",
+-                               //"x86_64/atanf_data_avx2.S",
+-                               //"x86_64/atanf_cout_avx2.S",
+-                               //"x86_64/atanf_avx2.S",
+-
+-                               "x86_64/cbrt_data_avx2.S",
+-                               "x86_64/cbrt_cout_avx2.S",
+-                               "x86_64/cbrt_avx2.S",
+-                               "x86_64/cbrtf_data_avx2.S",
+-                               "x86_64/cbrtf_cout_avx2.S",
+-                               "x86_64/cbrtf_avx2.S",
+-
+-                               "x86_64/cos_data_avx2.S",
+-                               "x86_64/cos_cout_avx2.S",
+-                                "x86_64/cos_avx2.S",
+-                               "x86_64/cosf_data_avx2.S",
+-                               "x86_64/cosf_cout_avx2.S",
+-                               "x86_64/cosf_avx2.S",
+-
+-                               "x86_64/log1p_data_avx2.S",
+-                               "x86_64/log1p_cout_avx2.S",
+-                               "x86_64/log1p_avx2.S",
+-                               "x86_64/log1pf_data_avx2.S",
+-                               "x86_64/log1pf_cout_avx2.S",
+-                               "x86_64/log1pf_avx2.S",
+-
+-                               "x86_64/sinf_data_avx2.S",
+-                               "x86_64/sinf_cout_avx2.S",
+-                               "x86_64/sinf_avx2.S",
+-                               "x86_64/sin_data_avx2.S",
+-                               "x86_64/sin_cout_avx2.S",
+-                               "x86_64/sin_avx2.S",
+-
+-                           ],
+-                            exclude_srcs: [
+-                               "upstream-freebsd/lib/msun/src/s_ceil.c",
+-                               "upstream-freebsd/lib/msun/src/s_ceilf.c",
+-                               "x86_64/ceil.S",
+-                               "x86_64/ceilf.S",
+-                               "upstream-freebsd/lib/msun/src/s_floor.c",
+-                               "upstream-freebsd/lib/msun/src/s_floorf.c",
+-                               "x86_64/floor.S",
+-                               "x86_64/floorf.S",
+-                               "upstream-freebsd/lib/msun/src/s_rint.c",
+-                               "upstream-freebsd/lib/msun/src/s_rintf.c",
+-                               "x86_64/rint.S",
+-                               "x86_64/rintf.S",
+-                               "upstream-freebsd/lib/msun/src/e_expf.c",
+-                               "upstream-freebsd/lib/msun/src/e_hypot.c",
+-                               "x86_64/e_hypot.S",
+-                               "upstream-freebsd/lib/msun/src/e_log10.c",
+-                               "upstream-freebsd/lib/msun/src/e_log10f.c",
+-                               "x86_64/e_log10.S",
+-                               "upstream-freebsd/lib/msun/src/e_sinh.c",
+-                               "upstream-freebsd/lib/msun/src/e_sinhf.c",
+-                               "x86_64/e_sinh.S",
+-                               "upstream-freebsd/lib/msun/src/s_atan.c",
+-                               //"upstream-freebsd/lib/msun/src/s_atanf.c",
+-                               //"x86_64/s_atan.S",
+-                               "upstream-freebsd/lib/msun/src/s_cbrt.c",
+-                               "upstream-freebsd/lib/msun/src/s_cbrtf.c",
+-                               "x86_64/s_cbrt.S",
+-                               "upstream-freebsd/lib/msun/src/s_cos.c",
+-                               "upstream-freebsd/lib/msun/src/s_cosf.c",
+-                               "x86_64/s_cos.S",
+-                               "upstream-freebsd/lib/msun/src/s_log1p.c",
+-                               "upstream-freebsd/lib/msun/src/s_log1pf.c",
+-                               "x86_64/s_log1p.S",
+-                               "upstream-freebsd/lib/msun/src/s_sin.c",
+-                               "upstream-freebsd/lib/msun/src/s_sinf.c",
+-                               "x86_64/s_sin.S",
+-                ],
+-             },        
++            shared: {
++               srcs: ["x86_64/dynamic_function_dispatch.cpp"],
++            },
++            static: {
++               srcs: ["x86_64/static_function_dispatch.S"],
++            }, 
+             version_script: ":libm.x86_64.map",
+         },
+     },
+-
+     local_include_dirs: [
+         "upstream-freebsd/android/include/",
+         "upstream-freebsd/lib/msun/src/",
+@@ -616,6 +578,26 @@ cc_library {
+     ],
+ }
+ 
++/*cc_library_static {
++    name: "libm_dynamic_dispatch",
++    srcs: ["dynamic_function_dispatch.cpp"],
++    arch: {
++       x86_64: {
++          srcs: ["x86_64/dynamic_function_dispatch.cpp"],
++       },
++    },
++}
++ 
++cc_library_static {
++    name: "libm_static_dispatch",
++    srcs: ["static_function_dispatch.S"],
++    arch: {
++       x86_64: {
++          srcs: ["x86_64/static_function_dispatch.S"],
++       },
++    },
++}*/
++
+ ndk_library {
+     name: "libm",
+     native_bridge_supported: true,
+diff --git a/libm/x86_64/atan_avx2.S b/libm/x86_64/atan_avx2.S
+deleted file mode 100644
+index 6ba53c3d0..000000000
+--- a/libm/x86_64/atan_avx2.S
++++ /dev/null
+@@ -1,198 +0,0 @@
+-/*
+-Copyright (C) 2019 The Android Open Source Project
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+- * Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+- * Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in
+-   the documentation and/or other materials provided with the
+-   distribution.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+-FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+-AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+-OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-SUCH DAMAGE.
+-*/
+-
+-#include <private/bionic_asm.h>
+-# -- Begin  atan
+-ENTRY(atan)
+-# parameter 1: %xmm0
+-..B1.1:
+-..L1:
+-
+-        pushq     %rbp
+-	.cfi_def_cfa_offset 16
+-        movq      %rsp, %rbp
+-	.cfi_def_cfa 6, 16
+-	.cfi_offset 6, -16
+-        andq      $-64, %rsp
+-        subq      $256, %rsp
+-        vmovapd   %xmm0, %xmm3
+-        vandpd    1152+__svml_datan_ha_data_internal(%rip), %xmm3, %xmm0
+-        lea       __svml_datan_ha_data_internal(%rip), %r8
+-        vpshufd   $221, %xmm0, %xmm6
+-        vxorpd    %xmm0, %xmm3, %xmm2
+-        vmovq     2560+__svml_datan_ha_data_internal(%rip), %xmm1
+-        vpsubd    %xmm1, %xmm6, %xmm7
+-        vmovq     2624+__svml_datan_ha_data_internal(%rip), %xmm1
+-        vmovups   %xmm14, 160(%rsp)
+-        vpcmpgtd  %xmm1, %xmm7, %xmm14
+-        vmovups   %xmm13, 144(%rsp)
+-        vpcmpeqd  %xmm1, %xmm7, %xmm13
+-        vpor      %xmm13, %xmm14, %xmm5
+-        vmovmskps %xmm5, %edx
+-        vmovq     1408+__svml_datan_ha_data_internal(%rip), %xmm13
+-        vmovq     1472+__svml_datan_ha_data_internal(%rip), %xmm4
+-        vpsubd    %xmm6, %xmm13, %xmm13
+-        vmovq     1536+__svml_datan_ha_data_internal(%rip), %xmm5
+-        vpsubd    %xmm6, %xmm4, %xmm4
+-        vmovq     1600+__svml_datan_ha_data_internal(%rip), %xmm7
+-        vpsrad    $31, %xmm13, %xmm13
+-        vpsubd    %xmm6, %xmm7, %xmm7
+-        vpsubd    %xmm6, %xmm5, %xmm6
+-        vpsrad    $31, %xmm7, %xmm7
+-        vpsrad    $31, %xmm4, %xmm4
+-        vpsrad    $31, %xmm6, %xmm6
+-        vpaddd    %xmm7, %xmm13, %xmm7
+-        vpaddd    %xmm6, %xmm4, %xmm13
+-        vmovq     1664+__svml_datan_ha_data_internal(%rip), %xmm14
+-        vpaddd    %xmm13, %xmm7, %xmm5
+-        vpaddd    %xmm14, %xmm5, %xmm14
+-        vpslld    $5, %xmm14, %xmm4
+-        vmovd     %xmm4, %eax
+-        vmovupd   1728+__svml_datan_ha_data_internal(%rip), %xmm1
+-        vpextrd   $1, %xmm4, %ecx
+-        vmovq     8(%rax,%r8), %xmm7
+-        vmovq     (%rax,%r8), %xmm6
+-        vmovq     16(%rax,%r8), %xmm13
+-        vmovhpd   8(%rcx,%r8), %xmm7, %xmm4
+-        vmovhpd   (%rcx,%r8), %xmm6, %xmm5
+-        vmovhpd   16(%rcx,%r8), %xmm13, %xmm6
+-        vandpd    %xmm0, %xmm4, %xmm13
+-        vmovq     24(%rax,%r8), %xmm14
+-        vmovhpd   24(%rcx,%r8), %xmm14, %xmm7
+-        vsubpd    %xmm5, %xmm13, %xmm14
+-        vandpd    %xmm1, %xmm4, %xmm13
+-        vmovapd   %xmm1, %xmm4
+-        vfmadd231pd %xmm5, %xmm0, %xmm13
+-        vcvtpd2ps %xmm13, %xmm0
+-        vmovlhps  %xmm0, %xmm0, %xmm0
+-        vrcpps    %xmm0, %xmm5
+-        vcvtps2pd %xmm5, %xmm5
+-        vfnmadd231pd %xmm13, %xmm5, %xmm4
+-        vfmadd213pd %xmm4, %xmm4, %xmm4
+-        vfmadd213pd %xmm5, %xmm4, %xmm5
+-        vfnmadd231pd %xmm13, %xmm5, %xmm1
+-        vfmadd213pd %xmm5, %xmm1, %xmm5
+-        vmulpd    %xmm5, %xmm14, %xmm0
+-        vfnmadd213pd %xmm14, %xmm0, %xmm13
+-        vmovupd   1792+__svml_datan_ha_data_internal(%rip), %xmm14
+-        vmulpd    %xmm13, %xmm5, %xmm1
+-        vmulpd    %xmm0, %xmm0, %xmm5
+-        vaddpd    %xmm1, %xmm7, %xmm1
+-        vmulpd    %xmm5, %xmm5, %xmm4
+-        vmovupd   1856+__svml_datan_ha_data_internal(%rip), %xmm13
+-        vfmadd213pd 1920+__svml_datan_ha_data_internal(%rip), %xmm4, %xmm14
+-        vfmadd213pd 1984+__svml_datan_ha_data_internal(%rip), %xmm4, %xmm13
+-        vfmadd213pd 2048+__svml_datan_ha_data_internal(%rip), %xmm4, %xmm14
+-        vfmadd213pd 2112+__svml_datan_ha_data_internal(%rip), %xmm4, %xmm13
+-        vfmadd213pd 2176+__svml_datan_ha_data_internal(%rip), %xmm4, %xmm14
+-        vfmadd213pd 2240+__svml_datan_ha_data_internal(%rip), %xmm4, %xmm13
+-        vfmadd213pd 2304+__svml_datan_ha_data_internal(%rip), %xmm4, %xmm14
+-        vfmadd213pd 2368+__svml_datan_ha_data_internal(%rip), %xmm4, %xmm13
+-        vfmadd213pd 2432+__svml_datan_ha_data_internal(%rip), %xmm4, %xmm14
+-        vfmadd213pd 2496+__svml_datan_ha_data_internal(%rip), %xmm4, %xmm13
+-        vfmadd213pd %xmm13, %xmm5, %xmm14
+-        vmulpd    %xmm14, %xmm5, %xmm4
+-        vfmadd213pd %xmm1, %xmm0, %xmm4
+-        vaddpd    %xmm4, %xmm0, %xmm7
+-        vaddpd    %xmm7, %xmm6, %xmm0
+-        vorpd     %xmm2, %xmm0, %xmm0
+-        andl      $3, %edx
+-        jne       ..B1.3
+-..B1.2:
+-        vmovups   144(%rsp), %xmm13
+-	.cfi_restore 30
+-        vmovups   160(%rsp), %xmm14
+-	.cfi_restore 31
+-        movq      %rbp, %rsp
+-        popq      %rbp
+-	.cfi_def_cfa 7, 8
+-	.cfi_restore 6
+-        ret
+-	.cfi_def_cfa 6, 16
+-	.cfi_offset 6, -16
+-..B1.3:
+-        vmovupd   %xmm3, 128(%rsp)
+-        vmovupd   %xmm0, 192(%rsp)
+-        je        ..B1.2
+-..B1.6:
+-        xorl      %eax, %eax
+-        vmovups   %xmm8, 80(%rsp)
+-        vmovups   %xmm9, 64(%rsp)
+-        vmovups   %xmm10, 48(%rsp)
+-        vmovups   %xmm11, 32(%rsp)
+-        vmovups   %xmm12, 16(%rsp)
+-        vmovups   %xmm15, (%rsp)
+-        movq      %rsi, 104(%rsp)
+-        movq      %rdi, 96(%rsp)
+-        movq      %r12, 120(%rsp)
+-        movl      %eax, %r12d
+-        movq      %r13, 112(%rsp)
+-        movl      %edx, %r13d
+-..B1.7:
+-        btl       %r12d, %r13d
+-        jc        ..B1.10
+-..B1.8:
+-        incl      %r12d
+-        cmpl      $2, %r12d
+-        jl        ..B1.7
+-..B1.9:
+-        vmovups   80(%rsp), %xmm8
+-	.cfi_restore 25
+-        vmovups   64(%rsp), %xmm9
+-	.cfi_restore 26
+-        vmovups   48(%rsp), %xmm10
+-	.cfi_restore 27
+-        vmovups   32(%rsp), %xmm11
+-	.cfi_restore 28
+-        vmovups   16(%rsp), %xmm12
+-	.cfi_restore 29
+-        vmovups   (%rsp), %xmm15
+-	.cfi_restore 32
+-        movq      104(%rsp), %rsi
+-	.cfi_restore 4
+-        movq      96(%rsp), %rdi
+-	.cfi_restore 5
+-        movq      120(%rsp), %r12
+-	.cfi_restore 12
+-        movq      112(%rsp), %r13
+-	.cfi_restore 13
+-        vmovupd   192(%rsp), %xmm0
+-        jmp       ..B1.2
+-..B1.10:
+-        lea       128(%rsp,%r12,8), %rdi
+-        lea       192(%rsp,%r12,8), %rsi
+-        call      __svml_datan_ha_cout_rare_internal
+-        jmp       ..B1.8
+-END(atan)
+-	.data
+-# -- End  __svml_atan2_ha_l9
+-	.data
+-	.hidden __svml_datan_ha_data_internal
+-	.hidden __svml_datan_ha_cout_rare_internal
+-	.section .note.GNU-stack, ""
+-# End
+diff --git a/libm/x86_64/atan_cout_avx2.S b/libm/x86_64/atan_cout_avx2.S
+deleted file mode 100644
+index 212ffd3c3..000000000
+--- a/libm/x86_64/atan_cout_avx2.S
++++ /dev/null
+@@ -1,859 +0,0 @@
+-/*
+-Copyright (C) 2019 The Android Open Source Project
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+- * Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+- * Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in
+-   the documentation and/or other materials provided with the
+-   distribution.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+-FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+-AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+-OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-SUCH DAMAGE.
+-*/
+-
+-# -- Machine type EM64t
+-	.text
+-..TXTST0:
+-.L_2__routine_start___svml_datan_ha_cout_rare_internal_0:
+-# -- Begin  __svml_datan_ha_cout_rare_internal
+-	.text
+-       .align    16,0x90
+-	.hidden __svml_datan_ha_cout_rare_internal
+-	.globl __svml_datan_ha_cout_rare_internal
+-__svml_datan_ha_cout_rare_internal:
+-# parameter 1: %rdi
+-# parameter 2: %rsi
+-..B1.1:
+-	.cfi_startproc
+-..L1:
+-
+-        movzwl    6(%rdi), %r8d
+-        andl      $32752, %r8d
+-        shrl      $4, %r8d
+-        cmpl      $2047, %r8d
+-        je        ..B1.12
+-..B1.2:
+-        movq      (%rdi), %rdx
+-        movq      %rdx, -16(%rsp)
+-        shrq      $56, %rdx
+-        movb      7(%rdi), %al
+-        andl      $127, %edx
+-        movb      %dl, -9(%rsp)
+-        movsd     -16(%rsp), %xmm0
+-        shrb      $7, %al
+-        comisd    1888+_vmldAtanHATab(%rip), %xmm0
+-        movl      -12(%rsp), %ecx
+-        jb        ..B1.6
+-..B1.3:
+-        movsd     1896+_vmldAtanHATab(%rip), %xmm1
+-        comisd    %xmm0, %xmm1
+-        jbe       ..B1.5
+-..B1.4:
+-        movl      4(%rdi), %edx
+-        movl      %ecx, %edi
+-        andl      $-524288, %ecx
+-        andl      $-1048576, %edi
+-        addl      $262144, %ecx
+-        movaps    %xmm0, %xmm8
+-        andl      $1048575, %ecx
+-        movaps    %xmm0, %xmm9
+-        movsd     %xmm0, -56(%rsp)
+-        orl       %ecx, %edi
+-        movl      $0, -56(%rsp)
+-        andl      $1048575, %edx
+-        movl      %edi, -52(%rsp)
+-        lea       _vmldAtanHATab(%rip), %rcx
+-        movsd     1928+_vmldAtanHATab(%rip), %xmm3
+-        movsd     -56(%rsp), %xmm14
+-        shll      $20, %r8d
+-        subsd     -56(%rsp), %xmm8
+-        mulsd     1928+_vmldAtanHATab(%rip), %xmm9
+-        shlb      $7, %al
+-        mulsd     %xmm8, %xmm3
+-        movsd     %xmm3, -48(%rsp)
+-        orl       %edx, %r8d
+-        movsd     -48(%rsp), %xmm4
+-        addl      $-1069547520, %r8d
+-        sarl      $18, %r8d
+-        subsd     %xmm8, %xmm4
+-        movsd     %xmm4, -40(%rsp)
+-        andl      $-2, %r8d
+-        movsd     -48(%rsp), %xmm6
+-        movsd     -40(%rsp), %xmm5
+-        movslq    %r8d, %r8
+-        subsd     %xmm5, %xmm6
+-        movsd     %xmm6, -48(%rsp)
+-        movsd     -48(%rsp), %xmm7
+-        movsd     1904+_vmldAtanHATab(%rip), %xmm5
+-        subsd     %xmm7, %xmm8
+-        movsd     %xmm8, -40(%rsp)
+-        movsd     -48(%rsp), %xmm1
+-        movsd     -40(%rsp), %xmm2
+-        movsd     %xmm9, -48(%rsp)
+-        movsd     -48(%rsp), %xmm10
+-        movsd     1904+_vmldAtanHATab(%rip), %xmm7
+-        subsd     -16(%rsp), %xmm10
+-        movsd     %xmm10, -40(%rsp)
+-        movsd     -48(%rsp), %xmm12
+-        movsd     -40(%rsp), %xmm11
+-        subsd     %xmm11, %xmm12
+-        movsd     %xmm12, -48(%rsp)
+-        movsd     -48(%rsp), %xmm13
+-        subsd     %xmm13, %xmm0
+-        movsd     1904+_vmldAtanHATab(%rip), %xmm13
+-        movsd     %xmm0, -40(%rsp)
+-        movsd     -48(%rsp), %xmm3
+-        movsd     -40(%rsp), %xmm4
+-        mulsd     %xmm14, %xmm3
+-        mulsd     %xmm14, %xmm4
+-        movaps    %xmm3, %xmm15
+-        addsd     %xmm4, %xmm15
+-        movsd     %xmm15, -48(%rsp)
+-        movsd     -48(%rsp), %xmm0
+-        subsd     %xmm0, %xmm3
+-        addsd     %xmm3, %xmm4
+-        movsd     %xmm4, -40(%rsp)
+-        movsd     -48(%rsp), %xmm11
+-        movsd     -40(%rsp), %xmm0
+-        addsd     %xmm11, %xmm5
+-        movsd     %xmm5, -48(%rsp)
+-        movsd     -48(%rsp), %xmm6
+-        movsd     1928+_vmldAtanHATab(%rip), %xmm4
+-        subsd     %xmm6, %xmm7
+-        movsd     %xmm7, -40(%rsp)
+-        movsd     -48(%rsp), %xmm9
+-        movsd     -40(%rsp), %xmm8
+-        addsd     %xmm8, %xmm9
+-        movsd     1904+_vmldAtanHATab(%rip), %xmm8
+-        movsd     %xmm9, -32(%rsp)
+-        movsd     -40(%rsp), %xmm10
+-        addsd     %xmm10, %xmm11
+-        movsd     %xmm11, -40(%rsp)
+-        movsd     -32(%rsp), %xmm12
+-        subsd     %xmm12, %xmm13
+-        movsd     %xmm13, -32(%rsp)
+-        movsd     -40(%rsp), %xmm3
+-        movsd     -32(%rsp), %xmm14
+-        addsd     %xmm14, %xmm3
+-        movsd     %xmm3, -32(%rsp)
+-        movsd     -48(%rsp), %xmm7
+-        mulsd     %xmm7, %xmm4
+-        movsd     -32(%rsp), %xmm15
+-        movsd     %xmm4, -48(%rsp)
+-        addsd     %xmm15, %xmm0
+-        movsd     -48(%rsp), %xmm5
+-        subsd     %xmm7, %xmm5
+-        movsd     %xmm5, -40(%rsp)
+-        movsd     -48(%rsp), %xmm6
+-        movsd     -40(%rsp), %xmm15
+-        subsd     %xmm15, %xmm6
+-        movsd     %xmm6, -48(%rsp)
+-        movsd     -48(%rsp), %xmm3
+-        subsd     %xmm3, %xmm7
+-        movsd     %xmm7, -40(%rsp)
+-        movsd     -48(%rsp), %xmm13
+-        divsd     %xmm13, %xmm8
+-        movsd     -40(%rsp), %xmm3
+-        addsd     %xmm0, %xmm3
+-        movsd     1928+_vmldAtanHATab(%rip), %xmm0
+-        mulsd     %xmm8, %xmm0
+-        movsd     %xmm0, -40(%rsp)
+-        movsd     -40(%rsp), %xmm9
+-        movsd     1904+_vmldAtanHATab(%rip), %xmm0
+-        subsd     %xmm8, %xmm9
+-        movsd     %xmm9, -32(%rsp)
+-        movsd     -40(%rsp), %xmm11
+-        movsd     -32(%rsp), %xmm10
+-        subsd     %xmm10, %xmm11
+-        movsd     %xmm11, -32(%rsp)
+-        movsd     -32(%rsp), %xmm12
+-        mulsd     %xmm12, %xmm13
+-        movsd     -32(%rsp), %xmm14
+-        subsd     %xmm13, %xmm0
+-        mulsd     %xmm14, %xmm3
+-        movsd     %xmm3, -40(%rsp)
+-        movsd     -40(%rsp), %xmm13
+-        movsd     (%rcx,%r8,8), %xmm3
+-        subsd     %xmm13, %xmm0
+-        movsd     %xmm0, -40(%rsp)
+-        movaps    %xmm3, %xmm0
+-        movsd     -40(%rsp), %xmm7
+-        movsd     -32(%rsp), %xmm6
+-        movsd     -40(%rsp), %xmm4
+-        movaps    %xmm6, %xmm9
+-        movsd     -32(%rsp), %xmm5
+-        mulsd     %xmm2, %xmm6
+-        addsd     1904+_vmldAtanHATab(%rip), %xmm7
+-        mulsd     %xmm1, %xmm9
+-        mulsd     %xmm4, %xmm7
+-        mulsd     %xmm5, %xmm7
+-        movaps    %xmm7, %xmm8
+-        mulsd     %xmm2, %xmm8
+-        mulsd     %xmm7, %xmm1
+-        addsd     %xmm6, %xmm8
+-        movsd     1872+_vmldAtanHATab(%rip), %xmm4
+-        addsd     %xmm1, %xmm8
+-        movsd     %xmm8, -48(%rsp)
+-        movaps    %xmm9, %xmm1
+-        movsd     -48(%rsp), %xmm6
+-        addsd     %xmm6, %xmm1
+-        movsd     %xmm1, -48(%rsp)
+-        movsd     -48(%rsp), %xmm2
+-        subsd     %xmm2, %xmm9
+-        addsd     %xmm6, %xmm9
+-        movsd     %xmm9, -40(%rsp)
+-        movsd     -48(%rsp), %xmm7
+-        movaps    %xmm7, %xmm5
+-        addsd     %xmm7, %xmm0
+-        mulsd     %xmm7, %xmm5
+-        mulsd     %xmm5, %xmm4
+-        movsd     -40(%rsp), %xmm8
+-        movsd     %xmm0, -48(%rsp)
+-        movsd     -48(%rsp), %xmm1
+-        addsd     1864+_vmldAtanHATab(%rip), %xmm4
+-        subsd     %xmm1, %xmm3
+-        mulsd     %xmm5, %xmm4
+-        addsd     %xmm7, %xmm3
+-        addsd     1856+_vmldAtanHATab(%rip), %xmm4
+-        mulsd     %xmm5, %xmm4
+-        movsd     %xmm3, -40(%rsp)
+-        movsd     -48(%rsp), %xmm11
+-        movsd     -40(%rsp), %xmm10
+-        addsd     1848+_vmldAtanHATab(%rip), %xmm4
+-        mulsd     %xmm5, %xmm4
+-        addsd     1840+_vmldAtanHATab(%rip), %xmm4
+-        mulsd     %xmm5, %xmm4
+-        addsd     1832+_vmldAtanHATab(%rip), %xmm4
+-        mulsd     %xmm5, %xmm4
+-        addsd     1824+_vmldAtanHATab(%rip), %xmm4
+-        mulsd     %xmm4, %xmm5
+-        mulsd     %xmm5, %xmm7
+-        addsd     %xmm7, %xmm8
+-        addsd     8(%rcx,%r8,8), %xmm8
+-        addsd     %xmm8, %xmm10
+-        addsd     %xmm10, %xmm11
+-        movsd     %xmm11, -24(%rsp)
+-        movb      -17(%rsp), %r9b
+-        andb      $127, %r9b
+-        orb       %al, %r9b
+-        movb      %r9b, -17(%rsp)
+-        movq      -24(%rsp), %rax
+-        movq      %rax, (%rsi)
+-        jmp       ..B1.11
+-..B1.5:
+-        movsd     1912+_vmldAtanHATab(%rip), %xmm0
+-        shlb      $7, %al
+-        addsd     1920+_vmldAtanHATab(%rip), %xmm0
+-        movsd     %xmm0, -24(%rsp)
+-        movb      -17(%rsp), %dl
+-        andb      $127, %dl
+-        orb       %al, %dl
+-        movb      %dl, -17(%rsp)
+-        movq      -24(%rsp), %rax
+-        movq      %rax, (%rsi)
+-        jmp       ..B1.11
+-..B1.6:
+-        comisd    1880+_vmldAtanHATab(%rip), %xmm0
+-        jb        ..B1.8
+-..B1.7:
+-        movaps    %xmm0, %xmm2
+-        mulsd     %xmm0, %xmm2
+-        shlb      $7, %al
+-        movsd     1872+_vmldAtanHATab(%rip), %xmm1
+-        mulsd     %xmm2, %xmm1
+-        addsd     1864+_vmldAtanHATab(%rip), %xmm1
+-        mulsd     %xmm2, %xmm1
+-        addsd     1856+_vmldAtanHATab(%rip), %xmm1
+-        mulsd     %xmm2, %xmm1
+-        addsd     1848+_vmldAtanHATab(%rip), %xmm1
+-        mulsd     %xmm2, %xmm1
+-        addsd     1840+_vmldAtanHATab(%rip), %xmm1
+-        mulsd     %xmm2, %xmm1
+-        addsd     1832+_vmldAtanHATab(%rip), %xmm1
+-        mulsd     %xmm2, %xmm1
+-        addsd     1824+_vmldAtanHATab(%rip), %xmm1
+-        mulsd     %xmm1, %xmm2
+-        mulsd     %xmm0, %xmm2
+-        addsd     %xmm0, %xmm2
+-        movsd     %xmm2, -24(%rsp)
+-        movb      -17(%rsp), %dl
+-        andb      $127, %dl
+-        orb       %al, %dl
+-        movb      %dl, -17(%rsp)
+-        movq      -24(%rsp), %rax
+-        movq      %rax, (%rsi)
+-        jmp       ..B1.11
+-..B1.8:
+-        movzwl    -10(%rsp), %edx
+-        testl     $32752, %edx
+-        je        ..B1.10
+-..B1.9:
+-        movsd     1904+_vmldAtanHATab(%rip), %xmm1
+-        shlb      $7, %al
+-        addsd     %xmm0, %xmm1
+-        movsd     %xmm1, -48(%rsp)
+-        movsd     -48(%rsp), %xmm0
+-        mulsd     -16(%rsp), %xmm0
+-        movsd     %xmm0, -24(%rsp)
+-        movb      -17(%rsp), %dl
+-        andb      $127, %dl
+-        orb       %al, %dl
+-        movb      %dl, -17(%rsp)
+-        movq      -24(%rsp), %rax
+-        movq      %rax, (%rsi)
+-        jmp       ..B1.11
+-..B1.10:
+-        mulsd     %xmm0, %xmm0
+-        shlb      $7, %al
+-        movsd     %xmm0, -48(%rsp)
+-        movsd     -48(%rsp), %xmm0
+-        addsd     -16(%rsp), %xmm0
+-        movsd     %xmm0, -24(%rsp)
+-        movb      -17(%rsp), %dl
+-        andb      $127, %dl
+-        orb       %al, %dl
+-        movb      %dl, -17(%rsp)
+-        movq      -24(%rsp), %rax
+-        movq      %rax, (%rsi)
+-..B1.11:
+-        xorl      %eax, %eax
+-        ret
+-..B1.12:
+-        testl     $1048575, 4(%rdi)
+-        jne       ..B1.15
+-..B1.13:
+-        cmpl      $0, (%rdi)
+-        jne       ..B1.15
+-..B1.14:
+-        movsd     1912+_vmldAtanHATab(%rip), %xmm0
+-        movb      7(%rdi), %al
+-        andb      $-128, %al
+-        addsd     1920+_vmldAtanHATab(%rip), %xmm0
+-        movsd     %xmm0, -24(%rsp)
+-        movb      -17(%rsp), %dl
+-        andb      $127, %dl
+-        orb       %al, %dl
+-        movb      %dl, -17(%rsp)
+-        movq      -24(%rsp), %rcx
+-        movq      %rcx, (%rsi)
+-        jmp       ..B1.11
+-..B1.15:
+-        movsd     (%rdi), %xmm0
+-        addsd     %xmm0, %xmm0
+-        movsd     %xmm0, (%rsi)
+-        jmp       ..B1.11
+-        .align    16,0x90
+-	.cfi_endproc
+-	.type	__svml_datan_ha_cout_rare_internal,@function
+-	.size	__svml_datan_ha_cout_rare_internal,.-__svml_datan_ha_cout_rare_internal
+-..LN__svml_datan_ha_cout_rare_internal.0:
+-	.data
+-# -- End  __svml_datan_ha_cout_rare_internal
+-	.section .rodata, "a"
+-	.align 32
+-	.align 32
+-_vmldAtanHATab:
+-	.long	3892314112
+-	.long	1069799150
+-	.long	2332892550
+-	.long	1039715405
+-	.long	1342177280
+-	.long	1070305495
+-	.long	270726690
+-	.long	1041535749
+-	.long	939524096
+-	.long	1070817911
+-	.long	2253973841
+-	.long	3188654726
+-	.long	3221225472
+-	.long	1071277294
+-	.long	3853927037
+-	.long	1043226911
+-	.long	2818572288
+-	.long	1071767563
+-	.long	2677759107
+-	.long	1044314101
+-	.long	3355443200
+-	.long	1072103591
+-	.long	1636578514
+-	.long	3191094734
+-	.long	1476395008
+-	.long	1072475260
+-	.long	1864703685
+-	.long	3188646936
+-	.long	805306368
+-	.long	1072747407
+-	.long	192551812
+-	.long	3192726267
+-	.long	2013265920
+-	.long	1072892781
+-	.long	2240369452
+-	.long	1043768538
+-	.long	0
+-	.long	1072999953
+-	.long	3665168337
+-	.long	3192705970
+-	.long	402653184
+-	.long	1073084787
+-	.long	1227953434
+-	.long	3192313277
+-	.long	2013265920
+-	.long	1073142981
+-	.long	3853283127
+-	.long	1045277487
+-	.long	805306368
+-	.long	1073187261
+-	.long	1676192264
+-	.long	3192868861
+-	.long	134217728
+-	.long	1073217000
+-	.long	4290763938
+-	.long	1042034855
+-	.long	671088640
+-	.long	1073239386
+-	.long	994303084
+-	.long	3189643768
+-	.long	402653184
+-	.long	1073254338
+-	.long	1878067156
+-	.long	1042652475
+-	.long	1610612736
+-	.long	1073265562
+-	.long	670314820
+-	.long	1045138554
+-	.long	3221225472
+-	.long	1073273048
+-	.long	691126919
+-	.long	3189987794
+-	.long	3489660928
+-	.long	1073278664
+-	.long	1618990832
+-	.long	3188194509
+-	.long	1207959552
+-	.long	1073282409
+-	.long	2198872939
+-	.long	1044806069
+-	.long	3489660928
+-	.long	1073285217
+-	.long	2633982383
+-	.long	1042307894
+-	.long	939524096
+-	.long	1073287090
+-	.long	1059367786
+-	.long	3189114230
+-	.long	2281701376
+-	.long	1073288494
+-	.long	3158525533
+-	.long	1044484961
+-	.long	3221225472
+-	.long	1073289430
+-	.long	286581777
+-	.long	1044893263
+-	.long	4026531840
+-	.long	1073290132
+-	.long	2000245215
+-	.long	3191647611
+-	.long	134217728
+-	.long	1073290601
+-	.long	4205071590
+-	.long	1045035927
+-	.long	536870912
+-	.long	1073290952
+-	.long	2334392229
+-	.long	1043447393
+-	.long	805306368
+-	.long	1073291186
+-	.long	2281458177
+-	.long	3188885569
+-	.long	3087007744
+-	.long	1073291361
+-	.long	691611507
+-	.long	1044733832
+-	.long	3221225472
+-	.long	1073291478
+-	.long	1816229550
+-	.long	1044363390
+-	.long	2281701376
+-	.long	1073291566
+-	.long	1993843750
+-	.long	3189837440
+-	.long	134217728
+-	.long	1073291625
+-	.long	3654754496
+-	.long	1044970837
+-	.long	4026531840
+-	.long	1073291668
+-	.long	3224300229
+-	.long	3191935390
+-	.long	805306368
+-	.long	1073291698
+-	.long	2988777976
+-	.long	3188950659
+-	.long	536870912
+-	.long	1073291720
+-	.long	1030371341
+-	.long	1043402665
+-	.long	3221225472
+-	.long	1073291734
+-	.long	1524463765
+-	.long	1044361356
+-	.long	3087007744
+-	.long	1073291745
+-	.long	2754295320
+-	.long	1044731036
+-	.long	134217728
+-	.long	1073291753
+-	.long	3099629057
+-	.long	1044970710
+-	.long	2281701376
+-	.long	1073291758
+-	.long	962914160
+-	.long	3189838838
+-	.long	805306368
+-	.long	1073291762
+-	.long	3543908206
+-	.long	3188950786
+-	.long	4026531840
+-	.long	1073291764
+-	.long	1849909620
+-	.long	3191935434
+-	.long	3221225472
+-	.long	1073291766
+-	.long	1641333636
+-	.long	1044361352
+-	.long	536870912
+-	.long	1073291768
+-	.long	1373968792
+-	.long	1043402654
+-	.long	134217728
+-	.long	1073291769
+-	.long	2033191599
+-	.long	1044970710
+-	.long	3087007744
+-	.long	1073291769
+-	.long	4117947437
+-	.long	1044731035
+-	.long	805306368
+-	.long	1073291770
+-	.long	315378368
+-	.long	3188950787
+-	.long	2281701376
+-	.long	1073291770
+-	.long	2428571750
+-	.long	3189838838
+-	.long	3221225472
+-	.long	1073291770
+-	.long	1608007466
+-	.long	1044361352
+-	.long	4026531840
+-	.long	1073291770
+-	.long	1895711420
+-	.long	3191935434
+-	.long	134217728
+-	.long	1073291771
+-	.long	2031108713
+-	.long	1044970710
+-	.long	536870912
+-	.long	1073291771
+-	.long	1362518342
+-	.long	1043402654
+-	.long	805306368
+-	.long	1073291771
+-	.long	317461253
+-	.long	3188950787
+-	.long	939524096
+-	.long	1073291771
+-	.long	4117231784
+-	.long	1044731035
+-	.long	1073741824
+-	.long	1073291771
+-	.long	1607942376
+-	.long	1044361352
+-	.long	1207959552
+-	.long	1073291771
+-	.long	2428929577
+-	.long	3189838838
+-	.long	1207959552
+-	.long	1073291771
+-	.long	2031104645
+-	.long	1044970710
+-	.long	1342177280
+-	.long	1073291771
+-	.long	1895722602
+-	.long	3191935434
+-	.long	1342177280
+-	.long	1073291771
+-	.long	317465322
+-	.long	3188950787
+-	.long	1342177280
+-	.long	1073291771
+-	.long	1362515546
+-	.long	1043402654
+-	.long	1342177280
+-	.long	1073291771
+-	.long	1607942248
+-	.long	1044361352
+-	.long	1342177280
+-	.long	1073291771
+-	.long	4117231610
+-	.long	1044731035
+-	.long	1342177280
+-	.long	1073291771
+-	.long	2031104637
+-	.long	1044970710
+-	.long	1342177280
+-	.long	1073291771
+-	.long	1540251232
+-	.long	1045150466
+-	.long	1342177280
+-	.long	1073291771
+-	.long	2644671394
+-	.long	1045270303
+-	.long	1342177280
+-	.long	1073291771
+-	.long	2399244691
+-	.long	1045360181
+-	.long	1342177280
+-	.long	1073291771
+-	.long	803971124
+-	.long	1045420100
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3613709523
+-	.long	3192879152
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2263862659
+-	.long	3192849193
+-	.long	1476395008
+-	.long	1073291771
+-	.long	177735686
+-	.long	3192826724
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1650295902
+-	.long	3192811744
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2754716064
+-	.long	3192800509
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3490996172
+-	.long	3192793019
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1895722605
+-	.long	3192787402
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2263862659
+-	.long	3192783657
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3613709523
+-	.long	3192780848
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1650295902
+-	.long	3192778976
+-	.long	1476395008
+-	.long	1073291771
+-	.long	177735686
+-	.long	3192777572
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3490996172
+-	.long	3192776635
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2754716064
+-	.long	3192775933
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2263862659
+-	.long	3192775465
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1895722605
+-	.long	3192775114
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1650295902
+-	.long	3192774880
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3613709523
+-	.long	3192774704
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3490996172
+-	.long	3192774587
+-	.long	1476395008
+-	.long	1073291771
+-	.long	177735686
+-	.long	3192774500
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2263862659
+-	.long	3192774441
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2754716064
+-	.long	3192774397
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1650295902
+-	.long	3192774368
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1895722605
+-	.long	3192774346
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3490996172
+-	.long	3192774331
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3613709523
+-	.long	3192774320
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2263862659
+-	.long	3192774313
+-	.long	1476395008
+-	.long	1073291771
+-	.long	177735686
+-	.long	3192774308
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1650295902
+-	.long	3192774304
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2754716064
+-	.long	3192774301
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3490996172
+-	.long	3192774299
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1895722605
+-	.long	3192774298
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2263862659
+-	.long	3192774297
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3613709523
+-	.long	3192774296
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1650295902
+-	.long	3192774296
+-	.long	1476395008
+-	.long	1073291771
+-	.long	177735686
+-	.long	3192774296
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3490996172
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2754716064
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2263862659
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1895722605
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1650295902
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1466225875
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1343512524
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1251477510
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1190120835
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1144103328
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1113424990
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1090416237
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1075077068
+-	.long	3192774295
+-	.long	1431655765
+-	.long	3218429269
+-	.long	2576978363
+-	.long	1070176665
+-	.long	2453154343
+-	.long	3217180964
+-	.long	4189149139
+-	.long	1069314502
+-	.long	1775019125
+-	.long	3216459198
+-	.long	273199057
+-	.long	1068739452
+-	.long	874748308
+-	.long	3215993277
+-	.long	0
+-	.long	1017118720
+-	.long	0
+-	.long	1069547520
+-	.long	0
+-	.long	1129316352
+-	.long	0
+-	.long	1072693248
+-	.long	1413754136
+-	.long	1073291771
+-	.long	856972295
+-	.long	1016178214
+-	.long	33554432
+-	.long	1101004800
+-	.type	_vmldAtanHATab,@object
+-	.size	_vmldAtanHATab,1936
+-	.data
+-	.section .note.GNU-stack, ""
+-# End
+diff --git a/libm/x86_64/atan_data_avx2.S b/libm/x86_64/atan_data_avx2.S
+deleted file mode 100644
+index 3d799321b..000000000
+--- a/libm/x86_64/atan_data_avx2.S
++++ /dev/null
+@@ -1,1102 +0,0 @@
+-/*
+-Copyright (C) 2019 The Android Open Source Project
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+- * Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+- * Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in
+-   the documentation and/or other materials provided with the
+-   distribution.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+-FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+-AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+-OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-SUCH DAMAGE.
+-*/
+-
+-# -- Machine type EM64t
+-	.section .rodata, "a"
+-	.align 64
+-	.align 64
+-	.hidden __svml_datan_ha_data_internal_avx512
+-	.globl __svml_datan_ha_data_internal_avx512
+-__svml_datan_ha_data_internal_avx512:
+-	.long	4294967295
+-	.long	2147483647
+-	.long	4294967295
+-	.long	2147483647
+-	.long	4294967295
+-	.long	2147483647
+-	.long	4294967295
+-	.long	2147483647
+-	.long	4294967295
+-	.long	2147483647
+-	.long	4294967295
+-	.long	2147483647
+-	.long	4294967295
+-	.long	2147483647
+-	.long	4294967295
+-	.long	2147483647
+-	.long	0
+-	.long	1125646336
+-	.long	0
+-	.long	1125646336
+-	.long	0
+-	.long	1125646336
+-	.long	0
+-	.long	1125646336
+-	.long	0
+-	.long	1125646336
+-	.long	0
+-	.long	1125646336
+-	.long	0
+-	.long	1125646336
+-	.long	0
+-	.long	1125646336
+-	.long	0
+-	.long	1075806208
+-	.long	0
+-	.long	1075806208
+-	.long	0
+-	.long	1075806208
+-	.long	0
+-	.long	1075806208
+-	.long	0
+-	.long	1075806208
+-	.long	0
+-	.long	1075806208
+-	.long	0
+-	.long	1075806208
+-	.long	0
+-	.long	1075806208
+-	.long	0
+-	.long	3220176896
+-	.long	0
+-	.long	3220176896
+-	.long	0
+-	.long	3220176896
+-	.long	0
+-	.long	3220176896
+-	.long	0
+-	.long	3220176896
+-	.long	0
+-	.long	3220176896
+-	.long	0
+-	.long	3220176896
+-	.long	0
+-	.long	3220176896
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1206910976
+-	.long	0
+-	.long	1206910976
+-	.long	0
+-	.long	1206910976
+-	.long	0
+-	.long	1206910976
+-	.long	0
+-	.long	1206910976
+-	.long	0
+-	.long	1206910976
+-	.long	0
+-	.long	1206910976
+-	.long	0
+-	.long	1206910976
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	4180443357
+-	.long	1070553973
+-	.long	90291023
+-	.long	1071492199
+-	.long	2737217249
+-	.long	1071945615
+-	.long	1413754136
+-	.long	1072243195
+-	.long	1468297118
+-	.long	1072475260
+-	.long	3531732635
+-	.long	1072657163
+-	.long	744202399
+-	.long	1072747407
+-	.long	2464923204
+-	.long	1072805601
+-	.long	1436891685
+-	.long	1072853231
+-	.long	2037009832
+-	.long	1072892781
+-	.long	1826698067
+-	.long	1072926058
+-	.long	1803191648
+-	.long	1072954391
+-	.long	2205372832
+-	.long	1072978772
+-	.long	4234512805
+-	.long	1072999952
+-	.long	3932628503
+-	.long	1073018509
+-	.long	2501811453
+-	.long	1073034892
+-	.long	866379431
+-	.long	1073049455
+-	.long	1376865888
+-	.long	1073062480
+-	.long	3290094269
+-	.long	1073074195
+-	.long	354764887
+-	.long	1073084787
+-	.long	3332975497
+-	.long	1073094406
+-	.long	1141460092
+-	.long	1073103181
+-	.long	745761286
+-	.long	1073111216
+-	.long	1673304509
+-	.long	1073118600
+-	.long	983388243
+-	.long	1073125409
+-	.long	3895509104
+-	.long	1073131706
+-	.long	2128523669
+-	.long	1073137548
+-	.long	2075485693
+-	.long	1073142981
+-	.long	121855980
+-	.long	1073148047
+-	.long	4181733783
+-	.long	1073152780
+-	.long	2887813284
+-	.long	1073157214
+-	.long	0
+-	.long	0
+-	.long	1022865341
+-	.long	1013492590
+-	.long	573531618
+-	.long	1014639487
+-	.long	2280825944
+-	.long	1014120858
+-	.long	856972295
+-	.long	1015129638
+-	.long	986810987
+-	.long	1015077601
+-	.long	2062601149
+-	.long	1013974920
+-	.long	589036912
+-	.long	3164328156
+-	.long	1787331214
+-	.long	1016798022
+-	.long	2942272763
+-	.long	3164235441
+-	.long	2956702105
+-	.long	1016472908
+-	.long	3903328092
+-	.long	3162582135
+-	.long	3175026820
+-	.long	3158589859
+-	.long	787328196
+-	.long	1014621351
+-	.long	2317874517
+-	.long	3163795518
+-	.long	4071621134
+-	.long	1016673529
+-	.long	2492111345
+-	.long	3164172103
+-	.long	3606178875
+-	.long	3162371821
+-	.long	3365790232
+-	.long	1014547152
+-	.long	2710887773
+-	.long	1017086651
+-	.long	2755350986
+-	.long	3162706257
+-	.long	198095269
+-	.long	3162802133
+-	.long	2791076759
+-	.long	3164364640
+-	.long	4214434319
+-	.long	3162164074
+-	.long	773754012
+-	.long	3164190653
+-	.long	139561443
+-	.long	3164313657
+-	.long	2197796619
+-	.long	3164066219
+-	.long	3592486882
+-	.long	1016669082
+-	.long	1148791015
+-	.long	3163724934
+-	.long	386789398
+-	.long	3163117479
+-	.long	2518816264
+-	.long	3162291736
+-	.long	2545101323
+-	.long	3164592727
+-	.long	16
+-	.long	1125646336
+-	.long	16
+-	.long	1125646336
+-	.long	16
+-	.long	1125646336
+-	.long	16
+-	.long	1125646336
+-	.long	16
+-	.long	1125646336
+-	.long	16
+-	.long	1125646336
+-	.long	16
+-	.long	1125646336
+-	.long	16
+-	.long	1125646336
+-	.long	1413754136
+-	.long	1073291771
+-	.long	1413754136
+-	.long	1073291771
+-	.long	1413754136
+-	.long	1073291771
+-	.long	1413754136
+-	.long	1073291771
+-	.long	1413754136
+-	.long	1073291771
+-	.long	1413754136
+-	.long	1073291771
+-	.long	1413754136
+-	.long	1073291771
+-	.long	1413754136
+-	.long	1073291771
+-	.long	856972295
+-	.long	1016178214
+-	.long	856972295
+-	.long	1016178214
+-	.long	856972295
+-	.long	1016178214
+-	.long	856972295
+-	.long	1016178214
+-	.long	856972295
+-	.long	1016178214
+-	.long	856972295
+-	.long	1016178214
+-	.long	856972295
+-	.long	1016178214
+-	.long	856972295
+-	.long	1016178214
+-	.long	4123328151
+-	.long	1068689849
+-	.long	4123328151
+-	.long	1068689849
+-	.long	4123328151
+-	.long	1068689849
+-	.long	4123328151
+-	.long	1068689849
+-	.long	4123328151
+-	.long	1068689849
+-	.long	4123328151
+-	.long	1068689849
+-	.long	4123328151
+-	.long	1068689849
+-	.long	4123328151
+-	.long	1068689849
+-	.long	3295121612
+-	.long	3216458327
+-	.long	3295121612
+-	.long	3216458327
+-	.long	3295121612
+-	.long	3216458327
+-	.long	3295121612
+-	.long	3216458327
+-	.long	3295121612
+-	.long	3216458327
+-	.long	3295121612
+-	.long	3216458327
+-	.long	3295121612
+-	.long	3216458327
+-	.long	3295121612
+-	.long	3216458327
+-	.long	4026078880
+-	.long	1069314495
+-	.long	4026078880
+-	.long	1069314495
+-	.long	4026078880
+-	.long	1069314495
+-	.long	4026078880
+-	.long	1069314495
+-	.long	4026078880
+-	.long	1069314495
+-	.long	4026078880
+-	.long	1069314495
+-	.long	4026078880
+-	.long	1069314495
+-	.long	4026078880
+-	.long	1069314495
+-	.long	2398029018
+-	.long	3217180964
+-	.long	2398029018
+-	.long	3217180964
+-	.long	2398029018
+-	.long	3217180964
+-	.long	2398029018
+-	.long	3217180964
+-	.long	2398029018
+-	.long	3217180964
+-	.long	2398029018
+-	.long	3217180964
+-	.long	2398029018
+-	.long	3217180964
+-	.long	2398029018
+-	.long	3217180964
+-	.long	2576905246
+-	.long	1070176665
+-	.long	2576905246
+-	.long	1070176665
+-	.long	2576905246
+-	.long	1070176665
+-	.long	2576905246
+-	.long	1070176665
+-	.long	2576905246
+-	.long	1070176665
+-	.long	2576905246
+-	.long	1070176665
+-	.long	2576905246
+-	.long	1070176665
+-	.long	2576905246
+-	.long	1070176665
+-	.long	1431655757
+-	.long	3218429269
+-	.long	1431655757
+-	.long	3218429269
+-	.long	1431655757
+-	.long	3218429269
+-	.long	1431655757
+-	.long	3218429269
+-	.long	1431655757
+-	.long	3218429269
+-	.long	1431655757
+-	.long	3218429269
+-	.long	1431655757
+-	.long	3218429269
+-	.long	1431655757
+-	.long	3218429269
+-	.type	__svml_datan_ha_data_internal_avx512,@object
+-	.size	__svml_datan_ha_data_internal_avx512,1536
+-	.align 64
+-	.hidden __svml_datan_ha_data_internal
+-	.globl __svml_datan_ha_data_internal
+-__svml_datan_ha_data_internal:
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	0
+-	.long	1413754136
+-	.long	1073291771
+-	.long	856972295
+-	.long	1016178214
+-	.long	0
+-	.long	1073217536
+-	.long	4294967295
+-	.long	4294967295
+-	.long	3531732635
+-	.long	1072657163
+-	.long	2062601149
+-	.long	1013974920
+-	.long	0
+-	.long	1072693248
+-	.long	4294967295
+-	.long	4294967295
+-	.long	1413754136
+-	.long	1072243195
+-	.long	856972295
+-	.long	1015129638
+-	.long	0
+-	.long	1071644672
+-	.long	4294967295
+-	.long	4294967295
+-	.long	90291023
+-	.long	1071492199
+-	.long	573531618
+-	.long	1014639487
+-	.long	0
+-	.long	0
+-	.long	4294967295
+-	.long	4294967295
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	1071382528
+-	.long	0
+-	.long	1071382528
+-	.long	0
+-	.long	1071382528
+-	.long	0
+-	.long	1071382528
+-	.long	0
+-	.long	1071382528
+-	.long	0
+-	.long	1071382528
+-	.long	0
+-	.long	1071382528
+-	.long	0
+-	.long	1071382528
+-	.long	0
+-	.long	1072889856
+-	.long	0
+-	.long	1072889856
+-	.long	0
+-	.long	1072889856
+-	.long	0
+-	.long	1072889856
+-	.long	0
+-	.long	1072889856
+-	.long	0
+-	.long	1072889856
+-	.long	0
+-	.long	1072889856
+-	.long	0
+-	.long	1072889856
+-	.long	0
+-	.long	1073971200
+-	.long	0
+-	.long	1073971200
+-	.long	0
+-	.long	1073971200
+-	.long	0
+-	.long	1073971200
+-	.long	0
+-	.long	1073971200
+-	.long	0
+-	.long	1073971200
+-	.long	0
+-	.long	1073971200
+-	.long	0
+-	.long	1073971200
+-	.long	0
+-	.long	1072037888
+-	.long	0
+-	.long	1072037888
+-	.long	0
+-	.long	1072037888
+-	.long	0
+-	.long	1072037888
+-	.long	0
+-	.long	1072037888
+-	.long	0
+-	.long	1072037888
+-	.long	0
+-	.long	1072037888
+-	.long	0
+-	.long	1072037888
+-	.long	90291023
+-	.long	1071492199
+-	.long	90291023
+-	.long	1071492199
+-	.long	90291023
+-	.long	1071492199
+-	.long	90291023
+-	.long	1071492199
+-	.long	90291023
+-	.long	1071492199
+-	.long	90291023
+-	.long	1071492199
+-	.long	90291023
+-	.long	1071492199
+-	.long	90291023
+-	.long	1071492199
+-	.long	573531618
+-	.long	1014639487
+-	.long	573531618
+-	.long	1014639487
+-	.long	573531618
+-	.long	1014639487
+-	.long	573531618
+-	.long	1014639487
+-	.long	573531618
+-	.long	1014639487
+-	.long	573531618
+-	.long	1014639487
+-	.long	573531618
+-	.long	1014639487
+-	.long	573531618
+-	.long	1014639487
+-	.long	1413754136
+-	.long	1072243195
+-	.long	1413754136
+-	.long	1072243195
+-	.long	1413754136
+-	.long	1072243195
+-	.long	1413754136
+-	.long	1072243195
+-	.long	1413754136
+-	.long	1072243195
+-	.long	1413754136
+-	.long	1072243195
+-	.long	1413754136
+-	.long	1072243195
+-	.long	1413754136
+-	.long	1072243195
+-	.long	856972295
+-	.long	1015129638
+-	.long	856972295
+-	.long	1015129638
+-	.long	856972295
+-	.long	1015129638
+-	.long	856972295
+-	.long	1015129638
+-	.long	856972295
+-	.long	1015129638
+-	.long	856972295
+-	.long	1015129638
+-	.long	856972295
+-	.long	1015129638
+-	.long	856972295
+-	.long	1015129638
+-	.long	3531732635
+-	.long	1072657163
+-	.long	3531732635
+-	.long	1072657163
+-	.long	3531732635
+-	.long	1072657163
+-	.long	3531732635
+-	.long	1072657163
+-	.long	3531732635
+-	.long	1072657163
+-	.long	3531732635
+-	.long	1072657163
+-	.long	3531732635
+-	.long	1072657163
+-	.long	3531732635
+-	.long	1072657163
+-	.long	2062601149
+-	.long	1013974920
+-	.long	2062601149
+-	.long	1013974920
+-	.long	2062601149
+-	.long	1013974920
+-	.long	2062601149
+-	.long	1013974920
+-	.long	2062601149
+-	.long	1013974920
+-	.long	2062601149
+-	.long	1013974920
+-	.long	2062601149
+-	.long	1013974920
+-	.long	2062601149
+-	.long	1013974920
+-	.long	1413754136
+-	.long	1073291771
+-	.long	1413754136
+-	.long	1073291771
+-	.long	1413754136
+-	.long	1073291771
+-	.long	1413754136
+-	.long	1073291771
+-	.long	1413754136
+-	.long	1073291771
+-	.long	1413754136
+-	.long	1073291771
+-	.long	1413754136
+-	.long	1073291771
+-	.long	1413754136
+-	.long	1073291771
+-	.long	856972295
+-	.long	1016178214
+-	.long	856972295
+-	.long	1016178214
+-	.long	856972295
+-	.long	1016178214
+-	.long	856972295
+-	.long	1016178214
+-	.long	856972295
+-	.long	1016178214
+-	.long	856972295
+-	.long	1016178214
+-	.long	856972295
+-	.long	1016178214
+-	.long	856972295
+-	.long	1016178214
+-	.long	0
+-	.long	1071644672
+-	.long	0
+-	.long	1071644672
+-	.long	0
+-	.long	1071644672
+-	.long	0
+-	.long	1071644672
+-	.long	0
+-	.long	1071644672
+-	.long	0
+-	.long	1071644672
+-	.long	0
+-	.long	1071644672
+-	.long	0
+-	.long	1071644672
+-	.long	0
+-	.long	1073217536
+-	.long	0
+-	.long	1073217536
+-	.long	0
+-	.long	1073217536
+-	.long	0
+-	.long	1073217536
+-	.long	0
+-	.long	1073217536
+-	.long	0
+-	.long	1073217536
+-	.long	0
+-	.long	1073217536
+-	.long	0
+-	.long	1073217536
+-	.long	0
+-	.long	2147483648
+-	.long	0
+-	.long	2147483648
+-	.long	0
+-	.long	2147483648
+-	.long	0
+-	.long	2147483648
+-	.long	0
+-	.long	2147483648
+-	.long	0
+-	.long	2147483648
+-	.long	0
+-	.long	2147483648
+-	.long	0
+-	.long	2147483648
+-	.long	4294967295
+-	.long	2147483647
+-	.long	4294967295
+-	.long	2147483647
+-	.long	4294967295
+-	.long	2147483647
+-	.long	4294967295
+-	.long	2147483647
+-	.long	4294967295
+-	.long	2147483647
+-	.long	4294967295
+-	.long	2147483647
+-	.long	4294967295
+-	.long	2147483647
+-	.long	4294967295
+-	.long	2147483647
+-	.long	1413754136
+-	.long	1074340347
+-	.long	1413754136
+-	.long	1074340347
+-	.long	1413754136
+-	.long	1074340347
+-	.long	1413754136
+-	.long	1074340347
+-	.long	1413754136
+-	.long	1074340347
+-	.long	1413754136
+-	.long	1074340347
+-	.long	1413754136
+-	.long	1074340347
+-	.long	1413754136
+-	.long	1074340347
+-	.long	0
+-	.long	1017226816
+-	.long	0
+-	.long	1017226816
+-	.long	0
+-	.long	1017226816
+-	.long	0
+-	.long	1017226816
+-	.long	0
+-	.long	1017226816
+-	.long	0
+-	.long	1017226816
+-	.long	0
+-	.long	1017226816
+-	.long	0
+-	.long	1017226816
+-	.long	4160749568
+-	.long	4294967295
+-	.long	4160749568
+-	.long	4294967295
+-	.long	4160749568
+-	.long	4294967295
+-	.long	4160749568
+-	.long	4294967295
+-	.long	4160749568
+-	.long	4294967295
+-	.long	4160749568
+-	.long	4294967295
+-	.long	4160749568
+-	.long	4294967295
+-	.long	4160749568
+-	.long	4294967295
+-	.long	1071382528
+-	.long	1071382528
+-	.long	1071382528
+-	.long	1071382528
+-	.long	1071382528
+-	.long	1071382528
+-	.long	1071382528
+-	.long	1071382528
+-	.long	1071382528
+-	.long	1071382528
+-	.long	1071382528
+-	.long	1071382528
+-	.long	1071382528
+-	.long	1071382528
+-	.long	1071382528
+-	.long	1071382528
+-	.long	1072889856
+-	.long	1072889856
+-	.long	1072889856
+-	.long	1072889856
+-	.long	1072889856
+-	.long	1072889856
+-	.long	1072889856
+-	.long	1072889856
+-	.long	1072889856
+-	.long	1072889856
+-	.long	1072889856
+-	.long	1072889856
+-	.long	1072889856
+-	.long	1072889856
+-	.long	1072889856
+-	.long	1072889856
+-	.long	1073971200
+-	.long	1073971200
+-	.long	1073971200
+-	.long	1073971200
+-	.long	1073971200
+-	.long	1073971200
+-	.long	1073971200
+-	.long	1073971200
+-	.long	1073971200
+-	.long	1073971200
+-	.long	1073971200
+-	.long	1073971200
+-	.long	1073971200
+-	.long	1073971200
+-	.long	1073971200
+-	.long	1073971200
+-	.long	1072037888
+-	.long	1072037888
+-	.long	1072037888
+-	.long	1072037888
+-	.long	1072037888
+-	.long	1072037888
+-	.long	1072037888
+-	.long	1072037888
+-	.long	1072037888
+-	.long	1072037888
+-	.long	1072037888
+-	.long	1072037888
+-	.long	1072037888
+-	.long	1072037888
+-	.long	1072037888
+-	.long	1072037888
+-	.long	4
+-	.long	4
+-	.long	4
+-	.long	4
+-	.long	4
+-	.long	4
+-	.long	4
+-	.long	4
+-	.long	4
+-	.long	4
+-	.long	4
+-	.long	4
+-	.long	4
+-	.long	4
+-	.long	4
+-	.long	4
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	3866310424
+-	.long	1066132731
+-	.long	3866310424
+-	.long	1066132731
+-	.long	3866310424
+-	.long	1066132731
+-	.long	3866310424
+-	.long	1066132731
+-	.long	3866310424
+-	.long	1066132731
+-	.long	3866310424
+-	.long	1066132731
+-	.long	3866310424
+-	.long	1066132731
+-	.long	3866310424
+-	.long	1066132731
+-	.long	529668190
+-	.long	3214953687
+-	.long	529668190
+-	.long	3214953687
+-	.long	529668190
+-	.long	3214953687
+-	.long	529668190
+-	.long	3214953687
+-	.long	529668190
+-	.long	3214953687
+-	.long	529668190
+-	.long	3214953687
+-	.long	529668190
+-	.long	3214953687
+-	.long	529668190
+-	.long	3214953687
+-	.long	1493047753
+-	.long	1067887957
+-	.long	1493047753
+-	.long	1067887957
+-	.long	1493047753
+-	.long	1067887957
+-	.long	1493047753
+-	.long	1067887957
+-	.long	1493047753
+-	.long	1067887957
+-	.long	1493047753
+-	.long	1067887957
+-	.long	1493047753
+-	.long	1067887957
+-	.long	1493047753
+-	.long	1067887957
+-	.long	1554070819
+-	.long	3215629941
+-	.long	1554070819
+-	.long	3215629941
+-	.long	1554070819
+-	.long	3215629941
+-	.long	1554070819
+-	.long	3215629941
+-	.long	1554070819
+-	.long	3215629941
+-	.long	1554070819
+-	.long	3215629941
+-	.long	1554070819
+-	.long	3215629941
+-	.long	1554070819
+-	.long	3215629941
+-	.long	3992437651
+-	.long	1068372721
+-	.long	3992437651
+-	.long	1068372721
+-	.long	3992437651
+-	.long	1068372721
+-	.long	3992437651
+-	.long	1068372721
+-	.long	3992437651
+-	.long	1068372721
+-	.long	3992437651
+-	.long	1068372721
+-	.long	3992437651
+-	.long	1068372721
+-	.long	3992437651
+-	.long	1068372721
+-	.long	845965549
+-	.long	3216052365
+-	.long	845965549
+-	.long	3216052365
+-	.long	845965549
+-	.long	3216052365
+-	.long	845965549
+-	.long	3216052365
+-	.long	845965549
+-	.long	3216052365
+-	.long	845965549
+-	.long	3216052365
+-	.long	845965549
+-	.long	3216052365
+-	.long	845965549
+-	.long	3216052365
+-	.long	3073500986
+-	.long	1068740914
+-	.long	3073500986
+-	.long	1068740914
+-	.long	3073500986
+-	.long	1068740914
+-	.long	3073500986
+-	.long	1068740914
+-	.long	3073500986
+-	.long	1068740914
+-	.long	3073500986
+-	.long	1068740914
+-	.long	3073500986
+-	.long	1068740914
+-	.long	3073500986
+-	.long	1068740914
+-	.long	426211919
+-	.long	3216459217
+-	.long	426211919
+-	.long	3216459217
+-	.long	426211919
+-	.long	3216459217
+-	.long	426211919
+-	.long	3216459217
+-	.long	426211919
+-	.long	3216459217
+-	.long	426211919
+-	.long	3216459217
+-	.long	426211919
+-	.long	3216459217
+-	.long	426211919
+-	.long	3216459217
+-	.long	435789718
+-	.long	1069314503
+-	.long	435789718
+-	.long	1069314503
+-	.long	435789718
+-	.long	1069314503
+-	.long	435789718
+-	.long	1069314503
+-	.long	435789718
+-	.long	1069314503
+-	.long	435789718
+-	.long	1069314503
+-	.long	435789718
+-	.long	1069314503
+-	.long	435789718
+-	.long	1069314503
+-	.long	2453936673
+-	.long	3217180964
+-	.long	2453936673
+-	.long	3217180964
+-	.long	2453936673
+-	.long	3217180964
+-	.long	2453936673
+-	.long	3217180964
+-	.long	2453936673
+-	.long	3217180964
+-	.long	2453936673
+-	.long	3217180964
+-	.long	2453936673
+-	.long	3217180964
+-	.long	2453936673
+-	.long	3217180964
+-	.long	2576977731
+-	.long	1070176665
+-	.long	2576977731
+-	.long	1070176665
+-	.long	2576977731
+-	.long	1070176665
+-	.long	2576977731
+-	.long	1070176665
+-	.long	2576977731
+-	.long	1070176665
+-	.long	2576977731
+-	.long	1070176665
+-	.long	2576977731
+-	.long	1070176665
+-	.long	2576977731
+-	.long	1070176665
+-	.long	1431655762
+-	.long	3218429269
+-	.long	1431655762
+-	.long	3218429269
+-	.long	1431655762
+-	.long	3218429269
+-	.long	1431655762
+-	.long	3218429269
+-	.long	1431655762
+-	.long	3218429269
+-	.long	1431655762
+-	.long	3218429269
+-	.long	1431655762
+-	.long	3218429269
+-	.long	1431655762
+-	.long	3218429269
+-	.long	2150629376
+-	.long	2150629376
+-	.long	2150629376
+-	.long	2150629376
+-	.long	2150629376
+-	.long	2150629376
+-	.long	2150629376
+-	.long	2150629376
+-	.long	2150629376
+-	.long	2150629376
+-	.long	2150629376
+-	.long	2150629376
+-	.long	2150629376
+-	.long	2150629376
+-	.long	2150629376
+-	.long	2150629376
+-	.long	4258267136
+-	.long	4258267136
+-	.long	4258267136
+-	.long	4258267136
+-	.long	4258267136
+-	.long	4258267136
+-	.long	4258267136
+-	.long	4258267136
+-	.long	4258267136
+-	.long	4258267136
+-	.long	4258267136
+-	.long	4258267136
+-	.long	4258267136
+-	.long	4258267136
+-	.long	4258267136
+-	.long	4258267136
+-	.type	__svml_datan_ha_data_internal,@object
+-	.size	__svml_datan_ha_data_internal,2688
+-	.data
+-	.section .note.GNU-stack, ""
+-# End
+diff --git a/libm/x86_64/atanf_avx2.S b/libm/x86_64/atanf_avx2.S
+deleted file mode 100644
+index fee676fe9..000000000
+--- a/libm/x86_64/atanf_avx2.S
++++ /dev/null
+@@ -1,220 +0,0 @@
+-/*
+-Copyright (C) 2019 The Android Open Source Project
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+- * Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+- * Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in
+-   the documentation and/or other materials provided with the
+-   distribution.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+-FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+-AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+-OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-SUCH DAMAGE.
+-*/
+-
+-#include <private/bionic_asm.h>
+-# -- Begin  atanf
+-ENTRY(atanf)
+-# parameter 1: %xmm0
+-..B1.1:
+-..L1:
+-
+-        pushq     %rbp
+-	.cfi_def_cfa_offset 16
+-        movq      %rsp, %rbp
+-	.cfi_def_cfa 6, 16
+-	.cfi_offset 6, -16
+-        andq      $-64, %rsp
+-        subq      $192, %rsp
+-        vandps    192+__svml_satan_ha_data_internal(%rip), %xmm0, %xmm3
+-        vmovups   1984+__svml_satan_ha_data_internal(%rip), %xmm6
+-        vpsubd    1920+__svml_satan_ha_data_internal(%rip), %xmm3, %xmm7
+-        vpcmpgtd  %xmm6, %xmm7, %xmm4
+-        vpcmpeqd  %xmm6, %xmm7, %xmm2
+-        vmovups   384+__svml_satan_ha_data_internal(%rip), %xmm7
+-        vpor      %xmm2, %xmm4, %xmm1
+-        vmovups   %xmm12, 176(%rsp)
+-        vpcmpgtd  %xmm3, %xmm7, %xmm5
+-        vmovups   %xmm11, 48(%rsp)
+-        vmovups   256+__svml_satan_ha_data_internal(%rip), %xmm12
+-        vmovups   320+__svml_satan_ha_data_internal(%rip), %xmm11
+-        vpcmpgtd  448+__svml_satan_ha_data_internal(%rip), %xmm3, %xmm7
+-        vmovups   %xmm13, 144(%rsp)
+-        vmovups   %xmm10, 160(%rsp)
+-        vmovups   %xmm9, 80(%rsp)
+-        vpcmpgtd  %xmm3, %xmm11, %xmm9
+-        vmovups   %xmm0, (%rsp)
+-        vpandn    %xmm5, %xmm9, %xmm6
+-        vandps    128+__svml_satan_ha_data_internal(%rip), %xmm0, %xmm10
+-        vpcmpgtd  %xmm3, %xmm12, %xmm0
+-        vmovmskps %xmm1, %edx
+-        vpxor     1728+__svml_satan_ha_data_internal(%rip), %xmm7, %xmm13
+-        vmovups   768+__svml_satan_ha_data_internal(%rip), %xmm1
+-        vmovups   832+__svml_satan_ha_data_internal(%rip), %xmm2
+-        vsubps    %xmm1, %xmm3, %xmm12
+-        vmovups   896+__svml_satan_ha_data_internal(%rip), %xmm4
+-        vmovups   %xmm14, 112(%rsp)
+-        vsubps    %xmm4, %xmm3, %xmm14
+-        vmulps    %xmm4, %xmm3, %xmm4
+-        vmovups   %xmm8, 96(%rsp)
+-        vpandn    %xmm9, %xmm0, %xmm8
+-        vpandn    %xmm13, %xmm5, %xmm9
+-        vandps    %xmm0, %xmm3, %xmm13
+-        vandps    %xmm8, %xmm12, %xmm11
+-        vsubps    %xmm2, %xmm3, %xmm5
+-        vmulps    %xmm2, %xmm3, %xmm2
+-        vandps    %xmm6, %xmm5, %xmm12
+-        vandps    %xmm9, %xmm14, %xmm5
+-        vorps     %xmm11, %xmm13, %xmm11
+-        vorps     %xmm5, %xmm12, %xmm12
+-        vandps    64+__svml_satan_ha_data_internal(%rip), %xmm7, %xmm14
+-        vorps     %xmm12, %xmm11, %xmm11
+-        vmovups   __svml_satan_ha_data_internal(%rip), %xmm13
+-        vorps     %xmm14, %xmm11, %xmm5
+-        vandps    %xmm0, %xmm13, %xmm11
+-        vaddps    %xmm2, %xmm13, %xmm14
+-        vmulps    %xmm1, %xmm3, %xmm0
+-        vcvtps2pd %xmm5, %ymm5
+-        vandps    %xmm6, %xmm14, %xmm14
+-        vaddps    %xmm0, %xmm13, %xmm1
+-        vaddps    %xmm4, %xmm13, %xmm13
+-        vandps    %xmm8, %xmm1, %xmm12
+-        vandps    %xmm9, %xmm13, %xmm0
+-        vandps    %xmm7, %xmm3, %xmm13
+-        vorps     %xmm12, %xmm11, %xmm3
+-        vorps     %xmm0, %xmm14, %xmm12
+-        vorps     %xmm12, %xmm3, %xmm11
+-        vandps    960+__svml_satan_ha_data_internal(%rip), %xmm8, %xmm0
+-        vorps     %xmm13, %xmm11, %xmm11
+-        vandps    1088+__svml_satan_ha_data_internal(%rip), %xmm6, %xmm1
+-        vorps     %xmm1, %xmm0, %xmm4
+-        vrcpps    %xmm11, %xmm0
+-        vcvtps2pd %xmm11, %ymm13
+-        vcvtps2pd %xmm0, %ymm1
+-        vandps    1216+__svml_satan_ha_data_internal(%rip), %xmm9, %xmm2
+-        vandps    1344+__svml_satan_ha_data_internal(%rip), %xmm7, %xmm3
+-        vorps     %xmm3, %xmm2, %xmm14
+-        vmulpd    %ymm1, %ymm13, %ymm13
+-        vorps     %xmm14, %xmm4, %xmm12
+-        vmovupd   1856+__svml_satan_ha_data_internal(%rip), %ymm4
+-        vandps    1024+__svml_satan_ha_data_internal(%rip), %xmm8, %xmm8
+-        vandps    1152+__svml_satan_ha_data_internal(%rip), %xmm6, %xmm6
+-        vandps    1280+__svml_satan_ha_data_internal(%rip), %xmm9, %xmm9
+-        vorps     %xmm6, %xmm8, %xmm6
+-        vandps    1408+__svml_satan_ha_data_internal(%rip), %xmm7, %xmm7
+-        vsubpd    %ymm13, %ymm4, %ymm3
+-        vorps     %xmm7, %xmm9, %xmm7
+-        vmulpd    %ymm3, %ymm1, %ymm2
+-        vmulpd    %ymm3, %ymm3, %ymm14
+-        vaddpd    %ymm2, %ymm1, %ymm11
+-        vaddpd    %ymm14, %ymm4, %ymm0
+-        vmulpd    %ymm0, %ymm11, %ymm1
+-        vmulpd    %ymm1, %ymm5, %ymm5
+-        vandpd    1792+__svml_satan_ha_data_internal(%rip), %ymm5, %ymm0
+-        vcvtpd2ps %ymm0, %xmm11
+-        vsubpd    %ymm0, %ymm5, %ymm1
+-        vorps     %xmm7, %xmm6, %xmm0
+-        vmulps    %xmm11, %xmm11, %xmm13
+-        vcvtpd2ps %ymm1, %xmm2
+-        vmulps    %xmm13, %xmm13, %xmm3
+-        vaddps    %xmm0, %xmm2, %xmm0
+-        vmulps    1472+__svml_satan_ha_data_internal(%rip), %xmm3, %xmm1
+-        vmulps    1536+__svml_satan_ha_data_internal(%rip), %xmm3, %xmm4
+-        vaddps    1600+__svml_satan_ha_data_internal(%rip), %xmm1, %xmm5
+-        vaddps    1664+__svml_satan_ha_data_internal(%rip), %xmm4, %xmm8
+-        vmulps    %xmm5, %xmm13, %xmm9
+-        vaddps    %xmm9, %xmm8, %xmm14
+-        vmulps    %xmm14, %xmm13, %xmm1
+-        vmulps    %xmm1, %xmm11, %xmm2
+-        vmovups   (%rsp), %xmm1
+-        vaddps    %xmm2, %xmm0, %xmm3
+-        vaddps    %xmm3, %xmm11, %xmm11
+-        vaddps    %xmm11, %xmm12, %xmm12
+-        vorps     %xmm10, %xmm12, %xmm0
+-        vmovups   176(%rsp), %xmm12
+-	.cfi_restore 29
+-        testl     %edx, %edx
+-        jne       ..B1.3
+-..B1.2:
+-        vzeroupper
+-        vmovups   96(%rsp), %xmm8
+-	.cfi_restore 25
+-        vmovups   80(%rsp), %xmm9
+-	.cfi_restore 26
+-        vmovups   160(%rsp), %xmm10
+-	.cfi_restore 27
+-        vmovups   48(%rsp), %xmm11
+-	.cfi_restore 28
+-        vmovups   144(%rsp), %xmm13
+-	.cfi_restore 30
+-        vmovups   112(%rsp), %xmm14
+-	.cfi_restore 31
+-        movq      %rbp, %rsp
+-        popq      %rbp
+-	.cfi_def_cfa 7, 8
+-	.cfi_restore 6
+-        ret
+-        .cfi_def_cfa 6, 16
+-	.cfi_offset 6, -16
+-..B1.3:
+-        vmovups   %xmm1, 64(%rsp)
+-        vmovups   %xmm0, 128(%rsp)
+-..B1.6:
+-        xorl      %eax, %eax
+-        vmovups   %xmm12, 176(%rsp)
+-        vmovups   %xmm15, (%rsp)
+-        movq      %rsi, 24(%rsp)
+-        movq      %rdi, 16(%rsp)
+-        movq      %r12, 40(%rsp)
+-        movl      %eax, %r12d
+-        movq      %r13, 32(%rsp)
+-        movl      %edx, %r13d
+-..B1.7:
+-        btl       %r12d, %r13d
+-        jc        ..B1.10
+-..B1.8:
+-        incl      %r12d
+-        cmpl      $4, %r12d
+-        jl        ..B1.7
+-..B1.9:
+-        vmovups   176(%rsp), %xmm12
+-	.cfi_restore 29
+-        vmovups   (%rsp), %xmm15
+-	.cfi_restore 32
+-        movq      24(%rsp), %rsi
+-	.cfi_restore 4
+-        movq      16(%rsp), %rdi
+-	.cfi_restore 5
+-        movq      40(%rsp), %r12
+-	.cfi_restore 12
+-        movq      32(%rsp), %r13
+-	.cfi_restore 13
+-        vmovups   128(%rsp), %xmm0
+-        jmp       ..B1.2
+-..B1.10:
+-        vzeroupper
+-        lea       64(%rsp,%r12,4), %rdi
+-        lea       128(%rsp,%r12,4), %rsi
+-        call      __svml_satan_ha_cout_rare_internal
+-        jmp       ..B1.8
+-END(atanf)        
+-# -- End  __svml_atanf4_ha_e9
+-	.data
+-	.hidden __svml_satan_ha_data_internal
+-	.hidden __svml_satan_ha_cout_rare_internal
+-	.section .note.GNU-stack, ""
+-# End
+diff --git a/libm/x86_64/atanf_cout_avx2.S b/libm/x86_64/atanf_cout_avx2.S
+deleted file mode 100644
+index 7927f9bbe..000000000
+--- a/libm/x86_64/atanf_cout_avx2.S
++++ /dev/null
+@@ -1,865 +0,0 @@
+-/*
+-Copyright (C) 2019 The Android Open Source Project
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+- * Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+- * Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in
+-   the documentation and/or other materials provided with the
+-   distribution.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+-FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+-AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+-OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-SUCH DAMAGE.
+-*/
+-
+-# -- Machine type EM64t
+-	.text
+-..TXTST0:
+-.L_2__routine_start___svml_satan_ha_cout_rare_internal_0:
+-# -- Begin  __svml_satan_ha_cout_rare_internal
+-	.text
+-       .align    16,0x90
+-	.hidden __svml_satan_ha_cout_rare_internal
+-	.globl __svml_satan_ha_cout_rare_internal
+-__svml_satan_ha_cout_rare_internal:
+-# parameter 1: %rdi
+-# parameter 2: %rsi
+-..B1.1:
+-	.cfi_startproc
+-..L1:
+-
+-        movzwl    2(%rdi), %edx
+-        andl      $32640, %edx
+-        shrl      $7, %edx
+-        cmpl      $255, %edx
+-        je        ..B1.12
+-..B1.2:
+-        movss     (%rdi), %xmm1
+-        pxor      %xmm0, %xmm0
+-        cvtss2sd  %xmm1, %xmm0
+-        movsd     %xmm0, -8(%rsp)
+-        andb      $127, -1(%rsp)
+-        movsd     -8(%rsp), %xmm0
+-        movb      3(%rdi), %al
+-        shrb      $7, %al
+-        comisd    1888+_vmlsAtanHATab(%rip), %xmm0
+-        movl      -4(%rsp), %ecx
+-        jb        ..B1.6
+-..B1.3:
+-        movsd     1896+_vmlsAtanHATab(%rip), %xmm1
+-        comisd    %xmm0, %xmm1
+-        jbe       ..B1.5
+-..B1.4:
+-        movl      %ecx, %edx
+-        movl      %ecx, %edi
+-        andl      $-524288, %ecx
+-        andl      $-1048576, %edi
+-        addl      $262144, %ecx
+-        movaps    %xmm0, %xmm8
+-        andl      $1048575, %ecx
+-        movaps    %xmm0, %xmm9
+-        movsd     %xmm0, -40(%rsp)
+-        orl       %ecx, %edi
+-        movl      $0, -40(%rsp)
+-        andl      $1048575, %edx
+-        movl      %edi, -36(%rsp)
+-        lea       _vmlsAtanHATab(%rip), %rcx
+-        movsd     1928+_vmlsAtanHATab(%rip), %xmm3
+-        movsd     -40(%rsp), %xmm14
+-        movzwl    -2(%rsp), %r8d
+-        mulsd     1928+_vmlsAtanHATab(%rip), %xmm9
+-        andl      $32752, %r8d
+-        subsd     -40(%rsp), %xmm8
+-        shlb      $7, %al
+-        mulsd     %xmm8, %xmm3
+-        movsd     %xmm3, -32(%rsp)
+-        movsd     -32(%rsp), %xmm4
+-        shrl      $4, %r8d
+-        subsd     %xmm8, %xmm4
+-        movsd     %xmm4, -24(%rsp)
+-        movsd     -32(%rsp), %xmm6
+-        movsd     -24(%rsp), %xmm5
+-        shll      $20, %r8d
+-        subsd     %xmm5, %xmm6
+-        movsd     %xmm6, -32(%rsp)
+-        orl       %edx, %r8d
+-        movsd     -32(%rsp), %xmm7
+-        addl      $-1069547520, %r8d
+-        movsd     1904+_vmlsAtanHATab(%rip), %xmm5
+-        subsd     %xmm7, %xmm8
+-        movsd     %xmm8, -24(%rsp)
+-        movsd     -32(%rsp), %xmm1
+-        movsd     -24(%rsp), %xmm2
+-        movsd     %xmm9, -32(%rsp)
+-        movsd     -32(%rsp), %xmm10
+-        movsd     1904+_vmlsAtanHATab(%rip), %xmm7
+-        sarl      $18, %r8d
+-        subsd     -8(%rsp), %xmm10
+-        movsd     %xmm10, -24(%rsp)
+-        andl      $-2, %r8d
+-        movsd     -32(%rsp), %xmm12
+-        movsd     -24(%rsp), %xmm11
+-        movslq    %r8d, %r8
+-        subsd     %xmm11, %xmm12
+-        movsd     %xmm12, -32(%rsp)
+-        movsd     -32(%rsp), %xmm13
+-        subsd     %xmm13, %xmm0
+-        movsd     1904+_vmlsAtanHATab(%rip), %xmm13
+-        movsd     %xmm0, -24(%rsp)
+-        movsd     -32(%rsp), %xmm3
+-        movsd     -24(%rsp), %xmm4
+-        mulsd     %xmm14, %xmm3
+-        mulsd     %xmm14, %xmm4
+-        movaps    %xmm3, %xmm15
+-        addsd     %xmm4, %xmm15
+-        movsd     %xmm15, -32(%rsp)
+-        movsd     -32(%rsp), %xmm0
+-        subsd     %xmm0, %xmm3
+-        addsd     %xmm3, %xmm4
+-        movsd     %xmm4, -24(%rsp)
+-        movsd     -32(%rsp), %xmm11
+-        movsd     -24(%rsp), %xmm0
+-        addsd     %xmm11, %xmm5
+-        movsd     %xmm5, -32(%rsp)
+-        movsd     -32(%rsp), %xmm6
+-        movsd     1928+_vmlsAtanHATab(%rip), %xmm4
+-        subsd     %xmm6, %xmm7
+-        movsd     %xmm7, -24(%rsp)
+-        movsd     -32(%rsp), %xmm9
+-        movsd     -24(%rsp), %xmm8
+-        addsd     %xmm8, %xmm9
+-        movsd     1904+_vmlsAtanHATab(%rip), %xmm8
+-        movsd     %xmm9, -16(%rsp)
+-        movsd     -24(%rsp), %xmm10
+-        addsd     %xmm10, %xmm11
+-        movsd     %xmm11, -24(%rsp)
+-        movsd     -16(%rsp), %xmm12
+-        subsd     %xmm12, %xmm13
+-        movsd     %xmm13, -16(%rsp)
+-        movsd     -24(%rsp), %xmm3
+-        movsd     -16(%rsp), %xmm14
+-        addsd     %xmm14, %xmm3
+-        movsd     %xmm3, -16(%rsp)
+-        movsd     -32(%rsp), %xmm7
+-        mulsd     %xmm7, %xmm4
+-        movsd     -16(%rsp), %xmm15
+-        movsd     %xmm4, -32(%rsp)
+-        addsd     %xmm15, %xmm0
+-        movsd     -32(%rsp), %xmm5
+-        subsd     %xmm7, %xmm5
+-        movsd     %xmm5, -24(%rsp)
+-        movsd     -32(%rsp), %xmm6
+-        movsd     -24(%rsp), %xmm15
+-        subsd     %xmm15, %xmm6
+-        movsd     %xmm6, -32(%rsp)
+-        movsd     -32(%rsp), %xmm3
+-        subsd     %xmm3, %xmm7
+-        movsd     %xmm7, -24(%rsp)
+-        movsd     -32(%rsp), %xmm13
+-        divsd     %xmm13, %xmm8
+-        movsd     -24(%rsp), %xmm3
+-        addsd     %xmm0, %xmm3
+-        movsd     1928+_vmlsAtanHATab(%rip), %xmm0
+-        mulsd     %xmm8, %xmm0
+-        movsd     %xmm0, -24(%rsp)
+-        movsd     -24(%rsp), %xmm9
+-        movsd     1904+_vmlsAtanHATab(%rip), %xmm0
+-        subsd     %xmm8, %xmm9
+-        movsd     %xmm9, -16(%rsp)
+-        movsd     -24(%rsp), %xmm11
+-        movsd     -16(%rsp), %xmm10
+-        subsd     %xmm10, %xmm11
+-        movsd     %xmm11, -16(%rsp)
+-        movsd     -16(%rsp), %xmm12
+-        mulsd     %xmm12, %xmm13
+-        movsd     -16(%rsp), %xmm14
+-        subsd     %xmm13, %xmm0
+-        mulsd     %xmm14, %xmm3
+-        movsd     %xmm3, -24(%rsp)
+-        movsd     -24(%rsp), %xmm13
+-        movsd     (%rcx,%r8,8), %xmm3
+-        subsd     %xmm13, %xmm0
+-        movsd     %xmm0, -24(%rsp)
+-        movaps    %xmm3, %xmm0
+-        movsd     -24(%rsp), %xmm7
+-        movsd     -16(%rsp), %xmm6
+-        movsd     -24(%rsp), %xmm4
+-        movaps    %xmm6, %xmm9
+-        movsd     -16(%rsp), %xmm5
+-        mulsd     %xmm2, %xmm6
+-        addsd     1904+_vmlsAtanHATab(%rip), %xmm7
+-        mulsd     %xmm1, %xmm9
+-        mulsd     %xmm4, %xmm7
+-        mulsd     %xmm5, %xmm7
+-        movaps    %xmm7, %xmm8
+-        mulsd     %xmm2, %xmm8
+-        mulsd     %xmm7, %xmm1
+-        addsd     %xmm6, %xmm8
+-        movsd     1872+_vmlsAtanHATab(%rip), %xmm4
+-        addsd     %xmm1, %xmm8
+-        movsd     %xmm8, -32(%rsp)
+-        movaps    %xmm9, %xmm1
+-        movsd     -32(%rsp), %xmm6
+-        addsd     %xmm6, %xmm1
+-        movsd     %xmm1, -32(%rsp)
+-        movsd     -32(%rsp), %xmm2
+-        subsd     %xmm2, %xmm9
+-        addsd     %xmm6, %xmm9
+-        movsd     %xmm9, -24(%rsp)
+-        movsd     -32(%rsp), %xmm7
+-        movaps    %xmm7, %xmm5
+-        addsd     %xmm7, %xmm0
+-        mulsd     %xmm7, %xmm5
+-        mulsd     %xmm5, %xmm4
+-        movsd     -24(%rsp), %xmm8
+-        movsd     %xmm0, -32(%rsp)
+-        movsd     -32(%rsp), %xmm1
+-        addsd     1864+_vmlsAtanHATab(%rip), %xmm4
+-        subsd     %xmm1, %xmm3
+-        mulsd     %xmm5, %xmm4
+-        addsd     %xmm7, %xmm3
+-        addsd     1856+_vmlsAtanHATab(%rip), %xmm4
+-        mulsd     %xmm5, %xmm4
+-        movsd     %xmm3, -24(%rsp)
+-        movsd     -32(%rsp), %xmm11
+-        movsd     -24(%rsp), %xmm10
+-        addsd     1848+_vmlsAtanHATab(%rip), %xmm4
+-        mulsd     %xmm5, %xmm4
+-        addsd     1840+_vmlsAtanHATab(%rip), %xmm4
+-        mulsd     %xmm5, %xmm4
+-        addsd     1832+_vmlsAtanHATab(%rip), %xmm4
+-        mulsd     %xmm5, %xmm4
+-        addsd     1824+_vmlsAtanHATab(%rip), %xmm4
+-        mulsd     %xmm4, %xmm5
+-        mulsd     %xmm5, %xmm7
+-        addsd     %xmm7, %xmm8
+-        addsd     8(%rcx,%r8,8), %xmm8
+-        addsd     %xmm8, %xmm10
+-        addsd     %xmm10, %xmm11
+-        movsd     %xmm11, -48(%rsp)
+-        movb      -41(%rsp), %r9b
+-        andb      $127, %r9b
+-        orb       %al, %r9b
+-        movb      %r9b, -41(%rsp)
+-        movsd     -48(%rsp), %xmm2
+-        cvtsd2ss  %xmm2, %xmm2
+-        movss     %xmm2, (%rsi)
+-        jmp       ..B1.11
+-..B1.5:
+-        movsd     1912+_vmlsAtanHATab(%rip), %xmm0
+-        shlb      $7, %al
+-        addsd     1920+_vmlsAtanHATab(%rip), %xmm0
+-        movsd     %xmm0, -48(%rsp)
+-        movb      -41(%rsp), %dl
+-        andb      $127, %dl
+-        orb       %al, %dl
+-        movb      %dl, -41(%rsp)
+-        movsd     -48(%rsp), %xmm1
+-        cvtsd2ss  %xmm1, %xmm1
+-        movss     %xmm1, (%rsi)
+-        jmp       ..B1.11
+-..B1.6:
+-        comisd    1880+_vmlsAtanHATab(%rip), %xmm0
+-        jb        ..B1.8
+-..B1.7:
+-        movaps    %xmm0, %xmm2
+-        mulsd     %xmm0, %xmm2
+-        shlb      $7, %al
+-        movsd     1872+_vmlsAtanHATab(%rip), %xmm1
+-        mulsd     %xmm2, %xmm1
+-        addsd     1864+_vmlsAtanHATab(%rip), %xmm1
+-        mulsd     %xmm2, %xmm1
+-        addsd     1856+_vmlsAtanHATab(%rip), %xmm1
+-        mulsd     %xmm2, %xmm1
+-        addsd     1848+_vmlsAtanHATab(%rip), %xmm1
+-        mulsd     %xmm2, %xmm1
+-        addsd     1840+_vmlsAtanHATab(%rip), %xmm1
+-        mulsd     %xmm2, %xmm1
+-        addsd     1832+_vmlsAtanHATab(%rip), %xmm1
+-        mulsd     %xmm2, %xmm1
+-        addsd     1824+_vmlsAtanHATab(%rip), %xmm1
+-        mulsd     %xmm1, %xmm2
+-        mulsd     %xmm0, %xmm2
+-        addsd     %xmm0, %xmm2
+-        movsd     %xmm2, -48(%rsp)
+-        movb      -41(%rsp), %dl
+-        andb      $127, %dl
+-        orb       %al, %dl
+-        movb      %dl, -41(%rsp)
+-        movsd     -48(%rsp), %xmm0
+-        cvtsd2ss  %xmm0, %xmm0
+-        movss     %xmm0, (%rsi)
+-        jmp       ..B1.11
+-..B1.8:
+-        testl     %edx, %edx
+-        je        ..B1.10
+-..B1.9:
+-        movsd     1904+_vmlsAtanHATab(%rip), %xmm1
+-        shlb      $7, %al
+-        addsd     %xmm0, %xmm1
+-        movsd     %xmm1, -32(%rsp)
+-        movsd     -32(%rsp), %xmm0
+-        mulsd     -8(%rsp), %xmm0
+-        movsd     %xmm0, -48(%rsp)
+-        movb      -41(%rsp), %dl
+-        andb      $127, %dl
+-        orb       %al, %dl
+-        movb      %dl, -41(%rsp)
+-        movsd     -48(%rsp), %xmm2
+-        cvtsd2ss  %xmm2, %xmm2
+-        movss     %xmm2, (%rsi)
+-        jmp       ..B1.11
+-..B1.10:
+-        mulss     %xmm1, %xmm1
+-        shlb      $7, %al
+-        movss     %xmm1, -56(%rsp)
+-        movss     -56(%rsp), %xmm0
+-        cvtss2sd  %xmm0, %xmm0
+-        addsd     -8(%rsp), %xmm0
+-        movsd     %xmm0, -48(%rsp)
+-        movb      -41(%rsp), %dl
+-        andb      $127, %dl
+-        orb       %al, %dl
+-        movb      %dl, -41(%rsp)
+-        movsd     -48(%rsp), %xmm1
+-        cvtsd2ss  %xmm1, %xmm1
+-        movss     %xmm1, (%rsi)
+-..B1.11:
+-        xorl      %eax, %eax
+-        ret
+-..B1.12:
+-        testl     $8388607, (%rdi)
+-        jne       ..B1.14
+-..B1.13:
+-        movsd     1912+_vmlsAtanHATab(%rip), %xmm0
+-        movb      3(%rdi), %al
+-        andb      $-128, %al
+-        addsd     1920+_vmlsAtanHATab(%rip), %xmm0
+-        movsd     %xmm0, -48(%rsp)
+-        movb      -41(%rsp), %dl
+-        andb      $127, %dl
+-        orb       %al, %dl
+-        movb      %dl, -41(%rsp)
+-        movsd     -48(%rsp), %xmm1
+-        cvtsd2ss  %xmm1, %xmm1
+-        movss     %xmm1, (%rsi)
+-        jmp       ..B1.11
+-..B1.14:
+-        movss     (%rdi), %xmm0
+-        addss     %xmm0, %xmm0
+-        movss     %xmm0, (%rsi)
+-        jmp       ..B1.11
+-        .align    16,0x90
+-	.cfi_endproc
+-	.type	__svml_satan_ha_cout_rare_internal,@function
+-	.size	__svml_satan_ha_cout_rare_internal,.-__svml_satan_ha_cout_rare_internal
+-..LN__svml_satan_ha_cout_rare_internal.0:
+-	.data
+-# -- End  __svml_satan_ha_cout_rare_internal
+-	.section .rodata, "a"
+-	.align 32
+-	.align 32
+-_vmlsAtanHATab:
+-	.long	3892314112
+-	.long	1069799150
+-	.long	2332892550
+-	.long	1039715405
+-	.long	1342177280
+-	.long	1070305495
+-	.long	270726690
+-	.long	1041535749
+-	.long	939524096
+-	.long	1070817911
+-	.long	2253973841
+-	.long	3188654726
+-	.long	3221225472
+-	.long	1071277294
+-	.long	3853927037
+-	.long	1043226911
+-	.long	2818572288
+-	.long	1071767563
+-	.long	2677759107
+-	.long	1044314101
+-	.long	3355443200
+-	.long	1072103591
+-	.long	1636578514
+-	.long	3191094734
+-	.long	1476395008
+-	.long	1072475260
+-	.long	1864703685
+-	.long	3188646936
+-	.long	805306368
+-	.long	1072747407
+-	.long	192551812
+-	.long	3192726267
+-	.long	2013265920
+-	.long	1072892781
+-	.long	2240369452
+-	.long	1043768538
+-	.long	0
+-	.long	1072999953
+-	.long	3665168337
+-	.long	3192705970
+-	.long	402653184
+-	.long	1073084787
+-	.long	1227953434
+-	.long	3192313277
+-	.long	2013265920
+-	.long	1073142981
+-	.long	3853283127
+-	.long	1045277487
+-	.long	805306368
+-	.long	1073187261
+-	.long	1676192264
+-	.long	3192868861
+-	.long	134217728
+-	.long	1073217000
+-	.long	4290763938
+-	.long	1042034855
+-	.long	671088640
+-	.long	1073239386
+-	.long	994303084
+-	.long	3189643768
+-	.long	402653184
+-	.long	1073254338
+-	.long	1878067156
+-	.long	1042652475
+-	.long	1610612736
+-	.long	1073265562
+-	.long	670314820
+-	.long	1045138554
+-	.long	3221225472
+-	.long	1073273048
+-	.long	691126919
+-	.long	3189987794
+-	.long	3489660928
+-	.long	1073278664
+-	.long	1618990832
+-	.long	3188194509
+-	.long	1207959552
+-	.long	1073282409
+-	.long	2198872939
+-	.long	1044806069
+-	.long	3489660928
+-	.long	1073285217
+-	.long	2633982383
+-	.long	1042307894
+-	.long	939524096
+-	.long	1073287090
+-	.long	1059367786
+-	.long	3189114230
+-	.long	2281701376
+-	.long	1073288494
+-	.long	3158525533
+-	.long	1044484961
+-	.long	3221225472
+-	.long	1073289430
+-	.long	286581777
+-	.long	1044893263
+-	.long	4026531840
+-	.long	1073290132
+-	.long	2000245215
+-	.long	3191647611
+-	.long	134217728
+-	.long	1073290601
+-	.long	4205071590
+-	.long	1045035927
+-	.long	536870912
+-	.long	1073290952
+-	.long	2334392229
+-	.long	1043447393
+-	.long	805306368
+-	.long	1073291186
+-	.long	2281458177
+-	.long	3188885569
+-	.long	3087007744
+-	.long	1073291361
+-	.long	691611507
+-	.long	1044733832
+-	.long	3221225472
+-	.long	1073291478
+-	.long	1816229550
+-	.long	1044363390
+-	.long	2281701376
+-	.long	1073291566
+-	.long	1993843750
+-	.long	3189837440
+-	.long	134217728
+-	.long	1073291625
+-	.long	3654754496
+-	.long	1044970837
+-	.long	4026531840
+-	.long	1073291668
+-	.long	3224300229
+-	.long	3191935390
+-	.long	805306368
+-	.long	1073291698
+-	.long	2988777976
+-	.long	3188950659
+-	.long	536870912
+-	.long	1073291720
+-	.long	1030371341
+-	.long	1043402665
+-	.long	3221225472
+-	.long	1073291734
+-	.long	1524463765
+-	.long	1044361356
+-	.long	3087007744
+-	.long	1073291745
+-	.long	2754295320
+-	.long	1044731036
+-	.long	134217728
+-	.long	1073291753
+-	.long	3099629057
+-	.long	1044970710
+-	.long	2281701376
+-	.long	1073291758
+-	.long	962914160
+-	.long	3189838838
+-	.long	805306368
+-	.long	1073291762
+-	.long	3543908206
+-	.long	3188950786
+-	.long	4026531840
+-	.long	1073291764
+-	.long	1849909620
+-	.long	3191935434
+-	.long	3221225472
+-	.long	1073291766
+-	.long	1641333636
+-	.long	1044361352
+-	.long	536870912
+-	.long	1073291768
+-	.long	1373968792
+-	.long	1043402654
+-	.long	134217728
+-	.long	1073291769
+-	.long	2033191599
+-	.long	1044970710
+-	.long	3087007744
+-	.long	1073291769
+-	.long	4117947437
+-	.long	1044731035
+-	.long	805306368
+-	.long	1073291770
+-	.long	315378368
+-	.long	3188950787
+-	.long	2281701376
+-	.long	1073291770
+-	.long	2428571750
+-	.long	3189838838
+-	.long	3221225472
+-	.long	1073291770
+-	.long	1608007466
+-	.long	1044361352
+-	.long	4026531840
+-	.long	1073291770
+-	.long	1895711420
+-	.long	3191935434
+-	.long	134217728
+-	.long	1073291771
+-	.long	2031108713
+-	.long	1044970710
+-	.long	536870912
+-	.long	1073291771
+-	.long	1362518342
+-	.long	1043402654
+-	.long	805306368
+-	.long	1073291771
+-	.long	317461253
+-	.long	3188950787
+-	.long	939524096
+-	.long	1073291771
+-	.long	4117231784
+-	.long	1044731035
+-	.long	1073741824
+-	.long	1073291771
+-	.long	1607942376
+-	.long	1044361352
+-	.long	1207959552
+-	.long	1073291771
+-	.long	2428929577
+-	.long	3189838838
+-	.long	1207959552
+-	.long	1073291771
+-	.long	2031104645
+-	.long	1044970710
+-	.long	1342177280
+-	.long	1073291771
+-	.long	1895722602
+-	.long	3191935434
+-	.long	1342177280
+-	.long	1073291771
+-	.long	317465322
+-	.long	3188950787
+-	.long	1342177280
+-	.long	1073291771
+-	.long	1362515546
+-	.long	1043402654
+-	.long	1342177280
+-	.long	1073291771
+-	.long	1607942248
+-	.long	1044361352
+-	.long	1342177280
+-	.long	1073291771
+-	.long	4117231610
+-	.long	1044731035
+-	.long	1342177280
+-	.long	1073291771
+-	.long	2031104637
+-	.long	1044970710
+-	.long	1342177280
+-	.long	1073291771
+-	.long	1540251232
+-	.long	1045150466
+-	.long	1342177280
+-	.long	1073291771
+-	.long	2644671394
+-	.long	1045270303
+-	.long	1342177280
+-	.long	1073291771
+-	.long	2399244691
+-	.long	1045360181
+-	.long	1342177280
+-	.long	1073291771
+-	.long	803971124
+-	.long	1045420100
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3613709523
+-	.long	3192879152
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2263862659
+-	.long	3192849193
+-	.long	1476395008
+-	.long	1073291771
+-	.long	177735686
+-	.long	3192826724
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1650295902
+-	.long	3192811744
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2754716064
+-	.long	3192800509
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3490996172
+-	.long	3192793019
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1895722605
+-	.long	3192787402
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2263862659
+-	.long	3192783657
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3613709523
+-	.long	3192780848
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1650295902
+-	.long	3192778976
+-	.long	1476395008
+-	.long	1073291771
+-	.long	177735686
+-	.long	3192777572
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3490996172
+-	.long	3192776635
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2754716064
+-	.long	3192775933
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2263862659
+-	.long	3192775465
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1895722605
+-	.long	3192775114
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1650295902
+-	.long	3192774880
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3613709523
+-	.long	3192774704
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3490996172
+-	.long	3192774587
+-	.long	1476395008
+-	.long	1073291771
+-	.long	177735686
+-	.long	3192774500
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2263862659
+-	.long	3192774441
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2754716064
+-	.long	3192774397
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1650295902
+-	.long	3192774368
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1895722605
+-	.long	3192774346
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3490996172
+-	.long	3192774331
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3613709523
+-	.long	3192774320
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2263862659
+-	.long	3192774313
+-	.long	1476395008
+-	.long	1073291771
+-	.long	177735686
+-	.long	3192774308
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1650295902
+-	.long	3192774304
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2754716064
+-	.long	3192774301
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3490996172
+-	.long	3192774299
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1895722605
+-	.long	3192774298
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2263862659
+-	.long	3192774297
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3613709523
+-	.long	3192774296
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1650295902
+-	.long	3192774296
+-	.long	1476395008
+-	.long	1073291771
+-	.long	177735686
+-	.long	3192774296
+-	.long	1476395008
+-	.long	1073291771
+-	.long	3490996172
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2754716064
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	2263862659
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1895722605
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1650295902
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1466225875
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1343512524
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1251477510
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1190120835
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1144103328
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1113424990
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1090416237
+-	.long	3192774295
+-	.long	1476395008
+-	.long	1073291771
+-	.long	1075077068
+-	.long	3192774295
+-	.long	1431655765
+-	.long	3218429269
+-	.long	2576978363
+-	.long	1070176665
+-	.long	2453154343
+-	.long	3217180964
+-	.long	4189149139
+-	.long	1069314502
+-	.long	1775019125
+-	.long	3216459198
+-	.long	273199057
+-	.long	1068739452
+-	.long	874748308
+-	.long	3215993277
+-	.long	0
+-	.long	1017118720
+-	.long	0
+-	.long	1069547520
+-	.long	0
+-	.long	1129316352
+-	.long	0
+-	.long	1072693248
+-	.long	1413754136
+-	.long	1073291771
+-	.long	856972295
+-	.long	1016178214
+-	.long	33554432
+-	.long	1101004800
+-	.type	_vmlsAtanHATab,@object
+-	.size	_vmlsAtanHATab,1936
+-	.data
+-	.section .note.GNU-stack, ""
+-# End
+diff --git a/libm/x86_64/atanf_data_avx2.S b/libm/x86_64/atanf_data_avx2.S
+deleted file mode 100644
+index b9102540c..000000000
+--- a/libm/x86_64/atanf_data_avx2.S
++++ /dev/null
+@@ -1,814 +0,0 @@
+-/*
+-Copyright (C) 2019 The Android Open Source Project
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+- * Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+- * Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in
+-   the documentation and/or other materials provided with the
+-   distribution.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+-FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+-AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+-OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-SUCH DAMAGE.
+-*/
+-
+-# -- Machine type EM64t
+-	.section .rodata, "a"
+-	.align 64
+-	.align 64
+-	.hidden __svml_satan_ha_data_internal_avx512
+-	.globl __svml_satan_ha_data_internal_avx512
+-__svml_satan_ha_data_internal_avx512:
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	1241513984
+-	.long	1241513984
+-	.long	1241513984
+-	.long	1241513984
+-	.long	1241513984
+-	.long	1241513984
+-	.long	1241513984
+-	.long	1241513984
+-	.long	1241513984
+-	.long	1241513984
+-	.long	1241513984
+-	.long	1241513984
+-	.long	1241513984
+-	.long	1241513984
+-	.long	1241513984
+-	.long	1241513984
+-	.long	1089994752
+-	.long	1089994752
+-	.long	1089994752
+-	.long	1089994752
+-	.long	1089994752
+-	.long	1089994752
+-	.long	1089994752
+-	.long	1089994752
+-	.long	1089994752
+-	.long	1089994752
+-	.long	1089994752
+-	.long	1089994752
+-	.long	1089994752
+-	.long	1089994752
+-	.long	1089994752
+-	.long	1089994752
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1333788672
+-	.long	1333788672
+-	.long	1333788672
+-	.long	1333788672
+-	.long	1333788672
+-	.long	1333788672
+-	.long	1333788672
+-	.long	1333788672
+-	.long	1333788672
+-	.long	1333788672
+-	.long	1333788672
+-	.long	1333788672
+-	.long	1333788672
+-	.long	1333788672
+-	.long	1333788672
+-	.long	1333788672
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	0
+-	.long	1048239024
+-	.long	1055744824
+-	.long	1059372157
+-	.long	1061752795
+-	.long	1063609315
+-	.long	1065064543
+-	.long	1065786489
+-	.long	1066252045
+-	.long	1066633083
+-	.long	1066949484
+-	.long	1067215699
+-	.long	1067442363
+-	.long	1067637412
+-	.long	1067806856
+-	.long	1067955311
+-	.long	1068086373
+-	.long	1068202874
+-	.long	1068307075
+-	.long	1068400798
+-	.long	1068485529
+-	.long	1068562486
+-	.long	1068632682
+-	.long	1068696961
+-	.long	1068756035
+-	.long	1068810506
+-	.long	1068860887
+-	.long	1068907620
+-	.long	1068951084
+-	.long	1068991608
+-	.long	1069029480
+-	.long	1069064949
+-	.long	0
+-	.long	2975494116
+-	.long	833369962
+-	.long	835299256
+-	.long	2998648110
+-	.long	2995239174
+-	.long	3000492182
+-	.long	860207626
+-	.long	3008447516
+-	.long	3005590622
+-	.long	3000153675
+-	.long	860754741
+-	.long	859285590
+-	.long	844944488
+-	.long	2993069463
+-	.long	858157665
+-	.long	3006142000
+-	.long	3007693206
+-	.long	3009342234
+-	.long	847469400
+-	.long	3006114683
+-	.long	852829553
+-	.long	847325583
+-	.long	860305056
+-	.long	846145135
+-	.long	2997638646
+-	.long	855837703
+-	.long	2979047222
+-	.long	2995344192
+-	.long	854092798
+-	.long	3000498637
+-	.long	859965578
+-	.long	1070141403
+-	.long	1070141403
+-	.long	1070141403
+-	.long	1070141403
+-	.long	1070141403
+-	.long	1070141403
+-	.long	1070141403
+-	.long	1070141403
+-	.long	1070141403
+-	.long	1070141403
+-	.long	1070141403
+-	.long	1070141403
+-	.long	1070141403
+-	.long	1070141403
+-	.long	1070141403
+-	.long	1070141403
+-	.long	3007036718
+-	.long	3007036718
+-	.long	3007036718
+-	.long	3007036718
+-	.long	3007036718
+-	.long	3007036718
+-	.long	3007036718
+-	.long	3007036718
+-	.long	3007036718
+-	.long	3007036718
+-	.long	3007036718
+-	.long	3007036718
+-	.long	3007036718
+-	.long	3007036718
+-	.long	3007036718
+-	.long	3007036718
+-	.long	3188697310
+-	.long	3188697310
+-	.long	3188697310
+-	.long	3188697310
+-	.long	3188697310
+-	.long	3188697310
+-	.long	3188697310
+-	.long	3188697310
+-	.long	3188697310
+-	.long	3188697310
+-	.long	3188697310
+-	.long	3188697310
+-	.long	3188697310
+-	.long	3188697310
+-	.long	3188697310
+-	.long	3188697310
+-	.long	1045219554
+-	.long	1045219554
+-	.long	1045219554
+-	.long	1045219554
+-	.long	1045219554
+-	.long	1045219554
+-	.long	1045219554
+-	.long	1045219554
+-	.long	1045219554
+-	.long	1045219554
+-	.long	1045219554
+-	.long	1045219554
+-	.long	1045219554
+-	.long	1045219554
+-	.long	1045219554
+-	.long	1045219554
+-	.long	3198855850
+-	.long	3198855850
+-	.long	3198855850
+-	.long	3198855850
+-	.long	3198855850
+-	.long	3198855850
+-	.long	3198855850
+-	.long	3198855850
+-	.long	3198855850
+-	.long	3198855850
+-	.long	3198855850
+-	.long	3198855850
+-	.long	3198855850
+-	.long	3198855850
+-	.long	3198855850
+-	.long	3198855850
+-	.type	__svml_satan_ha_data_internal_avx512,@object
+-	.size	__svml_satan_ha_data_internal_avx512,1024
+-	.align 64
+-	.hidden __svml_satan_ha_data_internal
+-	.globl __svml_satan_ha_data_internal
+-__svml_satan_ha_data_internal:
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	3212836864
+-	.long	2147483648
+-	.long	2147483648
+-	.long	2147483648
+-	.long	2147483648
+-	.long	2147483648
+-	.long	2147483648
+-	.long	2147483648
+-	.long	2147483648
+-	.long	2147483648
+-	.long	2147483648
+-	.long	2147483648
+-	.long	2147483648
+-	.long	2147483648
+-	.long	2147483648
+-	.long	2147483648
+-	.long	2147483648
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	2147483647
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1052770304
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1060655596
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1071644672
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1076625408
+-	.long	1056964608
+-	.long	1056964608
+-	.long	1056964608
+-	.long	1056964608
+-	.long	1056964608
+-	.long	1056964608
+-	.long	1056964608
+-	.long	1056964608
+-	.long	1056964608
+-	.long	1056964608
+-	.long	1056964608
+-	.long	1056964608
+-	.long	1056964608
+-	.long	1056964608
+-	.long	1056964608
+-	.long	1056964608
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1065353216
+-	.long	1073741824
+-	.long	1073741824
+-	.long	1073741824
+-	.long	1073741824
+-	.long	1073741824
+-	.long	1073741824
+-	.long	1073741824
+-	.long	1073741824
+-	.long	1073741824
+-	.long	1073741824
+-	.long	1073741824
+-	.long	1073741824
+-	.long	1073741824
+-	.long	1073741824
+-	.long	1073741824
+-	.long	1073741824
+-	.long	1055744824
+-	.long	1055744824
+-	.long	1055744824
+-	.long	1055744824
+-	.long	1055744824
+-	.long	1055744824
+-	.long	1055744824
+-	.long	1055744824
+-	.long	1055744824
+-	.long	1055744824
+-	.long	1055744824
+-	.long	1055744824
+-	.long	1055744824
+-	.long	1055744824
+-	.long	1055744824
+-	.long	1055744824
+-	.long	833369960
+-	.long	833369960
+-	.long	833369960
+-	.long	833369960
+-	.long	833369960
+-	.long	833369960
+-	.long	833369960
+-	.long	833369960
+-	.long	833369960
+-	.long	833369960
+-	.long	833369960
+-	.long	833369960
+-	.long	833369960
+-	.long	833369960
+-	.long	833369960
+-	.long	833369960
+-	.long	1061752792
+-	.long	1061752792
+-	.long	1061752792
+-	.long	1061752792
+-	.long	1061752792
+-	.long	1061752792
+-	.long	1061752792
+-	.long	1061752792
+-	.long	1061752792
+-	.long	1061752792
+-	.long	1061752792
+-	.long	1061752792
+-	.long	1061752792
+-	.long	1061752792
+-	.long	1061752792
+-	.long	1061752792
+-	.long	875071576
+-	.long	875071576
+-	.long	875071576
+-	.long	875071576
+-	.long	875071576
+-	.long	875071576
+-	.long	875071576
+-	.long	875071576
+-	.long	875071576
+-	.long	875071576
+-	.long	875071576
+-	.long	875071576
+-	.long	875071576
+-	.long	875071576
+-	.long	875071576
+-	.long	875071576
+-	.long	1066252048
+-	.long	1066252048
+-	.long	1066252048
+-	.long	1066252048
+-	.long	1066252048
+-	.long	1066252048
+-	.long	1066252048
+-	.long	1066252048
+-	.long	1066252048
+-	.long	1066252048
+-	.long	1066252048
+-	.long	1066252048
+-	.long	1066252048
+-	.long	1066252048
+-	.long	1066252048
+-	.long	1066252048
+-	.long	3034196096
+-	.long	3034196096
+-	.long	3034196096
+-	.long	3034196096
+-	.long	3034196096
+-	.long	3034196096
+-	.long	3034196096
+-	.long	3034196096
+-	.long	3034196096
+-	.long	3034196096
+-	.long	3034196096
+-	.long	3034196096
+-	.long	3034196096
+-	.long	3034196096
+-	.long	3034196096
+-	.long	3034196096
+-	.long	1070141400
+-	.long	1070141400
+-	.long	1070141400
+-	.long	1070141400
+-	.long	1070141400
+-	.long	1070141400
+-	.long	1070141400
+-	.long	1070141400
+-	.long	1070141400
+-	.long	1070141400
+-	.long	1070141400
+-	.long	1070141400
+-	.long	1070141400
+-	.long	1070141400
+-	.long	1070141400
+-	.long	1070141400
+-	.long	883460184
+-	.long	883460184
+-	.long	883460184
+-	.long	883460184
+-	.long	883460184
+-	.long	883460184
+-	.long	883460184
+-	.long	883460184
+-	.long	883460184
+-	.long	883460184
+-	.long	883460184
+-	.long	883460184
+-	.long	883460184
+-	.long	883460184
+-	.long	883460184
+-	.long	883460184
+-	.long	1034818345
+-	.long	1034818345
+-	.long	1034818345
+-	.long	1034818345
+-	.long	1034818345
+-	.long	1034818345
+-	.long	1034818345
+-	.long	1034818345
+-	.long	1034818345
+-	.long	1034818345
+-	.long	1034818345
+-	.long	1034818345
+-	.long	1034818345
+-	.long	1034818345
+-	.long	1034818345
+-	.long	1034818345
+-	.long	3188674126
+-	.long	3188674126
+-	.long	3188674126
+-	.long	3188674126
+-	.long	3188674126
+-	.long	3188674126
+-	.long	3188674126
+-	.long	3188674126
+-	.long	3188674126
+-	.long	3188674126
+-	.long	3188674126
+-	.long	3188674126
+-	.long	3188674126
+-	.long	3188674126
+-	.long	3188674126
+-	.long	3188674126
+-	.long	1045211707
+-	.long	1045211707
+-	.long	1045211707
+-	.long	1045211707
+-	.long	1045211707
+-	.long	1045211707
+-	.long	1045211707
+-	.long	1045211707
+-	.long	1045211707
+-	.long	1045211707
+-	.long	1045211707
+-	.long	1045211707
+-	.long	1045211707
+-	.long	1045211707
+-	.long	1045211707
+-	.long	1045211707
+-	.long	3198855788
+-	.long	3198855788
+-	.long	3198855788
+-	.long	3198855788
+-	.long	3198855788
+-	.long	3198855788
+-	.long	3198855788
+-	.long	3198855788
+-	.long	3198855788
+-	.long	3198855788
+-	.long	3198855788
+-	.long	3198855788
+-	.long	3198855788
+-	.long	3198855788
+-	.long	3198855788
+-	.long	3198855788
+-	.long	4294967295
+-	.long	4294967295
+-	.long	4294967295
+-	.long	4294967295
+-	.long	4294967295
+-	.long	4294967295
+-	.long	4294967295
+-	.long	4294967295
+-	.long	4294967295
+-	.long	4294967295
+-	.long	4294967295
+-	.long	4294967295
+-	.long	4294967295
+-	.long	4294967295
+-	.long	4294967295
+-	.long	4294967295
+-	.long	3758096384
+-	.long	4294967295
+-	.long	3758096384
+-	.long	4294967295
+-	.long	3758096384
+-	.long	4294967295
+-	.long	3758096384
+-	.long	4294967295
+-	.long	3758096384
+-	.long	4294967295
+-	.long	3758096384
+-	.long	4294967295
+-	.long	3758096384
+-	.long	4294967295
+-	.long	3758096384
+-	.long	4294967295
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	0
+-	.long	1072693248
+-	.long	2164260864
+-	.long	2164260864
+-	.long	2164260864
+-	.long	2164260864
+-	.long	2164260864
+-	.long	2164260864
+-	.long	2164260864
+-	.long	2164260864
+-	.long	2164260864
+-	.long	2164260864
+-	.long	2164260864
+-	.long	2164260864
+-	.long	2164260864
+-	.long	2164260864
+-	.long	2164260864
+-	.long	2164260864
+-	.long	4227858432
+-	.long	4227858432
+-	.long	4227858432
+-	.long	4227858432
+-	.long	4227858432
+-	.long	4227858432
+-	.long	4227858432
+-	.long	4227858432
+-	.long	4227858432
+-	.long	4227858432
+-	.long	4227858432
+-	.long	4227858432
+-	.long	4227858432
+-	.long	4227858432
+-	.long	4227858432
+-	.long	4227858432
+-	.type	__svml_satan_ha_data_internal,@object
+-	.size	__svml_satan_ha_data_internal,2048
+-	.data
+-	.section .note.GNU-stack, ""
+-# End
+diff --git a/libm/x86_64/dynamic_function_dispatch.cpp b/libm/x86_64/dynamic_function_dispatch.cpp
+new file mode 100644
+index 000000000..3710873a9
+--- /dev/null
++++ b/libm/x86_64/dynamic_function_dispatch.cpp
+@@ -0,0 +1,175 @@
++/*
++ * Copyright (C) 2008 The Android Open Source Project
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *  * Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ *  * Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in
++ *    the documentation and/or other materials provided with the
++ *    distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
++ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
++ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
++ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
++ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
++ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
++ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
++ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
++ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++#include <stddef.h>
++
++#include <private/bionic_ifuncs.h>
++
++extern "C" {
++
++typedef double ceil_func(double __x);
++DEFINE_IFUNC_FOR(ceil) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(ceil_func, ceil_avx2);
++    RETURN_FUNC(ceil_func, ceil_generic);
++}
++
++typedef float ceilf_func(float __x);
++DEFINE_IFUNC_FOR(ceilf) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(ceilf_func, ceilf_avx2);
++    RETURN_FUNC(ceilf_func, ceilf_generic);
++}
++
++typedef double floor_func(double __x);
++DEFINE_IFUNC_FOR(floor) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(floor_func, floor_avx2);
++    RETURN_FUNC(floor_func, floor_generic);
++}
++
++typedef float floorf_func(float __x);
++DEFINE_IFUNC_FOR(floorf) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(floorf_func, floorf_avx2);
++    RETURN_FUNC(floorf_func, floorf_generic);
++}
++
++typedef double rint_func(double __x);
++DEFINE_IFUNC_FOR(rint) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(rint_func, rint_avx2);
++    RETURN_FUNC(rint_func, rint_generic);
++}
++
++typedef float rintf_func(float __x);
++DEFINE_IFUNC_FOR(rintf) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(rintf_func, rintf_avx2);
++    RETURN_FUNC(rintf_func, rintf_generic);
++}
++
++typedef double hypot_func(double __x, double __y);
++DEFINE_IFUNC_FOR(hypot) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(hypot_func, hypot_avx2);
++    RETURN_FUNC(hypot_func, hypot_generic);
++}
++
++typedef double log10_func(double __x);
++DEFINE_IFUNC_FOR(log10) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(log10_func, log10_avx2);
++    RETURN_FUNC(log10_func, log10_generic);
++}
++
++typedef float log10f_func(float __x);
++DEFINE_IFUNC_FOR(log10f) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(log10f_func, log10f_avx2);
++    RETURN_FUNC(log10f_func, log10f_generic);
++}
++
++typedef double log1p_func(double __x);
++DEFINE_IFUNC_FOR(log1p) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(log1p_func, log1p_avx2);
++    RETURN_FUNC(log1p_func, log1p_generic);
++}
++
++typedef float log1pf_func(float __x);
++DEFINE_IFUNC_FOR(log1pf) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(log1pf_func, log1pf_avx2);
++    RETURN_FUNC(log1pf_func, log1pf_generic);
++}
++
++typedef double cbrt_func(double __x);
++DEFINE_IFUNC_FOR(cbrt) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(cbrt_func, cbrt_avx2);
++    RETURN_FUNC(cbrt_func, cbrt_generic);
++}
++
++typedef float cbrtf_func(float __x);
++DEFINE_IFUNC_FOR(cbrtf) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(cbrtf_func, cbrtf_avx2);
++    RETURN_FUNC(cbrtf_func, cbrtf_generic);
++}
++
++typedef double cos_func(double __x);
++DEFINE_IFUNC_FOR(cos) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(cos_func, cos_avx2);
++    RETURN_FUNC(cos_func, cos_generic);
++}
++
++typedef float cosf_func(float __x);
++DEFINE_IFUNC_FOR(cosf) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(cosf_func, cosf_avx2);
++    RETURN_FUNC(cosf_func, cosf_generic);
++}
++
++typedef double sin_func(double __x);
++DEFINE_IFUNC_FOR(sin) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(sin_func, sin_avx2);
++    RETURN_FUNC(sin_func, sin_generic);
++}
++
++typedef float sinf_func(float __x);
++DEFINE_IFUNC_FOR(sinf) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(sinf_func, sinf_avx2);
++    RETURN_FUNC(sinf_func, sinf_generic);
++}
++
++typedef double sinh_func(double __x);
++DEFINE_IFUNC_FOR(sinh) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(sinh_func, sinh_avx2);
++    RETURN_FUNC(sinh_func, sinh_generic);
++}
++
++typedef float sinhf_func(float __x);
++DEFINE_IFUNC_FOR(sinhf) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(sinhf_func, sinhf_avx2);
++    RETURN_FUNC(sinhf_func, sinhf_generic);
++}
++
++typedef float expf_func(float __x);
++DEFINE_IFUNC_FOR(expf) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(expf_func, expf_avx2);
++    RETURN_FUNC(expf_func, expf_generic);
++}
++
++}  // extern "C"
+diff --git a/libm/x86_64/ceil.S b/libm/x86_64/generic/ceil.S
+similarity index 97%
+rename from libm/x86_64/ceil.S
+rename to libm/x86_64/generic/ceil.S
+index d4492c404..201749a65 100644
+--- a/libm/x86_64/ceil.S
++++ b/libm/x86_64/generic/ceil.S
+@@ -30,7 +30,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ 
+-ENTRY(ceil)
++
++ENTRY(ceil_generic)
+ roundsd $0x2,%xmm0,%xmm0
+ retq
+-END(ceil)
++END(ceil_generic)
+diff --git a/libm/x86_64/ceilf.S b/libm/x86_64/generic/ceilf.S
+similarity index 97%
+rename from libm/x86_64/ceilf.S
+rename to libm/x86_64/generic/ceilf.S
+index 0e1ca95dc..72f0364d9 100644
+--- a/libm/x86_64/ceilf.S
++++ b/libm/x86_64/generic/ceilf.S
+@@ -30,7 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ 
+-ENTRY(ceilf)
++ENTRY(ceilf_generic)
+ roundss $0x2,%xmm0,%xmm0
+ retq
+-END(ceilf)
++END(ceilf_generic)
+diff --git a/libm/x86_64/generic/cosf.c b/libm/x86_64/generic/cosf.c
+new file mode 100644
+index 000000000..e980df018
+--- /dev/null
++++ b/libm/x86_64/generic/cosf.c
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define  cosf cosf_generic
++
++#include <../../external/arm-optimized-routines/math/cosf.c>
+diff --git a/libm/x86_64/e_acos.S b/libm/x86_64/generic/e_acos.S
+similarity index 100%
+rename from libm/x86_64/e_acos.S
+rename to libm/x86_64/generic/e_acos.S
+diff --git a/libm/x86_64/e_asin.S b/libm/x86_64/generic/e_asin.S
+similarity index 100%
+rename from libm/x86_64/e_asin.S
+rename to libm/x86_64/generic/e_asin.S
+diff --git a/libm/x86_64/e_atan2.S b/libm/x86_64/generic/e_atan2.S
+similarity index 100%
+rename from libm/x86_64/e_atan2.S
+rename to libm/x86_64/generic/e_atan2.S
+diff --git a/libm/x86_64/e_cosh.S b/libm/x86_64/generic/e_cosh.S
+similarity index 100%
+rename from libm/x86_64/e_cosh.S
+rename to libm/x86_64/generic/e_cosh.S
+diff --git a/libm/x86_64/e_hypot.S b/libm/x86_64/generic/e_hypot.S
+similarity index 99%
+rename from libm/x86_64/e_hypot.S
+rename to libm/x86_64/generic/e_hypot.S
+index 089b2b47c..ec02b65b2 100644
+--- a/libm/x86_64/e_hypot.S
++++ b/libm/x86_64/generic/e_hypot.S
+@@ -65,7 +65,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  hypot
+-ENTRY(hypot)
++ENTRY(hypot_generic)
+ # parameter 1: %xmm0
+ # parameter 2: %xmm1
+ ..B1.1:
+@@ -174,7 +174,7 @@ ENTRY(hypot)
+         ret       
+ ..B1.3:
+ ..___tag_value_hypot.4:
+-END(hypot)
++END(hypot_generic)
+ # -- End  hypot
+ 	.section .rodata, "a"
+ 	.align 16
+diff --git a/libm/x86_64/e_log10.S b/libm/x86_64/generic/e_log10.S
+similarity index 99%
+rename from libm/x86_64/e_log10.S
+rename to libm/x86_64/generic/e_log10.S
+index 4f43a36e5..90e545515 100644
+--- a/libm/x86_64/e_log10.S
++++ b/libm/x86_64/generic/e_log10.S
+@@ -55,7 +55,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  log10
+-ENTRY(log10)
++ENTRY(log10_generic)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..___tag_value_log10.1:
+@@ -219,7 +219,7 @@ ENTRY(log10)
+ ..___tag_value_log10.4:
+         ret       
+ ..___tag_value_log10.5:
+-END(log10)
++END(log10_generic)
+ # -- End  log10
+ 	.section .rodata, "a"
+ 	.align 16
+diff --git a/libm/x86_64/generic/e_log10f.c b/libm/x86_64/generic/e_log10f.c
+new file mode 100644
+index 000000000..d03281253
+--- /dev/null
++++ b/libm/x86_64/generic/e_log10f.c
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define  log10f log10f_generic
++
++#include <upstream-freebsd/lib/msun/src/e_log10f.c>
+diff --git a/libm/x86_64/e_sinh.S b/libm/x86_64/generic/e_sinh.S
+similarity index 99%
+rename from libm/x86_64/e_sinh.S
+rename to libm/x86_64/generic/e_sinh.S
+index 4d8db630a..7d0775e62 100644
+--- a/libm/x86_64/e_sinh.S
++++ b/libm/x86_64/generic/e_sinh.S
+@@ -78,7 +78,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  sinh
+-ENTRY(sinh)
++ENTRY(sinh_generic)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..___tag_value_sinh.1:
+@@ -300,7 +300,7 @@ ENTRY(sinh)
+ ..___tag_value_sinh.4:
+         ret       
+ ..___tag_value_sinh.5:
+-END(sinh)
++END(sinh_generic)
+ # -- End  sinh
+ 	.section .rodata, "a"
+ 	.align 16
+diff --git a/libm/x86_64/generic/e_sinhf.c b/libm/x86_64/generic/e_sinhf.c
+new file mode 100644
+index 000000000..48623406d
+--- /dev/null
++++ b/libm/x86_64/generic/e_sinhf.c
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define  sinhf sinhf_generic
++
++#include <upstream-freebsd/lib/msun/src/e_sinhf.c>
+diff --git a/libm/x86_64/generic/expf.c b/libm/x86_64/generic/expf.c
+new file mode 100644
+index 000000000..2e1aa26f0
+--- /dev/null
++++ b/libm/x86_64/generic/expf.c
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define expf expf_generic
++#define FROM_LIBM 
++#include <../../external/arm-optimized-routines/math/expf.c>
+diff --git a/libm/x86_64/floor.S b/libm/x86_64/generic/floor.S
+similarity index 97%
+rename from libm/x86_64/floor.S
+rename to libm/x86_64/generic/floor.S
+index dc80e88b7..c3e3ed429 100644
+--- a/libm/x86_64/floor.S
++++ b/libm/x86_64/generic/floor.S
+@@ -30,7 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ 
+-ENTRY(floor)
++ENTRY(floor_generic)
+ roundsd $0x1,%xmm0,%xmm0
+ retq
+-END(floor)
++END(floor_generic)
+diff --git a/libm/x86_64/floorf.S b/libm/x86_64/generic/floorf.S
+similarity index 97%
+rename from libm/x86_64/floorf.S
+rename to libm/x86_64/generic/floorf.S
+index 832f9c5fc..ae46602d1 100644
+--- a/libm/x86_64/floorf.S
++++ b/libm/x86_64/generic/floorf.S
+@@ -30,7 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ 
+-ENTRY(floorf)
++ENTRY(floorf_generic)
+ roundss $0x1,%xmm0,%xmm0
+ retq
+-END(floorf)
++END(floorf_generic)
+diff --git a/libm/x86_64/lrint.S b/libm/x86_64/generic/lrint.S
+similarity index 100%
+rename from libm/x86_64/lrint.S
+rename to libm/x86_64/generic/lrint.S
+diff --git a/libm/x86_64/lrintf.S b/libm/x86_64/generic/lrintf.S
+similarity index 100%
+rename from libm/x86_64/lrintf.S
+rename to libm/x86_64/generic/lrintf.S
+diff --git a/libm/x86_64/rint.S b/libm/x86_64/generic/rint.S
+similarity index 97%
+rename from libm/x86_64/rint.S
+rename to libm/x86_64/generic/rint.S
+index 9731daad6..9f50f8365 100644
+--- a/libm/x86_64/rint.S
++++ b/libm/x86_64/generic/rint.S
+@@ -30,7 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ 
+-ENTRY(rint)
++ENTRY(rint_generic)
+   roundsd $0x4,%xmm0,%xmm0
+   retq
+-END(rint)
++END(rint_generic)
+diff --git a/libm/x86_64/rintf.S b/libm/x86_64/generic/rintf.S
+similarity index 97%
+rename from libm/x86_64/rintf.S
+rename to libm/x86_64/generic/rintf.S
+index c3e98bf8c..8b8eaceae 100644
+--- a/libm/x86_64/rintf.S
++++ b/libm/x86_64/generic/rintf.S
+@@ -30,7 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ 
+-ENTRY(rintf)
++ENTRY(rintf_generic)
+   roundss $0x4,%xmm0,%xmm0
+   retq
+-END(rintf)
++END(rintf_generic)
+diff --git a/libm/x86_64/s_atan.S b/libm/x86_64/generic/s_atan.S
+similarity index 100%
+rename from libm/x86_64/s_atan.S
+rename to libm/x86_64/generic/s_atan.S
+diff --git a/libm/x86_64/s_cbrt.S b/libm/x86_64/generic/s_cbrt.S
+similarity index 99%
+rename from libm/x86_64/s_cbrt.S
+rename to libm/x86_64/generic/s_cbrt.S
+index 4aa4373e4..5a648f325 100644
+--- a/libm/x86_64/s_cbrt.S
++++ b/libm/x86_64/generic/s_cbrt.S
+@@ -49,7 +49,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  cbrt
+-ENTRY(cbrt)
++ENTRY(cbrt_generic)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..___tag_value_cbrt.1:
+@@ -198,7 +198,7 @@ ENTRY(cbrt)
+ ..___tag_value_cbrt.4:
+         ret       
+ ..___tag_value_cbrt.5:
+-END(cbrt)
++END(cbrt_generic)
+ # -- End  cbrt
+ 	.section .rodata, "a"
+ 	.align 16
+diff --git a/libm/x86_64/generic/s_cbrtf.c b/libm/x86_64/generic/s_cbrtf.c
+new file mode 100644
+index 000000000..a431ecc87
+--- /dev/null
++++ b/libm/x86_64/generic/s_cbrtf.c
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define  cbrtf cbrtf_generic
++
++#include <upstream-freebsd/lib/msun/src/s_cbrtf.c>
+diff --git a/libm/x86_64/s_cos.S b/libm/x86_64/generic/s_cos.S
+similarity index 99%
+rename from libm/x86_64/s_cos.S
+rename to libm/x86_64/generic/s_cos.S
+index ab5a0e1b7..cde8596d2 100644
+--- a/libm/x86_64/s_cos.S
++++ b/libm/x86_64/generic/s_cos.S
+@@ -173,7 +173,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  cos
+-ENTRY(cos)
++ENTRY(cos_generic)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..___tag_value_cos.1:
+@@ -589,7 +589,7 @@ ENTRY(cos)
+ ..___tag_value_cos.8:
+         ret       
+ ..___tag_value_cos.9:
+-END(cos)
++END(cos_generic)
+ # -- End  cos
+ 	.section .rodata, "a"
+ 	.align 16
+diff --git a/libm/x86_64/s_expm1.S b/libm/x86_64/generic/s_expm1.S
+similarity index 100%
+rename from libm/x86_64/s_expm1.S
+rename to libm/x86_64/generic/s_expm1.S
+diff --git a/libm/x86_64/s_log1p.S b/libm/x86_64/generic/s_log1p.S
+similarity index 99%
+rename from libm/x86_64/s_log1p.S
+rename to libm/x86_64/generic/s_log1p.S
+index 1ff2d3965..d0e3e9825 100644
+--- a/libm/x86_64/s_log1p.S
++++ b/libm/x86_64/generic/s_log1p.S
+@@ -55,7 +55,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  log1p
+-ENTRY(log1p)
++ENTRY(log1p_generic)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..___tag_value_log1p.1:
+@@ -241,7 +241,7 @@ ENTRY(log1p)
+ ..___tag_value_log1p.4:
+         ret       
+ ..___tag_value_log1p.5:
+-END(log1p)
++END(log1p_generic)
+ # -- End  log1p
+ 	.section .rodata, "a"
+ 	.align 16
+diff --git a/libm/x86_64/generic/s_log1pf.c b/libm/x86_64/generic/s_log1pf.c
+new file mode 100644
+index 000000000..31fa03f11
+--- /dev/null
++++ b/libm/x86_64/generic/s_log1pf.c
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define  log1pf log1pf_generic
++
++#include <upstream-freebsd/lib/msun/src/s_log1pf.c>
+diff --git a/libm/x86_64/s_sin.S b/libm/x86_64/generic/s_sin.S
+similarity index 99%
+rename from libm/x86_64/s_sin.S
+rename to libm/x86_64/generic/s_sin.S
+index 2f93a34bb..ec2058fda 100644
+--- a/libm/x86_64/s_sin.S
++++ b/libm/x86_64/generic/s_sin.S
+@@ -174,7 +174,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  sin
+-ENTRY(sin)
++ENTRY(sin_generic)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..___tag_value_sin.1:
+@@ -596,7 +596,7 @@ ENTRY(sin)
+ ..___tag_value_sin.8:
+         ret       
+ ..___tag_value_sin.9:
+-END(sin)
++END(sin_generic)
+ # -- End  sin
+ 	.section .rodata, "a"
+ 	.align 16
+diff --git a/libm/x86_64/s_tan.S b/libm/x86_64/generic/s_tan.S
+similarity index 100%
+rename from libm/x86_64/s_tan.S
+rename to libm/x86_64/generic/s_tan.S
+diff --git a/libm/x86_64/s_tanh.S b/libm/x86_64/generic/s_tanh.S
+similarity index 100%
+rename from libm/x86_64/s_tanh.S
+rename to libm/x86_64/generic/s_tanh.S
+diff --git a/libm/x86_64/generic/sinf.c b/libm/x86_64/generic/sinf.c
+new file mode 100644
+index 000000000..6b004c7e7
+--- /dev/null
++++ b/libm/x86_64/generic/sinf.c
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define  sinf sinf_generic
++
++#include <../../external/arm-optimized-routines/math/sinf.c>
+diff --git a/libm/x86_64/sqrt.S b/libm/x86_64/generic/sqrt.S
+similarity index 100%
+rename from libm/x86_64/sqrt.S
+rename to libm/x86_64/generic/sqrt.S
+diff --git a/libm/x86_64/sqrtf.S b/libm/x86_64/generic/sqrtf.S
+similarity index 100%
+rename from libm/x86_64/sqrtf.S
+rename to libm/x86_64/generic/sqrtf.S
+diff --git a/libm/x86_64/trunc.S b/libm/x86_64/generic/trunc.S
+similarity index 100%
+rename from libm/x86_64/trunc.S
+rename to libm/x86_64/generic/trunc.S
+diff --git a/libm/x86_64/truncf.S b/libm/x86_64/generic/truncf.S
+similarity index 100%
+rename from libm/x86_64/truncf.S
+rename to libm/x86_64/generic/truncf.S
+diff --git a/libm/x86_64/cbrt_avx2.S b/libm/x86_64/kabylake/cbrt_avx2.S
+similarity index 99%
+rename from libm/x86_64/cbrt_avx2.S
+rename to libm/x86_64/kabylake/cbrt_avx2.S
+index a37ef81cf..a00b833d3 100644
+--- a/libm/x86_64/cbrt_avx2.S
++++ b/libm/x86_64/kabylake/cbrt_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  cbrt
+-ENTRY(cbrt)
++ENTRY(cbrt_avx2)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..L1:
+@@ -159,7 +159,7 @@ ENTRY(cbrt)
+         lea       64(%rsp), %rsi
+         call      __svml_dcbrt_ha_cout_rare_internal
+         jmp       ..B1.4
+-END(cbrt)
++END(cbrt_avx2)
+ 	.hidden __svml_dcbrt_ha_data_internal
+ 	.hidden __svml_dcbrt_ha_cout_rare_internal
+ 	.section .note.GNU-stack, ""
+diff --git a/libm/x86_64/cbrt_cout_avx2.S b/libm/x86_64/kabylake/cbrt_cout_avx2.S
+similarity index 100%
+rename from libm/x86_64/cbrt_cout_avx2.S
+rename to libm/x86_64/kabylake/cbrt_cout_avx2.S
+diff --git a/libm/x86_64/cbrt_data_avx2.S b/libm/x86_64/kabylake/cbrt_data_avx2.S
+similarity index 100%
+rename from libm/x86_64/cbrt_data_avx2.S
+rename to libm/x86_64/kabylake/cbrt_data_avx2.S
+diff --git a/libm/x86_64/cbrtf_avx2.S b/libm/x86_64/kabylake/cbrtf_avx2.S
+similarity index 99%
+rename from libm/x86_64/cbrtf_avx2.S
+rename to libm/x86_64/kabylake/cbrtf_avx2.S
+index 350e0f9b2..aff038d85 100644
+--- a/libm/x86_64/cbrtf_avx2.S
++++ b/libm/x86_64/kabylake/cbrtf_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  
+-ENTRY(cbrtf)
++ENTRY(cbrtf_avx2)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..L1:
+@@ -152,7 +152,7 @@ ENTRY(cbrtf)
+         lea       64(%rsp), %rsi
+         call      __svml_scbrt_ha_cout_rare_internal
+         jmp       ..B1.4
+-END(cbrtf)
++END(cbrtf_avx2)
+ 	.data
+ # -- End  __svml_cbrtf1_ha_l9
+ 	.data
+diff --git a/libm/x86_64/cbrtf_cout_avx2.S b/libm/x86_64/kabylake/cbrtf_cout_avx2.S
+similarity index 100%
+rename from libm/x86_64/cbrtf_cout_avx2.S
+rename to libm/x86_64/kabylake/cbrtf_cout_avx2.S
+diff --git a/libm/x86_64/cbrtf_data_avx2.S b/libm/x86_64/kabylake/cbrtf_data_avx2.S
+similarity index 100%
+rename from libm/x86_64/cbrtf_data_avx2.S
+rename to libm/x86_64/kabylake/cbrtf_data_avx2.S
+diff --git a/libm/x86_64/ceil_avx2.S b/libm/x86_64/kabylake/ceil_avx2.S
+similarity index 97%
+rename from libm/x86_64/ceil_avx2.S
+rename to libm/x86_64/kabylake/ceil_avx2.S
+index 32aaea132..8c4bcf1c5 100644
+--- a/libm/x86_64/ceil_avx2.S
++++ b/libm/x86_64/kabylake/ceil_avx2.S
+@@ -27,7 +27,7 @@ SUCH DAMAGE.
+ */
+ #include <private/bionic_asm.h>
+ 
+-ENTRY(ceil)
++ENTRY(ceil_avx2)
+         vroundpd  $2, %xmm0, %xmm0
+         ret
+-END(ceil)
++END(ceil_avx2)
+diff --git a/libm/x86_64/ceilf_avx2.S b/libm/x86_64/kabylake/ceilf_avx2.S
+similarity index 97%
+rename from libm/x86_64/ceilf_avx2.S
+rename to libm/x86_64/kabylake/ceilf_avx2.S
+index fc3df2174..0917d1049 100644
+--- a/libm/x86_64/ceilf_avx2.S
++++ b/libm/x86_64/kabylake/ceilf_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ 
+-ENTRY(ceilf)
++ENTRY(ceilf_avx2)
+         vroundps  $2, %xmm0, %xmm0
+         ret
+-END(ceilf)
++END(ceilf_avx2)
+diff --git a/libm/x86_64/cos_avx2.S b/libm/x86_64/kabylake/cos_avx2.S
+similarity index 99%
+rename from libm/x86_64/cos_avx2.S
+rename to libm/x86_64/kabylake/cos_avx2.S
+index f6b21ac7a..5cafd4a06 100644
+--- a/libm/x86_64/cos_avx2.S
++++ b/libm/x86_64/kabylake/cos_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  
+-ENTRY(cos)
++ENTRY(cos_avx2)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..L1:
+@@ -306,7 +306,7 @@ ENTRY(cos)
+         vmovups   48(%rsp), %xmm13
+ 	.cfi_restore 30
+         jmp       ..B1.2
+-END(cos)
++END(cos_avx2)
+ # -- End  __svml_cos1_ha_l9
+ 	.section .rodata, "a"
+ 	.align 16
+diff --git a/libm/x86_64/cos_cout_avx2.S b/libm/x86_64/kabylake/cos_cout_avx2.S
+similarity index 100%
+rename from libm/x86_64/cos_cout_avx2.S
+rename to libm/x86_64/kabylake/cos_cout_avx2.S
+diff --git a/libm/x86_64/cos_data_avx2.S b/libm/x86_64/kabylake/cos_data_avx2.S
+similarity index 100%
+rename from libm/x86_64/cos_data_avx2.S
+rename to libm/x86_64/kabylake/cos_data_avx2.S
+diff --git a/libm/x86_64/cosf_avx2.S b/libm/x86_64/kabylake/cosf_avx2.S
+similarity index 99%
+rename from libm/x86_64/cosf_avx2.S
+rename to libm/x86_64/kabylake/cosf_avx2.S
+index b8d6b967f..ba30845ea 100644
+--- a/libm/x86_64/cosf_avx2.S
++++ b/libm/x86_64/kabylake/cosf_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  asin
+-ENTRY(cosf)
++ENTRY(cosf_avx2)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..L1:
+@@ -292,7 +292,7 @@ ENTRY(cosf)
+         vmovups   32(%rsp), %xmm14
+ 	.cfi_restore 31
+         jmp       ..B1.2
+-END(cosf)
++END(cosf_avx2)
+ 	.data
+ # -- End  __svml_cosf1_ha_l9
+ 	.section .rodata, "a"
+diff --git a/libm/x86_64/cosf_cout_avx2.S b/libm/x86_64/kabylake/cosf_cout_avx2.S
+similarity index 100%
+rename from libm/x86_64/cosf_cout_avx2.S
+rename to libm/x86_64/kabylake/cosf_cout_avx2.S
+diff --git a/libm/x86_64/cosf_data_avx2.S b/libm/x86_64/kabylake/cosf_data_avx2.S
+similarity index 100%
+rename from libm/x86_64/cosf_data_avx2.S
+rename to libm/x86_64/kabylake/cosf_data_avx2.S
+diff --git a/libm/x86_64/exp_cout_avx2.S b/libm/x86_64/kabylake/exp_cout_avx2.S
+similarity index 100%
+rename from libm/x86_64/exp_cout_avx2.S
+rename to libm/x86_64/kabylake/exp_cout_avx2.S
+diff --git a/libm/x86_64/exp_data_avx2.S b/libm/x86_64/kabylake/exp_data_avx2.S
+similarity index 100%
+rename from libm/x86_64/exp_data_avx2.S
+rename to libm/x86_64/kabylake/exp_data_avx2.S
+diff --git a/libm/x86_64/expf_avx2.S b/libm/x86_64/kabylake/expf_avx2.S
+similarity index 99%
+rename from libm/x86_64/expf_avx2.S
+rename to libm/x86_64/kabylake/expf_avx2.S
+index c2b8e106a..995b21f2a 100644
+--- a/libm/x86_64/expf_avx2.S
++++ b/libm/x86_64/kabylake/expf_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  
+-ENTRY(expf)
++ENTRY(expf_avx2)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..L1:
+@@ -131,7 +131,7 @@ ENTRY(expf)
+         lea       64(%rsp), %rsi
+         call      __svml_sexp_ha_cout_rare_internal
+         jmp       ..B1.5
+-END(expf)
++END(expf_avx2)
+ 	.section .rodata, "a"
+ 	.align 16
+ 	.align 16
+diff --git a/libm/x86_64/floor_avx2.S b/libm/x86_64/kabylake/floor_avx2.S
+similarity index 97%
+rename from libm/x86_64/floor_avx2.S
+rename to libm/x86_64/kabylake/floor_avx2.S
+index 9428c6170..b02dd770a 100644
+--- a/libm/x86_64/floor_avx2.S
++++ b/libm/x86_64/kabylake/floor_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ 
+-ENTRY(floor)
++ENTRY(floor_avx2)
+ vroundpd  $1, %ymm0, %ymm0
+ ret
+-END(floor)
++END(floor_avx2)
+diff --git a/libm/x86_64/floorf_avx2.S b/libm/x86_64/kabylake/floorf_avx2.S
+similarity index 97%
+rename from libm/x86_64/floorf_avx2.S
+rename to libm/x86_64/kabylake/floorf_avx2.S
+index 05866c837..56c36f250 100644
+--- a/libm/x86_64/floorf_avx2.S
++++ b/libm/x86_64/kabylake/floorf_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ 
+-ENTRY(floorf)
++ENTRY(floorf_avx2)
+ vroundps  $1, %xmm0, %xmm0
+ ret
+-END(floorf)
+\ No newline at end of file
++END(floorf_avx2)
+diff --git a/libm/x86_64/hypot_avx2.S b/libm/x86_64/kabylake/hypot_avx2.S
+similarity index 99%
+rename from libm/x86_64/hypot_avx2.S
+rename to libm/x86_64/kabylake/hypot_avx2.S
+index 5ed035475..40464a845 100644
+--- a/libm/x86_64/hypot_avx2.S
++++ b/libm/x86_64/kabylake/hypot_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  hypot
+-ENTRY(hypot)
++ENTRY(hypot_avx2)
+ # parameter 1: %xmm0
+ # parameter 2: %xmm1
+ 
+@@ -153,7 +153,7 @@ ENTRY(hypot)
+         lea       128(%rsp), %rdx
+         call      __svml_dhypot_ha_cout_rare_internal
+         jmp       ..B1.4
+-END(hypot)
++END(hypot_avx2)
+ 	.data
+ 	.hidden __svml_dhypot_ha_data_internal
+ 	.hidden __svml_dhypot_ha_cout_rare_internal
+diff --git a/libm/x86_64/hypot_cout_avx2.S b/libm/x86_64/kabylake/hypot_cout_avx2.S
+similarity index 100%
+rename from libm/x86_64/hypot_cout_avx2.S
+rename to libm/x86_64/kabylake/hypot_cout_avx2.S
+diff --git a/libm/x86_64/hypot_data_avx2.S b/libm/x86_64/kabylake/hypot_data_avx2.S
+similarity index 100%
+rename from libm/x86_64/hypot_data_avx2.S
+rename to libm/x86_64/kabylake/hypot_data_avx2.S
+diff --git a/libm/x86_64/log10_avx2.S b/libm/x86_64/kabylake/log10_avx2.S
+similarity index 99%
+rename from libm/x86_64/log10_avx2.S
+rename to libm/x86_64/kabylake/log10_avx2.S
+index 3ddbadb53..fb9504502 100644
+--- a/libm/x86_64/log10_avx2.S
++++ b/libm/x86_64/kabylake/log10_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  
+-ENTRY(log10)
++ENTRY(log10_avx2)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..L1:
+@@ -139,7 +139,7 @@ ENTRY(log10)
+         lea       64(%rsp), %rsi
+         call      __svml_dlog10_ha_cout_rare_internal
+         jmp       ..B1.4
+-END(log10)
++END(log10_avx2)
+ 	.data
+ 	.hidden __svml_dlog10_ha_data_internal
+ 	.hidden __svml_dlog10_ha_cout_rare_internal
+diff --git a/libm/x86_64/log10_cout_avx2.S b/libm/x86_64/kabylake/log10_cout_avx2.S
+similarity index 100%
+rename from libm/x86_64/log10_cout_avx2.S
+rename to libm/x86_64/kabylake/log10_cout_avx2.S
+diff --git a/libm/x86_64/log10_data_avx2.S b/libm/x86_64/kabylake/log10_data_avx2.S
+similarity index 100%
+rename from libm/x86_64/log10_data_avx2.S
+rename to libm/x86_64/kabylake/log10_data_avx2.S
+diff --git a/libm/x86_64/log10f_avx2.S b/libm/x86_64/kabylake/log10f_avx2.S
+similarity index 99%
+rename from libm/x86_64/log10f_avx2.S
+rename to libm/x86_64/kabylake/log10f_avx2.S
+index 64e1e16a8..a377c17ad 100644
+--- a/libm/x86_64/log10f_avx2.S
++++ b/libm/x86_64/kabylake/log10f_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  asin
+-ENTRY(log10f)
++ENTRY(log10f_avx2)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..L1:
+@@ -128,7 +128,7 @@ ENTRY(log10f)
+         lea       64(%rsp), %rsi
+         call      __svml_slog10_ha_cout_rare_internal
+         jmp       ..B1.4
+-END(log10f)
++END(log10f_avx2)
+ 	.data
+ 	.hidden __svml_slog10_ha_data_internal
+ 	.hidden __svml_slog10_ha_cout_rare_internal
+diff --git a/libm/x86_64/log10f_cout_avx2.S b/libm/x86_64/kabylake/log10f_cout_avx2.S
+similarity index 100%
+rename from libm/x86_64/log10f_cout_avx2.S
+rename to libm/x86_64/kabylake/log10f_cout_avx2.S
+diff --git a/libm/x86_64/log10f_data_avx2.S b/libm/x86_64/kabylake/log10f_data_avx2.S
+similarity index 100%
+rename from libm/x86_64/log10f_data_avx2.S
+rename to libm/x86_64/kabylake/log10f_data_avx2.S
+diff --git a/libm/x86_64/log1p_avx2.S b/libm/x86_64/kabylake/log1p_avx2.S
+similarity index 99%
+rename from libm/x86_64/log1p_avx2.S
+rename to libm/x86_64/kabylake/log1p_avx2.S
+index 056e1115f..a89336f56 100644
+--- a/libm/x86_64/log1p_avx2.S
++++ b/libm/x86_64/kabylake/log1p_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  
+-ENTRY(log1p)
++ENTRY(log1p_avx2)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..L1:
+@@ -159,7 +159,7 @@ ENTRY(log1p)
+         lea       64(%rsp), %rsi
+         call      __svml_dlog1p_ha_cout_rare_internal
+         jmp       ..B1.4
+-END(log1p)
++END(log1p_avx2)
+ 	.data
+ 	.hidden __svml_dlog1p_ha_data_internal
+ 	.hidden __svml_dlog1p_ha_cout_rare_internal
+diff --git a/libm/x86_64/log1p_cout_avx2.S b/libm/x86_64/kabylake/log1p_cout_avx2.S
+similarity index 100%
+rename from libm/x86_64/log1p_cout_avx2.S
+rename to libm/x86_64/kabylake/log1p_cout_avx2.S
+diff --git a/libm/x86_64/log1p_data_avx2.S b/libm/x86_64/kabylake/log1p_data_avx2.S
+similarity index 100%
+rename from libm/x86_64/log1p_data_avx2.S
+rename to libm/x86_64/kabylake/log1p_data_avx2.S
+diff --git a/libm/x86_64/log1pf_avx2.S b/libm/x86_64/kabylake/log1pf_avx2.S
+similarity index 99%
+rename from libm/x86_64/log1pf_avx2.S
+rename to libm/x86_64/kabylake/log1pf_avx2.S
+index 1f803176a..49ec87966 100644
+--- a/libm/x86_64/log1pf_avx2.S
++++ b/libm/x86_64/kabylake/log1pf_avx2.S
+@@ -29,7 +29,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  asin
+-ENTRY(log1pf)
++ENTRY(log1pf_avx2)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..L1:
+@@ -153,7 +153,7 @@ ENTRY(log1pf)
+         lea       64(%rsp), %rsi
+         call      __svml_slog1p_ha_cout_rare_internal
+         jmp       ..B1.4
+-END(log1pf)
++END(log1pf_avx2)
+ # -- End  __svml_log1pf1_ha_l9
+ 	.data
+ 	.hidden __svml_slog1p_ha_data_internal
+diff --git a/libm/x86_64/log1pf_cout_avx2.S b/libm/x86_64/kabylake/log1pf_cout_avx2.S
+similarity index 100%
+rename from libm/x86_64/log1pf_cout_avx2.S
+rename to libm/x86_64/kabylake/log1pf_cout_avx2.S
+diff --git a/libm/x86_64/log1pf_data_avx2.S b/libm/x86_64/kabylake/log1pf_data_avx2.S
+similarity index 100%
+rename from libm/x86_64/log1pf_data_avx2.S
+rename to libm/x86_64/kabylake/log1pf_data_avx2.S
+diff --git a/libm/x86_64/rint_avx2.S b/libm/x86_64/kabylake/rint_avx2.S
+similarity index 97%
+rename from libm/x86_64/rint_avx2.S
+rename to libm/x86_64/kabylake/rint_avx2.S
+index f1dfcff55..b260beac3 100644
+--- a/libm/x86_64/rint_avx2.S
++++ b/libm/x86_64/kabylake/rint_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ 
+-ENTRY(rint)
++ENTRY(rint_avx2)
+ vroundpd  $4, %ymm0, %ymm0
+ ret
+-END(rint)
++END(rint_avx2)
+diff --git a/libm/x86_64/rintf_avx2.S b/libm/x86_64/kabylake/rintf_avx2.S
+similarity index 97%
+rename from libm/x86_64/rintf_avx2.S
+rename to libm/x86_64/kabylake/rintf_avx2.S
+index 5ddc4415c..c2af10dab 100644
+--- a/libm/x86_64/rintf_avx2.S
++++ b/libm/x86_64/kabylake/rintf_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ 
+-ENTRY(rintf)
++ENTRY(rintf_avx2)
+ vroundps  $4, %xmm0, %xmm0
+ ret
+-END(rintf)
+\ No newline at end of file
++END(rintf_avx2)
+diff --git a/libm/x86_64/sin_avx2.S b/libm/x86_64/kabylake/sin_avx2.S
+similarity index 99%
+rename from libm/x86_64/sin_avx2.S
+rename to libm/x86_64/kabylake/sin_avx2.S
+index 78b4657f6..2e83b2d0c 100644
+--- a/libm/x86_64/sin_avx2.S
++++ b/libm/x86_64/kabylake/sin_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  
+-ENTRY(sin)
++ENTRY(sin_avx2)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..L1:
+@@ -312,7 +312,7 @@ ENTRY(sin)
+         vxorpd    96(%rsp), %xmm1, %xmm1
+         vblendvpd %xmm2, %xmm1, %xmm3, %xmm3
+         jmp       ..B1.2
+-END(sin) 
++END(sin_avx2) 
+ 	.data
+ # -- End  __svml_sin1_ha_l9
+ 	.section .rodata, "a"
+diff --git a/libm/x86_64/sin_cout_avx2.S b/libm/x86_64/kabylake/sin_cout_avx2.S
+similarity index 100%
+rename from libm/x86_64/sin_cout_avx2.S
+rename to libm/x86_64/kabylake/sin_cout_avx2.S
+diff --git a/libm/x86_64/sin_data_avx2.S b/libm/x86_64/kabylake/sin_data_avx2.S
+similarity index 100%
+rename from libm/x86_64/sin_data_avx2.S
+rename to libm/x86_64/kabylake/sin_data_avx2.S
+diff --git a/libm/x86_64/sinf_avx2.S b/libm/x86_64/kabylake/sinf_avx2.S
+similarity index 99%
+rename from libm/x86_64/sinf_avx2.S
+rename to libm/x86_64/kabylake/sinf_avx2.S
+index de6082219..0942e2e27 100644
+--- a/libm/x86_64/sinf_avx2.S
++++ b/libm/x86_64/kabylake/sinf_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  sin
+-ENTRY(sinf)
++ENTRY(sinf_avx2)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..L1:
+@@ -293,7 +293,7 @@ ENTRY(sinf)
+         vmovups   32(%rsp), %xmm14
+ 	.cfi_restore 31
+         jmp       ..B1.2
+-END(sinf)
++END(sinf_avx2)
+ 	.section .rodata, "a"
+ 	.align 16
+ 	.align 16
+diff --git a/libm/x86_64/sinf_cout_avx2.S b/libm/x86_64/kabylake/sinf_cout_avx2.S
+similarity index 100%
+rename from libm/x86_64/sinf_cout_avx2.S
+rename to libm/x86_64/kabylake/sinf_cout_avx2.S
+diff --git a/libm/x86_64/sinf_data_avx2.S b/libm/x86_64/kabylake/sinf_data_avx2.S
+similarity index 100%
+rename from libm/x86_64/sinf_data_avx2.S
+rename to libm/x86_64/kabylake/sinf_data_avx2.S
+diff --git a/libm/x86_64/sinh_avx2.S b/libm/x86_64/kabylake/sinh_avx2.S
+similarity index 99%
+rename from libm/x86_64/sinh_avx2.S
+rename to libm/x86_64/kabylake/sinh_avx2.S
+index 323e381f1..7cb2f9340 100644
+--- a/libm/x86_64/sinh_avx2.S
++++ b/libm/x86_64/kabylake/sinh_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  sin
+-ENTRY(sinh)
++ENTRY(sinh_avx2)
+ # parameter 1: %ymm0
+ ..B1.1:
+ ..L1:
+@@ -187,7 +187,7 @@ ENTRY(sinh)
+         lea       256(%rsp,%r12,8), %rsi
+         call      __svml_dsinh_ha_cout_rare_internal
+         jmp       ..B1.8
+-END(sinh)
++END(sinh_avx2)
+ 	.data
+ 	.hidden __svml_dsinh_ha_data_internal
+ 	.hidden __svml_dsinh_ha_cout_rare_internal
+diff --git a/libm/x86_64/sinh_cout_avx2.S b/libm/x86_64/kabylake/sinh_cout_avx2.S
+similarity index 100%
+rename from libm/x86_64/sinh_cout_avx2.S
+rename to libm/x86_64/kabylake/sinh_cout_avx2.S
+diff --git a/libm/x86_64/sinh_data_avx2.S b/libm/x86_64/kabylake/sinh_data_avx2.S
+similarity index 100%
+rename from libm/x86_64/sinh_data_avx2.S
+rename to libm/x86_64/kabylake/sinh_data_avx2.S
+diff --git a/libm/x86_64/sinhf_avx2.S b/libm/x86_64/kabylake/sinhf_avx2.S
+similarity index 99%
+rename from libm/x86_64/sinhf_avx2.S
+rename to libm/x86_64/kabylake/sinhf_avx2.S
+index d057ade91..5b3b18de9 100644
+--- a/libm/x86_64/sinhf_avx2.S
++++ b/libm/x86_64/kabylake/sinhf_avx2.S
+@@ -28,7 +28,7 @@ SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ # -- Begin  sin
+-ENTRY(sinhf)
++ENTRY(sinhf_avx2)
+ # parameter 1: %xmm0
+ ..B1.1:
+ ..L1:
+@@ -167,7 +167,7 @@ ENTRY(sinhf)
+         lea       192(%rsp,%r12,4), %rsi
+         call      __svml_ssinh_ha_cout_rare_internal
+         jmp       ..B1.8
+-END(sinhf)
++END(sinhf_avx2)
+         .data
+ 	.hidden __svml_ssinh_ha_data_internal
+ 	.hidden __svml_ssinh_ha_cout_rare_internal
+diff --git a/libm/x86_64/sinhf_cout_avx2.S b/libm/x86_64/kabylake/sinhf_cout_avx2.S
+similarity index 100%
+rename from libm/x86_64/sinhf_cout_avx2.S
+rename to libm/x86_64/kabylake/sinhf_cout_avx2.S
+diff --git a/libm/x86_64/sinhf_data_avx2.S b/libm/x86_64/kabylake/sinhf_data_avx2.S
+similarity index 100%
+rename from libm/x86_64/sinhf_data_avx2.S
+rename to libm/x86_64/kabylake/sinhf_data_avx2.S
+diff --git a/libm/x86_64/static_function_dispatch.S b/libm/x86_64/static_function_dispatch.S
+new file mode 100644
+index 000000000..a4e8edab5
+--- /dev/null
++++ b/libm/x86_64/static_function_dispatch.S
+@@ -0,0 +1,55 @@
++/*
++ * Copyright (C) 2018 The Android Open Source Project
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *  * Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ *  * Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in
++ *    the documentation and/or other materials provided with the
++ *    distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
++ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
++ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
++ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
++ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
++ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
++ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
++ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
++ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++#include <private/bionic_asm.h>
++
++#define FUNCTION_DELEGATE(name, impl) \
++ENTRY(name); \
++    jmp impl; \
++END(name)
++
++FUNCTION_DELEGATE(ceil, ceil_generic)
++FUNCTION_DELEGATE(ceilf, ceilf_generic)
++FUNCTION_DELEGATE(floor, floor_generic)
++FUNCTION_DELEGATE(floorf, floorf_generic)
++FUNCTION_DELEGATE(rint, rint_generic)
++FUNCTION_DELEGATE(rintf, rintf_generic)
++FUNCTION_DELEGATE(hypot, hypot_generic)
++FUNCTION_DELEGATE(log10, log10_generic)
++FUNCTION_DELEGATE(log10f, log10f_generic)
++FUNCTION_DELEGATE(log1p, log1p_generic)
++FUNCTION_DELEGATE(log1pf, log1pf_generic)
++FUNCTION_DELEGATE(cbrt, cbrt_generic)
++FUNCTION_DELEGATE(cbrtf, cbrtf_generic)
++FUNCTION_DELEGATE(sin, sin_generic)
++FUNCTION_DELEGATE(sinf, sinf_generic)
++FUNCTION_DELEGATE(sinh, sinh_generic)
++FUNCTION_DELEGATE(sinhf, sinhf_generic)
++FUNCTION_DELEGATE(cos, cos_generic)
++FUNCTION_DELEGATE(cosf, cosf_generic)
++FUNCTION_DELEGATE(expf, expf_generic)
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/bionic/04_0004-Optimize-bionic-memory-functions-with-avx2-instructi.patch
+++ b/aosp_diff/preliminary/bionic/04_0004-Optimize-bionic-memory-functions-with-avx2-instructi.patch
@@ -1,0 +1,24847 @@
+From 38772320c5cf4c9359f3fa964f19bdcc29ae4f68 Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Thu, 24 Sep 2020 16:39:31 +0530
+Subject: [PATCH] Optimize bionic memory functions with avx2 instructions
+
+Following memory related functions are optimized with
+avx2 implementation:
+ - memcpy (for both 32-bit and 64-bit)
+ below functions ported from glibc 2.20 only for 64-bit
+ - memchr
+ - memcmp
+ - memmove
+ - memrchr
+
+Tracked-On:
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ libc/Android.bp                                    |   58 +-
+ libc/arch-x86/dynamic_function_dispatch.cpp        |    5 +-
+ libc/arch-x86/kabylake/string/avx2-memcpy-kbl.S    | 2052 +++++++++++
+ libc/arch-x86_64/dynamic_function_dispatch.cpp     |   78 +
+ libc/arch-x86_64/generic/string/memchr.c           |   19 +
+ libc/arch-x86_64/generic/string/memrchr.c          |   19 +
+ libc/arch-x86_64/generic/string/wmemset.c          |   19 +
+ libc/arch-x86_64/include/cache.h                   |   36 +
+ libc/arch-x86_64/kabylake/string/avx2-memchr-kbl.S |  371 ++
+ libc/arch-x86_64/kabylake/string/avx2-memcmp-kbl.S |  428 +++
+ libc/arch-x86_64/kabylake/string/avx2-memcpy-kbl.S | 3711 ++++++++++++++++++++
+ .../arch-x86_64/kabylake/string/avx2-memmove-kbl.S |  409 +++
+ .../arch-x86_64/kabylake/string/avx2-memrchr-kbl.S |  408 +++
+ .../arch-x86_64/kabylake/string/avx2-wmemset-kbl.S |  140 +
+ .../silvermont/string/sse2-memcpy-slm.s            | 1374 ++++++++
+ .../silvermont/string/sse2-memmove-slm.S           |  518 +++
+ .../silvermont/string/sse2-memset-slm.S            |  152 +
+ .../silvermont/string/sse2-stpcpy-slm.S            |   33 +
+ .../silvermont/string/sse2-stpncpy-slm.S           |   34 +
+ .../silvermont/string/sse2-strcat-slm.S            |   87 +
+ .../silvermont/string/sse2-strcpy-slm.S            | 1921 ++++++++++
+ .../silvermont/string/sse2-strlen-slm.S            |  294 ++
+ .../silvermont/string/sse2-strncat-slm.S           |   33 +
+ .../silvermont/string/sse2-strncpy-slm.S           |   33 +
+ .../silvermont/string/sse4-memcmp-slm.S            | 1799 ++++++++++
+ .../silvermont/string/ssse3-strcmp-slm.S           | 1925 ++++++++++
+ .../silvermont/string/ssse3-strncmp-slm.S          |   33 +
+ libc/arch-x86_64/static_function_dispatch.S        |   41 +
+ libc/arch-x86_64/string/avx2-wmemset-kbl.S         |  140 -
+ libc/arch-x86_64/string/cache.h                    |   36 -
+ libc/arch-x86_64/string/sse2-memcpy-slm.s          | 1374 --------
+ libc/arch-x86_64/string/sse2-memmove-slm.S         |  516 ---
+ libc/arch-x86_64/string/sse2-memset-slm.S          |  149 -
+ libc/arch-x86_64/string/sse2-stpcpy-slm.S          |   33 -
+ libc/arch-x86_64/string/sse2-stpncpy-slm.S         |   34 -
+ libc/arch-x86_64/string/sse2-strcat-slm.S          |   87 -
+ libc/arch-x86_64/string/sse2-strcpy-slm.S          | 1921 ----------
+ libc/arch-x86_64/string/sse2-strlen-slm.S          |  294 --
+ libc/arch-x86_64/string/sse2-strncat-slm.S         |   33 -
+ libc/arch-x86_64/string/sse2-strncpy-slm.S         |   33 -
+ libc/arch-x86_64/string/sse4-memcmp-slm.S          | 1799 ----------
+ libc/arch-x86_64/string/ssse3-strcmp-slm.S         | 1925 ----------
+ libc/arch-x86_64/string/ssse3-strncmp-slm.S        |   33 -
+ 43 files changed, 16015 insertions(+), 8422 deletions(-)
+ create mode 100644 libc/arch-x86/kabylake/string/avx2-memcpy-kbl.S
+ create mode 100644 libc/arch-x86_64/dynamic_function_dispatch.cpp
+ create mode 100644 libc/arch-x86_64/generic/string/memchr.c
+ create mode 100644 libc/arch-x86_64/generic/string/memrchr.c
+ create mode 100644 libc/arch-x86_64/generic/string/wmemset.c
+ create mode 100644 libc/arch-x86_64/include/cache.h
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-memchr-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-memcmp-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-memcpy-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-memmove-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-memrchr-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-wmemset-kbl.S
+ create mode 100644 libc/arch-x86_64/silvermont/string/sse2-memcpy-slm.s
+ create mode 100644 libc/arch-x86_64/silvermont/string/sse2-memmove-slm.S
+ create mode 100644 libc/arch-x86_64/silvermont/string/sse2-memset-slm.S
+ create mode 100644 libc/arch-x86_64/silvermont/string/sse2-stpcpy-slm.S
+ create mode 100644 libc/arch-x86_64/silvermont/string/sse2-stpncpy-slm.S
+ create mode 100644 libc/arch-x86_64/silvermont/string/sse2-strcat-slm.S
+ create mode 100644 libc/arch-x86_64/silvermont/string/sse2-strcpy-slm.S
+ create mode 100644 libc/arch-x86_64/silvermont/string/sse2-strlen-slm.S
+ create mode 100644 libc/arch-x86_64/silvermont/string/sse2-strncat-slm.S
+ create mode 100644 libc/arch-x86_64/silvermont/string/sse2-strncpy-slm.S
+ create mode 100644 libc/arch-x86_64/silvermont/string/sse4-memcmp-slm.S
+ create mode 100644 libc/arch-x86_64/silvermont/string/ssse3-strcmp-slm.S
+ create mode 100644 libc/arch-x86_64/silvermont/string/ssse3-strncmp-slm.S
+ create mode 100644 libc/arch-x86_64/static_function_dispatch.S
+ delete mode 100644 libc/arch-x86_64/string/avx2-wmemset-kbl.S
+ delete mode 100644 libc/arch-x86_64/string/cache.h
+ delete mode 100644 libc/arch-x86_64/string/sse2-memcpy-slm.s
+ delete mode 100644 libc/arch-x86_64/string/sse2-memmove-slm.S
+ delete mode 100644 libc/arch-x86_64/string/sse2-memset-slm.S
+ delete mode 100644 libc/arch-x86_64/string/sse2-stpcpy-slm.S
+ delete mode 100644 libc/arch-x86_64/string/sse2-stpncpy-slm.S
+ delete mode 100644 libc/arch-x86_64/string/sse2-strcat-slm.S
+ delete mode 100644 libc/arch-x86_64/string/sse2-strcpy-slm.S
+ delete mode 100644 libc/arch-x86_64/string/sse2-strlen-slm.S
+ delete mode 100644 libc/arch-x86_64/string/sse2-strncat-slm.S
+ delete mode 100644 libc/arch-x86_64/string/sse2-strncpy-slm.S
+ delete mode 100644 libc/arch-x86_64/string/sse4-memcmp-slm.S
+ delete mode 100644 libc/arch-x86_64/string/ssse3-strcmp-slm.S
+ delete mode 100644 libc/arch-x86_64/string/ssse3-strncmp-slm.S
+
+diff --git a/libc/Android.bp b/libc/Android.bp
+index 44d0117..58586a5 100644
+--- a/libc/Android.bp
++++ b/libc/Android.bp
+@@ -328,6 +328,11 @@ cc_library_static {
+                 "upstream-freebsd/lib/libc/string/wmemset.c",
+             ],
+         },
++        x86_64: {
++            exclude_srcs: [
++                "upstream-freebsd/lib/libc/string/wmemset.c",
++            ],
++        },
+     },
+ 
+     cflags: [
+@@ -631,6 +636,8 @@ cc_library_static {
+ 
+         x86_64: {
+             exclude_srcs: [
++                "upstream-openbsd/lib/libc/string/memchr.c",
++                "upstream-openbsd/lib/libc/string/memrchr.c",
+                 "upstream-openbsd/lib/libc/string/stpcpy.c",
+                 "upstream-openbsd/lib/libc/string/stpncpy.c",
+                 "upstream-openbsd/lib/libc/string/strcat.c",
+@@ -937,6 +944,7 @@ cc_library_static {
+ 
+                 // avx2 functions
+                 "arch-x86/kabylake/string/avx2-wmemset-kbl.S",
++                "arch-x86/kabylake/string/avx2-memcpy-kbl.S",
+             ],
+ 
+             exclude_srcs: [
+@@ -946,21 +954,37 @@ cc_library_static {
+             ],
+         },
+         x86_64: {
++            cflags: ["-include openbsd-compat.h"],
++            include_dirs: ["bionic/libc/arch-x86_64/include"],
++            local_include_dirs: [
++                // "private",
++                 "upstream-openbsd/android/include",
++            ],
+             srcs: [
+-                "arch-x86_64/string/sse2-memmove-slm.S",
+-                "arch-x86_64/string/sse2-memcpy-slm.s",
+-                "arch-x86_64/string/sse2-memset-slm.S",
+-                "arch-x86_64/string/sse2-stpcpy-slm.S",
+-                "arch-x86_64/string/sse2-stpncpy-slm.S",
+-                "arch-x86_64/string/sse2-strcat-slm.S",
+-                "arch-x86_64/string/sse2-strcpy-slm.S",
+-                "arch-x86_64/string/sse2-strlen-slm.S",
+-                "arch-x86_64/string/sse2-strncat-slm.S",
+-                "arch-x86_64/string/sse2-strncpy-slm.S",
+-                "arch-x86_64/string/sse4-memcmp-slm.S",
+-                "arch-x86_64/string/ssse3-strcmp-slm.S",
+-                "arch-x86_64/string/ssse3-strncmp-slm.S",
+-                "arch-x86_64/string/avx2-wmemset-kbl.S",
++                "arch-x86_64/generic/string/wmemset.c",
++                "arch-x86_64/generic/string/memchr.c",
++                "arch-x86_64/generic/string/memrchr.c",
++
++                "arch-x86_64/silvermont/string/sse2-memmove-slm.S",
++                "arch-x86_64/silvermont/string/sse2-memcpy-slm.s",
++                "arch-x86_64/silvermont/string/sse2-memset-slm.S",
++                "arch-x86_64/silvermont/string/sse2-stpcpy-slm.S",
++                "arch-x86_64/silvermont/string/sse2-stpncpy-slm.S",
++                "arch-x86_64/silvermont/string/sse2-strcat-slm.S",
++                "arch-x86_64/silvermont/string/sse2-strcpy-slm.S",
++                "arch-x86_64/silvermont/string/sse2-strlen-slm.S",
++                "arch-x86_64/silvermont/string/sse2-strncat-slm.S",
++                "arch-x86_64/silvermont/string/sse2-strncpy-slm.S",
++                "arch-x86_64/silvermont/string/sse4-memcmp-slm.S",
++                "arch-x86_64/silvermont/string/ssse3-strcmp-slm.S",
++                "arch-x86_64/silvermont/string/ssse3-strncmp-slm.S",
++
++                "arch-x86_64/kabylake/string/avx2-wmemset-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-memcpy-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-memcmp-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-memmove-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-memchr-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-memrchr-kbl.S",
+ 
+                 "arch-x86_64/bionic/__bionic_clone.S",
+                 "arch-x86_64/bionic/_exit_with_stack_teardown.S",
+@@ -1438,6 +1462,9 @@ cc_library_static {
+         x86: {
+             srcs: ["arch-x86/static_function_dispatch.S"],
+         },
++        x86_64: {
++            srcs: ["arch-x86_64/static_function_dispatch.S"],
++        },
+         arm: {
+             srcs: ["arch-arm/static_function_dispatch.S"],
+         },
+@@ -1463,6 +1490,9 @@ cc_library_static {
+         x86: {
+             srcs: ["arch-x86/dynamic_function_dispatch.cpp"],
+         },
++        x86_64: {
++            srcs: ["arch-x86_64/dynamic_function_dispatch.cpp"],
++        },
+         arm: {
+             srcs: ["arch-arm/dynamic_function_dispatch.cpp"],
+         },
+diff --git a/libc/arch-x86/dynamic_function_dispatch.cpp b/libc/arch-x86/dynamic_function_dispatch.cpp
+index e94fa1f..3f9ad34 100644
+--- a/libc/arch-x86/dynamic_function_dispatch.cpp
++++ b/libc/arch-x86/dynamic_function_dispatch.cpp
+@@ -63,7 +63,10 @@ DEFINE_IFUNC_FOR(memmove) {
+ 
+ typedef void* memcpy_func(void*, const void*, size_t);
+ DEFINE_IFUNC_FOR(memcpy) {
+-    return memmove_resolver();
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(memcpy_func, memcpy_avx2);
++    RETURN_FUNC(memcpy_func, memmove_generic);
++  	 
+ }
+ 
+ typedef char* strcpy_func(char* __dst, const char* __src);
+diff --git a/libc/arch-x86/kabylake/string/avx2-memcpy-kbl.S b/libc/arch-x86/kabylake/string/avx2-memcpy-kbl.S
+new file mode 100644
+index 0000000..69fca7c
+--- /dev/null
++++ b/libc/arch-x86/kabylake/string/avx2-memcpy-kbl.S
+@@ -0,0 +1,2052 @@
++#define ENTRY(f) \
++    .text; \
++    .globl f; \
++    .p2align    4, 0x90; \
++    .type f,@function; \
++    f: \
++
++#define END(f)
++    .size f, .-f; \
++    .section        .rodata,"a",@progbits; \
++    .p2align        2 \
++
++ENTRY(memcpy_avx2)
++# %bb.0:
++	pushl	%ebp
++	pushl	%ebx
++	pushl	%edi
++	pushl	%esi
++	movl	28(%esp), %ebx
++	movl	24(%esp), %ecx
++	movl	20(%esp), %eax
++	calll	.L0$pb
++.L0$pb:
++	popl	%esi
++.Ltmp0:
++	addl	$_GLOBAL_OFFSET_TABLE_+(.Ltmp0-.L0$pb), %esi
++	cmpl	$256, %ebx              # imm = 0x100
++	ja	.LBB0_251
++# %bb.1:
++	leal	-1(%ebx), %edi
++	cmpl	$255, %edi
++	ja	.LBB0_270
++# %bb.2:
++	addl	.LJTI0_1@GOTOFF(%esi,%edi,4), %esi
++	leal	(%eax,%ebx), %edx
++	addl	%ebx, %ecx
++	jmpl	*%esi
++.LBB0_251:
++	movl	%eax, %ebp
++	vmovups	(%ecx), %ymm0
++	movl	%ebx, %edi
++	negl	%ebp
++	andl	$31, %ebp
++	subl	%ebp, %edi
++	addl	%ebp, %ecx
++	leal	(%eax,%ebp), %edx
++	cmpl	$2097152, %edi          # imm = 0x200000
++	vmovups	%ymm0, (%eax)
++	ja	.LBB0_256
++# %bb.252:
++	cmpl	$256, %edi              # imm = 0x100
++	jb	.LBB0_260
++# %bb.253:
++	subl	%ebp, %ebx
++	.p2align	4, 0x90
++.LBB0_254:                              # =>This Inner Loop Header: Depth=1
++	vmovups	(%ecx), %ymm0
++	vmovups	32(%ecx), %ymm1
++	vmovups	64(%ecx), %ymm2
++	vmovups	96(%ecx), %ymm3
++	vmovups	128(%ecx), %ymm4
++	vmovups	160(%ecx), %ymm5
++	vmovups	192(%ecx), %ymm6
++	vmovups	224(%ecx), %ymm7
++	prefetchnta	512(%ecx)
++	addl	$-256, %edi
++	addl	$256, %ecx              # imm = 0x100
++	vmovups	%ymm0, (%edx)
++	vmovups	%ymm1, 32(%edx)
++	vmovups	%ymm2, 64(%edx)
++	vmovups	%ymm3, 96(%edx)
++	vmovups	%ymm4, 128(%edx)
++	vmovups	%ymm5, 160(%edx)
++	vmovups	%ymm6, 192(%edx)
++	vmovups	%ymm7, 224(%edx)
++	addl	$256, %edx              # imm = 0x100
++	cmpl	$255, %edi
++	ja	.LBB0_254
++# %bb.255:
++	movzbl	%bl, %edi
++	leal	-1(%edi), %ebx
++	cmpl	$255, %ebx
++	jbe	.LBB0_261
++	jmp	.LBB0_270
++.LBB0_256:
++	prefetchnta	(%ecx)
++	subl	%ebp, %ebx
++	testb	$31, %cl
++	je	.LBB0_257
++	.p2align	4, 0x90
++.LBB0_258:                              # =>This Inner Loop Header: Depth=1
++	vmovups	(%ecx), %ymm0
++	vmovups	32(%ecx), %ymm1
++	vmovups	64(%ecx), %ymm2
++	vmovups	96(%ecx), %ymm3
++	vmovups	128(%ecx), %ymm4
++	vmovups	160(%ecx), %ymm5
++	vmovups	192(%ecx), %ymm6
++	vmovups	224(%ecx), %ymm7
++	prefetchnta	512(%ecx)
++	addl	$-256, %edi
++	addl	$256, %ecx              # imm = 0x100
++	vmovntps	%ymm0, (%edx)
++	vmovntps	%ymm1, 32(%edx)
++	vmovntps	%ymm2, 64(%edx)
++	vmovntps	%ymm3, 96(%edx)
++	vmovntps	%ymm4, 128(%edx)
++	vmovntps	%ymm5, 160(%edx)
++	vmovntps	%ymm6, 192(%edx)
++	vmovntps	%ymm7, 224(%edx)
++	addl	$256, %edx              # imm = 0x100
++	cmpl	$255, %edi
++	ja	.LBB0_258
++	jmp	.LBB0_259
++	.p2align	4, 0x90
++.LBB0_257:                              # =>This Inner Loop Header: Depth=1
++	vmovaps	(%ecx), %ymm0
++	vmovaps	32(%ecx), %ymm1
++	vmovaps	64(%ecx), %ymm2
++	vmovaps	96(%ecx), %ymm3
++	vmovaps	128(%ecx), %ymm4
++	vmovaps	160(%ecx), %ymm5
++	vmovaps	192(%ecx), %ymm6
++	vmovaps	224(%ecx), %ymm7
++	prefetchnta	512(%ecx)
++	addl	$-256, %edi
++	addl	$256, %ecx              # imm = 0x100
++	vmovntps	%ymm0, (%edx)
++	vmovntps	%ymm1, 32(%edx)
++	vmovntps	%ymm2, 64(%edx)
++	vmovntps	%ymm3, 96(%edx)
++	vmovntps	%ymm4, 128(%edx)
++	vmovntps	%ymm5, 160(%edx)
++	vmovntps	%ymm6, 192(%edx)
++	vmovntps	%ymm7, 224(%edx)
++	addl	$256, %edx              # imm = 0x100
++	cmpl	$255, %edi
++	ja	.LBB0_257
++.LBB0_259:
++	sfence
++	movzbl	%bl, %edi
++.LBB0_260:
++	leal	-1(%edi), %ebx
++	cmpl	$255, %ebx
++	ja	.LBB0_270
++.LBB0_261:
++	addl	.LJTI0_0@GOTOFF(%esi,%ebx,4), %esi
++	addl	%edi, %edx
++	addl	%edi, %ecx
++	jmpl	*%esi
++.LBB0_11:
++	vmovups	-131(%ecx), %ymm0
++	vmovups	%ymm0, -131(%edx)
++	vmovups	-99(%ecx), %ymm0
++	vmovups	%ymm0, -99(%edx)
++	vmovups	-67(%ecx), %ymm0
++	vmovups	%ymm0, -67(%edx)
++	vmovups	-35(%ecx), %ymm0
++	vmovups	%ymm0, -35(%edx)
++.LBB0_12:
++	movzwl	-3(%ecx), %esi
++	movw	%si, -3(%edx)
++	jmp	.LBB0_6
++.LBB0_17:
++	vmovups	-133(%ecx), %ymm0
++	vmovups	%ymm0, -133(%edx)
++	vmovups	-101(%ecx), %ymm0
++	vmovups	%ymm0, -101(%edx)
++	vmovups	-69(%ecx), %ymm0
++	vmovups	%ymm0, -69(%edx)
++	vmovups	-37(%ecx), %ymm0
++	vmovups	%ymm0, -37(%edx)
++.LBB0_18:
++	movl	-5(%ecx), %esi
++	movl	%esi, -5(%edx)
++	jmp	.LBB0_6
++.LBB0_19:
++	vmovups	-134(%ecx), %ymm0
++	vmovups	%ymm0, -134(%edx)
++	vmovups	-102(%ecx), %ymm0
++	vmovups	%ymm0, -102(%edx)
++	vmovups	-70(%ecx), %ymm0
++	vmovups	%ymm0, -70(%edx)
++	vmovups	-38(%ecx), %ymm0
++	vmovups	%ymm0, -38(%edx)
++.LBB0_20:
++	movl	-6(%ecx), %esi
++	movl	%esi, -6(%edx)
++	jmp	.LBB0_10
++.LBB0_21:
++	vmovups	-135(%ecx), %ymm0
++	vmovups	%ymm0, -135(%edx)
++	vmovups	-103(%ecx), %ymm0
++	vmovups	%ymm0, -103(%edx)
++	vmovups	-71(%ecx), %ymm0
++	vmovups	%ymm0, -71(%edx)
++	vmovups	-39(%ecx), %ymm0
++	vmovups	%ymm0, -39(%edx)
++.LBB0_22:
++	movl	-7(%ecx), %esi
++	movl	%esi, -7(%edx)
++	jmp	.LBB0_16
++.LBB0_27:
++	vmovups	-137(%ecx), %ymm0
++	vmovups	%ymm0, -137(%edx)
++	vmovups	-105(%ecx), %ymm0
++	vmovups	%ymm0, -105(%edx)
++	vmovups	-73(%ecx), %ymm0
++	vmovups	%ymm0, -73(%edx)
++	vmovups	-41(%ecx), %ymm0
++	vmovups	%ymm0, -41(%edx)
++.LBB0_28:
++	vmovsd	-9(%ecx), %xmm0         # xmm0 = mem[0],zero
++	vmovsd	%xmm0, -9(%edx)
++	jmp	.LBB0_6
++.LBB0_29:
++	vmovups	-138(%ecx), %ymm0
++	vmovups	%ymm0, -138(%edx)
++	vmovups	-106(%ecx), %ymm0
++	vmovups	%ymm0, -106(%edx)
++	vmovups	-74(%ecx), %ymm0
++	vmovups	%ymm0, -74(%edx)
++	vmovups	-42(%ecx), %ymm0
++	vmovups	%ymm0, -42(%edx)
++.LBB0_30:
++	vmovsd	-10(%ecx), %xmm0        # xmm0 = mem[0],zero
++	vmovsd	%xmm0, -10(%edx)
++	jmp	.LBB0_10
++.LBB0_31:
++	vmovups	-139(%ecx), %ymm0
++	vmovups	%ymm0, -139(%edx)
++	vmovups	-107(%ecx), %ymm0
++	vmovups	%ymm0, -107(%edx)
++	vmovups	-75(%ecx), %ymm0
++	vmovups	%ymm0, -75(%edx)
++	vmovups	-43(%ecx), %ymm0
++	vmovups	%ymm0, -43(%edx)
++.LBB0_32:
++	vmovsd	-11(%ecx), %xmm0        # xmm0 = mem[0],zero
++	vmovsd	%xmm0, -11(%edx)
++	jmp	.LBB0_16
++.LBB0_33:
++	vmovups	-140(%ecx), %ymm0
++	vmovups	%ymm0, -140(%edx)
++	vmovups	-108(%ecx), %ymm0
++	vmovups	%ymm0, -108(%edx)
++	vmovups	-76(%ecx), %ymm0
++	vmovups	%ymm0, -76(%edx)
++	vmovups	-44(%ecx), %ymm0
++	vmovups	%ymm0, -44(%edx)
++.LBB0_34:
++	vmovsd	-12(%ecx), %xmm0        # xmm0 = mem[0],zero
++	vmovsd	%xmm0, -12(%edx)
++	jmp	.LBB0_16
++.LBB0_35:
++	vmovups	-141(%ecx), %ymm0
++	vmovups	%ymm0, -141(%edx)
++	vmovups	-109(%ecx), %ymm0
++	vmovups	%ymm0, -109(%edx)
++	vmovups	-77(%ecx), %ymm0
++	vmovups	%ymm0, -77(%edx)
++	vmovups	-45(%ecx), %ymm0
++	vmovups	%ymm0, -45(%edx)
++.LBB0_36:
++	vmovsd	-13(%ecx), %xmm0        # xmm0 = mem[0],zero
++	vmovsd	%xmm0, -13(%edx)
++	jmp	.LBB0_26
++.LBB0_37:
++	vmovups	-142(%ecx), %ymm0
++	vmovups	%ymm0, -142(%edx)
++	vmovups	-110(%ecx), %ymm0
++	vmovups	%ymm0, -110(%edx)
++	vmovups	-78(%ecx), %ymm0
++	vmovups	%ymm0, -78(%edx)
++	vmovups	-46(%ecx), %ymm0
++	vmovups	%ymm0, -46(%edx)
++.LBB0_38:
++	vmovsd	-14(%ecx), %xmm0        # xmm0 = mem[0],zero
++	vmovsd	%xmm0, -14(%edx)
++	jmp	.LBB0_26
++.LBB0_39:
++	vmovups	-143(%ecx), %ymm0
++	vmovups	%ymm0, -143(%edx)
++	vmovups	-111(%ecx), %ymm0
++	vmovups	%ymm0, -111(%edx)
++	vmovups	-79(%ecx), %ymm0
++	vmovups	%ymm0, -79(%edx)
++	vmovups	-47(%ecx), %ymm0
++	vmovups	%ymm0, -47(%edx)
++.LBB0_40:
++	vmovsd	-15(%ecx), %xmm0        # xmm0 = mem[0],zero
++	vmovsd	%xmm0, -15(%edx)
++	jmp	.LBB0_26
++.LBB0_45:
++	vmovups	-145(%ecx), %ymm0
++	vmovups	%ymm0, -145(%edx)
++	vmovups	-113(%ecx), %ymm0
++	vmovups	%ymm0, -113(%edx)
++	vmovups	-81(%ecx), %ymm0
++	vmovups	%ymm0, -81(%edx)
++	vmovups	-49(%ecx), %ymm0
++	vmovups	%ymm0, -49(%edx)
++.LBB0_46:
++	vmovups	-17(%ecx), %xmm0
++	vmovups	%xmm0, -17(%edx)
++	jmp	.LBB0_6
++.LBB0_47:
++	vmovups	-146(%ecx), %ymm0
++	vmovups	%ymm0, -146(%edx)
++	vmovups	-114(%ecx), %ymm0
++	vmovups	%ymm0, -114(%edx)
++	vmovups	-82(%ecx), %ymm0
++	vmovups	%ymm0, -82(%edx)
++	vmovups	-50(%ecx), %ymm0
++	vmovups	%ymm0, -50(%edx)
++.LBB0_48:
++	vmovups	-18(%ecx), %xmm0
++	vmovups	%xmm0, -18(%edx)
++	jmp	.LBB0_10
++.LBB0_49:
++	vmovups	-147(%ecx), %ymm0
++	vmovups	%ymm0, -147(%edx)
++	vmovups	-115(%ecx), %ymm0
++	vmovups	%ymm0, -115(%edx)
++	vmovups	-83(%ecx), %ymm0
++	vmovups	%ymm0, -83(%edx)
++	vmovups	-51(%ecx), %ymm0
++	vmovups	%ymm0, -51(%edx)
++.LBB0_50:
++	vmovups	-19(%ecx), %xmm0
++	vmovups	%xmm0, -19(%edx)
++	jmp	.LBB0_16
++.LBB0_51:
++	vmovups	-148(%ecx), %ymm0
++	vmovups	%ymm0, -148(%edx)
++	vmovups	-116(%ecx), %ymm0
++	vmovups	%ymm0, -116(%edx)
++	vmovups	-84(%ecx), %ymm0
++	vmovups	%ymm0, -84(%edx)
++	vmovups	-52(%ecx), %ymm0
++	vmovups	%ymm0, -52(%edx)
++.LBB0_52:
++	vmovups	-20(%ecx), %xmm0
++	vmovups	%xmm0, -20(%edx)
++	jmp	.LBB0_16
++.LBB0_53:
++	vmovups	-149(%ecx), %ymm0
++	vmovups	%ymm0, -149(%edx)
++	vmovups	-117(%ecx), %ymm0
++	vmovups	%ymm0, -117(%edx)
++	vmovups	-85(%ecx), %ymm0
++	vmovups	%ymm0, -85(%edx)
++	vmovups	-53(%ecx), %ymm0
++	vmovups	%ymm0, -53(%edx)
++.LBB0_54:
++	vmovups	-21(%ecx), %xmm0
++	vmovups	%xmm0, -21(%edx)
++	jmp	.LBB0_26
++.LBB0_55:
++	vmovups	-150(%ecx), %ymm0
++	vmovups	%ymm0, -150(%edx)
++	vmovups	-118(%ecx), %ymm0
++	vmovups	%ymm0, -118(%edx)
++	vmovups	-86(%ecx), %ymm0
++	vmovups	%ymm0, -86(%edx)
++	vmovups	-54(%ecx), %ymm0
++	vmovups	%ymm0, -54(%edx)
++.LBB0_56:
++	vmovups	-22(%ecx), %xmm0
++	vmovups	%xmm0, -22(%edx)
++	jmp	.LBB0_26
++.LBB0_57:
++	vmovups	-151(%ecx), %ymm0
++	vmovups	%ymm0, -151(%edx)
++	vmovups	-119(%ecx), %ymm0
++	vmovups	%ymm0, -119(%edx)
++	vmovups	-87(%ecx), %ymm0
++	vmovups	%ymm0, -87(%edx)
++	vmovups	-55(%ecx), %ymm0
++	vmovups	%ymm0, -55(%edx)
++.LBB0_58:
++	vmovups	-23(%ecx), %xmm0
++	vmovups	%xmm0, -23(%edx)
++	jmp	.LBB0_26
++.LBB0_59:
++	vmovups	-152(%ecx), %ymm0
++	vmovups	%ymm0, -152(%edx)
++	vmovups	-120(%ecx), %ymm0
++	vmovups	%ymm0, -120(%edx)
++	vmovups	-88(%ecx), %ymm0
++	vmovups	%ymm0, -88(%edx)
++	vmovups	-56(%ecx), %ymm0
++	vmovups	%ymm0, -56(%edx)
++.LBB0_60:
++	vmovups	-24(%ecx), %xmm0
++	vmovups	%xmm0, -24(%edx)
++	jmp	.LBB0_26
++.LBB0_61:
++	vmovups	-153(%ecx), %ymm0
++	vmovups	%ymm0, -153(%edx)
++	vmovups	-121(%ecx), %ymm0
++	vmovups	%ymm0, -121(%edx)
++	vmovups	-89(%ecx), %ymm0
++	vmovups	%ymm0, -89(%edx)
++	vmovups	-57(%ecx), %ymm0
++	vmovups	%ymm0, -57(%edx)
++.LBB0_62:
++	vmovups	-25(%ecx), %xmm0
++	vmovups	%xmm0, -25(%edx)
++	jmp	.LBB0_44
++.LBB0_63:
++	vmovups	-154(%ecx), %ymm0
++	vmovups	%ymm0, -154(%edx)
++	vmovups	-122(%ecx), %ymm0
++	vmovups	%ymm0, -122(%edx)
++	vmovups	-90(%ecx), %ymm0
++	vmovups	%ymm0, -90(%edx)
++	vmovups	-58(%ecx), %ymm0
++	vmovups	%ymm0, -58(%edx)
++.LBB0_64:
++	vmovups	-26(%ecx), %xmm0
++	vmovups	%xmm0, -26(%edx)
++	jmp	.LBB0_44
++.LBB0_65:
++	vmovups	-155(%ecx), %ymm0
++	vmovups	%ymm0, -155(%edx)
++	vmovups	-123(%ecx), %ymm0
++	vmovups	%ymm0, -123(%edx)
++	vmovups	-91(%ecx), %ymm0
++	vmovups	%ymm0, -91(%edx)
++	vmovups	-59(%ecx), %ymm0
++	vmovups	%ymm0, -59(%edx)
++.LBB0_66:
++	vmovups	-27(%ecx), %xmm0
++	vmovups	%xmm0, -27(%edx)
++	jmp	.LBB0_44
++.LBB0_67:
++	vmovups	-156(%ecx), %ymm0
++	vmovups	%ymm0, -156(%edx)
++	vmovups	-124(%ecx), %ymm0
++	vmovups	%ymm0, -124(%edx)
++	vmovups	-92(%ecx), %ymm0
++	vmovups	%ymm0, -92(%edx)
++	vmovups	-60(%ecx), %ymm0
++	vmovups	%ymm0, -60(%edx)
++.LBB0_68:
++	vmovups	-28(%ecx), %xmm0
++	vmovups	%xmm0, -28(%edx)
++	jmp	.LBB0_44
++.LBB0_69:
++	vmovups	-157(%ecx), %ymm0
++	vmovups	%ymm0, -157(%edx)
++	vmovups	-125(%ecx), %ymm0
++	vmovups	%ymm0, -125(%edx)
++	vmovups	-93(%ecx), %ymm0
++	vmovups	%ymm0, -93(%edx)
++	vmovups	-61(%ecx), %ymm0
++	vmovups	%ymm0, -61(%edx)
++.LBB0_70:
++	vmovups	-29(%ecx), %xmm0
++	vmovups	%xmm0, -29(%edx)
++	jmp	.LBB0_44
++.LBB0_71:
++	vmovups	-158(%ecx), %ymm0
++	vmovups	%ymm0, -158(%edx)
++	vmovups	-126(%ecx), %ymm0
++	vmovups	%ymm0, -126(%edx)
++	vmovups	-94(%ecx), %ymm0
++	vmovups	%ymm0, -94(%edx)
++	vmovups	-62(%ecx), %ymm0
++	vmovups	%ymm0, -62(%edx)
++.LBB0_72:
++	vmovups	-30(%ecx), %xmm0
++	vmovups	%xmm0, -30(%edx)
++	jmp	.LBB0_44
++.LBB0_73:
++	vmovups	-159(%ecx), %ymm0
++	vmovups	%ymm0, -159(%edx)
++	vmovups	-127(%ecx), %ymm0
++	vmovups	%ymm0, -127(%edx)
++	vmovups	-95(%ecx), %ymm0
++	vmovups	%ymm0, -95(%edx)
++	vmovups	-63(%ecx), %ymm0
++	vmovups	%ymm0, -63(%edx)
++.LBB0_74:
++	vmovups	-31(%ecx), %xmm0
++	vmovups	%xmm0, -31(%edx)
++	jmp	.LBB0_44
++.LBB0_75:
++	vmovups	-193(%ecx), %ymm0
++	vmovups	%ymm0, -193(%edx)
++.LBB0_76:
++	vmovups	-161(%ecx), %ymm0
++	vmovups	%ymm0, -161(%edx)
++.LBB0_3:
++	vmovups	-129(%ecx), %ymm0
++	vmovups	%ymm0, -129(%edx)
++	vmovups	-97(%ecx), %ymm0
++	vmovups	%ymm0, -97(%edx)
++.LBB0_4:
++	vmovups	-65(%ecx), %ymm0
++	vmovups	%ymm0, -65(%edx)
++.LBB0_5:
++	vmovups	-33(%ecx), %ymm0
++	vmovups	%ymm0, -33(%edx)
++.LBB0_6:
++	movb	-1(%ecx), %cl
++	movb	%cl, -1(%edx)
++	jmp	.LBB0_270
++.LBB0_77:
++	vmovups	-194(%ecx), %ymm0
++	vmovups	%ymm0, -194(%edx)
++.LBB0_78:
++	vmovups	-162(%ecx), %ymm0
++	vmovups	%ymm0, -162(%edx)
++.LBB0_7:
++	vmovups	-130(%ecx), %ymm0
++	vmovups	%ymm0, -130(%edx)
++	vmovups	-98(%ecx), %ymm0
++	vmovups	%ymm0, -98(%edx)
++.LBB0_8:
++	vmovups	-66(%ecx), %ymm0
++	vmovups	%ymm0, -66(%edx)
++.LBB0_9:
++	vmovups	-34(%ecx), %ymm0
++	vmovups	%ymm0, -34(%edx)
++.LBB0_10:
++	movzwl	-2(%ecx), %ecx
++	movw	%cx, -2(%edx)
++	jmp	.LBB0_270
++.LBB0_79:
++	vmovups	-195(%ecx), %ymm0
++	vmovups	%ymm0, -195(%edx)
++.LBB0_80:
++	vmovups	-163(%ecx), %ymm0
++	vmovups	%ymm0, -163(%edx)
++	vmovups	-131(%ecx), %ymm0
++	vmovups	%ymm0, -131(%edx)
++	vmovups	-99(%ecx), %ymm0
++	vmovups	%ymm0, -99(%edx)
++.LBB0_81:
++	vmovups	-67(%ecx), %ymm0
++	vmovups	%ymm0, -67(%edx)
++.LBB0_82:
++	vmovups	-35(%ecx), %ymm0
++	vmovups	%ymm0, -35(%edx)
++	jmp	.LBB0_16
++.LBB0_83:
++	vmovups	-196(%ecx), %ymm0
++	vmovups	%ymm0, -196(%edx)
++.LBB0_84:
++	vmovups	-164(%ecx), %ymm0
++	vmovups	%ymm0, -164(%edx)
++.LBB0_13:
++	vmovups	-132(%ecx), %ymm0
++	vmovups	%ymm0, -132(%edx)
++	vmovups	-100(%ecx), %ymm0
++	vmovups	%ymm0, -100(%edx)
++.LBB0_14:
++	vmovups	-68(%ecx), %ymm0
++	vmovups	%ymm0, -68(%edx)
++.LBB0_15:
++	vmovups	-36(%ecx), %ymm0
++	vmovups	%ymm0, -36(%edx)
++.LBB0_16:
++	movl	-4(%ecx), %ecx
++	movl	%ecx, -4(%edx)
++	jmp	.LBB0_270
++.LBB0_85:
++	vmovups	-197(%ecx), %ymm0
++	vmovups	%ymm0, -197(%edx)
++.LBB0_86:
++	vmovups	-165(%ecx), %ymm0
++	vmovups	%ymm0, -165(%edx)
++	vmovups	-133(%ecx), %ymm0
++	vmovups	%ymm0, -133(%edx)
++	vmovups	-101(%ecx), %ymm0
++	vmovups	%ymm0, -101(%edx)
++.LBB0_87:
++	vmovups	-69(%ecx), %ymm0
++	vmovups	%ymm0, -69(%edx)
++.LBB0_88:
++	vmovups	-37(%ecx), %ymm0
++	vmovups	%ymm0, -37(%edx)
++	jmp	.LBB0_26
++.LBB0_89:
++	vmovups	-198(%ecx), %ymm0
++	vmovups	%ymm0, -198(%edx)
++.LBB0_90:
++	vmovups	-166(%ecx), %ymm0
++	vmovups	%ymm0, -166(%edx)
++	vmovups	-134(%ecx), %ymm0
++	vmovups	%ymm0, -134(%edx)
++	vmovups	-102(%ecx), %ymm0
++	vmovups	%ymm0, -102(%edx)
++.LBB0_91:
++	vmovups	-70(%ecx), %ymm0
++	vmovups	%ymm0, -70(%edx)
++.LBB0_92:
++	vmovups	-38(%ecx), %ymm0
++	vmovups	%ymm0, -38(%edx)
++	jmp	.LBB0_26
++.LBB0_93:
++	vmovups	-199(%ecx), %ymm0
++	vmovups	%ymm0, -199(%edx)
++.LBB0_94:
++	vmovups	-167(%ecx), %ymm0
++	vmovups	%ymm0, -167(%edx)
++	vmovups	-135(%ecx), %ymm0
++	vmovups	%ymm0, -135(%edx)
++	vmovups	-103(%ecx), %ymm0
++	vmovups	%ymm0, -103(%edx)
++.LBB0_95:
++	vmovups	-71(%ecx), %ymm0
++	vmovups	%ymm0, -71(%edx)
++.LBB0_96:
++	vmovups	-39(%ecx), %ymm0
++	vmovups	%ymm0, -39(%edx)
++	jmp	.LBB0_26
++.LBB0_97:
++	vmovups	-200(%ecx), %ymm0
++	vmovups	%ymm0, -200(%edx)
++.LBB0_98:
++	vmovups	-168(%ecx), %ymm0
++	vmovups	%ymm0, -168(%edx)
++.LBB0_23:
++	vmovups	-136(%ecx), %ymm0
++	vmovups	%ymm0, -136(%edx)
++	vmovups	-104(%ecx), %ymm0
++	vmovups	%ymm0, -104(%edx)
++.LBB0_24:
++	vmovups	-72(%ecx), %ymm0
++	vmovups	%ymm0, -72(%edx)
++.LBB0_25:
++	vmovups	-40(%ecx), %ymm0
++	vmovups	%ymm0, -40(%edx)
++.LBB0_26:
++	vmovsd	-8(%ecx), %xmm0         # xmm0 = mem[0],zero
++	vmovsd	%xmm0, -8(%edx)
++	jmp	.LBB0_270
++.LBB0_99:
++	vmovups	-201(%ecx), %ymm0
++	vmovups	%ymm0, -201(%edx)
++.LBB0_100:
++	vmovups	-169(%ecx), %ymm0
++	vmovups	%ymm0, -169(%edx)
++	vmovups	-137(%ecx), %ymm0
++	vmovups	%ymm0, -137(%edx)
++	vmovups	-105(%ecx), %ymm0
++	vmovups	%ymm0, -105(%edx)
++.LBB0_101:
++	vmovups	-73(%ecx), %ymm0
++	vmovups	%ymm0, -73(%edx)
++.LBB0_102:
++	vmovups	-41(%ecx), %ymm0
++	vmovups	%ymm0, -41(%edx)
++	jmp	.LBB0_44
++.LBB0_103:
++	vmovups	-202(%ecx), %ymm0
++	vmovups	%ymm0, -202(%edx)
++.LBB0_104:
++	vmovups	-170(%ecx), %ymm0
++	vmovups	%ymm0, -170(%edx)
++	vmovups	-138(%ecx), %ymm0
++	vmovups	%ymm0, -138(%edx)
++	vmovups	-106(%ecx), %ymm0
++	vmovups	%ymm0, -106(%edx)
++.LBB0_105:
++	vmovups	-74(%ecx), %ymm0
++	vmovups	%ymm0, -74(%edx)
++.LBB0_106:
++	vmovups	-42(%ecx), %ymm0
++	vmovups	%ymm0, -42(%edx)
++	jmp	.LBB0_44
++.LBB0_107:
++	vmovups	-203(%ecx), %ymm0
++	vmovups	%ymm0, -203(%edx)
++.LBB0_108:
++	vmovups	-171(%ecx), %ymm0
++	vmovups	%ymm0, -171(%edx)
++	vmovups	-139(%ecx), %ymm0
++	vmovups	%ymm0, -139(%edx)
++	vmovups	-107(%ecx), %ymm0
++	vmovups	%ymm0, -107(%edx)
++.LBB0_109:
++	vmovups	-75(%ecx), %ymm0
++	vmovups	%ymm0, -75(%edx)
++.LBB0_110:
++	vmovups	-43(%ecx), %ymm0
++	vmovups	%ymm0, -43(%edx)
++	jmp	.LBB0_44
++.LBB0_111:
++	vmovups	-204(%ecx), %ymm0
++	vmovups	%ymm0, -204(%edx)
++.LBB0_112:
++	vmovups	-172(%ecx), %ymm0
++	vmovups	%ymm0, -172(%edx)
++	vmovups	-140(%ecx), %ymm0
++	vmovups	%ymm0, -140(%edx)
++	vmovups	-108(%ecx), %ymm0
++	vmovups	%ymm0, -108(%edx)
++.LBB0_113:
++	vmovups	-76(%ecx), %ymm0
++	vmovups	%ymm0, -76(%edx)
++.LBB0_114:
++	vmovups	-44(%ecx), %ymm0
++	vmovups	%ymm0, -44(%edx)
++	jmp	.LBB0_44
++.LBB0_115:
++	vmovups	-205(%ecx), %ymm0
++	vmovups	%ymm0, -205(%edx)
++.LBB0_116:
++	vmovups	-173(%ecx), %ymm0
++	vmovups	%ymm0, -173(%edx)
++	vmovups	-141(%ecx), %ymm0
++	vmovups	%ymm0, -141(%edx)
++	vmovups	-109(%ecx), %ymm0
++	vmovups	%ymm0, -109(%edx)
++.LBB0_117:
++	vmovups	-77(%ecx), %ymm0
++	vmovups	%ymm0, -77(%edx)
++.LBB0_118:
++	vmovups	-45(%ecx), %ymm0
++	vmovups	%ymm0, -45(%edx)
++	jmp	.LBB0_44
++.LBB0_119:
++	vmovups	-206(%ecx), %ymm0
++	vmovups	%ymm0, -206(%edx)
++.LBB0_120:
++	vmovups	-174(%ecx), %ymm0
++	vmovups	%ymm0, -174(%edx)
++	vmovups	-142(%ecx), %ymm0
++	vmovups	%ymm0, -142(%edx)
++	vmovups	-110(%ecx), %ymm0
++	vmovups	%ymm0, -110(%edx)
++.LBB0_121:
++	vmovups	-78(%ecx), %ymm0
++	vmovups	%ymm0, -78(%edx)
++.LBB0_122:
++	vmovups	-46(%ecx), %ymm0
++	vmovups	%ymm0, -46(%edx)
++	jmp	.LBB0_44
++.LBB0_123:
++	vmovups	-207(%ecx), %ymm0
++	vmovups	%ymm0, -207(%edx)
++.LBB0_124:
++	vmovups	-175(%ecx), %ymm0
++	vmovups	%ymm0, -175(%edx)
++	vmovups	-143(%ecx), %ymm0
++	vmovups	%ymm0, -143(%edx)
++	vmovups	-111(%ecx), %ymm0
++	vmovups	%ymm0, -111(%edx)
++.LBB0_125:
++	vmovups	-79(%ecx), %ymm0
++	vmovups	%ymm0, -79(%edx)
++.LBB0_126:
++	vmovups	-47(%ecx), %ymm0
++	vmovups	%ymm0, -47(%edx)
++	jmp	.LBB0_44
++.LBB0_127:
++	vmovups	-208(%ecx), %ymm0
++	vmovups	%ymm0, -208(%edx)
++.LBB0_128:
++	vmovups	-176(%ecx), %ymm0
++	vmovups	%ymm0, -176(%edx)
++.LBB0_41:
++	vmovups	-144(%ecx), %ymm0
++	vmovups	%ymm0, -144(%edx)
++	vmovups	-112(%ecx), %ymm0
++	vmovups	%ymm0, -112(%edx)
++.LBB0_42:
++	vmovups	-80(%ecx), %ymm0
++	vmovups	%ymm0, -80(%edx)
++.LBB0_43:
++	vmovups	-48(%ecx), %ymm0
++	vmovups	%ymm0, -48(%edx)
++.LBB0_44:
++	vmovups	-16(%ecx), %xmm0
++	vmovups	%xmm0, -16(%edx)
++	jmp	.LBB0_270
++.LBB0_129:
++	vmovups	-209(%ecx), %ymm0
++	vmovups	%ymm0, -209(%edx)
++.LBB0_130:
++	vmovups	-177(%ecx), %ymm0
++	vmovups	%ymm0, -177(%edx)
++	vmovups	-145(%ecx), %ymm0
++	vmovups	%ymm0, -145(%edx)
++	vmovups	-113(%ecx), %ymm0
++	vmovups	%ymm0, -113(%edx)
++.LBB0_131:
++	vmovups	-81(%ecx), %ymm0
++	vmovups	%ymm0, -81(%edx)
++.LBB0_132:
++	vmovups	-49(%ecx), %ymm0
++	vmovups	%ymm0, -49(%edx)
++	jmp	.LBB0_269
++.LBB0_133:
++	vmovups	-210(%ecx), %ymm0
++	vmovups	%ymm0, -210(%edx)
++.LBB0_134:
++	vmovups	-178(%ecx), %ymm0
++	vmovups	%ymm0, -178(%edx)
++	vmovups	-146(%ecx), %ymm0
++	vmovups	%ymm0, -146(%edx)
++	vmovups	-114(%ecx), %ymm0
++	vmovups	%ymm0, -114(%edx)
++.LBB0_135:
++	vmovups	-82(%ecx), %ymm0
++	vmovups	%ymm0, -82(%edx)
++.LBB0_136:
++	vmovups	-50(%ecx), %ymm0
++	vmovups	%ymm0, -50(%edx)
++	jmp	.LBB0_269
++.LBB0_137:
++	vmovups	-211(%ecx), %ymm0
++	vmovups	%ymm0, -211(%edx)
++.LBB0_138:
++	vmovups	-179(%ecx), %ymm0
++	vmovups	%ymm0, -179(%edx)
++	vmovups	-147(%ecx), %ymm0
++	vmovups	%ymm0, -147(%edx)
++	vmovups	-115(%ecx), %ymm0
++	vmovups	%ymm0, -115(%edx)
++.LBB0_139:
++	vmovups	-83(%ecx), %ymm0
++	vmovups	%ymm0, -83(%edx)
++.LBB0_140:
++	vmovups	-51(%ecx), %ymm0
++	vmovups	%ymm0, -51(%edx)
++	jmp	.LBB0_269
++.LBB0_141:
++	vmovups	-212(%ecx), %ymm0
++	vmovups	%ymm0, -212(%edx)
++.LBB0_142:
++	vmovups	-180(%ecx), %ymm0
++	vmovups	%ymm0, -180(%edx)
++	vmovups	-148(%ecx), %ymm0
++	vmovups	%ymm0, -148(%edx)
++	vmovups	-116(%ecx), %ymm0
++	vmovups	%ymm0, -116(%edx)
++.LBB0_143:
++	vmovups	-84(%ecx), %ymm0
++	vmovups	%ymm0, -84(%edx)
++.LBB0_144:
++	vmovups	-52(%ecx), %ymm0
++	vmovups	%ymm0, -52(%edx)
++	jmp	.LBB0_269
++.LBB0_145:
++	vmovups	-213(%ecx), %ymm0
++	vmovups	%ymm0, -213(%edx)
++.LBB0_146:
++	vmovups	-181(%ecx), %ymm0
++	vmovups	%ymm0, -181(%edx)
++	vmovups	-149(%ecx), %ymm0
++	vmovups	%ymm0, -149(%edx)
++	vmovups	-117(%ecx), %ymm0
++	vmovups	%ymm0, -117(%edx)
++.LBB0_147:
++	vmovups	-85(%ecx), %ymm0
++	vmovups	%ymm0, -85(%edx)
++.LBB0_148:
++	vmovups	-53(%ecx), %ymm0
++	vmovups	%ymm0, -53(%edx)
++	jmp	.LBB0_269
++.LBB0_149:
++	vmovups	-214(%ecx), %ymm0
++	vmovups	%ymm0, -214(%edx)
++.LBB0_150:
++	vmovups	-182(%ecx), %ymm0
++	vmovups	%ymm0, -182(%edx)
++	vmovups	-150(%ecx), %ymm0
++	vmovups	%ymm0, -150(%edx)
++	vmovups	-118(%ecx), %ymm0
++	vmovups	%ymm0, -118(%edx)
++.LBB0_151:
++	vmovups	-86(%ecx), %ymm0
++	vmovups	%ymm0, -86(%edx)
++.LBB0_152:
++	vmovups	-54(%ecx), %ymm0
++	vmovups	%ymm0, -54(%edx)
++	jmp	.LBB0_269
++.LBB0_153:
++	vmovups	-215(%ecx), %ymm0
++	vmovups	%ymm0, -215(%edx)
++.LBB0_154:
++	vmovups	-183(%ecx), %ymm0
++	vmovups	%ymm0, -183(%edx)
++	vmovups	-151(%ecx), %ymm0
++	vmovups	%ymm0, -151(%edx)
++	vmovups	-119(%ecx), %ymm0
++	vmovups	%ymm0, -119(%edx)
++.LBB0_155:
++	vmovups	-87(%ecx), %ymm0
++	vmovups	%ymm0, -87(%edx)
++.LBB0_156:
++	vmovups	-55(%ecx), %ymm0
++	vmovups	%ymm0, -55(%edx)
++	jmp	.LBB0_269
++.LBB0_157:
++	vmovups	-216(%ecx), %ymm0
++	vmovups	%ymm0, -216(%edx)
++.LBB0_158:
++	vmovups	-184(%ecx), %ymm0
++	vmovups	%ymm0, -184(%edx)
++	vmovups	-152(%ecx), %ymm0
++	vmovups	%ymm0, -152(%edx)
++	vmovups	-120(%ecx), %ymm0
++	vmovups	%ymm0, -120(%edx)
++.LBB0_159:
++	vmovups	-88(%ecx), %ymm0
++	vmovups	%ymm0, -88(%edx)
++.LBB0_160:
++	vmovups	-56(%ecx), %ymm0
++	vmovups	%ymm0, -56(%edx)
++	jmp	.LBB0_269
++.LBB0_161:
++	vmovups	-217(%ecx), %ymm0
++	vmovups	%ymm0, -217(%edx)
++.LBB0_162:
++	vmovups	-185(%ecx), %ymm0
++	vmovups	%ymm0, -185(%edx)
++	vmovups	-153(%ecx), %ymm0
++	vmovups	%ymm0, -153(%edx)
++	vmovups	-121(%ecx), %ymm0
++	vmovups	%ymm0, -121(%edx)
++.LBB0_163:
++	vmovups	-89(%ecx), %ymm0
++	vmovups	%ymm0, -89(%edx)
++.LBB0_164:
++	vmovups	-57(%ecx), %ymm0
++	vmovups	%ymm0, -57(%edx)
++	jmp	.LBB0_269
++.LBB0_165:
++	vmovups	-218(%ecx), %ymm0
++	vmovups	%ymm0, -218(%edx)
++.LBB0_166:
++	vmovups	-186(%ecx), %ymm0
++	vmovups	%ymm0, -186(%edx)
++	vmovups	-154(%ecx), %ymm0
++	vmovups	%ymm0, -154(%edx)
++	vmovups	-122(%ecx), %ymm0
++	vmovups	%ymm0, -122(%edx)
++.LBB0_167:
++	vmovups	-90(%ecx), %ymm0
++	vmovups	%ymm0, -90(%edx)
++.LBB0_168:
++	vmovups	-58(%ecx), %ymm0
++	vmovups	%ymm0, -58(%edx)
++	jmp	.LBB0_269
++.LBB0_169:
++	vmovups	-219(%ecx), %ymm0
++	vmovups	%ymm0, -219(%edx)
++.LBB0_170:
++	vmovups	-187(%ecx), %ymm0
++	vmovups	%ymm0, -187(%edx)
++	vmovups	-155(%ecx), %ymm0
++	vmovups	%ymm0, -155(%edx)
++	vmovups	-123(%ecx), %ymm0
++	vmovups	%ymm0, -123(%edx)
++.LBB0_171:
++	vmovups	-91(%ecx), %ymm0
++	vmovups	%ymm0, -91(%edx)
++.LBB0_172:
++	vmovups	-59(%ecx), %ymm0
++	vmovups	%ymm0, -59(%edx)
++	jmp	.LBB0_269
++.LBB0_173:
++	vmovups	-220(%ecx), %ymm0
++	vmovups	%ymm0, -220(%edx)
++.LBB0_174:
++	vmovups	-188(%ecx), %ymm0
++	vmovups	%ymm0, -188(%edx)
++	vmovups	-156(%ecx), %ymm0
++	vmovups	%ymm0, -156(%edx)
++	vmovups	-124(%ecx), %ymm0
++	vmovups	%ymm0, -124(%edx)
++.LBB0_175:
++	vmovups	-92(%ecx), %ymm0
++	vmovups	%ymm0, -92(%edx)
++.LBB0_176:
++	vmovups	-60(%ecx), %ymm0
++	vmovups	%ymm0, -60(%edx)
++	jmp	.LBB0_269
++.LBB0_177:
++	vmovups	-221(%ecx), %ymm0
++	vmovups	%ymm0, -221(%edx)
++.LBB0_178:
++	vmovups	-189(%ecx), %ymm0
++	vmovups	%ymm0, -189(%edx)
++	vmovups	-157(%ecx), %ymm0
++	vmovups	%ymm0, -157(%edx)
++	vmovups	-125(%ecx), %ymm0
++	vmovups	%ymm0, -125(%edx)
++.LBB0_179:
++	vmovups	-93(%ecx), %ymm0
++	vmovups	%ymm0, -93(%edx)
++.LBB0_180:
++	vmovups	-61(%ecx), %ymm0
++	vmovups	%ymm0, -61(%edx)
++	jmp	.LBB0_269
++.LBB0_181:
++	vmovups	-222(%ecx), %ymm0
++	vmovups	%ymm0, -222(%edx)
++.LBB0_182:
++	vmovups	-190(%ecx), %ymm0
++	vmovups	%ymm0, -190(%edx)
++	vmovups	-158(%ecx), %ymm0
++	vmovups	%ymm0, -158(%edx)
++	vmovups	-126(%ecx), %ymm0
++	vmovups	%ymm0, -126(%edx)
++.LBB0_183:
++	vmovups	-94(%ecx), %ymm0
++	vmovups	%ymm0, -94(%edx)
++.LBB0_184:
++	vmovups	-62(%ecx), %ymm0
++	vmovups	%ymm0, -62(%edx)
++	jmp	.LBB0_269
++.LBB0_185:
++	vmovups	-223(%ecx), %ymm0
++	vmovups	%ymm0, -223(%edx)
++.LBB0_186:
++	vmovups	-191(%ecx), %ymm0
++	vmovups	%ymm0, -191(%edx)
++	vmovups	-159(%ecx), %ymm0
++	vmovups	%ymm0, -159(%edx)
++	vmovups	-127(%ecx), %ymm0
++	vmovups	%ymm0, -127(%edx)
++.LBB0_187:
++	vmovups	-95(%ecx), %ymm0
++	vmovups	%ymm0, -95(%edx)
++.LBB0_188:
++	vmovups	-63(%ecx), %ymm0
++	vmovups	%ymm0, -63(%edx)
++	jmp	.LBB0_269
++.LBB0_189:
++	vmovups	-225(%ecx), %ymm0
++	vmovups	%ymm0, -225(%edx)
++	vmovups	-193(%ecx), %ymm0
++	vmovups	%ymm0, -193(%edx)
++	vmovups	-161(%ecx), %ymm0
++	vmovups	%ymm0, -161(%edx)
++	vmovups	-129(%ecx), %ymm0
++	vmovups	%ymm0, -129(%edx)
++.LBB0_190:
++	vmovups	-97(%ecx), %ymm0
++	vmovups	%ymm0, -97(%edx)
++	vmovups	-65(%ecx), %ymm0
++	vmovups	%ymm0, -65(%edx)
++	jmp	.LBB0_268
++.LBB0_191:
++	vmovups	-226(%ecx), %ymm0
++	vmovups	%ymm0, -226(%edx)
++	vmovups	-194(%ecx), %ymm0
++	vmovups	%ymm0, -194(%edx)
++	vmovups	-162(%ecx), %ymm0
++	vmovups	%ymm0, -162(%edx)
++	vmovups	-130(%ecx), %ymm0
++	vmovups	%ymm0, -130(%edx)
++.LBB0_192:
++	vmovups	-98(%ecx), %ymm0
++	vmovups	%ymm0, -98(%edx)
++	vmovups	-66(%ecx), %ymm0
++	vmovups	%ymm0, -66(%edx)
++	jmp	.LBB0_268
++.LBB0_193:
++	vmovups	-227(%ecx), %ymm0
++	vmovups	%ymm0, -227(%edx)
++	vmovups	-195(%ecx), %ymm0
++	vmovups	%ymm0, -195(%edx)
++	vmovups	-163(%ecx), %ymm0
++	vmovups	%ymm0, -163(%edx)
++	vmovups	-131(%ecx), %ymm0
++	vmovups	%ymm0, -131(%edx)
++.LBB0_194:
++	vmovups	-99(%ecx), %ymm0
++	vmovups	%ymm0, -99(%edx)
++	vmovups	-67(%ecx), %ymm0
++	vmovups	%ymm0, -67(%edx)
++	jmp	.LBB0_268
++.LBB0_195:
++	vmovups	-228(%ecx), %ymm0
++	vmovups	%ymm0, -228(%edx)
++	vmovups	-196(%ecx), %ymm0
++	vmovups	%ymm0, -196(%edx)
++	vmovups	-164(%ecx), %ymm0
++	vmovups	%ymm0, -164(%edx)
++	vmovups	-132(%ecx), %ymm0
++	vmovups	%ymm0, -132(%edx)
++.LBB0_196:
++	vmovups	-100(%ecx), %ymm0
++	vmovups	%ymm0, -100(%edx)
++	vmovups	-68(%ecx), %ymm0
++	vmovups	%ymm0, -68(%edx)
++	jmp	.LBB0_268
++.LBB0_197:
++	vmovups	-229(%ecx), %ymm0
++	vmovups	%ymm0, -229(%edx)
++	vmovups	-197(%ecx), %ymm0
++	vmovups	%ymm0, -197(%edx)
++	vmovups	-165(%ecx), %ymm0
++	vmovups	%ymm0, -165(%edx)
++	vmovups	-133(%ecx), %ymm0
++	vmovups	%ymm0, -133(%edx)
++.LBB0_198:
++	vmovups	-101(%ecx), %ymm0
++	vmovups	%ymm0, -101(%edx)
++	vmovups	-69(%ecx), %ymm0
++	vmovups	%ymm0, -69(%edx)
++	jmp	.LBB0_268
++.LBB0_199:
++	vmovups	-230(%ecx), %ymm0
++	vmovups	%ymm0, -230(%edx)
++	vmovups	-198(%ecx), %ymm0
++	vmovups	%ymm0, -198(%edx)
++	vmovups	-166(%ecx), %ymm0
++	vmovups	%ymm0, -166(%edx)
++	vmovups	-134(%ecx), %ymm0
++	vmovups	%ymm0, -134(%edx)
++.LBB0_200:
++	vmovups	-102(%ecx), %ymm0
++	vmovups	%ymm0, -102(%edx)
++	vmovups	-70(%ecx), %ymm0
++	vmovups	%ymm0, -70(%edx)
++	jmp	.LBB0_268
++.LBB0_201:
++	vmovups	-231(%ecx), %ymm0
++	vmovups	%ymm0, -231(%edx)
++	vmovups	-199(%ecx), %ymm0
++	vmovups	%ymm0, -199(%edx)
++	vmovups	-167(%ecx), %ymm0
++	vmovups	%ymm0, -167(%edx)
++	vmovups	-135(%ecx), %ymm0
++	vmovups	%ymm0, -135(%edx)
++.LBB0_202:
++	vmovups	-103(%ecx), %ymm0
++	vmovups	%ymm0, -103(%edx)
++	vmovups	-71(%ecx), %ymm0
++	vmovups	%ymm0, -71(%edx)
++	jmp	.LBB0_268
++.LBB0_203:
++	vmovups	-232(%ecx), %ymm0
++	vmovups	%ymm0, -232(%edx)
++	vmovups	-200(%ecx), %ymm0
++	vmovups	%ymm0, -200(%edx)
++	vmovups	-168(%ecx), %ymm0
++	vmovups	%ymm0, -168(%edx)
++	vmovups	-136(%ecx), %ymm0
++	vmovups	%ymm0, -136(%edx)
++.LBB0_204:
++	vmovups	-104(%ecx), %ymm0
++	vmovups	%ymm0, -104(%edx)
++	vmovups	-72(%ecx), %ymm0
++	vmovups	%ymm0, -72(%edx)
++	jmp	.LBB0_268
++.LBB0_205:
++	vmovups	-233(%ecx), %ymm0
++	vmovups	%ymm0, -233(%edx)
++	vmovups	-201(%ecx), %ymm0
++	vmovups	%ymm0, -201(%edx)
++	vmovups	-169(%ecx), %ymm0
++	vmovups	%ymm0, -169(%edx)
++	vmovups	-137(%ecx), %ymm0
++	vmovups	%ymm0, -137(%edx)
++.LBB0_206:
++	vmovups	-105(%ecx), %ymm0
++	vmovups	%ymm0, -105(%edx)
++	vmovups	-73(%ecx), %ymm0
++	vmovups	%ymm0, -73(%edx)
++	jmp	.LBB0_268
++.LBB0_207:
++	vmovups	-234(%ecx), %ymm0
++	vmovups	%ymm0, -234(%edx)
++	vmovups	-202(%ecx), %ymm0
++	vmovups	%ymm0, -202(%edx)
++	vmovups	-170(%ecx), %ymm0
++	vmovups	%ymm0, -170(%edx)
++	vmovups	-138(%ecx), %ymm0
++	vmovups	%ymm0, -138(%edx)
++.LBB0_208:
++	vmovups	-106(%ecx), %ymm0
++	vmovups	%ymm0, -106(%edx)
++	vmovups	-74(%ecx), %ymm0
++	vmovups	%ymm0, -74(%edx)
++	jmp	.LBB0_268
++.LBB0_209:
++	vmovups	-235(%ecx), %ymm0
++	vmovups	%ymm0, -235(%edx)
++	vmovups	-203(%ecx), %ymm0
++	vmovups	%ymm0, -203(%edx)
++	vmovups	-171(%ecx), %ymm0
++	vmovups	%ymm0, -171(%edx)
++	vmovups	-139(%ecx), %ymm0
++	vmovups	%ymm0, -139(%edx)
++.LBB0_210:
++	vmovups	-107(%ecx), %ymm0
++	vmovups	%ymm0, -107(%edx)
++	vmovups	-75(%ecx), %ymm0
++	vmovups	%ymm0, -75(%edx)
++	jmp	.LBB0_268
++.LBB0_211:
++	vmovups	-236(%ecx), %ymm0
++	vmovups	%ymm0, -236(%edx)
++	vmovups	-204(%ecx), %ymm0
++	vmovups	%ymm0, -204(%edx)
++	vmovups	-172(%ecx), %ymm0
++	vmovups	%ymm0, -172(%edx)
++	vmovups	-140(%ecx), %ymm0
++	vmovups	%ymm0, -140(%edx)
++.LBB0_212:
++	vmovups	-108(%ecx), %ymm0
++	vmovups	%ymm0, -108(%edx)
++	vmovups	-76(%ecx), %ymm0
++	vmovups	%ymm0, -76(%edx)
++	jmp	.LBB0_268
++.LBB0_213:
++	vmovups	-237(%ecx), %ymm0
++	vmovups	%ymm0, -237(%edx)
++	vmovups	-205(%ecx), %ymm0
++	vmovups	%ymm0, -205(%edx)
++	vmovups	-173(%ecx), %ymm0
++	vmovups	%ymm0, -173(%edx)
++	vmovups	-141(%ecx), %ymm0
++	vmovups	%ymm0, -141(%edx)
++.LBB0_214:
++	vmovups	-109(%ecx), %ymm0
++	vmovups	%ymm0, -109(%edx)
++	vmovups	-77(%ecx), %ymm0
++	vmovups	%ymm0, -77(%edx)
++	jmp	.LBB0_268
++.LBB0_215:
++	vmovups	-238(%ecx), %ymm0
++	vmovups	%ymm0, -238(%edx)
++	vmovups	-206(%ecx), %ymm0
++	vmovups	%ymm0, -206(%edx)
++	vmovups	-174(%ecx), %ymm0
++	vmovups	%ymm0, -174(%edx)
++	vmovups	-142(%ecx), %ymm0
++	vmovups	%ymm0, -142(%edx)
++.LBB0_216:
++	vmovups	-110(%ecx), %ymm0
++	vmovups	%ymm0, -110(%edx)
++	vmovups	-78(%ecx), %ymm0
++	vmovups	%ymm0, -78(%edx)
++	jmp	.LBB0_268
++.LBB0_217:
++	vmovups	-239(%ecx), %ymm0
++	vmovups	%ymm0, -239(%edx)
++	vmovups	-207(%ecx), %ymm0
++	vmovups	%ymm0, -207(%edx)
++	vmovups	-175(%ecx), %ymm0
++	vmovups	%ymm0, -175(%edx)
++	vmovups	-143(%ecx), %ymm0
++	vmovups	%ymm0, -143(%edx)
++.LBB0_218:
++	vmovups	-111(%ecx), %ymm0
++	vmovups	%ymm0, -111(%edx)
++	vmovups	-79(%ecx), %ymm0
++	vmovups	%ymm0, -79(%edx)
++	jmp	.LBB0_268
++.LBB0_219:
++	vmovups	-240(%ecx), %ymm0
++	vmovups	%ymm0, -240(%edx)
++	vmovups	-208(%ecx), %ymm0
++	vmovups	%ymm0, -208(%edx)
++	vmovups	-176(%ecx), %ymm0
++	vmovups	%ymm0, -176(%edx)
++	vmovups	-144(%ecx), %ymm0
++	vmovups	%ymm0, -144(%edx)
++.LBB0_220:
++	vmovups	-112(%ecx), %ymm0
++	vmovups	%ymm0, -112(%edx)
++	vmovups	-80(%ecx), %ymm0
++	vmovups	%ymm0, -80(%edx)
++	jmp	.LBB0_268
++.LBB0_221:
++	vmovups	-241(%ecx), %ymm0
++	vmovups	%ymm0, -241(%edx)
++	vmovups	-209(%ecx), %ymm0
++	vmovups	%ymm0, -209(%edx)
++	vmovups	-177(%ecx), %ymm0
++	vmovups	%ymm0, -177(%edx)
++	vmovups	-145(%ecx), %ymm0
++	vmovups	%ymm0, -145(%edx)
++.LBB0_222:
++	vmovups	-113(%ecx), %ymm0
++	vmovups	%ymm0, -113(%edx)
++	vmovups	-81(%ecx), %ymm0
++	vmovups	%ymm0, -81(%edx)
++	jmp	.LBB0_268
++.LBB0_223:
++	vmovups	-242(%ecx), %ymm0
++	vmovups	%ymm0, -242(%edx)
++	vmovups	-210(%ecx), %ymm0
++	vmovups	%ymm0, -210(%edx)
++	vmovups	-178(%ecx), %ymm0
++	vmovups	%ymm0, -178(%edx)
++	vmovups	-146(%ecx), %ymm0
++	vmovups	%ymm0, -146(%edx)
++.LBB0_224:
++	vmovups	-114(%ecx), %ymm0
++	vmovups	%ymm0, -114(%edx)
++	vmovups	-82(%ecx), %ymm0
++	vmovups	%ymm0, -82(%edx)
++	jmp	.LBB0_268
++.LBB0_225:
++	vmovups	-243(%ecx), %ymm0
++	vmovups	%ymm0, -243(%edx)
++	vmovups	-211(%ecx), %ymm0
++	vmovups	%ymm0, -211(%edx)
++	vmovups	-179(%ecx), %ymm0
++	vmovups	%ymm0, -179(%edx)
++	vmovups	-147(%ecx), %ymm0
++	vmovups	%ymm0, -147(%edx)
++.LBB0_226:
++	vmovups	-115(%ecx), %ymm0
++	vmovups	%ymm0, -115(%edx)
++	vmovups	-83(%ecx), %ymm0
++	vmovups	%ymm0, -83(%edx)
++	jmp	.LBB0_268
++.LBB0_227:
++	vmovups	-244(%ecx), %ymm0
++	vmovups	%ymm0, -244(%edx)
++	vmovups	-212(%ecx), %ymm0
++	vmovups	%ymm0, -212(%edx)
++	vmovups	-180(%ecx), %ymm0
++	vmovups	%ymm0, -180(%edx)
++	vmovups	-148(%ecx), %ymm0
++	vmovups	%ymm0, -148(%edx)
++.LBB0_228:
++	vmovups	-116(%ecx), %ymm0
++	vmovups	%ymm0, -116(%edx)
++	vmovups	-84(%ecx), %ymm0
++	vmovups	%ymm0, -84(%edx)
++	jmp	.LBB0_268
++.LBB0_229:
++	vmovups	-245(%ecx), %ymm0
++	vmovups	%ymm0, -245(%edx)
++	vmovups	-213(%ecx), %ymm0
++	vmovups	%ymm0, -213(%edx)
++	vmovups	-181(%ecx), %ymm0
++	vmovups	%ymm0, -181(%edx)
++	vmovups	-149(%ecx), %ymm0
++	vmovups	%ymm0, -149(%edx)
++.LBB0_230:
++	vmovups	-117(%ecx), %ymm0
++	vmovups	%ymm0, -117(%edx)
++	vmovups	-85(%ecx), %ymm0
++	vmovups	%ymm0, -85(%edx)
++	jmp	.LBB0_268
++.LBB0_231:
++	vmovups	-246(%ecx), %ymm0
++	vmovups	%ymm0, -246(%edx)
++	vmovups	-214(%ecx), %ymm0
++	vmovups	%ymm0, -214(%edx)
++	vmovups	-182(%ecx), %ymm0
++	vmovups	%ymm0, -182(%edx)
++	vmovups	-150(%ecx), %ymm0
++	vmovups	%ymm0, -150(%edx)
++.LBB0_232:
++	vmovups	-118(%ecx), %ymm0
++	vmovups	%ymm0, -118(%edx)
++	vmovups	-86(%ecx), %ymm0
++	vmovups	%ymm0, -86(%edx)
++	jmp	.LBB0_268
++.LBB0_233:
++	vmovups	-247(%ecx), %ymm0
++	vmovups	%ymm0, -247(%edx)
++	vmovups	-215(%ecx), %ymm0
++	vmovups	%ymm0, -215(%edx)
++	vmovups	-183(%ecx), %ymm0
++	vmovups	%ymm0, -183(%edx)
++	vmovups	-151(%ecx), %ymm0
++	vmovups	%ymm0, -151(%edx)
++.LBB0_234:
++	vmovups	-119(%ecx), %ymm0
++	vmovups	%ymm0, -119(%edx)
++	vmovups	-87(%ecx), %ymm0
++	vmovups	%ymm0, -87(%edx)
++	jmp	.LBB0_268
++.LBB0_235:
++	vmovups	-248(%ecx), %ymm0
++	vmovups	%ymm0, -248(%edx)
++	vmovups	-216(%ecx), %ymm0
++	vmovups	%ymm0, -216(%edx)
++	vmovups	-184(%ecx), %ymm0
++	vmovups	%ymm0, -184(%edx)
++	vmovups	-152(%ecx), %ymm0
++	vmovups	%ymm0, -152(%edx)
++.LBB0_236:
++	vmovups	-120(%ecx), %ymm0
++	vmovups	%ymm0, -120(%edx)
++	vmovups	-88(%ecx), %ymm0
++	vmovups	%ymm0, -88(%edx)
++	jmp	.LBB0_268
++.LBB0_237:
++	vmovups	-249(%ecx), %ymm0
++	vmovups	%ymm0, -249(%edx)
++	vmovups	-217(%ecx), %ymm0
++	vmovups	%ymm0, -217(%edx)
++	vmovups	-185(%ecx), %ymm0
++	vmovups	%ymm0, -185(%edx)
++	vmovups	-153(%ecx), %ymm0
++	vmovups	%ymm0, -153(%edx)
++.LBB0_238:
++	vmovups	-121(%ecx), %ymm0
++	vmovups	%ymm0, -121(%edx)
++	vmovups	-89(%ecx), %ymm0
++	vmovups	%ymm0, -89(%edx)
++	jmp	.LBB0_268
++.LBB0_239:
++	vmovups	-250(%ecx), %ymm0
++	vmovups	%ymm0, -250(%edx)
++	vmovups	-218(%ecx), %ymm0
++	vmovups	%ymm0, -218(%edx)
++	vmovups	-186(%ecx), %ymm0
++	vmovups	%ymm0, -186(%edx)
++	vmovups	-154(%ecx), %ymm0
++	vmovups	%ymm0, -154(%edx)
++.LBB0_240:
++	vmovups	-122(%ecx), %ymm0
++	vmovups	%ymm0, -122(%edx)
++	vmovups	-90(%ecx), %ymm0
++	vmovups	%ymm0, -90(%edx)
++	jmp	.LBB0_268
++.LBB0_241:
++	vmovups	-251(%ecx), %ymm0
++	vmovups	%ymm0, -251(%edx)
++	vmovups	-219(%ecx), %ymm0
++	vmovups	%ymm0, -219(%edx)
++	vmovups	-187(%ecx), %ymm0
++	vmovups	%ymm0, -187(%edx)
++	vmovups	-155(%ecx), %ymm0
++	vmovups	%ymm0, -155(%edx)
++.LBB0_242:
++	vmovups	-123(%ecx), %ymm0
++	vmovups	%ymm0, -123(%edx)
++	vmovups	-91(%ecx), %ymm0
++	vmovups	%ymm0, -91(%edx)
++	jmp	.LBB0_268
++.LBB0_243:
++	vmovups	-252(%ecx), %ymm0
++	vmovups	%ymm0, -252(%edx)
++	vmovups	-220(%ecx), %ymm0
++	vmovups	%ymm0, -220(%edx)
++	vmovups	-188(%ecx), %ymm0
++	vmovups	%ymm0, -188(%edx)
++	vmovups	-156(%ecx), %ymm0
++	vmovups	%ymm0, -156(%edx)
++.LBB0_244:
++	vmovups	-124(%ecx), %ymm0
++	vmovups	%ymm0, -124(%edx)
++	vmovups	-92(%ecx), %ymm0
++	vmovups	%ymm0, -92(%edx)
++	jmp	.LBB0_268
++.LBB0_245:
++	vmovups	-253(%ecx), %ymm0
++	vmovups	%ymm0, -253(%edx)
++	vmovups	-221(%ecx), %ymm0
++	vmovups	%ymm0, -221(%edx)
++	vmovups	-189(%ecx), %ymm0
++	vmovups	%ymm0, -189(%edx)
++	vmovups	-157(%ecx), %ymm0
++	vmovups	%ymm0, -157(%edx)
++.LBB0_246:
++	vmovups	-125(%ecx), %ymm0
++	vmovups	%ymm0, -125(%edx)
++	vmovups	-93(%ecx), %ymm0
++	vmovups	%ymm0, -93(%edx)
++	jmp	.LBB0_268
++.LBB0_247:
++	vmovups	-254(%ecx), %ymm0
++	vmovups	%ymm0, -254(%edx)
++	vmovups	-222(%ecx), %ymm0
++	vmovups	%ymm0, -222(%edx)
++	vmovups	-190(%ecx), %ymm0
++	vmovups	%ymm0, -190(%edx)
++	vmovups	-158(%ecx), %ymm0
++	vmovups	%ymm0, -158(%edx)
++.LBB0_248:
++	vmovups	-126(%ecx), %ymm0
++	vmovups	%ymm0, -126(%edx)
++	vmovups	-94(%ecx), %ymm0
++	vmovups	%ymm0, -94(%edx)
++	jmp	.LBB0_268
++.LBB0_249:
++	vmovups	-255(%ecx), %ymm0
++	vmovups	%ymm0, -255(%edx)
++	vmovups	-223(%ecx), %ymm0
++	vmovups	%ymm0, -223(%edx)
++	vmovups	-191(%ecx), %ymm0
++	vmovups	%ymm0, -191(%edx)
++	vmovups	-159(%ecx), %ymm0
++	vmovups	%ymm0, -159(%edx)
++.LBB0_250:
++	vmovups	-127(%ecx), %ymm0
++	vmovups	%ymm0, -127(%edx)
++	vmovups	-95(%ecx), %ymm0
++	vmovups	%ymm0, -95(%edx)
++	jmp	.LBB0_268
++.LBB0_262:
++	vmovups	-256(%ecx), %ymm0
++	vmovups	%ymm0, -256(%edx)
++.LBB0_263:
++	vmovups	-224(%ecx), %ymm0
++	vmovups	%ymm0, -224(%edx)
++.LBB0_264:
++	vmovups	-192(%ecx), %ymm0
++	vmovups	%ymm0, -192(%edx)
++.LBB0_265:
++	vmovups	-160(%ecx), %ymm0
++	vmovups	%ymm0, -160(%edx)
++.LBB0_266:
++	vmovups	-128(%ecx), %ymm0
++	vmovups	%ymm0, -128(%edx)
++.LBB0_267:
++	vmovups	-96(%ecx), %ymm0
++	vmovups	%ymm0, -96(%edx)
++.LBB0_268:
++	vmovups	-64(%ecx), %ymm0
++	vmovups	%ymm0, -64(%edx)
++.LBB0_269:
++	vmovups	-32(%ecx), %ymm0
++	vmovups	%ymm0, -32(%edx)
++.LBB0_270:
++	vzeroupper
++	popl	%esi
++	popl	%edi
++	popl	%ebx
++	popl	%ebp
++	retl
++END(memcpy_avx2)
++
++/*.Lfunc_end0:
++	.size	memcpy_avx2, .Lfunc_end0-memcpy_avx2
++	.section	.rodata,"a",@progbits
++	.p2align	2*/
++.LJTI0_0:
++	.long	.LBB0_6@GOTOFF
++	.long	.LBB0_10@GOTOFF
++	.long	.LBB0_12@GOTOFF
++	.long	.LBB0_16@GOTOFF
++	.long	.LBB0_18@GOTOFF
++	.long	.LBB0_20@GOTOFF
++	.long	.LBB0_22@GOTOFF
++	.long	.LBB0_26@GOTOFF
++	.long	.LBB0_28@GOTOFF
++	.long	.LBB0_30@GOTOFF
++	.long	.LBB0_32@GOTOFF
++	.long	.LBB0_34@GOTOFF
++	.long	.LBB0_36@GOTOFF
++	.long	.LBB0_38@GOTOFF
++	.long	.LBB0_40@GOTOFF
++	.long	.LBB0_44@GOTOFF
++	.long	.LBB0_46@GOTOFF
++	.long	.LBB0_48@GOTOFF
++	.long	.LBB0_50@GOTOFF
++	.long	.LBB0_52@GOTOFF
++	.long	.LBB0_54@GOTOFF
++	.long	.LBB0_56@GOTOFF
++	.long	.LBB0_58@GOTOFF
++	.long	.LBB0_60@GOTOFF
++	.long	.LBB0_62@GOTOFF
++	.long	.LBB0_64@GOTOFF
++	.long	.LBB0_66@GOTOFF
++	.long	.LBB0_68@GOTOFF
++	.long	.LBB0_70@GOTOFF
++	.long	.LBB0_72@GOTOFF
++	.long	.LBB0_74@GOTOFF
++	.long	.LBB0_269@GOTOFF
++	.long	.LBB0_5@GOTOFF
++	.long	.LBB0_9@GOTOFF
++	.long	.LBB0_82@GOTOFF
++	.long	.LBB0_15@GOTOFF
++	.long	.LBB0_88@GOTOFF
++	.long	.LBB0_92@GOTOFF
++	.long	.LBB0_96@GOTOFF
++	.long	.LBB0_25@GOTOFF
++	.long	.LBB0_102@GOTOFF
++	.long	.LBB0_106@GOTOFF
++	.long	.LBB0_110@GOTOFF
++	.long	.LBB0_114@GOTOFF
++	.long	.LBB0_118@GOTOFF
++	.long	.LBB0_122@GOTOFF
++	.long	.LBB0_126@GOTOFF
++	.long	.LBB0_43@GOTOFF
++	.long	.LBB0_132@GOTOFF
++	.long	.LBB0_136@GOTOFF
++	.long	.LBB0_140@GOTOFF
++	.long	.LBB0_144@GOTOFF
++	.long	.LBB0_148@GOTOFF
++	.long	.LBB0_152@GOTOFF
++	.long	.LBB0_156@GOTOFF
++	.long	.LBB0_160@GOTOFF
++	.long	.LBB0_164@GOTOFF
++	.long	.LBB0_168@GOTOFF
++	.long	.LBB0_172@GOTOFF
++	.long	.LBB0_176@GOTOFF
++	.long	.LBB0_180@GOTOFF
++	.long	.LBB0_184@GOTOFF
++	.long	.LBB0_188@GOTOFF
++	.long	.LBB0_268@GOTOFF
++	.long	.LBB0_4@GOTOFF
++	.long	.LBB0_8@GOTOFF
++	.long	.LBB0_81@GOTOFF
++	.long	.LBB0_14@GOTOFF
++	.long	.LBB0_87@GOTOFF
++	.long	.LBB0_91@GOTOFF
++	.long	.LBB0_95@GOTOFF
++	.long	.LBB0_24@GOTOFF
++	.long	.LBB0_101@GOTOFF
++	.long	.LBB0_105@GOTOFF
++	.long	.LBB0_109@GOTOFF
++	.long	.LBB0_113@GOTOFF
++	.long	.LBB0_117@GOTOFF
++	.long	.LBB0_121@GOTOFF
++	.long	.LBB0_125@GOTOFF
++	.long	.LBB0_42@GOTOFF
++	.long	.LBB0_131@GOTOFF
++	.long	.LBB0_135@GOTOFF
++	.long	.LBB0_139@GOTOFF
++	.long	.LBB0_143@GOTOFF
++	.long	.LBB0_147@GOTOFF
++	.long	.LBB0_151@GOTOFF
++	.long	.LBB0_155@GOTOFF
++	.long	.LBB0_159@GOTOFF
++	.long	.LBB0_163@GOTOFF
++	.long	.LBB0_167@GOTOFF
++	.long	.LBB0_171@GOTOFF
++	.long	.LBB0_175@GOTOFF
++	.long	.LBB0_179@GOTOFF
++	.long	.LBB0_183@GOTOFF
++	.long	.LBB0_187@GOTOFF
++	.long	.LBB0_267@GOTOFF
++	.long	.LBB0_190@GOTOFF
++	.long	.LBB0_192@GOTOFF
++	.long	.LBB0_194@GOTOFF
++	.long	.LBB0_196@GOTOFF
++	.long	.LBB0_198@GOTOFF
++	.long	.LBB0_200@GOTOFF
++	.long	.LBB0_202@GOTOFF
++	.long	.LBB0_204@GOTOFF
++	.long	.LBB0_206@GOTOFF
++	.long	.LBB0_208@GOTOFF
++	.long	.LBB0_210@GOTOFF
++	.long	.LBB0_212@GOTOFF
++	.long	.LBB0_214@GOTOFF
++	.long	.LBB0_216@GOTOFF
++	.long	.LBB0_218@GOTOFF
++	.long	.LBB0_220@GOTOFF
++	.long	.LBB0_222@GOTOFF
++	.long	.LBB0_224@GOTOFF
++	.long	.LBB0_226@GOTOFF
++	.long	.LBB0_228@GOTOFF
++	.long	.LBB0_230@GOTOFF
++	.long	.LBB0_232@GOTOFF
++	.long	.LBB0_234@GOTOFF
++	.long	.LBB0_236@GOTOFF
++	.long	.LBB0_238@GOTOFF
++	.long	.LBB0_240@GOTOFF
++	.long	.LBB0_242@GOTOFF
++	.long	.LBB0_244@GOTOFF
++	.long	.LBB0_246@GOTOFF
++	.long	.LBB0_248@GOTOFF
++	.long	.LBB0_250@GOTOFF
++	.long	.LBB0_266@GOTOFF
++	.long	.LBB0_3@GOTOFF
++	.long	.LBB0_7@GOTOFF
++	.long	.LBB0_11@GOTOFF
++	.long	.LBB0_13@GOTOFF
++	.long	.LBB0_17@GOTOFF
++	.long	.LBB0_19@GOTOFF
++	.long	.LBB0_21@GOTOFF
++	.long	.LBB0_23@GOTOFF
++	.long	.LBB0_27@GOTOFF
++	.long	.LBB0_29@GOTOFF
++	.long	.LBB0_31@GOTOFF
++	.long	.LBB0_33@GOTOFF
++	.long	.LBB0_35@GOTOFF
++	.long	.LBB0_37@GOTOFF
++	.long	.LBB0_39@GOTOFF
++	.long	.LBB0_41@GOTOFF
++	.long	.LBB0_45@GOTOFF
++	.long	.LBB0_47@GOTOFF
++	.long	.LBB0_49@GOTOFF
++	.long	.LBB0_51@GOTOFF
++	.long	.LBB0_53@GOTOFF
++	.long	.LBB0_55@GOTOFF
++	.long	.LBB0_57@GOTOFF
++	.long	.LBB0_59@GOTOFF
++	.long	.LBB0_61@GOTOFF
++	.long	.LBB0_63@GOTOFF
++	.long	.LBB0_65@GOTOFF
++	.long	.LBB0_67@GOTOFF
++	.long	.LBB0_69@GOTOFF
++	.long	.LBB0_71@GOTOFF
++	.long	.LBB0_73@GOTOFF
++	.long	.LBB0_265@GOTOFF
++	.long	.LBB0_76@GOTOFF
++	.long	.LBB0_78@GOTOFF
++	.long	.LBB0_80@GOTOFF
++	.long	.LBB0_84@GOTOFF
++	.long	.LBB0_86@GOTOFF
++	.long	.LBB0_90@GOTOFF
++	.long	.LBB0_94@GOTOFF
++	.long	.LBB0_98@GOTOFF
++	.long	.LBB0_100@GOTOFF
++	.long	.LBB0_104@GOTOFF
++	.long	.LBB0_108@GOTOFF
++	.long	.LBB0_112@GOTOFF
++	.long	.LBB0_116@GOTOFF
++	.long	.LBB0_120@GOTOFF
++	.long	.LBB0_124@GOTOFF
++	.long	.LBB0_128@GOTOFF
++	.long	.LBB0_130@GOTOFF
++	.long	.LBB0_134@GOTOFF
++	.long	.LBB0_138@GOTOFF
++	.long	.LBB0_142@GOTOFF
++	.long	.LBB0_146@GOTOFF
++	.long	.LBB0_150@GOTOFF
++	.long	.LBB0_154@GOTOFF
++	.long	.LBB0_158@GOTOFF
++	.long	.LBB0_162@GOTOFF
++	.long	.LBB0_166@GOTOFF
++	.long	.LBB0_170@GOTOFF
++	.long	.LBB0_174@GOTOFF
++	.long	.LBB0_178@GOTOFF
++	.long	.LBB0_182@GOTOFF
++	.long	.LBB0_186@GOTOFF
++	.long	.LBB0_264@GOTOFF
++	.long	.LBB0_75@GOTOFF
++	.long	.LBB0_77@GOTOFF
++	.long	.LBB0_79@GOTOFF
++	.long	.LBB0_83@GOTOFF
++	.long	.LBB0_85@GOTOFF
++	.long	.LBB0_89@GOTOFF
++	.long	.LBB0_93@GOTOFF
++	.long	.LBB0_97@GOTOFF
++	.long	.LBB0_99@GOTOFF
++	.long	.LBB0_103@GOTOFF
++	.long	.LBB0_107@GOTOFF
++	.long	.LBB0_111@GOTOFF
++	.long	.LBB0_115@GOTOFF
++	.long	.LBB0_119@GOTOFF
++	.long	.LBB0_123@GOTOFF
++	.long	.LBB0_127@GOTOFF
++	.long	.LBB0_129@GOTOFF
++	.long	.LBB0_133@GOTOFF
++	.long	.LBB0_137@GOTOFF
++	.long	.LBB0_141@GOTOFF
++	.long	.LBB0_145@GOTOFF
++	.long	.LBB0_149@GOTOFF
++	.long	.LBB0_153@GOTOFF
++	.long	.LBB0_157@GOTOFF
++	.long	.LBB0_161@GOTOFF
++	.long	.LBB0_165@GOTOFF
++	.long	.LBB0_169@GOTOFF
++	.long	.LBB0_173@GOTOFF
++	.long	.LBB0_177@GOTOFF
++	.long	.LBB0_181@GOTOFF
++	.long	.LBB0_185@GOTOFF
++	.long	.LBB0_263@GOTOFF
++	.long	.LBB0_189@GOTOFF
++	.long	.LBB0_191@GOTOFF
++	.long	.LBB0_193@GOTOFF
++	.long	.LBB0_195@GOTOFF
++	.long	.LBB0_197@GOTOFF
++	.long	.LBB0_199@GOTOFF
++	.long	.LBB0_201@GOTOFF
++	.long	.LBB0_203@GOTOFF
++	.long	.LBB0_205@GOTOFF
++	.long	.LBB0_207@GOTOFF
++	.long	.LBB0_209@GOTOFF
++	.long	.LBB0_211@GOTOFF
++	.long	.LBB0_213@GOTOFF
++	.long	.LBB0_215@GOTOFF
++	.long	.LBB0_217@GOTOFF
++	.long	.LBB0_219@GOTOFF
++	.long	.LBB0_221@GOTOFF
++	.long	.LBB0_223@GOTOFF
++	.long	.LBB0_225@GOTOFF
++	.long	.LBB0_227@GOTOFF
++	.long	.LBB0_229@GOTOFF
++	.long	.LBB0_231@GOTOFF
++	.long	.LBB0_233@GOTOFF
++	.long	.LBB0_235@GOTOFF
++	.long	.LBB0_237@GOTOFF
++	.long	.LBB0_239@GOTOFF
++	.long	.LBB0_241@GOTOFF
++	.long	.LBB0_243@GOTOFF
++	.long	.LBB0_245@GOTOFF
++	.long	.LBB0_247@GOTOFF
++	.long	.LBB0_249@GOTOFF
++	.long	.LBB0_262@GOTOFF
++.LJTI0_1:
++	.long	.LBB0_6@GOTOFF
++	.long	.LBB0_10@GOTOFF
++	.long	.LBB0_12@GOTOFF
++	.long	.LBB0_16@GOTOFF
++	.long	.LBB0_18@GOTOFF
++	.long	.LBB0_20@GOTOFF
++	.long	.LBB0_22@GOTOFF
++	.long	.LBB0_26@GOTOFF
++	.long	.LBB0_28@GOTOFF
++	.long	.LBB0_30@GOTOFF
++	.long	.LBB0_32@GOTOFF
++	.long	.LBB0_34@GOTOFF
++	.long	.LBB0_36@GOTOFF
++	.long	.LBB0_38@GOTOFF
++	.long	.LBB0_40@GOTOFF
++	.long	.LBB0_44@GOTOFF
++	.long	.LBB0_46@GOTOFF
++	.long	.LBB0_48@GOTOFF
++	.long	.LBB0_50@GOTOFF
++	.long	.LBB0_52@GOTOFF
++	.long	.LBB0_54@GOTOFF
++	.long	.LBB0_56@GOTOFF
++	.long	.LBB0_58@GOTOFF
++	.long	.LBB0_60@GOTOFF
++	.long	.LBB0_62@GOTOFF
++	.long	.LBB0_64@GOTOFF
++	.long	.LBB0_66@GOTOFF
++	.long	.LBB0_68@GOTOFF
++	.long	.LBB0_70@GOTOFF
++	.long	.LBB0_72@GOTOFF
++	.long	.LBB0_74@GOTOFF
++	.long	.LBB0_269@GOTOFF
++	.long	.LBB0_5@GOTOFF
++	.long	.LBB0_9@GOTOFF
++	.long	.LBB0_82@GOTOFF
++	.long	.LBB0_15@GOTOFF
++	.long	.LBB0_88@GOTOFF
++	.long	.LBB0_92@GOTOFF
++	.long	.LBB0_96@GOTOFF
++	.long	.LBB0_25@GOTOFF
++	.long	.LBB0_102@GOTOFF
++	.long	.LBB0_106@GOTOFF
++	.long	.LBB0_110@GOTOFF
++	.long	.LBB0_114@GOTOFF
++	.long	.LBB0_118@GOTOFF
++	.long	.LBB0_122@GOTOFF
++	.long	.LBB0_126@GOTOFF
++	.long	.LBB0_43@GOTOFF
++	.long	.LBB0_132@GOTOFF
++	.long	.LBB0_136@GOTOFF
++	.long	.LBB0_140@GOTOFF
++	.long	.LBB0_144@GOTOFF
++	.long	.LBB0_148@GOTOFF
++	.long	.LBB0_152@GOTOFF
++	.long	.LBB0_156@GOTOFF
++	.long	.LBB0_160@GOTOFF
++	.long	.LBB0_164@GOTOFF
++	.long	.LBB0_168@GOTOFF
++	.long	.LBB0_172@GOTOFF
++	.long	.LBB0_176@GOTOFF
++	.long	.LBB0_180@GOTOFF
++	.long	.LBB0_184@GOTOFF
++	.long	.LBB0_188@GOTOFF
++	.long	.LBB0_268@GOTOFF
++	.long	.LBB0_4@GOTOFF
++	.long	.LBB0_8@GOTOFF
++	.long	.LBB0_81@GOTOFF
++	.long	.LBB0_14@GOTOFF
++	.long	.LBB0_87@GOTOFF
++	.long	.LBB0_91@GOTOFF
++	.long	.LBB0_95@GOTOFF
++	.long	.LBB0_24@GOTOFF
++	.long	.LBB0_101@GOTOFF
++	.long	.LBB0_105@GOTOFF
++	.long	.LBB0_109@GOTOFF
++	.long	.LBB0_113@GOTOFF
++	.long	.LBB0_117@GOTOFF
++	.long	.LBB0_121@GOTOFF
++	.long	.LBB0_125@GOTOFF
++	.long	.LBB0_42@GOTOFF
++	.long	.LBB0_131@GOTOFF
++	.long	.LBB0_135@GOTOFF
++	.long	.LBB0_139@GOTOFF
++	.long	.LBB0_143@GOTOFF
++	.long	.LBB0_147@GOTOFF
++	.long	.LBB0_151@GOTOFF
++	.long	.LBB0_155@GOTOFF
++	.long	.LBB0_159@GOTOFF
++	.long	.LBB0_163@GOTOFF
++	.long	.LBB0_167@GOTOFF
++	.long	.LBB0_171@GOTOFF
++	.long	.LBB0_175@GOTOFF
++	.long	.LBB0_179@GOTOFF
++	.long	.LBB0_183@GOTOFF
++	.long	.LBB0_187@GOTOFF
++	.long	.LBB0_267@GOTOFF
++	.long	.LBB0_190@GOTOFF
++	.long	.LBB0_192@GOTOFF
++	.long	.LBB0_194@GOTOFF
++	.long	.LBB0_196@GOTOFF
++	.long	.LBB0_198@GOTOFF
++	.long	.LBB0_200@GOTOFF
++	.long	.LBB0_202@GOTOFF
++	.long	.LBB0_204@GOTOFF
++	.long	.LBB0_206@GOTOFF
++	.long	.LBB0_208@GOTOFF
++	.long	.LBB0_210@GOTOFF
++	.long	.LBB0_212@GOTOFF
++	.long	.LBB0_214@GOTOFF
++	.long	.LBB0_216@GOTOFF
++	.long	.LBB0_218@GOTOFF
++	.long	.LBB0_220@GOTOFF
++	.long	.LBB0_222@GOTOFF
++	.long	.LBB0_224@GOTOFF
++	.long	.LBB0_226@GOTOFF
++	.long	.LBB0_228@GOTOFF
++	.long	.LBB0_230@GOTOFF
++	.long	.LBB0_232@GOTOFF
++	.long	.LBB0_234@GOTOFF
++	.long	.LBB0_236@GOTOFF
++	.long	.LBB0_238@GOTOFF
++	.long	.LBB0_240@GOTOFF
++	.long	.LBB0_242@GOTOFF
++	.long	.LBB0_244@GOTOFF
++	.long	.LBB0_246@GOTOFF
++	.long	.LBB0_248@GOTOFF
++	.long	.LBB0_250@GOTOFF
++	.long	.LBB0_266@GOTOFF
++	.long	.LBB0_3@GOTOFF
++	.long	.LBB0_7@GOTOFF
++	.long	.LBB0_11@GOTOFF
++	.long	.LBB0_13@GOTOFF
++	.long	.LBB0_17@GOTOFF
++	.long	.LBB0_19@GOTOFF
++	.long	.LBB0_21@GOTOFF
++	.long	.LBB0_23@GOTOFF
++	.long	.LBB0_27@GOTOFF
++	.long	.LBB0_29@GOTOFF
++	.long	.LBB0_31@GOTOFF
++	.long	.LBB0_33@GOTOFF
++	.long	.LBB0_35@GOTOFF
++	.long	.LBB0_37@GOTOFF
++	.long	.LBB0_39@GOTOFF
++	.long	.LBB0_41@GOTOFF
++	.long	.LBB0_45@GOTOFF
++	.long	.LBB0_47@GOTOFF
++	.long	.LBB0_49@GOTOFF
++	.long	.LBB0_51@GOTOFF
++	.long	.LBB0_53@GOTOFF
++	.long	.LBB0_55@GOTOFF
++	.long	.LBB0_57@GOTOFF
++	.long	.LBB0_59@GOTOFF
++	.long	.LBB0_61@GOTOFF
++	.long	.LBB0_63@GOTOFF
++	.long	.LBB0_65@GOTOFF
++	.long	.LBB0_67@GOTOFF
++	.long	.LBB0_69@GOTOFF
++	.long	.LBB0_71@GOTOFF
++	.long	.LBB0_73@GOTOFF
++	.long	.LBB0_265@GOTOFF
++	.long	.LBB0_76@GOTOFF
++	.long	.LBB0_78@GOTOFF
++	.long	.LBB0_80@GOTOFF
++	.long	.LBB0_84@GOTOFF
++	.long	.LBB0_86@GOTOFF
++	.long	.LBB0_90@GOTOFF
++	.long	.LBB0_94@GOTOFF
++	.long	.LBB0_98@GOTOFF
++	.long	.LBB0_100@GOTOFF
++	.long	.LBB0_104@GOTOFF
++	.long	.LBB0_108@GOTOFF
++	.long	.LBB0_112@GOTOFF
++	.long	.LBB0_116@GOTOFF
++	.long	.LBB0_120@GOTOFF
++	.long	.LBB0_124@GOTOFF
++	.long	.LBB0_128@GOTOFF
++	.long	.LBB0_130@GOTOFF
++	.long	.LBB0_134@GOTOFF
++	.long	.LBB0_138@GOTOFF
++	.long	.LBB0_142@GOTOFF
++	.long	.LBB0_146@GOTOFF
++	.long	.LBB0_150@GOTOFF
++	.long	.LBB0_154@GOTOFF
++	.long	.LBB0_158@GOTOFF
++	.long	.LBB0_162@GOTOFF
++	.long	.LBB0_166@GOTOFF
++	.long	.LBB0_170@GOTOFF
++	.long	.LBB0_174@GOTOFF
++	.long	.LBB0_178@GOTOFF
++	.long	.LBB0_182@GOTOFF
++	.long	.LBB0_186@GOTOFF
++	.long	.LBB0_264@GOTOFF
++	.long	.LBB0_75@GOTOFF
++	.long	.LBB0_77@GOTOFF
++	.long	.LBB0_79@GOTOFF
++	.long	.LBB0_83@GOTOFF
++	.long	.LBB0_85@GOTOFF
++	.long	.LBB0_89@GOTOFF
++	.long	.LBB0_93@GOTOFF
++	.long	.LBB0_97@GOTOFF
++	.long	.LBB0_99@GOTOFF
++	.long	.LBB0_103@GOTOFF
++	.long	.LBB0_107@GOTOFF
++	.long	.LBB0_111@GOTOFF
++	.long	.LBB0_115@GOTOFF
++	.long	.LBB0_119@GOTOFF
++	.long	.LBB0_123@GOTOFF
++	.long	.LBB0_127@GOTOFF
++	.long	.LBB0_129@GOTOFF
++	.long	.LBB0_133@GOTOFF
++	.long	.LBB0_137@GOTOFF
++	.long	.LBB0_141@GOTOFF
++	.long	.LBB0_145@GOTOFF
++	.long	.LBB0_149@GOTOFF
++	.long	.LBB0_153@GOTOFF
++	.long	.LBB0_157@GOTOFF
++	.long	.LBB0_161@GOTOFF
++	.long	.LBB0_165@GOTOFF
++	.long	.LBB0_169@GOTOFF
++	.long	.LBB0_173@GOTOFF
++	.long	.LBB0_177@GOTOFF
++	.long	.LBB0_181@GOTOFF
++	.long	.LBB0_185@GOTOFF
++	.long	.LBB0_263@GOTOFF
++	.long	.LBB0_189@GOTOFF
++	.long	.LBB0_191@GOTOFF
++	.long	.LBB0_193@GOTOFF
++	.long	.LBB0_195@GOTOFF
++	.long	.LBB0_197@GOTOFF
++	.long	.LBB0_199@GOTOFF
++	.long	.LBB0_201@GOTOFF
++	.long	.LBB0_203@GOTOFF
++	.long	.LBB0_205@GOTOFF
++	.long	.LBB0_207@GOTOFF
++	.long	.LBB0_209@GOTOFF
++	.long	.LBB0_211@GOTOFF
++	.long	.LBB0_213@GOTOFF
++	.long	.LBB0_215@GOTOFF
++	.long	.LBB0_217@GOTOFF
++	.long	.LBB0_219@GOTOFF
++	.long	.LBB0_221@GOTOFF
++	.long	.LBB0_223@GOTOFF
++	.long	.LBB0_225@GOTOFF
++	.long	.LBB0_227@GOTOFF
++	.long	.LBB0_229@GOTOFF
++	.long	.LBB0_231@GOTOFF
++	.long	.LBB0_233@GOTOFF
++	.long	.LBB0_235@GOTOFF
++	.long	.LBB0_237@GOTOFF
++	.long	.LBB0_239@GOTOFF
++	.long	.LBB0_241@GOTOFF
++	.long	.LBB0_243@GOTOFF
++	.long	.LBB0_245@GOTOFF
++	.long	.LBB0_247@GOTOFF
++	.long	.LBB0_249@GOTOFF
++	.long	.LBB0_262@GOTOFF
++                                        # -- End function
+diff --git a/libc/arch-x86_64/dynamic_function_dispatch.cpp b/libc/arch-x86_64/dynamic_function_dispatch.cpp
+new file mode 100644
+index 0000000..3e8c0fe
+--- /dev/null
++++ b/libc/arch-x86_64/dynamic_function_dispatch.cpp
+@@ -0,0 +1,78 @@
++/*
++ * Copyright (C) 2008 The Android Open Source Project
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *  * Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ *  * Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in
++ *    the documentation and/or other materials provided with the
++ *    distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
++ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
++ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
++ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
++ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
++ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
++ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
++ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
++ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++#include <stddef.h>
++
++#include <private/bionic_ifuncs.h>
++
++extern "C" {
++
++typedef int memcmp_func(const void* __lhs, const void* __rhs, size_t __n);
++DEFINE_IFUNC_FOR(memcmp) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(memcmp_func, memcmp_avx2);
++    RETURN_FUNC(memcmp_func, memcmp_generic);
++}
++
++typedef void* memmove_func(void* __dst, const void* __src, size_t __n);
++DEFINE_IFUNC_FOR(memmove) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(memmove_func, memmove_avx2);
++    RETURN_FUNC(memmove_func, memmove_generic);
++}
++
++typedef void* memcpy_func(void* __dst, const void* __src, size_t __n);
++DEFINE_IFUNC_FOR(memcpy) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("sse2")) RETURN_FUNC(memcpy_func, memcpy_sse2);
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(memcpy_func, memcpy_avx2);
++    RETURN_FUNC(memcpy_func, memmove_generic);
++}
++
++typedef void* memchr_func(const void* __s, int __ch, size_t __n);
++DEFINE_IFUNC_FOR(memchr) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(memchr_func, memchr_avx2);
++    RETURN_FUNC(memchr_func, memchr_openbsd);
++}
++
++typedef void* memrchr_func(const void* __s, int __ch, size_t __n);
++DEFINE_IFUNC_FOR(memrchr) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(memrchr_func, memrchr_avx2);
++    RETURN_FUNC(memrchr_func, memrchr_openbsd);
++}
++
++typedef int wmemset_func(const wchar_t* __lhs, const wchar_t* __rhs, size_t __n);
++DEFINE_IFUNC_FOR(wmemset) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(wmemset_func, wmemset_avx2);
++    RETURN_FUNC(wmemset_func, wmemset_freebsd);
++}
++
++}  // extern "C"
+diff --git a/libc/arch-x86_64/generic/string/memchr.c b/libc/arch-x86_64/generic/string/memchr.c
+new file mode 100644
+index 0000000..f530eac
+--- /dev/null
++++ b/libc/arch-x86_64/generic/string/memchr.c
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define memchr memchr_openbsd
++
++#include <upstream-openbsd/lib/libc/string/memchr.c>
+diff --git a/libc/arch-x86_64/generic/string/memrchr.c b/libc/arch-x86_64/generic/string/memrchr.c
+new file mode 100644
+index 0000000..44262f2
+--- /dev/null
++++ b/libc/arch-x86_64/generic/string/memrchr.c
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define memrchr memrchr_openbsd
++
++#include <upstream-openbsd/lib/libc/string/memrchr.c>
+diff --git a/libc/arch-x86_64/generic/string/wmemset.c b/libc/arch-x86_64/generic/string/wmemset.c
+new file mode 100644
+index 0000000..35d489f
+--- /dev/null
++++ b/libc/arch-x86_64/generic/string/wmemset.c
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define wmemset wmemset_freebsd
++
++#include <upstream-freebsd/lib/libc/string/wmemset.c>
+diff --git a/libc/arch-x86_64/include/cache.h b/libc/arch-x86_64/include/cache.h
+new file mode 100644
+index 0000000..4131509
+--- /dev/null
++++ b/libc/arch-x86_64/include/cache.h
+@@ -0,0 +1,36 @@
++/*
++Copyright (c) 2014, Intel Corporation
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++    * Redistributions of source code must retain the above copyright notice,
++    * this list of conditions and the following disclaimer.
++
++    * Redistributions in binary form must reproduce the above copyright notice,
++    * this list of conditions and the following disclaimer in the documentation
++    * and/or other materials provided with the distribution.
++
++    * Neither the name of Intel Corporation nor the names of its contributors
++    * may be used to endorse or promote products derived from this software
++    * without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
++ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
++WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
++ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
++ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++/* Values are optimized for Core Architecture */
++#define SHARED_CACHE_SIZE (4096*1024)  /* Core Architecture L2 Cache */
++#define DATA_CACHE_SIZE   (24*1024)    /* Core Architecture L1 Data Cache */
++
++#define SHARED_CACHE_SIZE_HALF (SHARED_CACHE_SIZE / 2)
++#define DATA_CACHE_SIZE_HALF   (DATA_CACHE_SIZE / 2)
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-memchr-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-memchr-kbl.S
+new file mode 100644
+index 0000000..da667c9
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-memchr-kbl.S
+@@ -0,0 +1,371 @@
++#ifndef L
++# define L(label)	.L##label
++#endif
++
++#ifndef cfi_startproc
++# define cfi_startproc	.cfi_startproc
++#endif
++
++#ifndef cfi_endproc
++# define cfi_endproc	.cfi_endproc
++#endif
++
++#ifndef cfi_rel_offset
++# define cfi_rel_offset(reg, off)	.cfi_rel_offset reg, off
++#endif
++
++#ifndef cfi_restore
++# define cfi_restore(reg)	.cfi_restore reg
++#endif
++
++#ifndef cfi_adjust_cfa_offset
++# define cfi_adjust_cfa_offset(off)	.cfi_adjust_cfa_offset off
++#endif
++
++#ifndef ENTRY
++# define ENTRY(name)		\
++	.type name,  @function;		\
++	.globl name;		\
++	.p2align 4;		\
++name:		\
++	cfi_startproc
++#endif
++
++#ifndef END
++# define END(name)		\
++	cfi_endproc;		\
++	.size name, .-name
++#endif
++
++#define CFI_PUSH(REG)		\
++	cfi_adjust_cfa_offset (4);		\
++	cfi_rel_offset (REG, 0)
++
++#define CFI_POP(REG)		\
++	cfi_adjust_cfa_offset (-4);		\
++	cfi_restore (REG)
++
++#define PUSH(REG)	push REG;
++#define POP(REG)	pop REG;
++
++#define ENTRANCE	PUSH (%rbx);
++#define RETURN_END	POP (%rbx); ret
++#define RETURN		RETURN_END;
++
++# ifndef MEMCHR
++#  define MEMCHR          memchr_avx2
++# endif
++
++# ifdef USE_AS_WMEMCHR
++#  define VPCMPEQ         vpcmpeqd
++# else
++#  define VPCMPEQ         vpcmpeqb
++# endif
++
++# ifndef VZEROUPPER
++#  define VZEROUPPER  vzeroupper
++# endif
++
++# define VEC_SIZE 32
++
++                .section .text.avx,"ax",@progbits
++ENTRY (MEMCHR)
++# ifndef USE_AS_RAWMEMCHR
++                /* Check for zero length.  */
++                testq      %rdx, %rdx
++                jz             L(null)
++# endif
++                movl      %edi, %ecx
++                /* Broadcast CHAR to YMM0.  */
++                vmovd  %esi, %xmm0
++# ifdef USE_AS_WMEMCHR
++                shl          $2, %rdx
++                vpbroadcastd %xmm0, %ymm0
++# else
++                vpbroadcastb %xmm0, %ymm0
++# endif
++                /* Check if we may cross page boundary with one vector load.  */
++                andl       $(2 * VEC_SIZE - 1), %ecx
++                cmpl      $VEC_SIZE, %ecx
++                ja             L(cros_page_boundary)
++
++                /* Check the first VEC_SIZE bytes.  */
++                VPCMPEQ (%rdi), %ymm0, %ymm1
++                vpmovmskb %ymm1, %eax
++                testl       %eax, %eax
++
++# ifndef USE_AS_RAWMEMCHR
++                jnz          L(first_vec_x0_check)
++                /* Adjust length and check the end of data.  */
++                subq      $VEC_SIZE, %rdx
++                jbe          L(zero)
++# else
++                jnz          L(first_vec_x0)
++# endif
++
++                /* Align data for aligned loads in the loop.  */
++                addq      $VEC_SIZE, %rdi
++                andl       $(VEC_SIZE - 1), %ecx
++                andq      $-VEC_SIZE, %rdi
++
++# ifndef USE_AS_RAWMEMCHR
++                /* Adjust length.  */
++                addq      %rcx, %rdx
++
++                subq      $(VEC_SIZE * 4), %rdx
++                jbe          L(last_4x_vec_or_less)
++# endif
++                jmp         L(more_4x_vec)
++
++                .p2align 4
++L(cros_page_boundary):
++                andl       $(VEC_SIZE - 1), %ecx
++                andq      $-VEC_SIZE, %rdi
++                VPCMPEQ (%rdi), %ymm0, %ymm1
++                vpmovmskb %ymm1, %eax
++                /* Remove the leading bytes.  */
++                sarl         %cl, %eax
++                testl       %eax, %eax
++                jz             L(aligned_more)
++                tzcntl     %eax, %eax
++# ifndef USE_AS_RAWMEMCHR
++                /* Check the end of data.  */
++                cmpq     %rax, %rdx
++                jbe          L(zero)
++# endif
++                addq      %rdi, %rax
++                addq      %rcx, %rax
++                VZEROUPPER
++                ret
++
++                .p2align 4
++L(aligned_more):
++# ifndef USE_AS_RAWMEMCHR
++        /* Calculate "rdx + rcx - VEC_SIZE" with "rdx - (VEC_SIZE - rcx)"
++                  instead of "(rdx + rcx) - VEC_SIZE" to void possible addition
++                   overflow.  */
++                negq      %rcx
++                addq      $VEC_SIZE, %rcx
++
++                /* Check the end of data.  */
++                subq      %rcx, %rdx
++                jbe          L(zero)
++# endif
++
++                addq      $VEC_SIZE, %rdi
++
++# ifndef USE_AS_RAWMEMCHR
++                subq      $(VEC_SIZE * 4), %rdx
++                jbe          L(last_4x_vec_or_less)
++# endif
++
++L(more_4x_vec):
++                /* Check the first 4 * VEC_SIZE.  Only one VEC_SIZE at a time
++                   since data is only aligned to VEC_SIZE.  */
++                VPCMPEQ (%rdi), %ymm0, %ymm1
++                vpmovmskb %ymm1, %eax
++                testl       %eax, %eax
++                jnz          L(first_vec_x0)
++
++                VPCMPEQ VEC_SIZE(%rdi), %ymm0, %ymm1
++                vpmovmskb %ymm1, %eax
++                testl       %eax, %eax
++                jnz          L(first_vec_x1)
++
++                VPCMPEQ (VEC_SIZE * 2)(%rdi), %ymm0, %ymm1
++                vpmovmskb %ymm1, %eax
++                testl       %eax, %eax
++                jnz          L(first_vec_x2)
++
++                VPCMPEQ (VEC_SIZE * 3)(%rdi), %ymm0, %ymm1
++                vpmovmskb %ymm1, %eax
++                testl       %eax, %eax
++                jnz          L(first_vec_x3)
++
++                addq      $(VEC_SIZE * 4), %rdi
++
++# ifndef USE_AS_RAWMEMCHR
++                subq      $(VEC_SIZE * 4), %rdx
++                jbe          L(last_4x_vec_or_less)
++# endif
++
++                /* Align data to 4 * VEC_SIZE.  */
++                movq     %rdi, %rcx
++                andl       $(4 * VEC_SIZE - 1), %ecx
++                andq      $-(4 * VEC_SIZE), %rdi
++
++# ifndef USE_AS_RAWMEMCHR
++                /* Adjust length.  */
++                addq      %rcx, %rdx
++# endif
++
++                .p2align 4
++L(loop_4x_vec):
++                /* Compare 4 * VEC at a time forward.  */
++                VPCMPEQ (%rdi), %ymm0, %ymm1
++                VPCMPEQ VEC_SIZE(%rdi), %ymm0, %ymm2
++                VPCMPEQ (VEC_SIZE * 2)(%rdi), %ymm0, %ymm3
++                VPCMPEQ (VEC_SIZE * 3)(%rdi), %ymm0, %ymm4
++
++                vpor       %ymm1, %ymm2, %ymm5
++                vpor       %ymm3, %ymm4, %ymm6
++                vpor       %ymm5, %ymm6, %ymm5
++
++                vpmovmskb %ymm5, %eax
++                testl       %eax, %eax
++                jnz          L(4x_vec_end)
++
++                addq      $(VEC_SIZE * 4), %rdi
++
++# ifdef USE_AS_RAWMEMCHR
++                jmp         L(loop_4x_vec)
++# else
++                subq      $(VEC_SIZE * 4), %rdx
++                ja             L(loop_4x_vec)
++
++L(last_4x_vec_or_less):
++                /* Less than 4 * VEC and aligned to VEC_SIZE.  */
++                addl       $(VEC_SIZE * 2), %edx
++                jle           L(last_2x_vec)
++
++                VPCMPEQ (%rdi), %ymm0, %ymm1
++                vpmovmskb %ymm1, %eax
++                testl       %eax, %eax
++                jnz          L(first_vec_x0)
++
++                VPCMPEQ VEC_SIZE(%rdi), %ymm0, %ymm1
++                vpmovmskb %ymm1, %eax
++                testl       %eax, %eax
++                jnz          L(first_vec_x1)
++
++                VPCMPEQ (VEC_SIZE * 2)(%rdi), %ymm0, %ymm1
++                vpmovmskb %ymm1, %eax
++                testl       %eax, %eax
++
++                jnz          L(first_vec_x2_check)
++                subl       $VEC_SIZE, %edx
++                jle           L(zero)
++
++                VPCMPEQ (VEC_SIZE * 3)(%rdi), %ymm0, %ymm1
++                vpmovmskb %ymm1, %eax
++                testl       %eax, %eax
++
++                jnz          L(first_vec_x3_check)
++                xorl        %eax, %eax
++                VZEROUPPER
++                ret
++
++                .p2align 4
++L(last_2x_vec):
++                addl       $(VEC_SIZE * 2), %edx
++                VPCMPEQ (%rdi), %ymm0, %ymm1
++                vpmovmskb %ymm1, %eax
++                testl       %eax, %eax
++
++                jnz          L(first_vec_x0_check)
++                subl       $VEC_SIZE, %edx
++                jle           L(zero)
++
++                VPCMPEQ VEC_SIZE(%rdi), %ymm0, %ymm1
++                vpmovmskb %ymm1, %eax
++                testl       %eax, %eax
++                jnz          L(first_vec_x1_check)
++                xorl        %eax, %eax
++                VZEROUPPER
++                ret
++
++                .p2align 4
++L(first_vec_x0_check):
++                tzcntl     %eax, %eax
++                /* Check the end of data.  */
++                cmpq     %rax, %rdx
++                jbe          L(zero)
++                addq      %rdi, %rax
++                VZEROUPPER
++                ret
++
++                .p2align 4
++L(first_vec_x1_check):
++                tzcntl     %eax, %eax
++                /* Check the end of data.  */
++                cmpq     %rax, %rdx
++                jbe          L(zero)
++                addq      $VEC_SIZE, %rax
++                addq      %rdi, %rax
++                VZEROUPPER
++                ret
++
++                .p2align 4
++L(first_vec_x2_check):
++                tzcntl     %eax, %eax
++                /* Check the end of data.  */
++                cmpq     %rax, %rdx
++                jbe          L(zero)
++                addq      $(VEC_SIZE * 2), %rax
++                addq      %rdi, %rax
++                VZEROUPPER
++                ret
++
++                .p2align 4
++L(first_vec_x3_check):
++                tzcntl     %eax, %eax
++                /* Check the end of data.  */
++                cmpq     %rax, %rdx
++                jbe          L(zero)
++                addq      $(VEC_SIZE * 3), %rax
++                addq      %rdi, %rax
++                VZEROUPPER
++                ret
++
++                .p2align 4
++L(zero):
++                VZEROUPPER
++L(null):
++                xorl        %eax, %eax
++                ret
++# endif
++
++                .p2align 4
++L(first_vec_x0):
++                tzcntl     %eax, %eax
++                addq      %rdi, %rax
++                VZEROUPPER
++                ret
++
++                .p2align 4
++L(first_vec_x1):
++                tzcntl     %eax, %eax
++                addq      $VEC_SIZE, %rax
++                addq      %rdi, %rax
++                VZEROUPPER
++                ret
++
++                .p2align 4
++L(first_vec_x2):
++                tzcntl     %eax, %eax
++                addq      $(VEC_SIZE * 2), %rax
++                addq      %rdi, %rax
++                VZEROUPPER
++                ret
++
++                .p2align 4
++L(4x_vec_end):
++                vpmovmskb %ymm1, %eax
++                testl       %eax, %eax
++                jnz          L(first_vec_x0)
++                vpmovmskb %ymm2, %eax
++                testl       %eax, %eax
++                jnz          L(first_vec_x1)
++                vpmovmskb %ymm3, %eax
++                testl       %eax, %eax
++                jnz          L(first_vec_x2)
++                vpmovmskb %ymm4, %eax
++                testl       %eax, %eax
++L(first_vec_x3):
++                tzcntl     %eax, %eax
++                addq      $(VEC_SIZE * 3), %rax
++                addq      %rdi, %rax
++                VZEROUPPER
++                ret
++
++END (MEMCHR)
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-memcmp-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-memcmp-kbl.S
+new file mode 100644
+index 0000000..e9778ca
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-memcmp-kbl.S
+@@ -0,0 +1,428 @@
++/* Copyright (C) 2017-2019 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <http://www.gnu.org/licenses/>.  */
++
++/* memcmp/wmemcmp is implemented as:
++   1. For size from 2 to 7 bytes, load as big endian with movbe and bswap
++      to avoid branches.
++   2. Use overlapping compare to avoid branch.
++   3. Use vector compare when size >= 4 bytes for memcmp or size >= 8
++      bytes for wmemcmp.
++   4. If size is 8 * VEC_SIZE or less, unroll the loop.
++   5. Compare 4 * VEC_SIZE at a time with the aligned first memory
++      area.
++   6. Use 2 vector compares when size is 2 * VEC_SIZE or less.
++   7. Use 4 vector compares when size is 4 * VEC_SIZE or less.
++   8. Use 8 vector compares when size is 8 * VEC_SIZE or less.  */
++
++
++#ifndef MEMCMP
++# define MEMCMP		memcmp_avx2
++#endif
++
++#ifndef L
++# define L(label)	.L##label
++#endif
++
++#ifndef ALIGN
++# define ALIGN(n)	.p2align n
++#endif
++
++#ifndef cfi_startproc
++# define cfi_startproc			.cfi_startproc
++#endif
++
++#ifndef cfi_endproc
++# define cfi_endproc			.cfi_endproc
++#endif
++
++#ifndef ENTRY
++# define ENTRY(name)			\
++	.type name,  @function; 	\
++	.globl name;			\
++	.p2align 4;			\
++name:					\
++	cfi_startproc
++#endif
++
++#ifndef END
++# define END(name)			\
++	cfi_endproc;			\
++	.size name, .-name
++#endif
++
++#ifndef ALIGN
++# define ALIGN(n)	.p2align n
++#endif
++
++# ifdef USE_AS_WMEMCMP
++#  define VPCMPEQ        vpcmpeqd
++# else
++#  define VPCMPEQ        vpcmpeqb
++# endif
++# ifndef VZEROUPPER
++#  define VZEROUPPER        vzeroupper
++# endif
++# define VEC_SIZE 32
++# define VEC_MASK ((1 << VEC_SIZE) - 1)
++        .section .text.avx,"ax",@progbits
++ENTRY (MEMCMP)
++# ifdef USE_AS_WMEMCMP
++        shl        $2, %RDX_LP
++# elif defined __ILP32__
++        /* Clear the upper 32 bits.  */
++        movl        %edx, %edx
++# endif
++        cmp        $VEC_SIZE, %rdx
++        jb        L(less_vec)
++        /* From VEC to 2 * VEC.  No branch when size == VEC_SIZE.  */
++        vmovdqu        (%rsi), %ymm2
++        VPCMPEQ (%rdi), %ymm2, %ymm2
++        vpmovmskb %ymm2, %eax
++        subl    $VEC_MASK, %eax
++        jnz        L(first_vec)
++        cmpq        $(VEC_SIZE * 2), %rdx
++        jbe        L(last_vec)
++        VPCMPEQ        %ymm0, %ymm0, %ymm0
++        /* More than 2 * VEC.  */
++        cmpq        $(VEC_SIZE * 8), %rdx
++        ja        L(more_8x_vec)
++        cmpq        $(VEC_SIZE * 4), %rdx
++        jb        L(last_4x_vec)
++        /* From 4 * VEC to 8 * VEC, inclusively. */
++        vmovdqu        (%rsi), %ymm1
++        VPCMPEQ (%rdi), %ymm1, %ymm1
++        vmovdqu        VEC_SIZE(%rsi), %ymm2
++        VPCMPEQ VEC_SIZE(%rdi), %ymm2, %ymm2
++        vmovdqu        (VEC_SIZE * 2)(%rsi), %ymm3
++        VPCMPEQ (VEC_SIZE * 2)(%rdi), %ymm3, %ymm3
++        vmovdqu        (VEC_SIZE * 3)(%rsi), %ymm4
++        VPCMPEQ (VEC_SIZE * 3)(%rdi), %ymm4, %ymm4
++        vpand        %ymm1, %ymm2, %ymm5
++        vpand        %ymm3, %ymm4, %ymm6
++        vpand        %ymm5, %ymm6, %ymm5
++        vptest        %ymm0, %ymm5
++        jnc        L(4x_vec_end)
++        leaq        -(4 * VEC_SIZE)(%rdi, %rdx), %rdi
++        leaq        -(4 * VEC_SIZE)(%rsi, %rdx), %rsi
++        vmovdqu        (%rsi), %ymm1
++        VPCMPEQ (%rdi), %ymm1, %ymm1
++        vmovdqu        VEC_SIZE(%rsi), %ymm2
++        VPCMPEQ VEC_SIZE(%rdi), %ymm2, %ymm2
++        vpand        %ymm2, %ymm1, %ymm5
++        vmovdqu        (VEC_SIZE * 2)(%rsi), %ymm3
++        VPCMPEQ (VEC_SIZE * 2)(%rdi), %ymm3, %ymm3
++        vpand        %ymm3, %ymm5, %ymm5
++        vmovdqu        (VEC_SIZE * 3)(%rsi), %ymm4
++        VPCMPEQ (VEC_SIZE * 3)(%rdi), %ymm4, %ymm4
++        vpand        %ymm4, %ymm5, %ymm5
++        vptest        %ymm0, %ymm5
++        jnc        L(4x_vec_end)
++        xorl        %eax, %eax
++        VZEROUPPER
++        ret
++        .p2align 4
++L(last_2x_vec):
++        /* From VEC to 2 * VEC.  No branch when size == VEC_SIZE.  */
++        vmovdqu        (%rsi), %ymm2
++        VPCMPEQ (%rdi), %ymm2, %ymm2
++        vpmovmskb %ymm2, %eax
++        subl    $VEC_MASK, %eax
++        jnz        L(first_vec)
++L(last_vec):
++        /* Use overlapping loads to avoid branches.  */
++        leaq        -VEC_SIZE(%rdi, %rdx), %rdi
++        leaq        -VEC_SIZE(%rsi, %rdx), %rsi
++        vmovdqu        (%rsi), %ymm2
++        VPCMPEQ (%rdi), %ymm2, %ymm2
++        vpmovmskb %ymm2, %eax
++        subl    $VEC_MASK, %eax
++        jnz        L(first_vec)
++        VZEROUPPER
++        ret
++        .p2align 4
++L(first_vec):
++        /* A byte or int32 is different within 16 or 32 bytes.  */
++        tzcntl        %eax, %ecx
++# ifdef USE_AS_WMEMCMP
++        xorl        %eax, %eax
++        movl        (%rdi, %rcx), %edx
++        cmpl        (%rsi, %rcx), %edx
++L(wmemcmp_return):
++        setl        %al
++        negl        %eax
++        orl        $1, %eax
++# else
++        movzbl        (%rdi, %rcx), %eax
++        movzbl        (%rsi, %rcx), %edx
++        sub        %edx, %eax
++# endif
++        VZEROUPPER
++        ret
++# ifdef USE_AS_WMEMCMP
++        .p2align 4
++L(4):
++        xorl        %eax, %eax
++        movl        (%rdi), %edx
++        cmpl        (%rsi), %edx
++        jne        L(wmemcmp_return)
++        ret
++# else
++
++L(between_4_7):
++        /* Load as big endian with overlapping movbe to avoid branches.  */
++        movbe        (%rdi), %eax
++        movbe        (%rsi), %ecx
++        shlq        $32, %rax
++        shlq        $32, %rcx
++        movbe        -4(%rdi, %rdx), %edi
++        movbe        -4(%rsi, %rdx), %esi
++        orq        %rdi, %rax
++        orq        %rsi, %rcx
++        subq        %rcx, %rax
++        je        L(exit)
++        sbbl        %eax, %eax
++        orl        $1, %eax
++        ret
++        .p2align 4
++/*L(8):
++	giving two failures 
++	movl (%rdi), %eax
++	subl (%rsi), %eax
++	je L(between_4_7)
++        retq */
++
++L(exit):
++        ret
++        .p2align 4
++L(between_2_3):
++        /* Load as big endian to avoid branches.  */
++        movzwl        (%rdi), %eax
++        movzwl        (%rsi), %ecx
++        shll        $8, %eax
++        shll        $8, %ecx
++        bswap        %eax
++        bswap        %ecx
++        movb        -1(%rdi, %rdx), %al
++        movb        -1(%rsi, %rdx), %cl
++        /* Subtraction is okay because the upper 8 bits are zero.  */
++        subl        %ecx, %eax
++        ret
++        .p2align 4
++L(1):
++        movzbl        (%rdi), %eax
++        movzbl        (%rsi), %ecx
++        sub        %ecx, %eax
++        ret
++# endif
++        .p2align 4
++L(zero):
++        xorl        %eax, %eax
++        ret
++        .p2align 4
++L(less_vec):
++# ifdef USE_AS_WMEMCMP
++        /* It can only be 0, 4, 8, 12, 16, 20, 24, 28 bytes.  */
++        cmpb        $4, %dl
++        je        L(4)
++        jb        L(zero)
++# else
++/*	cmpb $8, %dl
++        jne L(tmp)
++        movl (%rdi), %eax
++        subl (%rsi), %eax
++        jne L(exit)
++L(temp):
++	movl    %edx, %edx
++	//jmp L(tmp) 
++L(tmp):*/ 
++
++        cmpb        $1, %dl
++        je        L(1)
++        jb        L(zero)
++
++        cmpb        $4, %dl
++        jb        L(between_2_3)
++        cmpb       $8, %dl
++        //je        L(8)
++        jb        L(between_4_7)
++# endif
++        cmpb        $16, %dl
++        jae        L(between_16_31)
++        /* It is between 8 and 15 bytes.  */
++        vmovq        (%rdi), %xmm1
++        vmovq        (%rsi), %xmm2
++        VPCMPEQ %xmm1, %xmm2, %xmm2
++        vpmovmskb %xmm2, %eax
++        subl    $0xffff, %eax
++        jnz        L(first_vec)
++        /* Use overlapping loads to avoid branches.  */
++        leaq        -8(%rdi, %rdx), %rdi
++        leaq        -8(%rsi, %rdx), %rsi
++        vmovq        (%rdi), %xmm1
++        vmovq        (%rsi), %xmm2
++        VPCMPEQ %xmm1, %xmm2, %xmm2
++        vpmovmskb %xmm2, %eax
++        subl    $0xffff, %eax
++        jnz        L(first_vec)
++        ret
++        .p2align 4
++L(between_16_31):
++        /* From 16 to 31 bytes.  No branch when size == 16.  */
++        vmovdqu        (%rsi), %xmm2
++        VPCMPEQ (%rdi), %xmm2, %xmm2
++        vpmovmskb %xmm2, %eax
++        subl    $0xffff, %eax
++        jnz        L(first_vec)
++        /* Use overlapping loads to avoid branches.  */
++        leaq        -16(%rdi, %rdx), %rdi
++        leaq        -16(%rsi, %rdx), %rsi
++        vmovdqu        (%rsi), %xmm2
++        VPCMPEQ (%rdi), %xmm2, %xmm2
++        vpmovmskb %xmm2, %eax
++        subl    $0xffff, %eax
++        jnz        L(first_vec)
++        ret
++        .p2align 4
++L(more_8x_vec):
++        /* More than 8 * VEC.  Check the first VEC.  */
++        vmovdqu        (%rsi), %ymm2
++        VPCMPEQ (%rdi), %ymm2, %ymm2
++        vpmovmskb %ymm2, %eax
++        subl    $VEC_MASK, %eax
++        jnz        L(first_vec)
++        /* Align the first memory area for aligned loads in the loop.
++           Compute how much the first memory area is misaligned.  */
++        movq        %rdi, %rcx
++        andl        $(VEC_SIZE - 1), %ecx
++        /* Get the negative of offset for alignment.  */
++        subq        $VEC_SIZE, %rcx
++        /* Adjust the second memory area.  */
++        subq        %rcx, %rsi
++        /* Adjust the first memory area which should be aligned now.  */
++        subq        %rcx, %rdi
++        /* Adjust length.  */
++        addq        %rcx, %rdx
++L(loop_4x_vec):
++        /* Compare 4 * VEC at a time forward.  */
++        vmovdqu        (%rsi), %ymm1
++        VPCMPEQ (%rdi), %ymm1, %ymm1
++        vmovdqu        VEC_SIZE(%rsi), %ymm2
++        VPCMPEQ VEC_SIZE(%rdi), %ymm2, %ymm2
++        vpand        %ymm2, %ymm1, %ymm5
++        vmovdqu        (VEC_SIZE * 2)(%rsi), %ymm3
++        VPCMPEQ (VEC_SIZE * 2)(%rdi), %ymm3, %ymm3
++        vpand        %ymm3, %ymm5, %ymm5
++        vmovdqu        (VEC_SIZE * 3)(%rsi), %ymm4
++        VPCMPEQ (VEC_SIZE * 3)(%rdi), %ymm4, %ymm4
++        vpand        %ymm4, %ymm5, %ymm5
++        vptest        %ymm0, %ymm5
++        jnc        L(4x_vec_end)
++        addq        $(VEC_SIZE * 4), %rdi
++        addq        $(VEC_SIZE * 4), %rsi
++        subq        $(VEC_SIZE * 4), %rdx
++        cmpq        $(VEC_SIZE * 4), %rdx
++        jae        L(loop_4x_vec)
++        /* Less than 4 * VEC.  */
++        cmpq        $VEC_SIZE, %rdx
++        jbe        L(last_vec)
++        cmpq        $(VEC_SIZE * 2), %rdx
++        jbe        L(last_2x_vec)
++L(last_4x_vec):
++        /* From 2 * VEC to 4 * VEC. */
++        vmovdqu        (%rsi), %ymm2
++        VPCMPEQ (%rdi), %ymm2, %ymm2
++        vpmovmskb %ymm2, %eax
++        subl    $VEC_MASK, %eax
++        jnz        L(first_vec)
++        addq        $VEC_SIZE, %rdi
++        addq        $VEC_SIZE, %rsi
++        vmovdqu        (%rsi), %ymm2
++        VPCMPEQ (%rdi), %ymm2, %ymm2
++        vpmovmskb %ymm2, %eax
++        subl    $VEC_MASK, %eax
++        jnz        L(first_vec)
++        /* Use overlapping loads to avoid branches.  */
++        leaq        -(3 * VEC_SIZE)(%rdi, %rdx), %rdi
++        leaq        -(3 * VEC_SIZE)(%rsi, %rdx), %rsi
++        vmovdqu        (%rsi), %ymm2
++        VPCMPEQ (%rdi), %ymm2, %ymm2
++        vpmovmskb %ymm2, %eax
++        subl    $VEC_MASK, %eax
++        jnz        L(first_vec)
++        addq        $VEC_SIZE, %rdi
++        addq        $VEC_SIZE, %rsi
++        vmovdqu        (%rsi), %ymm2
++        VPCMPEQ (%rdi), %ymm2, %ymm2
++        vpmovmskb %ymm2, %eax
++        subl    $VEC_MASK, %eax
++        jnz        L(first_vec)
++        VZEROUPPER
++        ret
++        .p2align 4
++L(4x_vec_end):
++        vpmovmskb %ymm1, %eax
++        subl        $VEC_MASK, %eax
++        jnz        L(first_vec)
++        vpmovmskb %ymm2, %eax
++        subl        $VEC_MASK, %eax
++        jnz        L(first_vec_x1)
++        vpmovmskb %ymm3, %eax
++        subl        $VEC_MASK, %eax
++        jnz        L(first_vec_x2)
++        vpmovmskb %ymm4, %eax
++        subl        $VEC_MASK, %eax
++        tzcntl        %eax, %ecx
++# ifdef USE_AS_WMEMCMP
++        xorl        %eax, %eax
++        movl        (VEC_SIZE * 3)(%rdi, %rcx), %edx
++        cmpl        (VEC_SIZE * 3)(%rsi, %rcx), %edx
++        jmp        L(wmemcmp_return)
++# else
++        movzbl        (VEC_SIZE * 3)(%rdi, %rcx), %eax
++        movzbl        (VEC_SIZE * 3)(%rsi, %rcx), %edx
++        sub        %edx, %eax
++# endif
++        VZEROUPPER
++        ret
++        .p2align 4
++L(first_vec_x1):
++        tzcntl        %eax, %ecx
++# ifdef USE_AS_WMEMCMP
++        xorl        %eax, %eax
++        movl        VEC_SIZE(%rdi, %rcx), %edx
++        cmpl        VEC_SIZE(%rsi, %rcx), %edx
++        jmp        L(wmemcmp_return)
++# else
++        movzbl        VEC_SIZE(%rdi, %rcx), %eax
++        movzbl        VEC_SIZE(%rsi, %rcx), %edx
++        sub        %edx, %eax
++# endif
++        VZEROUPPER
++        ret
++        .p2align 4
++L(first_vec_x2):
++        tzcntl        %eax, %ecx
++# ifdef USE_AS_WMEMCMP
++        xorl        %eax, %eax
++        movl        (VEC_SIZE * 2)(%rdi, %rcx), %edx
++        cmpl        (VEC_SIZE * 2)(%rsi, %rcx), %edx
++        jmp        L(wmemcmp_return)
++# else
++        movzbl        (VEC_SIZE * 2)(%rdi, %rcx), %eax
++        movzbl        (VEC_SIZE * 2)(%rsi, %rcx), %edx
++        sub        %edx, %eax
++# endif
++        VZEROUPPER
++        ret
++END (MEMCMP)
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-memcpy-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-memcpy-kbl.S
+new file mode 100644
+index 0000000..c481e3b
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-memcpy-kbl.S
+@@ -0,0 +1,3711 @@
++	/*.text
++	.file	"FastMemcpy_avx_sse2.c"
++	.globl	memcpy                  # -- Begin function memcpy
++	.p2align	4, 0x90
++	.type	memcpy,@function*/
++#define ENTRY(f) \
++    .text; \
++    .globl f; \
++    .p2align    4, 0x90; \
++    .type f,@function; \
++    f: \
++
++#define END(f)
++    .size f, .-f; \
++    .section        .rodata,"a",@progbits; \
++    .p2align        2 \
++
++/*memcpy:                                 # @memcpy
++	.cfi_startproc
++*/
++ENTRY(memcpy_avx2)
++	.cfi_startproc 
++# %bb.0:
++	movq	%rdi, %rax
++	cmpq	$256, %rdx              # imm = 0x100
++	ja	.LBB0_259
++# %bb.1:
++	leaq	-1(%rdx), %rdi
++	cmpq	$255, %rdi
++	ja	.LBB0_526
++# %bb.2:
++	leaq	(%rax,%rdx), %rcx
++	addq	%rdx, %rsi
++	leaq	.LJTI0_1(%rip), %rdx
++	movslq	(%rdx,%rdi,4), %rdi
++	addq	%rdx, %rdi
++	jmpq	*%rdi
++.LBB0_11:
++	vmovups	-131(%rsi), %ymm0
++	vmovups	%ymm0, -131(%rcx)
++	vmovups	-99(%rsi), %ymm0
++	vmovups	%ymm0, -99(%rcx)
++	vmovups	-67(%rsi), %ymm0
++	vmovups	%ymm0, -67(%rcx)
++	vmovups	-35(%rsi), %ymm0
++	vmovups	%ymm0, -35(%rcx)
++.LBB0_12:
++	movzwl	-3(%rsi), %edx
++	movw	%dx, -3(%rcx)
++	movb	-1(%rsi), %dl
++	movb	%dl, -1(%rcx)
++	vzeroupper
++	retq
++.LBB0_259:
++	movl	%eax, %ecx
++	negl	%ecx
++	andl	$31, %ecx
++	vmovups	(%rsi), %ymm0
++	vmovups	%ymm0, (%rax)
++	leaq	(%rax,%rcx), %r8
++	addq	%rcx, %rsi
++	movq	%rdx, %rdi
++	subq	%rcx, %rdi
++	cmpq	$2097152, %rdi          # imm = 0x200000
++	ja	.LBB0_264
++# %bb.260:
++	cmpq	$256, %rdi              # imm = 0x100
++	jb	.LBB0_268
++# %bb.261:
++	subq	%rcx, %rdx
++	.p2align	4, 0x90
++.LBB0_262:                              # =>This Inner Loop Header: Depth=1
++	vmovups	(%rsi), %ymm0
++	vmovups	32(%rsi), %ymm1
++	vmovups	64(%rsi), %ymm2
++	vmovups	96(%rsi), %ymm3
++	vmovups	128(%rsi), %ymm4
++	vmovups	160(%rsi), %ymm5
++	vmovups	192(%rsi), %ymm6
++	vmovups	224(%rsi), %ymm7
++	prefetchnta	512(%rsi)
++	addq	$256, %rsi              # imm = 0x100
++	vmovups	%ymm0, (%r8)
++	vmovups	%ymm1, 32(%r8)
++	vmovups	%ymm2, 64(%r8)
++	vmovups	%ymm3, 96(%r8)
++	vmovups	%ymm4, 128(%r8)
++	vmovups	%ymm5, 160(%r8)
++	vmovups	%ymm6, 192(%r8)
++	vmovups	%ymm7, 224(%r8)
++	addq	$256, %r8               # imm = 0x100
++	addq	$-256, %rdi
++	cmpq	$255, %rdi
++	ja	.LBB0_262
++# %bb.263:
++	movzbl	%dl, %edi
++	leaq	-1(%rdi), %rcx
++	cmpq	$255, %rcx
++	jbe	.LBB0_269
++	jmp	.LBB0_526
++.LBB0_264:
++	prefetchnta	(%rsi)
++	subq	%rcx, %rdx
++	testb	$31, %sil
++	je	.LBB0_265
++	.p2align	4, 0x90
++.LBB0_266:                              # =>This Inner Loop Header: Depth=1
++	vmovups	(%rsi), %ymm0
++	vmovups	32(%rsi), %ymm1
++	vmovups	64(%rsi), %ymm2
++	vmovups	96(%rsi), %ymm3
++	vmovups	128(%rsi), %ymm4
++	vmovups	160(%rsi), %ymm5
++	vmovups	192(%rsi), %ymm6
++	vmovups	224(%rsi), %ymm7
++	prefetchnta	512(%rsi)
++	addq	$256, %rsi              # imm = 0x100
++	vmovntps	%ymm0, (%r8)
++	vmovntps	%ymm1, 32(%r8)
++	vmovntps	%ymm2, 64(%r8)
++	vmovntps	%ymm3, 96(%r8)
++	vmovntps	%ymm4, 128(%r8)
++	vmovntps	%ymm5, 160(%r8)
++	vmovntps	%ymm6, 192(%r8)
++	vmovntps	%ymm7, 224(%r8)
++	addq	$256, %r8               # imm = 0x100
++	addq	$-256, %rdi
++	cmpq	$255, %rdi
++	ja	.LBB0_266
++	jmp	.LBB0_267
++	.p2align	4, 0x90
++.LBB0_265:                              # =>This Inner Loop Header: Depth=1
++	vmovaps	(%rsi), %ymm0
++	vmovaps	32(%rsi), %ymm1
++	vmovaps	64(%rsi), %ymm2
++	vmovaps	96(%rsi), %ymm3
++	vmovaps	128(%rsi), %ymm4
++	vmovaps	160(%rsi), %ymm5
++	vmovaps	192(%rsi), %ymm6
++	vmovaps	224(%rsi), %ymm7
++	prefetchnta	512(%rsi)
++	addq	$256, %rsi              # imm = 0x100
++	vmovntps	%ymm0, (%r8)
++	vmovntps	%ymm1, 32(%r8)
++	vmovntps	%ymm2, 64(%r8)
++	vmovntps	%ymm3, 96(%r8)
++	vmovntps	%ymm4, 128(%r8)
++	vmovntps	%ymm5, 160(%r8)
++	vmovntps	%ymm6, 192(%r8)
++	vmovntps	%ymm7, 224(%r8)
++	addq	$256, %r8               # imm = 0x100
++	addq	$-256, %rdi
++	cmpq	$255, %rdi
++	ja	.LBB0_265
++.LBB0_267:
++	movzbl	%dl, %edi
++	sfence
++.LBB0_268:
++	leaq	-1(%rdi), %rcx
++	cmpq	$255, %rcx
++	ja	.LBB0_526
++.LBB0_269:
++	addq	%rdi, %r8
++	addq	%rdi, %rsi
++	leaq	.LJTI0_0(%rip), %rdx
++	movslq	(%rdx,%rcx,4), %rcx
++	addq	%rdx, %rcx
++	jmpq	*%rcx
++.LBB0_278:
++	vmovups	-131(%rsi), %ymm0
++	vmovups	%ymm0, -131(%r8)
++	vmovups	-99(%rsi), %ymm0
++	vmovups	%ymm0, -99(%r8)
++	vmovups	-67(%rsi), %ymm0
++	vmovups	%ymm0, -67(%r8)
++	vmovups	-35(%rsi), %ymm0
++	vmovups	%ymm0, -35(%r8)
++.LBB0_279:
++	movzwl	-3(%rsi), %ecx
++	movw	%cx, -3(%r8)
++	movb	-1(%rsi), %cl
++	movb	%cl, -1(%r8)
++	vzeroupper
++	retq
++.LBB0_17:
++	vmovups	-133(%rsi), %ymm0
++	vmovups	%ymm0, -133(%rcx)
++	vmovups	-101(%rsi), %ymm0
++	vmovups	%ymm0, -101(%rcx)
++	vmovups	-69(%rsi), %ymm0
++	vmovups	%ymm0, -69(%rcx)
++	vmovups	-37(%rsi), %ymm0
++	vmovups	%ymm0, -37(%rcx)
++.LBB0_18:
++	movl	-5(%rsi), %edx
++	movl	%edx, -5(%rcx)
++	movb	-1(%rsi), %dl
++	movb	%dl, -1(%rcx)
++	vzeroupper
++	retq
++.LBB0_19:
++	vmovups	-134(%rsi), %ymm0
++	vmovups	%ymm0, -134(%rcx)
++	vmovups	-102(%rsi), %ymm0
++	vmovups	%ymm0, -102(%rcx)
++	vmovups	-70(%rsi), %ymm0
++	vmovups	%ymm0, -70(%rcx)
++	vmovups	-38(%rsi), %ymm0
++	vmovups	%ymm0, -38(%rcx)
++.LBB0_20:
++	movl	-6(%rsi), %edx
++	movl	%edx, -6(%rcx)
++	movzwl	-2(%rsi), %edx
++	movw	%dx, -2(%rcx)
++	vzeroupper
++	retq
++.LBB0_21:
++	vmovups	-135(%rsi), %ymm0
++	vmovups	%ymm0, -135(%rcx)
++	vmovups	-103(%rsi), %ymm0
++	vmovups	%ymm0, -103(%rcx)
++	vmovups	-71(%rsi), %ymm0
++	vmovups	%ymm0, -71(%rcx)
++	vmovups	-39(%rsi), %ymm0
++	vmovups	%ymm0, -39(%rcx)
++.LBB0_22:
++	movl	-7(%rsi), %edx
++	movl	%edx, -7(%rcx)
++	movl	-4(%rsi), %edx
++	movl	%edx, -4(%rcx)
++	vzeroupper
++	retq
++.LBB0_27:
++	vmovups	-137(%rsi), %ymm0
++	vmovups	%ymm0, -137(%rcx)
++	vmovups	-105(%rsi), %ymm0
++	vmovups	%ymm0, -105(%rcx)
++	vmovups	-73(%rsi), %ymm0
++	vmovups	%ymm0, -73(%rcx)
++	vmovups	-41(%rsi), %ymm0
++	vmovups	%ymm0, -41(%rcx)
++.LBB0_28:
++	movq	-9(%rsi), %rdx
++	movq	%rdx, -9(%rcx)
++	movb	-1(%rsi), %dl
++	movb	%dl, -1(%rcx)
++	vzeroupper
++	retq
++.LBB0_29:
++	vmovups	-138(%rsi), %ymm0
++	vmovups	%ymm0, -138(%rcx)
++	vmovups	-106(%rsi), %ymm0
++	vmovups	%ymm0, -106(%rcx)
++	vmovups	-74(%rsi), %ymm0
++	vmovups	%ymm0, -74(%rcx)
++	vmovups	-42(%rsi), %ymm0
++	vmovups	%ymm0, -42(%rcx)
++.LBB0_30:
++	movq	-10(%rsi), %rdx
++	movq	%rdx, -10(%rcx)
++	movzwl	-2(%rsi), %edx
++	movw	%dx, -2(%rcx)
++	vzeroupper
++	retq
++.LBB0_31:
++	vmovups	-139(%rsi), %ymm0
++	vmovups	%ymm0, -139(%rcx)
++	vmovups	-107(%rsi), %ymm0
++	vmovups	%ymm0, -107(%rcx)
++	vmovups	-75(%rsi), %ymm0
++	vmovups	%ymm0, -75(%rcx)
++	vmovups	-43(%rsi), %ymm0
++	vmovups	%ymm0, -43(%rcx)
++.LBB0_32:
++	movq	-11(%rsi), %rdx
++	movq	%rdx, -11(%rcx)
++	movl	-4(%rsi), %edx
++	movl	%edx, -4(%rcx)
++	vzeroupper
++	retq
++.LBB0_33:
++	vmovups	-140(%rsi), %ymm0
++	vmovups	%ymm0, -140(%rcx)
++	vmovups	-108(%rsi), %ymm0
++	vmovups	%ymm0, -108(%rcx)
++	vmovups	-76(%rsi), %ymm0
++	vmovups	%ymm0, -76(%rcx)
++	vmovups	-44(%rsi), %ymm0
++	vmovups	%ymm0, -44(%rcx)
++.LBB0_34:
++	movq	-12(%rsi), %rdx
++	movq	%rdx, -12(%rcx)
++	movl	-4(%rsi), %edx
++	movl	%edx, -4(%rcx)
++	vzeroupper
++	retq
++.LBB0_35:
++	vmovups	-141(%rsi), %ymm0
++	vmovups	%ymm0, -141(%rcx)
++	vmovups	-109(%rsi), %ymm0
++	vmovups	%ymm0, -109(%rcx)
++	vmovups	-77(%rsi), %ymm0
++	vmovups	%ymm0, -77(%rcx)
++	vmovups	-45(%rsi), %ymm0
++	vmovups	%ymm0, -45(%rcx)
++.LBB0_36:
++	movq	-13(%rsi), %rdx
++	movq	%rdx, -13(%rcx)
++	movq	-8(%rsi), %rdx
++	movq	%rdx, -8(%rcx)
++	vzeroupper
++	retq
++.LBB0_37:
++	vmovups	-142(%rsi), %ymm0
++	vmovups	%ymm0, -142(%rcx)
++	vmovups	-110(%rsi), %ymm0
++	vmovups	%ymm0, -110(%rcx)
++	vmovups	-78(%rsi), %ymm0
++	vmovups	%ymm0, -78(%rcx)
++	vmovups	-46(%rsi), %ymm0
++	vmovups	%ymm0, -46(%rcx)
++.LBB0_38:
++	movq	-14(%rsi), %rdx
++	movq	%rdx, -14(%rcx)
++	movq	-8(%rsi), %rdx
++	movq	%rdx, -8(%rcx)
++	vzeroupper
++	retq
++.LBB0_39:
++	vmovups	-143(%rsi), %ymm0
++	vmovups	%ymm0, -143(%rcx)
++	vmovups	-111(%rsi), %ymm0
++	vmovups	%ymm0, -111(%rcx)
++	vmovups	-79(%rsi), %ymm0
++	vmovups	%ymm0, -79(%rcx)
++	vmovups	-47(%rsi), %ymm0
++	vmovups	%ymm0, -47(%rcx)
++.LBB0_40:
++	movq	-15(%rsi), %rdx
++	movq	%rdx, -15(%rcx)
++	movq	-8(%rsi), %rdx
++	movq	%rdx, -8(%rcx)
++	vzeroupper
++	retq
++.LBB0_45:
++	vmovups	-145(%rsi), %ymm0
++	vmovups	%ymm0, -145(%rcx)
++	vmovups	-113(%rsi), %ymm0
++	vmovups	%ymm0, -113(%rcx)
++	vmovups	-81(%rsi), %ymm0
++	vmovups	%ymm0, -81(%rcx)
++	vmovups	-49(%rsi), %ymm0
++	vmovups	%ymm0, -49(%rcx)
++.LBB0_46:
++	vmovups	-17(%rsi), %xmm0
++	vmovups	%xmm0, -17(%rcx)
++	movb	-1(%rsi), %dl
++	movb	%dl, -1(%rcx)
++	vzeroupper
++	retq
++.LBB0_47:
++	vmovups	-146(%rsi), %ymm0
++	vmovups	%ymm0, -146(%rcx)
++	vmovups	-114(%rsi), %ymm0
++	vmovups	%ymm0, -114(%rcx)
++	vmovups	-82(%rsi), %ymm0
++	vmovups	%ymm0, -82(%rcx)
++	vmovups	-50(%rsi), %ymm0
++	vmovups	%ymm0, -50(%rcx)
++.LBB0_48:
++	vmovups	-18(%rsi), %xmm0
++	vmovups	%xmm0, -18(%rcx)
++	movzwl	-2(%rsi), %edx
++	movw	%dx, -2(%rcx)
++	vzeroupper
++	retq
++.LBB0_49:
++	vmovups	-147(%rsi), %ymm0
++	vmovups	%ymm0, -147(%rcx)
++	vmovups	-115(%rsi), %ymm0
++	vmovups	%ymm0, -115(%rcx)
++	vmovups	-83(%rsi), %ymm0
++	vmovups	%ymm0, -83(%rcx)
++	vmovups	-51(%rsi), %ymm0
++	vmovups	%ymm0, -51(%rcx)
++.LBB0_50:
++	vmovups	-19(%rsi), %xmm0
++	vmovups	%xmm0, -19(%rcx)
++	movl	-4(%rsi), %edx
++	movl	%edx, -4(%rcx)
++	vzeroupper
++	retq
++.LBB0_51:
++	vmovups	-148(%rsi), %ymm0
++	vmovups	%ymm0, -148(%rcx)
++	vmovups	-116(%rsi), %ymm0
++	vmovups	%ymm0, -116(%rcx)
++	vmovups	-84(%rsi), %ymm0
++	vmovups	%ymm0, -84(%rcx)
++	vmovups	-52(%rsi), %ymm0
++	vmovups	%ymm0, -52(%rcx)
++.LBB0_52:
++	vmovups	-20(%rsi), %xmm0
++	vmovups	%xmm0, -20(%rcx)
++	movl	-4(%rsi), %edx
++	movl	%edx, -4(%rcx)
++	vzeroupper
++	retq
++.LBB0_53:
++	vmovups	-149(%rsi), %ymm0
++	vmovups	%ymm0, -149(%rcx)
++	vmovups	-117(%rsi), %ymm0
++	vmovups	%ymm0, -117(%rcx)
++	vmovups	-85(%rsi), %ymm0
++	vmovups	%ymm0, -85(%rcx)
++	vmovups	-53(%rsi), %ymm0
++	vmovups	%ymm0, -53(%rcx)
++.LBB0_54:
++	vmovups	-21(%rsi), %xmm0
++	vmovups	%xmm0, -21(%rcx)
++	movq	-8(%rsi), %rdx
++	movq	%rdx, -8(%rcx)
++	vzeroupper
++	retq
++.LBB0_55:
++	vmovups	-150(%rsi), %ymm0
++	vmovups	%ymm0, -150(%rcx)
++	vmovups	-118(%rsi), %ymm0
++	vmovups	%ymm0, -118(%rcx)
++	vmovups	-86(%rsi), %ymm0
++	vmovups	%ymm0, -86(%rcx)
++	vmovups	-54(%rsi), %ymm0
++	vmovups	%ymm0, -54(%rcx)
++.LBB0_56:
++	vmovups	-22(%rsi), %xmm0
++	vmovups	%xmm0, -22(%rcx)
++	movq	-8(%rsi), %rdx
++	movq	%rdx, -8(%rcx)
++	vzeroupper
++	retq
++.LBB0_57:
++	vmovups	-151(%rsi), %ymm0
++	vmovups	%ymm0, -151(%rcx)
++	vmovups	-119(%rsi), %ymm0
++	vmovups	%ymm0, -119(%rcx)
++	vmovups	-87(%rsi), %ymm0
++	vmovups	%ymm0, -87(%rcx)
++	vmovups	-55(%rsi), %ymm0
++	vmovups	%ymm0, -55(%rcx)
++.LBB0_58:
++	vmovups	-23(%rsi), %xmm0
++	vmovups	%xmm0, -23(%rcx)
++	movq	-8(%rsi), %rdx
++	movq	%rdx, -8(%rcx)
++	vzeroupper
++	retq
++.LBB0_59:
++	vmovups	-152(%rsi), %ymm0
++	vmovups	%ymm0, -152(%rcx)
++	vmovups	-120(%rsi), %ymm0
++	vmovups	%ymm0, -120(%rcx)
++	vmovups	-88(%rsi), %ymm0
++	vmovups	%ymm0, -88(%rcx)
++	vmovups	-56(%rsi), %ymm0
++	vmovups	%ymm0, -56(%rcx)
++.LBB0_60:
++	vmovups	-24(%rsi), %xmm0
++	vmovups	%xmm0, -24(%rcx)
++	movq	-8(%rsi), %rdx
++	movq	%rdx, -8(%rcx)
++	vzeroupper
++	retq
++.LBB0_61:
++	vmovups	-153(%rsi), %ymm0
++	vmovups	%ymm0, -153(%rcx)
++	vmovups	-121(%rsi), %ymm0
++	vmovups	%ymm0, -121(%rcx)
++	vmovups	-89(%rsi), %ymm0
++	vmovups	%ymm0, -89(%rcx)
++	vmovups	-57(%rsi), %ymm0
++	vmovups	%ymm0, -57(%rcx)
++.LBB0_62:
++	vmovups	-25(%rsi), %xmm0
++	vmovups	%xmm0, -25(%rcx)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%rcx)
++	vzeroupper
++	retq
++.LBB0_63:
++	vmovups	-154(%rsi), %ymm0
++	vmovups	%ymm0, -154(%rcx)
++	vmovups	-122(%rsi), %ymm0
++	vmovups	%ymm0, -122(%rcx)
++	vmovups	-90(%rsi), %ymm0
++	vmovups	%ymm0, -90(%rcx)
++	vmovups	-58(%rsi), %ymm0
++	vmovups	%ymm0, -58(%rcx)
++.LBB0_64:
++	vmovups	-26(%rsi), %xmm0
++	vmovups	%xmm0, -26(%rcx)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%rcx)
++	vzeroupper
++	retq
++.LBB0_65:
++	vmovups	-155(%rsi), %ymm0
++	vmovups	%ymm0, -155(%rcx)
++	vmovups	-123(%rsi), %ymm0
++	vmovups	%ymm0, -123(%rcx)
++	vmovups	-91(%rsi), %ymm0
++	vmovups	%ymm0, -91(%rcx)
++	vmovups	-59(%rsi), %ymm0
++	vmovups	%ymm0, -59(%rcx)
++.LBB0_66:
++	vmovups	-27(%rsi), %xmm0
++	vmovups	%xmm0, -27(%rcx)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%rcx)
++	vzeroupper
++	retq
++.LBB0_67:
++	vmovups	-156(%rsi), %ymm0
++	vmovups	%ymm0, -156(%rcx)
++	vmovups	-124(%rsi), %ymm0
++	vmovups	%ymm0, -124(%rcx)
++	vmovups	-92(%rsi), %ymm0
++	vmovups	%ymm0, -92(%rcx)
++	vmovups	-60(%rsi), %ymm0
++	vmovups	%ymm0, -60(%rcx)
++.LBB0_68:
++	vmovups	-28(%rsi), %xmm0
++	vmovups	%xmm0, -28(%rcx)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%rcx)
++	vzeroupper
++	retq
++.LBB0_69:
++	vmovups	-157(%rsi), %ymm0
++	vmovups	%ymm0, -157(%rcx)
++	vmovups	-125(%rsi), %ymm0
++	vmovups	%ymm0, -125(%rcx)
++	vmovups	-93(%rsi), %ymm0
++	vmovups	%ymm0, -93(%rcx)
++	vmovups	-61(%rsi), %ymm0
++	vmovups	%ymm0, -61(%rcx)
++.LBB0_70:
++	vmovups	-29(%rsi), %xmm0
++	vmovups	%xmm0, -29(%rcx)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%rcx)
++	vzeroupper
++	retq
++.LBB0_71:
++	vmovups	-158(%rsi), %ymm0
++	vmovups	%ymm0, -158(%rcx)
++	vmovups	-126(%rsi), %ymm0
++	vmovups	%ymm0, -126(%rcx)
++	vmovups	-94(%rsi), %ymm0
++	vmovups	%ymm0, -94(%rcx)
++	vmovups	-62(%rsi), %ymm0
++	vmovups	%ymm0, -62(%rcx)
++.LBB0_72:
++	vmovups	-30(%rsi), %xmm0
++	vmovups	%xmm0, -30(%rcx)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%rcx)
++	vzeroupper
++	retq
++.LBB0_73:
++	vmovups	-159(%rsi), %ymm0
++	vmovups	%ymm0, -159(%rcx)
++	vmovups	-127(%rsi), %ymm0
++	vmovups	%ymm0, -127(%rcx)
++	vmovups	-95(%rsi), %ymm0
++	vmovups	%ymm0, -95(%rcx)
++	vmovups	-63(%rsi), %ymm0
++	vmovups	%ymm0, -63(%rcx)
++.LBB0_74:
++	vmovups	-31(%rsi), %xmm0
++	vmovups	%xmm0, -31(%rcx)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%rcx)
++	vzeroupper
++	retq
++.LBB0_75:
++	vmovups	-193(%rsi), %ymm0
++	vmovups	%ymm0, -193(%rcx)
++.LBB0_76:
++	vmovups	-161(%rsi), %ymm0
++	vmovups	%ymm0, -161(%rcx)
++.LBB0_3:
++	vmovups	-129(%rsi), %ymm0
++	vmovups	%ymm0, -129(%rcx)
++	vmovups	-97(%rsi), %ymm0
++	vmovups	%ymm0, -97(%rcx)
++.LBB0_4:
++	vmovups	-65(%rsi), %ymm0
++	vmovups	%ymm0, -65(%rcx)
++.LBB0_5:
++	vmovups	-33(%rsi), %ymm0
++	vmovups	%ymm0, -33(%rcx)
++.LBB0_6:
++	movb	-1(%rsi), %dl
++	movb	%dl, -1(%rcx)
++	vzeroupper
++	retq
++.LBB0_77:
++	vmovups	-194(%rsi), %ymm0
++	vmovups	%ymm0, -194(%rcx)
++.LBB0_78:
++	vmovups	-162(%rsi), %ymm0
++	vmovups	%ymm0, -162(%rcx)
++.LBB0_7:
++	vmovups	-130(%rsi), %ymm0
++	vmovups	%ymm0, -130(%rcx)
++	vmovups	-98(%rsi), %ymm0
++	vmovups	%ymm0, -98(%rcx)
++.LBB0_8:
++	vmovups	-66(%rsi), %ymm0
++	vmovups	%ymm0, -66(%rcx)
++.LBB0_9:
++	vmovups	-34(%rsi), %ymm0
++	vmovups	%ymm0, -34(%rcx)
++.LBB0_10:
++	movzwl	-2(%rsi), %edx
++	movw	%dx, -2(%rcx)
++	vzeroupper
++	retq
++.LBB0_79:
++	vmovups	-195(%rsi), %ymm0
++	vmovups	%ymm0, -195(%rcx)
++.LBB0_80:
++	vmovups	-163(%rsi), %ymm0
++	vmovups	%ymm0, -163(%rcx)
++	vmovups	-131(%rsi), %ymm0
++	vmovups	%ymm0, -131(%rcx)
++	vmovups	-99(%rsi), %ymm0
++	vmovups	%ymm0, -99(%rcx)
++.LBB0_81:
++	vmovups	-67(%rsi), %ymm0
++	vmovups	%ymm0, -67(%rcx)
++.LBB0_82:
++	vmovups	-35(%rsi), %ymm0
++	vmovups	%ymm0, -35(%rcx)
++	movl	-4(%rsi), %edx
++	movl	%edx, -4(%rcx)
++	vzeroupper
++	retq
++.LBB0_83:
++	vmovups	-196(%rsi), %ymm0
++	vmovups	%ymm0, -196(%rcx)
++.LBB0_84:
++	vmovups	-164(%rsi), %ymm0
++	vmovups	%ymm0, -164(%rcx)
++.LBB0_13:
++	vmovups	-132(%rsi), %ymm0
++	vmovups	%ymm0, -132(%rcx)
++	vmovups	-100(%rsi), %ymm0
++	vmovups	%ymm0, -100(%rcx)
++.LBB0_14:
++	vmovups	-68(%rsi), %ymm0
++	vmovups	%ymm0, -68(%rcx)
++.LBB0_15:
++	vmovups	-36(%rsi), %ymm0
++	vmovups	%ymm0, -36(%rcx)
++.LBB0_16:
++	movl	-4(%rsi), %edx
++	movl	%edx, -4(%rcx)
++	vzeroupper
++	retq
++.LBB0_85:
++	vmovups	-197(%rsi), %ymm0
++	vmovups	%ymm0, -197(%rcx)
++.LBB0_86:
++	vmovups	-165(%rsi), %ymm0
++	vmovups	%ymm0, -165(%rcx)
++	vmovups	-133(%rsi), %ymm0
++	vmovups	%ymm0, -133(%rcx)
++	vmovups	-101(%rsi), %ymm0
++	vmovups	%ymm0, -101(%rcx)
++.LBB0_87:
++	vmovups	-69(%rsi), %ymm0
++	vmovups	%ymm0, -69(%rcx)
++.LBB0_88:
++	vmovups	-37(%rsi), %ymm0
++	vmovups	%ymm0, -37(%rcx)
++	movq	-8(%rsi), %rdx
++	movq	%rdx, -8(%rcx)
++	vzeroupper
++	retq
++.LBB0_89:
++	vmovups	-198(%rsi), %ymm0
++	vmovups	%ymm0, -198(%rcx)
++.LBB0_90:
++	vmovups	-166(%rsi), %ymm0
++	vmovups	%ymm0, -166(%rcx)
++	vmovups	-134(%rsi), %ymm0
++	vmovups	%ymm0, -134(%rcx)
++	vmovups	-102(%rsi), %ymm0
++	vmovups	%ymm0, -102(%rcx)
++.LBB0_91:
++	vmovups	-70(%rsi), %ymm0
++	vmovups	%ymm0, -70(%rcx)
++.LBB0_92:
++	vmovups	-38(%rsi), %ymm0
++	vmovups	%ymm0, -38(%rcx)
++	movq	-8(%rsi), %rdx
++	movq	%rdx, -8(%rcx)
++	vzeroupper
++	retq
++.LBB0_93:
++	vmovups	-199(%rsi), %ymm0
++	vmovups	%ymm0, -199(%rcx)
++.LBB0_94:
++	vmovups	-167(%rsi), %ymm0
++	vmovups	%ymm0, -167(%rcx)
++	vmovups	-135(%rsi), %ymm0
++	vmovups	%ymm0, -135(%rcx)
++	vmovups	-103(%rsi), %ymm0
++	vmovups	%ymm0, -103(%rcx)
++.LBB0_95:
++	vmovups	-71(%rsi), %ymm0
++	vmovups	%ymm0, -71(%rcx)
++.LBB0_96:
++	vmovups	-39(%rsi), %ymm0
++	vmovups	%ymm0, -39(%rcx)
++	movq	-8(%rsi), %rdx
++	movq	%rdx, -8(%rcx)
++	vzeroupper
++	retq
++.LBB0_97:
++	vmovups	-200(%rsi), %ymm0
++	vmovups	%ymm0, -200(%rcx)
++.LBB0_98:
++	vmovups	-168(%rsi), %ymm0
++	vmovups	%ymm0, -168(%rcx)
++.LBB0_23:
++	vmovups	-136(%rsi), %ymm0
++	vmovups	%ymm0, -136(%rcx)
++	vmovups	-104(%rsi), %ymm0
++	vmovups	%ymm0, -104(%rcx)
++.LBB0_24:
++	vmovups	-72(%rsi), %ymm0
++	vmovups	%ymm0, -72(%rcx)
++.LBB0_25:
++	vmovups	-40(%rsi), %ymm0
++	vmovups	%ymm0, -40(%rcx)
++.LBB0_26:
++	movq	-8(%rsi), %rdx
++	movq	%rdx, -8(%rcx)
++	vzeroupper
++	retq
++.LBB0_99:
++	vmovups	-201(%rsi), %ymm0
++	vmovups	%ymm0, -201(%rcx)
++.LBB0_100:
++	vmovups	-169(%rsi), %ymm0
++	vmovups	%ymm0, -169(%rcx)
++	vmovups	-137(%rsi), %ymm0
++	vmovups	%ymm0, -137(%rcx)
++	vmovups	-105(%rsi), %ymm0
++	vmovups	%ymm0, -105(%rcx)
++.LBB0_101:
++	vmovups	-73(%rsi), %ymm0
++	vmovups	%ymm0, -73(%rcx)
++.LBB0_102:
++	vmovups	-41(%rsi), %ymm0
++	vmovups	%ymm0, -41(%rcx)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%rcx)
++	vzeroupper
++	retq
++.LBB0_103:
++	vmovups	-202(%rsi), %ymm0
++	vmovups	%ymm0, -202(%rcx)
++.LBB0_104:
++	vmovups	-170(%rsi), %ymm0
++	vmovups	%ymm0, -170(%rcx)
++	vmovups	-138(%rsi), %ymm0
++	vmovups	%ymm0, -138(%rcx)
++	vmovups	-106(%rsi), %ymm0
++	vmovups	%ymm0, -106(%rcx)
++.LBB0_105:
++	vmovups	-74(%rsi), %ymm0
++	vmovups	%ymm0, -74(%rcx)
++.LBB0_106:
++	vmovups	-42(%rsi), %ymm0
++	vmovups	%ymm0, -42(%rcx)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%rcx)
++	vzeroupper
++	retq
++.LBB0_107:
++	vmovups	-203(%rsi), %ymm0
++	vmovups	%ymm0, -203(%rcx)
++.LBB0_108:
++	vmovups	-171(%rsi), %ymm0
++	vmovups	%ymm0, -171(%rcx)
++	vmovups	-139(%rsi), %ymm0
++	vmovups	%ymm0, -139(%rcx)
++	vmovups	-107(%rsi), %ymm0
++	vmovups	%ymm0, -107(%rcx)
++.LBB0_109:
++	vmovups	-75(%rsi), %ymm0
++	vmovups	%ymm0, -75(%rcx)
++.LBB0_110:
++	vmovups	-43(%rsi), %ymm0
++	vmovups	%ymm0, -43(%rcx)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%rcx)
++	vzeroupper
++	retq
++.LBB0_111:
++	vmovups	-204(%rsi), %ymm0
++	vmovups	%ymm0, -204(%rcx)
++.LBB0_112:
++	vmovups	-172(%rsi), %ymm0
++	vmovups	%ymm0, -172(%rcx)
++	vmovups	-140(%rsi), %ymm0
++	vmovups	%ymm0, -140(%rcx)
++	vmovups	-108(%rsi), %ymm0
++	vmovups	%ymm0, -108(%rcx)
++.LBB0_113:
++	vmovups	-76(%rsi), %ymm0
++	vmovups	%ymm0, -76(%rcx)
++.LBB0_114:
++	vmovups	-44(%rsi), %ymm0
++	vmovups	%ymm0, -44(%rcx)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%rcx)
++	vzeroupper
++	retq
++.LBB0_115:
++	vmovups	-205(%rsi), %ymm0
++	vmovups	%ymm0, -205(%rcx)
++.LBB0_116:
++	vmovups	-173(%rsi), %ymm0
++	vmovups	%ymm0, -173(%rcx)
++	vmovups	-141(%rsi), %ymm0
++	vmovups	%ymm0, -141(%rcx)
++	vmovups	-109(%rsi), %ymm0
++	vmovups	%ymm0, -109(%rcx)
++.LBB0_117:
++	vmovups	-77(%rsi), %ymm0
++	vmovups	%ymm0, -77(%rcx)
++.LBB0_118:
++	vmovups	-45(%rsi), %ymm0
++	vmovups	%ymm0, -45(%rcx)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%rcx)
++	vzeroupper
++	retq
++.LBB0_119:
++	vmovups	-206(%rsi), %ymm0
++	vmovups	%ymm0, -206(%rcx)
++.LBB0_120:
++	vmovups	-174(%rsi), %ymm0
++	vmovups	%ymm0, -174(%rcx)
++	vmovups	-142(%rsi), %ymm0
++	vmovups	%ymm0, -142(%rcx)
++	vmovups	-110(%rsi), %ymm0
++	vmovups	%ymm0, -110(%rcx)
++.LBB0_121:
++	vmovups	-78(%rsi), %ymm0
++	vmovups	%ymm0, -78(%rcx)
++.LBB0_122:
++	vmovups	-46(%rsi), %ymm0
++	vmovups	%ymm0, -46(%rcx)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%rcx)
++	vzeroupper
++	retq
++.LBB0_123:
++	vmovups	-207(%rsi), %ymm0
++	vmovups	%ymm0, -207(%rcx)
++.LBB0_124:
++	vmovups	-175(%rsi), %ymm0
++	vmovups	%ymm0, -175(%rcx)
++	vmovups	-143(%rsi), %ymm0
++	vmovups	%ymm0, -143(%rcx)
++	vmovups	-111(%rsi), %ymm0
++	vmovups	%ymm0, -111(%rcx)
++.LBB0_125:
++	vmovups	-79(%rsi), %ymm0
++	vmovups	%ymm0, -79(%rcx)
++.LBB0_126:
++	vmovups	-47(%rsi), %ymm0
++	vmovups	%ymm0, -47(%rcx)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%rcx)
++	vzeroupper
++	retq
++.LBB0_127:
++	vmovups	-208(%rsi), %ymm0
++	vmovups	%ymm0, -208(%rcx)
++.LBB0_128:
++	vmovups	-176(%rsi), %ymm0
++	vmovups	%ymm0, -176(%rcx)
++.LBB0_41:
++	vmovups	-144(%rsi), %ymm0
++	vmovups	%ymm0, -144(%rcx)
++	vmovups	-112(%rsi), %ymm0
++	vmovups	%ymm0, -112(%rcx)
++.LBB0_42:
++	vmovups	-80(%rsi), %ymm0
++	vmovups	%ymm0, -80(%rcx)
++.LBB0_43:
++	vmovups	-48(%rsi), %ymm0
++	vmovups	%ymm0, -48(%rcx)
++.LBB0_44:
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%rcx)
++	vzeroupper
++	retq
++.LBB0_129:
++	vmovups	-209(%rsi), %ymm0
++	vmovups	%ymm0, -209(%rcx)
++.LBB0_130:
++	vmovups	-177(%rsi), %ymm0
++	vmovups	%ymm0, -177(%rcx)
++	vmovups	-145(%rsi), %ymm0
++	vmovups	%ymm0, -145(%rcx)
++	vmovups	-113(%rsi), %ymm0
++	vmovups	%ymm0, -113(%rcx)
++.LBB0_131:
++	vmovups	-81(%rsi), %ymm0
++	vmovups	%ymm0, -81(%rcx)
++.LBB0_132:
++	vmovups	-49(%rsi), %ymm0
++	vmovups	%ymm0, -49(%rcx)
++	vmovups	-32(%rsi), %ymm0
++	vmovups	%ymm0, -32(%rcx)
++	vzeroupper
++	retq
++.LBB0_133:
++	vmovups	-210(%rsi), %ymm0
++	vmovups	%ymm0, -210(%rcx)
++.LBB0_134:
++	vmovups	-178(%rsi), %ymm0
++	vmovups	%ymm0, -178(%rcx)
++	vmovups	-146(%rsi), %ymm0
++	vmovups	%ymm0, -146(%rcx)
++	vmovups	-114(%rsi), %ymm0
++	vmovups	%ymm0, -114(%rcx)
++.LBB0_135:
++	vmovups	-82(%rsi), %ymm0
++	vmovups	%ymm0, -82(%rcx)
++.LBB0_136:
++	vmovups	-50(%rsi), %ymm0
++	vmovups	%ymm0, -50(%rcx)
++	vmovups	-32(%rsi), %ymm0
++	vmovups	%ymm0, -32(%rcx)
++	vzeroupper
++	retq
++.LBB0_137:
++	vmovups	-211(%rsi), %ymm0
++	vmovups	%ymm0, -211(%rcx)
++.LBB0_138:
++	vmovups	-179(%rsi), %ymm0
++	vmovups	%ymm0, -179(%rcx)
++	vmovups	-147(%rsi), %ymm0
++	vmovups	%ymm0, -147(%rcx)
++	vmovups	-115(%rsi), %ymm0
++	vmovups	%ymm0, -115(%rcx)
++.LBB0_139:
++	vmovups	-83(%rsi), %ymm0
++	vmovups	%ymm0, -83(%rcx)
++.LBB0_140:
++	vmovups	-51(%rsi), %ymm0
++	vmovups	%ymm0, -51(%rcx)
++	vmovups	-32(%rsi), %ymm0
++	vmovups	%ymm0, -32(%rcx)
++	vzeroupper
++	retq
++.LBB0_141:
++	vmovups	-212(%rsi), %ymm0
++	vmovups	%ymm0, -212(%rcx)
++.LBB0_142:
++	vmovups	-180(%rsi), %ymm0
++	vmovups	%ymm0, -180(%rcx)
++	vmovups	-148(%rsi), %ymm0
++	vmovups	%ymm0, -148(%rcx)
++	vmovups	-116(%rsi), %ymm0
++	vmovups	%ymm0, -116(%rcx)
++.LBB0_143:
++	vmovups	-84(%rsi), %ymm0
++	vmovups	%ymm0, -84(%rcx)
++.LBB0_144:
++	vmovups	-52(%rsi), %ymm0
++	vmovups	%ymm0, -52(%rcx)
++	vmovups	-32(%rsi), %ymm0
++	vmovups	%ymm0, -32(%rcx)
++	vzeroupper
++	retq
++.LBB0_145:
++	vmovups	-213(%rsi), %ymm0
++	vmovups	%ymm0, -213(%rcx)
++.LBB0_146:
++	vmovups	-181(%rsi), %ymm0
++	vmovups	%ymm0, -181(%rcx)
++	vmovups	-149(%rsi), %ymm0
++	vmovups	%ymm0, -149(%rcx)
++	vmovups	-117(%rsi), %ymm0
++	vmovups	%ymm0, -117(%rcx)
++.LBB0_147:
++	vmovups	-85(%rsi), %ymm0
++	vmovups	%ymm0, -85(%rcx)
++.LBB0_148:
++	vmovups	-53(%rsi), %ymm0
++	vmovups	%ymm0, -53(%rcx)
++	vmovups	-32(%rsi), %ymm0
++	vmovups	%ymm0, -32(%rcx)
++	vzeroupper
++	retq
++.LBB0_149:
++	vmovups	-214(%rsi), %ymm0
++	vmovups	%ymm0, -214(%rcx)
++.LBB0_150:
++	vmovups	-182(%rsi), %ymm0
++	vmovups	%ymm0, -182(%rcx)
++	vmovups	-150(%rsi), %ymm0
++	vmovups	%ymm0, -150(%rcx)
++	vmovups	-118(%rsi), %ymm0
++	vmovups	%ymm0, -118(%rcx)
++.LBB0_151:
++	vmovups	-86(%rsi), %ymm0
++	vmovups	%ymm0, -86(%rcx)
++.LBB0_152:
++	vmovups	-54(%rsi), %ymm0
++	vmovups	%ymm0, -54(%rcx)
++	vmovups	-32(%rsi), %ymm0
++	vmovups	%ymm0, -32(%rcx)
++	vzeroupper
++	retq
++.LBB0_153:
++	vmovups	-215(%rsi), %ymm0
++	vmovups	%ymm0, -215(%rcx)
++.LBB0_154:
++	vmovups	-183(%rsi), %ymm0
++	vmovups	%ymm0, -183(%rcx)
++	vmovups	-151(%rsi), %ymm0
++	vmovups	%ymm0, -151(%rcx)
++	vmovups	-119(%rsi), %ymm0
++	vmovups	%ymm0, -119(%rcx)
++.LBB0_155:
++	vmovups	-87(%rsi), %ymm0
++	vmovups	%ymm0, -87(%rcx)
++.LBB0_156:
++	vmovups	-55(%rsi), %ymm0
++	vmovups	%ymm0, -55(%rcx)
++	vmovups	-32(%rsi), %ymm0
++	vmovups	%ymm0, -32(%rcx)
++	vzeroupper
++	retq
++.LBB0_157:
++	vmovups	-216(%rsi), %ymm0
++	vmovups	%ymm0, -216(%rcx)
++.LBB0_158:
++	vmovups	-184(%rsi), %ymm0
++	vmovups	%ymm0, -184(%rcx)
++	vmovups	-152(%rsi), %ymm0
++	vmovups	%ymm0, -152(%rcx)
++	vmovups	-120(%rsi), %ymm0
++	vmovups	%ymm0, -120(%rcx)
++.LBB0_159:
++	vmovups	-88(%rsi), %ymm0
++	vmovups	%ymm0, -88(%rcx)
++.LBB0_160:
++	vmovups	-56(%rsi), %ymm0
++	vmovups	%ymm0, -56(%rcx)
++	vmovups	-32(%rsi), %ymm0
++	vmovups	%ymm0, -32(%rcx)
++	vzeroupper
++	retq
++.LBB0_161:
++	vmovups	-217(%rsi), %ymm0
++	vmovups	%ymm0, -217(%rcx)
++.LBB0_162:
++	vmovups	-185(%rsi), %ymm0
++	vmovups	%ymm0, -185(%rcx)
++	vmovups	-153(%rsi), %ymm0
++	vmovups	%ymm0, -153(%rcx)
++	vmovups	-121(%rsi), %ymm0
++	vmovups	%ymm0, -121(%rcx)
++.LBB0_163:
++	vmovups	-89(%rsi), %ymm0
++	vmovups	%ymm0, -89(%rcx)
++.LBB0_164:
++	vmovups	-57(%rsi), %ymm0
++	vmovups	%ymm0, -57(%rcx)
++	vmovups	-32(%rsi), %ymm0
++	vmovups	%ymm0, -32(%rcx)
++	vzeroupper
++	retq
++.LBB0_165:
++	vmovups	-218(%rsi), %ymm0
++	vmovups	%ymm0, -218(%rcx)
++.LBB0_166:
++	vmovups	-186(%rsi), %ymm0
++	vmovups	%ymm0, -186(%rcx)
++	vmovups	-154(%rsi), %ymm0
++	vmovups	%ymm0, -154(%rcx)
++	vmovups	-122(%rsi), %ymm0
++	vmovups	%ymm0, -122(%rcx)
++.LBB0_167:
++	vmovups	-90(%rsi), %ymm0
++	vmovups	%ymm0, -90(%rcx)
++.LBB0_168:
++	vmovups	-58(%rsi), %ymm0
++	vmovups	%ymm0, -58(%rcx)
++	vmovups	-32(%rsi), %ymm0
++	vmovups	%ymm0, -32(%rcx)
++	vzeroupper
++	retq
++.LBB0_169:
++	vmovups	-219(%rsi), %ymm0
++	vmovups	%ymm0, -219(%rcx)
++.LBB0_170:
++	vmovups	-187(%rsi), %ymm0
++	vmovups	%ymm0, -187(%rcx)
++	vmovups	-155(%rsi), %ymm0
++	vmovups	%ymm0, -155(%rcx)
++	vmovups	-123(%rsi), %ymm0
++	vmovups	%ymm0, -123(%rcx)
++.LBB0_171:
++	vmovups	-91(%rsi), %ymm0
++	vmovups	%ymm0, -91(%rcx)
++.LBB0_172:
++	vmovups	-59(%rsi), %ymm0
++	vmovups	%ymm0, -59(%rcx)
++	vmovups	-32(%rsi), %ymm0
++	vmovups	%ymm0, -32(%rcx)
++	vzeroupper
++	retq
++.LBB0_173:
++	vmovups	-220(%rsi), %ymm0
++	vmovups	%ymm0, -220(%rcx)
++.LBB0_174:
++	vmovups	-188(%rsi), %ymm0
++	vmovups	%ymm0, -188(%rcx)
++	vmovups	-156(%rsi), %ymm0
++	vmovups	%ymm0, -156(%rcx)
++	vmovups	-124(%rsi), %ymm0
++	vmovups	%ymm0, -124(%rcx)
++.LBB0_175:
++	vmovups	-92(%rsi), %ymm0
++	vmovups	%ymm0, -92(%rcx)
++.LBB0_176:
++	vmovups	-60(%rsi), %ymm0
++	vmovups	%ymm0, -60(%rcx)
++	vmovups	-32(%rsi), %ymm0
++	vmovups	%ymm0, -32(%rcx)
++	vzeroupper
++	retq
++.LBB0_177:
++	vmovups	-221(%rsi), %ymm0
++	vmovups	%ymm0, -221(%rcx)
++.LBB0_178:
++	vmovups	-189(%rsi), %ymm0
++	vmovups	%ymm0, -189(%rcx)
++	vmovups	-157(%rsi), %ymm0
++	vmovups	%ymm0, -157(%rcx)
++	vmovups	-125(%rsi), %ymm0
++	vmovups	%ymm0, -125(%rcx)
++.LBB0_179:
++	vmovups	-93(%rsi), %ymm0
++	vmovups	%ymm0, -93(%rcx)
++.LBB0_180:
++	vmovups	-61(%rsi), %ymm0
++	vmovups	%ymm0, -61(%rcx)
++	vmovups	-32(%rsi), %ymm0
++	vmovups	%ymm0, -32(%rcx)
++	vzeroupper
++	retq
++.LBB0_181:
++	vmovups	-222(%rsi), %ymm0
++	vmovups	%ymm0, -222(%rcx)
++.LBB0_182:
++	vmovups	-190(%rsi), %ymm0
++	vmovups	%ymm0, -190(%rcx)
++	vmovups	-158(%rsi), %ymm0
++	vmovups	%ymm0, -158(%rcx)
++	vmovups	-126(%rsi), %ymm0
++	vmovups	%ymm0, -126(%rcx)
++.LBB0_183:
++	vmovups	-94(%rsi), %ymm0
++	vmovups	%ymm0, -94(%rcx)
++.LBB0_184:
++	vmovups	-62(%rsi), %ymm0
++	vmovups	%ymm0, -62(%rcx)
++	vmovups	-32(%rsi), %ymm0
++	vmovups	%ymm0, -32(%rcx)
++	vzeroupper
++	retq
++.LBB0_185:
++	vmovups	-223(%rsi), %ymm0
++	vmovups	%ymm0, -223(%rcx)
++.LBB0_186:
++	vmovups	-191(%rsi), %ymm0
++	vmovups	%ymm0, -191(%rcx)
++	vmovups	-159(%rsi), %ymm0
++	vmovups	%ymm0, -159(%rcx)
++	vmovups	-127(%rsi), %ymm0
++	vmovups	%ymm0, -127(%rcx)
++.LBB0_187:
++	vmovups	-95(%rsi), %ymm0
++	vmovups	%ymm0, -95(%rcx)
++.LBB0_188:
++	vmovups	-63(%rsi), %ymm0
++	vmovups	%ymm0, -63(%rcx)
++	vmovups	-32(%rsi), %ymm0
++	vmovups	%ymm0, -32(%rcx)
++	vzeroupper
++	retq
++.LBB0_189:
++	vmovups	-225(%rsi), %ymm0
++	vmovups	%ymm0, -225(%rcx)
++	vmovups	-193(%rsi), %ymm0
++	vmovups	%ymm0, -193(%rcx)
++	vmovups	-161(%rsi), %ymm0
++	vmovups	%ymm0, -161(%rcx)
++	vmovups	-129(%rsi), %ymm0
++	vmovups	%ymm0, -129(%rcx)
++.LBB0_190:
++	vmovups	-97(%rsi), %ymm0
++	vmovups	%ymm0, -97(%rcx)
++	vmovups	-65(%rsi), %ymm0
++	vmovups	%ymm0, -65(%rcx)
++	jmp	.LBB0_257
++.LBB0_191:
++	vmovups	-226(%rsi), %ymm0
++	vmovups	%ymm0, -226(%rcx)
++	vmovups	-194(%rsi), %ymm0
++	vmovups	%ymm0, -194(%rcx)
++	vmovups	-162(%rsi), %ymm0
++	vmovups	%ymm0, -162(%rcx)
++	vmovups	-130(%rsi), %ymm0
++	vmovups	%ymm0, -130(%rcx)
++.LBB0_192:
++	vmovups	-98(%rsi), %ymm0
++	vmovups	%ymm0, -98(%rcx)
++	vmovups	-66(%rsi), %ymm0
++	vmovups	%ymm0, -66(%rcx)
++	jmp	.LBB0_257
++.LBB0_193:
++	vmovups	-227(%rsi), %ymm0
++	vmovups	%ymm0, -227(%rcx)
++	vmovups	-195(%rsi), %ymm0
++	vmovups	%ymm0, -195(%rcx)
++	vmovups	-163(%rsi), %ymm0
++	vmovups	%ymm0, -163(%rcx)
++	vmovups	-131(%rsi), %ymm0
++	vmovups	%ymm0, -131(%rcx)
++.LBB0_194:
++	vmovups	-99(%rsi), %ymm0
++	vmovups	%ymm0, -99(%rcx)
++	vmovups	-67(%rsi), %ymm0
++	vmovups	%ymm0, -67(%rcx)
++	jmp	.LBB0_257
++.LBB0_195:
++	vmovups	-228(%rsi), %ymm0
++	vmovups	%ymm0, -228(%rcx)
++	vmovups	-196(%rsi), %ymm0
++	vmovups	%ymm0, -196(%rcx)
++	vmovups	-164(%rsi), %ymm0
++	vmovups	%ymm0, -164(%rcx)
++	vmovups	-132(%rsi), %ymm0
++	vmovups	%ymm0, -132(%rcx)
++.LBB0_196:
++	vmovups	-100(%rsi), %ymm0
++	vmovups	%ymm0, -100(%rcx)
++	vmovups	-68(%rsi), %ymm0
++	vmovups	%ymm0, -68(%rcx)
++	jmp	.LBB0_257
++.LBB0_197:
++	vmovups	-229(%rsi), %ymm0
++	vmovups	%ymm0, -229(%rcx)
++	vmovups	-197(%rsi), %ymm0
++	vmovups	%ymm0, -197(%rcx)
++	vmovups	-165(%rsi), %ymm0
++	vmovups	%ymm0, -165(%rcx)
++	vmovups	-133(%rsi), %ymm0
++	vmovups	%ymm0, -133(%rcx)
++.LBB0_198:
++	vmovups	-101(%rsi), %ymm0
++	vmovups	%ymm0, -101(%rcx)
++	vmovups	-69(%rsi), %ymm0
++	vmovups	%ymm0, -69(%rcx)
++	jmp	.LBB0_257
++.LBB0_199:
++	vmovups	-230(%rsi), %ymm0
++	vmovups	%ymm0, -230(%rcx)
++	vmovups	-198(%rsi), %ymm0
++	vmovups	%ymm0, -198(%rcx)
++	vmovups	-166(%rsi), %ymm0
++	vmovups	%ymm0, -166(%rcx)
++	vmovups	-134(%rsi), %ymm0
++	vmovups	%ymm0, -134(%rcx)
++.LBB0_200:
++	vmovups	-102(%rsi), %ymm0
++	vmovups	%ymm0, -102(%rcx)
++	vmovups	-70(%rsi), %ymm0
++	vmovups	%ymm0, -70(%rcx)
++	jmp	.LBB0_257
++.LBB0_201:
++	vmovups	-231(%rsi), %ymm0
++	vmovups	%ymm0, -231(%rcx)
++	vmovups	-199(%rsi), %ymm0
++	vmovups	%ymm0, -199(%rcx)
++	vmovups	-167(%rsi), %ymm0
++	vmovups	%ymm0, -167(%rcx)
++	vmovups	-135(%rsi), %ymm0
++	vmovups	%ymm0, -135(%rcx)
++.LBB0_202:
++	vmovups	-103(%rsi), %ymm0
++	vmovups	%ymm0, -103(%rcx)
++	vmovups	-71(%rsi), %ymm0
++	vmovups	%ymm0, -71(%rcx)
++	jmp	.LBB0_257
++.LBB0_203:
++	vmovups	-232(%rsi), %ymm0
++	vmovups	%ymm0, -232(%rcx)
++	vmovups	-200(%rsi), %ymm0
++	vmovups	%ymm0, -200(%rcx)
++	vmovups	-168(%rsi), %ymm0
++	vmovups	%ymm0, -168(%rcx)
++	vmovups	-136(%rsi), %ymm0
++	vmovups	%ymm0, -136(%rcx)
++.LBB0_204:
++	vmovups	-104(%rsi), %ymm0
++	vmovups	%ymm0, -104(%rcx)
++	vmovups	-72(%rsi), %ymm0
++	vmovups	%ymm0, -72(%rcx)
++	jmp	.LBB0_257
++.LBB0_205:
++	vmovups	-233(%rsi), %ymm0
++	vmovups	%ymm0, -233(%rcx)
++	vmovups	-201(%rsi), %ymm0
++	vmovups	%ymm0, -201(%rcx)
++	vmovups	-169(%rsi), %ymm0
++	vmovups	%ymm0, -169(%rcx)
++	vmovups	-137(%rsi), %ymm0
++	vmovups	%ymm0, -137(%rcx)
++.LBB0_206:
++	vmovups	-105(%rsi), %ymm0
++	vmovups	%ymm0, -105(%rcx)
++	vmovups	-73(%rsi), %ymm0
++	vmovups	%ymm0, -73(%rcx)
++	jmp	.LBB0_257
++.LBB0_207:
++	vmovups	-234(%rsi), %ymm0
++	vmovups	%ymm0, -234(%rcx)
++	vmovups	-202(%rsi), %ymm0
++	vmovups	%ymm0, -202(%rcx)
++	vmovups	-170(%rsi), %ymm0
++	vmovups	%ymm0, -170(%rcx)
++	vmovups	-138(%rsi), %ymm0
++	vmovups	%ymm0, -138(%rcx)
++.LBB0_208:
++	vmovups	-106(%rsi), %ymm0
++	vmovups	%ymm0, -106(%rcx)
++	vmovups	-74(%rsi), %ymm0
++	vmovups	%ymm0, -74(%rcx)
++	jmp	.LBB0_257
++.LBB0_209:
++	vmovups	-235(%rsi), %ymm0
++	vmovups	%ymm0, -235(%rcx)
++	vmovups	-203(%rsi), %ymm0
++	vmovups	%ymm0, -203(%rcx)
++	vmovups	-171(%rsi), %ymm0
++	vmovups	%ymm0, -171(%rcx)
++	vmovups	-139(%rsi), %ymm0
++	vmovups	%ymm0, -139(%rcx)
++.LBB0_210:
++	vmovups	-107(%rsi), %ymm0
++	vmovups	%ymm0, -107(%rcx)
++	vmovups	-75(%rsi), %ymm0
++	vmovups	%ymm0, -75(%rcx)
++	jmp	.LBB0_257
++.LBB0_211:
++	vmovups	-236(%rsi), %ymm0
++	vmovups	%ymm0, -236(%rcx)
++	vmovups	-204(%rsi), %ymm0
++	vmovups	%ymm0, -204(%rcx)
++	vmovups	-172(%rsi), %ymm0
++	vmovups	%ymm0, -172(%rcx)
++	vmovups	-140(%rsi), %ymm0
++	vmovups	%ymm0, -140(%rcx)
++.LBB0_212:
++	vmovups	-108(%rsi), %ymm0
++	vmovups	%ymm0, -108(%rcx)
++	vmovups	-76(%rsi), %ymm0
++	vmovups	%ymm0, -76(%rcx)
++	jmp	.LBB0_257
++.LBB0_213:
++	vmovups	-237(%rsi), %ymm0
++	vmovups	%ymm0, -237(%rcx)
++	vmovups	-205(%rsi), %ymm0
++	vmovups	%ymm0, -205(%rcx)
++	vmovups	-173(%rsi), %ymm0
++	vmovups	%ymm0, -173(%rcx)
++	vmovups	-141(%rsi), %ymm0
++	vmovups	%ymm0, -141(%rcx)
++.LBB0_214:
++	vmovups	-109(%rsi), %ymm0
++	vmovups	%ymm0, -109(%rcx)
++	vmovups	-77(%rsi), %ymm0
++	vmovups	%ymm0, -77(%rcx)
++	jmp	.LBB0_257
++.LBB0_215:
++	vmovups	-238(%rsi), %ymm0
++	vmovups	%ymm0, -238(%rcx)
++	vmovups	-206(%rsi), %ymm0
++	vmovups	%ymm0, -206(%rcx)
++	vmovups	-174(%rsi), %ymm0
++	vmovups	%ymm0, -174(%rcx)
++	vmovups	-142(%rsi), %ymm0
++	vmovups	%ymm0, -142(%rcx)
++.LBB0_216:
++	vmovups	-110(%rsi), %ymm0
++	vmovups	%ymm0, -110(%rcx)
++	vmovups	-78(%rsi), %ymm0
++	vmovups	%ymm0, -78(%rcx)
++	jmp	.LBB0_257
++.LBB0_217:
++	vmovups	-239(%rsi), %ymm0
++	vmovups	%ymm0, -239(%rcx)
++	vmovups	-207(%rsi), %ymm0
++	vmovups	%ymm0, -207(%rcx)
++	vmovups	-175(%rsi), %ymm0
++	vmovups	%ymm0, -175(%rcx)
++	vmovups	-143(%rsi), %ymm0
++	vmovups	%ymm0, -143(%rcx)
++.LBB0_218:
++	vmovups	-111(%rsi), %ymm0
++	vmovups	%ymm0, -111(%rcx)
++	vmovups	-79(%rsi), %ymm0
++	vmovups	%ymm0, -79(%rcx)
++	jmp	.LBB0_257
++.LBB0_219:
++	vmovups	-240(%rsi), %ymm0
++	vmovups	%ymm0, -240(%rcx)
++	vmovups	-208(%rsi), %ymm0
++	vmovups	%ymm0, -208(%rcx)
++	vmovups	-176(%rsi), %ymm0
++	vmovups	%ymm0, -176(%rcx)
++	vmovups	-144(%rsi), %ymm0
++	vmovups	%ymm0, -144(%rcx)
++.LBB0_220:
++	vmovups	-112(%rsi), %ymm0
++	vmovups	%ymm0, -112(%rcx)
++	vmovups	-80(%rsi), %ymm0
++	vmovups	%ymm0, -80(%rcx)
++	jmp	.LBB0_257
++.LBB0_221:
++	vmovups	-241(%rsi), %ymm0
++	vmovups	%ymm0, -241(%rcx)
++	vmovups	-209(%rsi), %ymm0
++	vmovups	%ymm0, -209(%rcx)
++	vmovups	-177(%rsi), %ymm0
++	vmovups	%ymm0, -177(%rcx)
++	vmovups	-145(%rsi), %ymm0
++	vmovups	%ymm0, -145(%rcx)
++.LBB0_222:
++	vmovups	-113(%rsi), %ymm0
++	vmovups	%ymm0, -113(%rcx)
++	vmovups	-81(%rsi), %ymm0
++	vmovups	%ymm0, -81(%rcx)
++	jmp	.LBB0_257
++.LBB0_223:
++	vmovups	-242(%rsi), %ymm0
++	vmovups	%ymm0, -242(%rcx)
++	vmovups	-210(%rsi), %ymm0
++	vmovups	%ymm0, -210(%rcx)
++	vmovups	-178(%rsi), %ymm0
++	vmovups	%ymm0, -178(%rcx)
++	vmovups	-146(%rsi), %ymm0
++	vmovups	%ymm0, -146(%rcx)
++.LBB0_224:
++	vmovups	-114(%rsi), %ymm0
++	vmovups	%ymm0, -114(%rcx)
++	vmovups	-82(%rsi), %ymm0
++	vmovups	%ymm0, -82(%rcx)
++	jmp	.LBB0_257
++.LBB0_225:
++	vmovups	-243(%rsi), %ymm0
++	vmovups	%ymm0, -243(%rcx)
++	vmovups	-211(%rsi), %ymm0
++	vmovups	%ymm0, -211(%rcx)
++	vmovups	-179(%rsi), %ymm0
++	vmovups	%ymm0, -179(%rcx)
++	vmovups	-147(%rsi), %ymm0
++	vmovups	%ymm0, -147(%rcx)
++.LBB0_226:
++	vmovups	-115(%rsi), %ymm0
++	vmovups	%ymm0, -115(%rcx)
++	vmovups	-83(%rsi), %ymm0
++	vmovups	%ymm0, -83(%rcx)
++	jmp	.LBB0_257
++.LBB0_227:
++	vmovups	-244(%rsi), %ymm0
++	vmovups	%ymm0, -244(%rcx)
++	vmovups	-212(%rsi), %ymm0
++	vmovups	%ymm0, -212(%rcx)
++	vmovups	-180(%rsi), %ymm0
++	vmovups	%ymm0, -180(%rcx)
++	vmovups	-148(%rsi), %ymm0
++	vmovups	%ymm0, -148(%rcx)
++.LBB0_228:
++	vmovups	-116(%rsi), %ymm0
++	vmovups	%ymm0, -116(%rcx)
++	vmovups	-84(%rsi), %ymm0
++	vmovups	%ymm0, -84(%rcx)
++	jmp	.LBB0_257
++.LBB0_229:
++	vmovups	-245(%rsi), %ymm0
++	vmovups	%ymm0, -245(%rcx)
++	vmovups	-213(%rsi), %ymm0
++	vmovups	%ymm0, -213(%rcx)
++	vmovups	-181(%rsi), %ymm0
++	vmovups	%ymm0, -181(%rcx)
++	vmovups	-149(%rsi), %ymm0
++	vmovups	%ymm0, -149(%rcx)
++.LBB0_230:
++	vmovups	-117(%rsi), %ymm0
++	vmovups	%ymm0, -117(%rcx)
++	vmovups	-85(%rsi), %ymm0
++	vmovups	%ymm0, -85(%rcx)
++	jmp	.LBB0_257
++.LBB0_231:
++	vmovups	-246(%rsi), %ymm0
++	vmovups	%ymm0, -246(%rcx)
++	vmovups	-214(%rsi), %ymm0
++	vmovups	%ymm0, -214(%rcx)
++	vmovups	-182(%rsi), %ymm0
++	vmovups	%ymm0, -182(%rcx)
++	vmovups	-150(%rsi), %ymm0
++	vmovups	%ymm0, -150(%rcx)
++.LBB0_232:
++	vmovups	-118(%rsi), %ymm0
++	vmovups	%ymm0, -118(%rcx)
++	vmovups	-86(%rsi), %ymm0
++	vmovups	%ymm0, -86(%rcx)
++	jmp	.LBB0_257
++.LBB0_233:
++	vmovups	-247(%rsi), %ymm0
++	vmovups	%ymm0, -247(%rcx)
++	vmovups	-215(%rsi), %ymm0
++	vmovups	%ymm0, -215(%rcx)
++	vmovups	-183(%rsi), %ymm0
++	vmovups	%ymm0, -183(%rcx)
++	vmovups	-151(%rsi), %ymm0
++	vmovups	%ymm0, -151(%rcx)
++.LBB0_234:
++	vmovups	-119(%rsi), %ymm0
++	vmovups	%ymm0, -119(%rcx)
++	vmovups	-87(%rsi), %ymm0
++	vmovups	%ymm0, -87(%rcx)
++	jmp	.LBB0_257
++.LBB0_235:
++	vmovups	-248(%rsi), %ymm0
++	vmovups	%ymm0, -248(%rcx)
++	vmovups	-216(%rsi), %ymm0
++	vmovups	%ymm0, -216(%rcx)
++	vmovups	-184(%rsi), %ymm0
++	vmovups	%ymm0, -184(%rcx)
++	vmovups	-152(%rsi), %ymm0
++	vmovups	%ymm0, -152(%rcx)
++.LBB0_236:
++	vmovups	-120(%rsi), %ymm0
++	vmovups	%ymm0, -120(%rcx)
++	vmovups	-88(%rsi), %ymm0
++	vmovups	%ymm0, -88(%rcx)
++	jmp	.LBB0_257
++.LBB0_237:
++	vmovups	-249(%rsi), %ymm0
++	vmovups	%ymm0, -249(%rcx)
++	vmovups	-217(%rsi), %ymm0
++	vmovups	%ymm0, -217(%rcx)
++	vmovups	-185(%rsi), %ymm0
++	vmovups	%ymm0, -185(%rcx)
++	vmovups	-153(%rsi), %ymm0
++	vmovups	%ymm0, -153(%rcx)
++.LBB0_238:
++	vmovups	-121(%rsi), %ymm0
++	vmovups	%ymm0, -121(%rcx)
++	vmovups	-89(%rsi), %ymm0
++	vmovups	%ymm0, -89(%rcx)
++	jmp	.LBB0_257
++.LBB0_239:
++	vmovups	-250(%rsi), %ymm0
++	vmovups	%ymm0, -250(%rcx)
++	vmovups	-218(%rsi), %ymm0
++	vmovups	%ymm0, -218(%rcx)
++	vmovups	-186(%rsi), %ymm0
++	vmovups	%ymm0, -186(%rcx)
++	vmovups	-154(%rsi), %ymm0
++	vmovups	%ymm0, -154(%rcx)
++.LBB0_240:
++	vmovups	-122(%rsi), %ymm0
++	vmovups	%ymm0, -122(%rcx)
++	vmovups	-90(%rsi), %ymm0
++	vmovups	%ymm0, -90(%rcx)
++	jmp	.LBB0_257
++.LBB0_241:
++	vmovups	-251(%rsi), %ymm0
++	vmovups	%ymm0, -251(%rcx)
++	vmovups	-219(%rsi), %ymm0
++	vmovups	%ymm0, -219(%rcx)
++	vmovups	-187(%rsi), %ymm0
++	vmovups	%ymm0, -187(%rcx)
++	vmovups	-155(%rsi), %ymm0
++	vmovups	%ymm0, -155(%rcx)
++.LBB0_242:
++	vmovups	-123(%rsi), %ymm0
++	vmovups	%ymm0, -123(%rcx)
++	vmovups	-91(%rsi), %ymm0
++	vmovups	%ymm0, -91(%rcx)
++	jmp	.LBB0_257
++.LBB0_243:
++	vmovups	-252(%rsi), %ymm0
++	vmovups	%ymm0, -252(%rcx)
++	vmovups	-220(%rsi), %ymm0
++	vmovups	%ymm0, -220(%rcx)
++	vmovups	-188(%rsi), %ymm0
++	vmovups	%ymm0, -188(%rcx)
++	vmovups	-156(%rsi), %ymm0
++	vmovups	%ymm0, -156(%rcx)
++.LBB0_244:
++	vmovups	-124(%rsi), %ymm0
++	vmovups	%ymm0, -124(%rcx)
++	vmovups	-92(%rsi), %ymm0
++	vmovups	%ymm0, -92(%rcx)
++	jmp	.LBB0_257
++.LBB0_245:
++	vmovups	-253(%rsi), %ymm0
++	vmovups	%ymm0, -253(%rcx)
++	vmovups	-221(%rsi), %ymm0
++	vmovups	%ymm0, -221(%rcx)
++	vmovups	-189(%rsi), %ymm0
++	vmovups	%ymm0, -189(%rcx)
++	vmovups	-157(%rsi), %ymm0
++	vmovups	%ymm0, -157(%rcx)
++.LBB0_246:
++	vmovups	-125(%rsi), %ymm0
++	vmovups	%ymm0, -125(%rcx)
++	vmovups	-93(%rsi), %ymm0
++	vmovups	%ymm0, -93(%rcx)
++	jmp	.LBB0_257
++.LBB0_247:
++	vmovups	-254(%rsi), %ymm0
++	vmovups	%ymm0, -254(%rcx)
++	vmovups	-222(%rsi), %ymm0
++	vmovups	%ymm0, -222(%rcx)
++	vmovups	-190(%rsi), %ymm0
++	vmovups	%ymm0, -190(%rcx)
++	vmovups	-158(%rsi), %ymm0
++	vmovups	%ymm0, -158(%rcx)
++.LBB0_248:
++	vmovups	-126(%rsi), %ymm0
++	vmovups	%ymm0, -126(%rcx)
++	vmovups	-94(%rsi), %ymm0
++	vmovups	%ymm0, -94(%rcx)
++	jmp	.LBB0_257
++.LBB0_249:
++	vmovups	-255(%rsi), %ymm0
++	vmovups	%ymm0, -255(%rcx)
++	vmovups	-223(%rsi), %ymm0
++	vmovups	%ymm0, -223(%rcx)
++	vmovups	-191(%rsi), %ymm0
++	vmovups	%ymm0, -191(%rcx)
++	vmovups	-159(%rsi), %ymm0
++	vmovups	%ymm0, -159(%rcx)
++.LBB0_250:
++	vmovups	-127(%rsi), %ymm0
++	vmovups	%ymm0, -127(%rcx)
++	vmovups	-95(%rsi), %ymm0
++	vmovups	%ymm0, -95(%rcx)
++	jmp	.LBB0_257
++.LBB0_251:
++	vmovups	-256(%rsi), %ymm0
++	vmovups	%ymm0, -256(%rcx)
++.LBB0_252:
++	vmovups	-224(%rsi), %ymm0
++	vmovups	%ymm0, -224(%rcx)
++.LBB0_253:
++	vmovups	-192(%rsi), %ymm0
++	vmovups	%ymm0, -192(%rcx)
++.LBB0_254:
++	vmovups	-160(%rsi), %ymm0
++	vmovups	%ymm0, -160(%rcx)
++.LBB0_255:
++	vmovups	-128(%rsi), %ymm0
++	vmovups	%ymm0, -128(%rcx)
++.LBB0_256:
++	vmovups	-96(%rsi), %ymm0
++	vmovups	%ymm0, -96(%rcx)
++.LBB0_257:
++	vmovups	-64(%rsi), %ymm0
++	vmovups	%ymm0, -64(%rcx)
++.LBB0_258:
++	vmovups	-32(%rsi), %ymm0
++	vmovups	%ymm0, -32(%rcx)
++	vzeroupper
++	retq
++.LBB0_284:
++	vmovups	-133(%rsi), %ymm0
++	vmovups	%ymm0, -133(%r8)
++	vmovups	-101(%rsi), %ymm0
++	vmovups	%ymm0, -101(%r8)
++	vmovups	-69(%rsi), %ymm0
++	vmovups	%ymm0, -69(%r8)
++	vmovups	-37(%rsi), %ymm0
++	vmovups	%ymm0, -37(%r8)
++.LBB0_285:
++	movl	-5(%rsi), %ecx
++	movl	%ecx, -5(%r8)
++	movb	-1(%rsi), %cl
++	movb	%cl, -1(%r8)
++	vzeroupper
++	retq
++.LBB0_286:
++	vmovups	-134(%rsi), %ymm0
++	vmovups	%ymm0, -134(%r8)
++	vmovups	-102(%rsi), %ymm0
++	vmovups	%ymm0, -102(%r8)
++	vmovups	-70(%rsi), %ymm0
++	vmovups	%ymm0, -70(%r8)
++	vmovups	-38(%rsi), %ymm0
++	vmovups	%ymm0, -38(%r8)
++.LBB0_287:
++	movl	-6(%rsi), %ecx
++	movl	%ecx, -6(%r8)
++	movzwl	-2(%rsi), %ecx
++	movw	%cx, -2(%r8)
++	vzeroupper
++	retq
++.LBB0_288:
++	vmovups	-135(%rsi), %ymm0
++	vmovups	%ymm0, -135(%r8)
++	vmovups	-103(%rsi), %ymm0
++	vmovups	%ymm0, -103(%r8)
++	vmovups	-71(%rsi), %ymm0
++	vmovups	%ymm0, -71(%r8)
++	vmovups	-39(%rsi), %ymm0
++	vmovups	%ymm0, -39(%r8)
++.LBB0_289:
++	movl	-7(%rsi), %ecx
++	movl	%ecx, -7(%r8)
++	movl	-4(%rsi), %ecx
++	movl	%ecx, -4(%r8)
++	vzeroupper
++	retq
++.LBB0_294:
++	vmovups	-137(%rsi), %ymm0
++	vmovups	%ymm0, -137(%r8)
++	vmovups	-105(%rsi), %ymm0
++	vmovups	%ymm0, -105(%r8)
++	vmovups	-73(%rsi), %ymm0
++	vmovups	%ymm0, -73(%r8)
++	vmovups	-41(%rsi), %ymm0
++	vmovups	%ymm0, -41(%r8)
++.LBB0_295:
++	movq	-9(%rsi), %rcx
++	movq	%rcx, -9(%r8)
++	movb	-1(%rsi), %cl
++	movb	%cl, -1(%r8)
++	vzeroupper
++	retq
++.LBB0_296:
++	vmovups	-138(%rsi), %ymm0
++	vmovups	%ymm0, -138(%r8)
++	vmovups	-106(%rsi), %ymm0
++	vmovups	%ymm0, -106(%r8)
++	vmovups	-74(%rsi), %ymm0
++	vmovups	%ymm0, -74(%r8)
++	vmovups	-42(%rsi), %ymm0
++	vmovups	%ymm0, -42(%r8)
++.LBB0_297:
++	movq	-10(%rsi), %rcx
++	movq	%rcx, -10(%r8)
++	movzwl	-2(%rsi), %ecx
++	movw	%cx, -2(%r8)
++	vzeroupper
++	retq
++.LBB0_298:
++	vmovups	-139(%rsi), %ymm0
++	vmovups	%ymm0, -139(%r8)
++	vmovups	-107(%rsi), %ymm0
++	vmovups	%ymm0, -107(%r8)
++	vmovups	-75(%rsi), %ymm0
++	vmovups	%ymm0, -75(%r8)
++	vmovups	-43(%rsi), %ymm0
++	vmovups	%ymm0, -43(%r8)
++.LBB0_299:
++	movq	-11(%rsi), %rcx
++	movq	%rcx, -11(%r8)
++	movl	-4(%rsi), %ecx
++	movl	%ecx, -4(%r8)
++	vzeroupper
++	retq
++.LBB0_300:
++	vmovups	-140(%rsi), %ymm0
++	vmovups	%ymm0, -140(%r8)
++	vmovups	-108(%rsi), %ymm0
++	vmovups	%ymm0, -108(%r8)
++	vmovups	-76(%rsi), %ymm0
++	vmovups	%ymm0, -76(%r8)
++	vmovups	-44(%rsi), %ymm0
++	vmovups	%ymm0, -44(%r8)
++.LBB0_301:
++	movq	-12(%rsi), %rcx
++	movq	%rcx, -12(%r8)
++	movl	-4(%rsi), %ecx
++	movl	%ecx, -4(%r8)
++	vzeroupper
++	retq
++.LBB0_302:
++	vmovups	-141(%rsi), %ymm0
++	vmovups	%ymm0, -141(%r8)
++	vmovups	-109(%rsi), %ymm0
++	vmovups	%ymm0, -109(%r8)
++	vmovups	-77(%rsi), %ymm0
++	vmovups	%ymm0, -77(%r8)
++	vmovups	-45(%rsi), %ymm0
++	vmovups	%ymm0, -45(%r8)
++.LBB0_303:
++	movq	-13(%rsi), %rcx
++	movq	%rcx, -13(%r8)
++	movq	-8(%rsi), %rcx
++	movq	%rcx, -8(%r8)
++	vzeroupper
++	retq
++.LBB0_304:
++	vmovups	-142(%rsi), %ymm0
++	vmovups	%ymm0, -142(%r8)
++	vmovups	-110(%rsi), %ymm0
++	vmovups	%ymm0, -110(%r8)
++	vmovups	-78(%rsi), %ymm0
++	vmovups	%ymm0, -78(%r8)
++	vmovups	-46(%rsi), %ymm0
++	vmovups	%ymm0, -46(%r8)
++.LBB0_305:
++	movq	-14(%rsi), %rcx
++	movq	%rcx, -14(%r8)
++	movq	-8(%rsi), %rcx
++	movq	%rcx, -8(%r8)
++	vzeroupper
++	retq
++.LBB0_306:
++	vmovups	-143(%rsi), %ymm0
++	vmovups	%ymm0, -143(%r8)
++	vmovups	-111(%rsi), %ymm0
++	vmovups	%ymm0, -111(%r8)
++	vmovups	-79(%rsi), %ymm0
++	vmovups	%ymm0, -79(%r8)
++	vmovups	-47(%rsi), %ymm0
++	vmovups	%ymm0, -47(%r8)
++.LBB0_307:
++	movq	-15(%rsi), %rcx
++	movq	%rcx, -15(%r8)
++	movq	-8(%rsi), %rcx
++	movq	%rcx, -8(%r8)
++	vzeroupper
++	retq
++.LBB0_312:
++	vmovups	-145(%rsi), %ymm0
++	vmovups	%ymm0, -145(%r8)
++	vmovups	-113(%rsi), %ymm0
++	vmovups	%ymm0, -113(%r8)
++	vmovups	-81(%rsi), %ymm0
++	vmovups	%ymm0, -81(%r8)
++	vmovups	-49(%rsi), %ymm0
++	vmovups	%ymm0, -49(%r8)
++.LBB0_313:
++	vmovups	-17(%rsi), %xmm0
++	vmovups	%xmm0, -17(%r8)
++	movb	-1(%rsi), %cl
++	movb	%cl, -1(%r8)
++	vzeroupper
++	retq
++.LBB0_314:
++	vmovups	-146(%rsi), %ymm0
++	vmovups	%ymm0, -146(%r8)
++	vmovups	-114(%rsi), %ymm0
++	vmovups	%ymm0, -114(%r8)
++	vmovups	-82(%rsi), %ymm0
++	vmovups	%ymm0, -82(%r8)
++	vmovups	-50(%rsi), %ymm0
++	vmovups	%ymm0, -50(%r8)
++.LBB0_315:
++	vmovups	-18(%rsi), %xmm0
++	vmovups	%xmm0, -18(%r8)
++	movzwl	-2(%rsi), %ecx
++	movw	%cx, -2(%r8)
++	vzeroupper
++	retq
++.LBB0_316:
++	vmovups	-147(%rsi), %ymm0
++	vmovups	%ymm0, -147(%r8)
++	vmovups	-115(%rsi), %ymm0
++	vmovups	%ymm0, -115(%r8)
++	vmovups	-83(%rsi), %ymm0
++	vmovups	%ymm0, -83(%r8)
++	vmovups	-51(%rsi), %ymm0
++	vmovups	%ymm0, -51(%r8)
++.LBB0_317:
++	vmovups	-19(%rsi), %xmm0
++	vmovups	%xmm0, -19(%r8)
++	movl	-4(%rsi), %ecx
++	movl	%ecx, -4(%r8)
++	vzeroupper
++	retq
++.LBB0_318:
++	vmovups	-148(%rsi), %ymm0
++	vmovups	%ymm0, -148(%r8)
++	vmovups	-116(%rsi), %ymm0
++	vmovups	%ymm0, -116(%r8)
++	vmovups	-84(%rsi), %ymm0
++	vmovups	%ymm0, -84(%r8)
++	vmovups	-52(%rsi), %ymm0
++	vmovups	%ymm0, -52(%r8)
++.LBB0_319:
++	vmovups	-20(%rsi), %xmm0
++	vmovups	%xmm0, -20(%r8)
++	movl	-4(%rsi), %ecx
++	movl	%ecx, -4(%r8)
++	vzeroupper
++	retq
++.LBB0_320:
++	vmovups	-149(%rsi), %ymm0
++	vmovups	%ymm0, -149(%r8)
++	vmovups	-117(%rsi), %ymm0
++	vmovups	%ymm0, -117(%r8)
++	vmovups	-85(%rsi), %ymm0
++	vmovups	%ymm0, -85(%r8)
++	vmovups	-53(%rsi), %ymm0
++	vmovups	%ymm0, -53(%r8)
++.LBB0_321:
++	vmovups	-21(%rsi), %xmm0
++	vmovups	%xmm0, -21(%r8)
++	movq	-8(%rsi), %rcx
++	movq	%rcx, -8(%r8)
++	vzeroupper
++	retq
++.LBB0_322:
++	vmovups	-150(%rsi), %ymm0
++	vmovups	%ymm0, -150(%r8)
++	vmovups	-118(%rsi), %ymm0
++	vmovups	%ymm0, -118(%r8)
++	vmovups	-86(%rsi), %ymm0
++	vmovups	%ymm0, -86(%r8)
++	vmovups	-54(%rsi), %ymm0
++	vmovups	%ymm0, -54(%r8)
++.LBB0_323:
++	vmovups	-22(%rsi), %xmm0
++	vmovups	%xmm0, -22(%r8)
++	movq	-8(%rsi), %rcx
++	movq	%rcx, -8(%r8)
++	vzeroupper
++	retq
++.LBB0_324:
++	vmovups	-151(%rsi), %ymm0
++	vmovups	%ymm0, -151(%r8)
++	vmovups	-119(%rsi), %ymm0
++	vmovups	%ymm0, -119(%r8)
++	vmovups	-87(%rsi), %ymm0
++	vmovups	%ymm0, -87(%r8)
++	vmovups	-55(%rsi), %ymm0
++	vmovups	%ymm0, -55(%r8)
++.LBB0_325:
++	vmovups	-23(%rsi), %xmm0
++	vmovups	%xmm0, -23(%r8)
++	movq	-8(%rsi), %rcx
++	movq	%rcx, -8(%r8)
++	vzeroupper
++	retq
++.LBB0_326:
++	vmovups	-152(%rsi), %ymm0
++	vmovups	%ymm0, -152(%r8)
++	vmovups	-120(%rsi), %ymm0
++	vmovups	%ymm0, -120(%r8)
++	vmovups	-88(%rsi), %ymm0
++	vmovups	%ymm0, -88(%r8)
++	vmovups	-56(%rsi), %ymm0
++	vmovups	%ymm0, -56(%r8)
++.LBB0_327:
++	vmovups	-24(%rsi), %xmm0
++	vmovups	%xmm0, -24(%r8)
++	movq	-8(%rsi), %rcx
++	movq	%rcx, -8(%r8)
++	vzeroupper
++	retq
++.LBB0_328:
++	vmovups	-153(%rsi), %ymm0
++	vmovups	%ymm0, -153(%r8)
++	vmovups	-121(%rsi), %ymm0
++	vmovups	%ymm0, -121(%r8)
++	vmovups	-89(%rsi), %ymm0
++	vmovups	%ymm0, -89(%r8)
++	vmovups	-57(%rsi), %ymm0
++	vmovups	%ymm0, -57(%r8)
++.LBB0_329:
++	vmovups	-25(%rsi), %xmm0
++	vmovups	%xmm0, -25(%r8)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%r8)
++	vzeroupper
++	retq
++.LBB0_330:
++	vmovups	-154(%rsi), %ymm0
++	vmovups	%ymm0, -154(%r8)
++	vmovups	-122(%rsi), %ymm0
++	vmovups	%ymm0, -122(%r8)
++	vmovups	-90(%rsi), %ymm0
++	vmovups	%ymm0, -90(%r8)
++	vmovups	-58(%rsi), %ymm0
++	vmovups	%ymm0, -58(%r8)
++.LBB0_331:
++	vmovups	-26(%rsi), %xmm0
++	vmovups	%xmm0, -26(%r8)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%r8)
++	vzeroupper
++	retq
++.LBB0_332:
++	vmovups	-155(%rsi), %ymm0
++	vmovups	%ymm0, -155(%r8)
++	vmovups	-123(%rsi), %ymm0
++	vmovups	%ymm0, -123(%r8)
++	vmovups	-91(%rsi), %ymm0
++	vmovups	%ymm0, -91(%r8)
++	vmovups	-59(%rsi), %ymm0
++	vmovups	%ymm0, -59(%r8)
++.LBB0_333:
++	vmovups	-27(%rsi), %xmm0
++	vmovups	%xmm0, -27(%r8)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%r8)
++	vzeroupper
++	retq
++.LBB0_334:
++	vmovups	-156(%rsi), %ymm0
++	vmovups	%ymm0, -156(%r8)
++	vmovups	-124(%rsi), %ymm0
++	vmovups	%ymm0, -124(%r8)
++	vmovups	-92(%rsi), %ymm0
++	vmovups	%ymm0, -92(%r8)
++	vmovups	-60(%rsi), %ymm0
++	vmovups	%ymm0, -60(%r8)
++.LBB0_335:
++	vmovups	-28(%rsi), %xmm0
++	vmovups	%xmm0, -28(%r8)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%r8)
++	vzeroupper
++	retq
++.LBB0_336:
++	vmovups	-157(%rsi), %ymm0
++	vmovups	%ymm0, -157(%r8)
++	vmovups	-125(%rsi), %ymm0
++	vmovups	%ymm0, -125(%r8)
++	vmovups	-93(%rsi), %ymm0
++	vmovups	%ymm0, -93(%r8)
++	vmovups	-61(%rsi), %ymm0
++	vmovups	%ymm0, -61(%r8)
++.LBB0_337:
++	vmovups	-29(%rsi), %xmm0
++	vmovups	%xmm0, -29(%r8)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%r8)
++	vzeroupper
++	retq
++.LBB0_338:
++	vmovups	-158(%rsi), %ymm0
++	vmovups	%ymm0, -158(%r8)
++	vmovups	-126(%rsi), %ymm0
++	vmovups	%ymm0, -126(%r8)
++	vmovups	-94(%rsi), %ymm0
++	vmovups	%ymm0, -94(%r8)
++	vmovups	-62(%rsi), %ymm0
++	vmovups	%ymm0, -62(%r8)
++.LBB0_339:
++	vmovups	-30(%rsi), %xmm0
++	vmovups	%xmm0, -30(%r8)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%r8)
++	vzeroupper
++	retq
++.LBB0_340:
++	vmovups	-159(%rsi), %ymm0
++	vmovups	%ymm0, -159(%r8)
++	vmovups	-127(%rsi), %ymm0
++	vmovups	%ymm0, -127(%r8)
++	vmovups	-95(%rsi), %ymm0
++	vmovups	%ymm0, -95(%r8)
++	vmovups	-63(%rsi), %ymm0
++	vmovups	%ymm0, -63(%r8)
++.LBB0_341:
++	vmovups	-31(%rsi), %xmm0
++	vmovups	%xmm0, -31(%r8)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%r8)
++	vzeroupper
++	retq
++.LBB0_342:
++	vmovups	-193(%rsi), %ymm0
++	vmovups	%ymm0, -193(%r8)
++.LBB0_343:
++	vmovups	-161(%rsi), %ymm0
++	vmovups	%ymm0, -161(%r8)
++.LBB0_270:
++	vmovups	-129(%rsi), %ymm0
++	vmovups	%ymm0, -129(%r8)
++	vmovups	-97(%rsi), %ymm0
++	vmovups	%ymm0, -97(%r8)
++.LBB0_271:
++	vmovups	-65(%rsi), %ymm0
++	vmovups	%ymm0, -65(%r8)
++.LBB0_272:
++	vmovups	-33(%rsi), %ymm0
++	vmovups	%ymm0, -33(%r8)
++.LBB0_273:
++	movb	-1(%rsi), %cl
++	movb	%cl, -1(%r8)
++	vzeroupper
++	retq
++.LBB0_344:
++	vmovups	-194(%rsi), %ymm0
++	vmovups	%ymm0, -194(%r8)
++.LBB0_345:
++	vmovups	-162(%rsi), %ymm0
++	vmovups	%ymm0, -162(%r8)
++.LBB0_274:
++	vmovups	-130(%rsi), %ymm0
++	vmovups	%ymm0, -130(%r8)
++	vmovups	-98(%rsi), %ymm0
++	vmovups	%ymm0, -98(%r8)
++.LBB0_275:
++	vmovups	-66(%rsi), %ymm0
++	vmovups	%ymm0, -66(%r8)
++.LBB0_276:
++	vmovups	-34(%rsi), %ymm0
++	vmovups	%ymm0, -34(%r8)
++.LBB0_277:
++	movzwl	-2(%rsi), %ecx
++	movw	%cx, -2(%r8)
++	vzeroupper
++	retq
++.LBB0_346:
++	vmovups	-195(%rsi), %ymm0
++	vmovups	%ymm0, -195(%r8)
++.LBB0_347:
++	vmovups	-163(%rsi), %ymm0
++	vmovups	%ymm0, -163(%r8)
++	vmovups	-131(%rsi), %ymm0
++	vmovups	%ymm0, -131(%r8)
++	vmovups	-99(%rsi), %ymm0
++	vmovups	%ymm0, -99(%r8)
++.LBB0_348:
++	vmovups	-67(%rsi), %ymm0
++	vmovups	%ymm0, -67(%r8)
++.LBB0_349:
++	vmovups	-35(%rsi), %ymm0
++	vmovups	%ymm0, -35(%r8)
++	movl	-4(%rsi), %ecx
++	movl	%ecx, -4(%r8)
++	vzeroupper
++	retq
++.LBB0_350:
++	vmovups	-196(%rsi), %ymm0
++	vmovups	%ymm0, -196(%r8)
++.LBB0_351:
++	vmovups	-164(%rsi), %ymm0
++	vmovups	%ymm0, -164(%r8)
++.LBB0_280:
++	vmovups	-132(%rsi), %ymm0
++	vmovups	%ymm0, -132(%r8)
++	vmovups	-100(%rsi), %ymm0
++	vmovups	%ymm0, -100(%r8)
++.LBB0_281:
++	vmovups	-68(%rsi), %ymm0
++	vmovups	%ymm0, -68(%r8)
++.LBB0_282:
++	vmovups	-36(%rsi), %ymm0
++	vmovups	%ymm0, -36(%r8)
++.LBB0_283:
++	movl	-4(%rsi), %ecx
++	movl	%ecx, -4(%r8)
++	vzeroupper
++	retq
++.LBB0_352:
++	vmovups	-197(%rsi), %ymm0
++	vmovups	%ymm0, -197(%r8)
++.LBB0_353:
++	vmovups	-165(%rsi), %ymm0
++	vmovups	%ymm0, -165(%r8)
++	vmovups	-133(%rsi), %ymm0
++	vmovups	%ymm0, -133(%r8)
++	vmovups	-101(%rsi), %ymm0
++	vmovups	%ymm0, -101(%r8)
++.LBB0_354:
++	vmovups	-69(%rsi), %ymm0
++	vmovups	%ymm0, -69(%r8)
++.LBB0_355:
++	vmovups	-37(%rsi), %ymm0
++	vmovups	%ymm0, -37(%r8)
++	movq	-8(%rsi), %rcx
++	movq	%rcx, -8(%r8)
++	vzeroupper
++	retq
++.LBB0_356:
++	vmovups	-198(%rsi), %ymm0
++	vmovups	%ymm0, -198(%r8)
++.LBB0_357:
++	vmovups	-166(%rsi), %ymm0
++	vmovups	%ymm0, -166(%r8)
++	vmovups	-134(%rsi), %ymm0
++	vmovups	%ymm0, -134(%r8)
++	vmovups	-102(%rsi), %ymm0
++	vmovups	%ymm0, -102(%r8)
++.LBB0_358:
++	vmovups	-70(%rsi), %ymm0
++	vmovups	%ymm0, -70(%r8)
++.LBB0_359:
++	vmovups	-38(%rsi), %ymm0
++	vmovups	%ymm0, -38(%r8)
++	movq	-8(%rsi), %rcx
++	movq	%rcx, -8(%r8)
++	vzeroupper
++	retq
++.LBB0_360:
++	vmovups	-199(%rsi), %ymm0
++	vmovups	%ymm0, -199(%r8)
++.LBB0_361:
++	vmovups	-167(%rsi), %ymm0
++	vmovups	%ymm0, -167(%r8)
++	vmovups	-135(%rsi), %ymm0
++	vmovups	%ymm0, -135(%r8)
++	vmovups	-103(%rsi), %ymm0
++	vmovups	%ymm0, -103(%r8)
++.LBB0_362:
++	vmovups	-71(%rsi), %ymm0
++	vmovups	%ymm0, -71(%r8)
++.LBB0_363:
++	vmovups	-39(%rsi), %ymm0
++	vmovups	%ymm0, -39(%r8)
++	movq	-8(%rsi), %rcx
++	movq	%rcx, -8(%r8)
++	vzeroupper
++	retq
++.LBB0_364:
++	vmovups	-200(%rsi), %ymm0
++	vmovups	%ymm0, -200(%r8)
++.LBB0_365:
++	vmovups	-168(%rsi), %ymm0
++	vmovups	%ymm0, -168(%r8)
++.LBB0_290:
++	vmovups	-136(%rsi), %ymm0
++	vmovups	%ymm0, -136(%r8)
++	vmovups	-104(%rsi), %ymm0
++	vmovups	%ymm0, -104(%r8)
++.LBB0_291:
++	vmovups	-72(%rsi), %ymm0
++	vmovups	%ymm0, -72(%r8)
++.LBB0_292:
++	vmovups	-40(%rsi), %ymm0
++	vmovups	%ymm0, -40(%r8)
++.LBB0_293:
++	movq	-8(%rsi), %rcx
++	movq	%rcx, -8(%r8)
++	vzeroupper
++	retq
++.LBB0_366:
++	vmovups	-201(%rsi), %ymm0
++	vmovups	%ymm0, -201(%r8)
++.LBB0_367:
++	vmovups	-169(%rsi), %ymm0
++	vmovups	%ymm0, -169(%r8)
++	vmovups	-137(%rsi), %ymm0
++	vmovups	%ymm0, -137(%r8)
++	vmovups	-105(%rsi), %ymm0
++	vmovups	%ymm0, -105(%r8)
++.LBB0_368:
++	vmovups	-73(%rsi), %ymm0
++	vmovups	%ymm0, -73(%r8)
++.LBB0_369:
++	vmovups	-41(%rsi), %ymm0
++	vmovups	%ymm0, -41(%r8)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%r8)
++	vzeroupper
++	retq
++.LBB0_370:
++	vmovups	-202(%rsi), %ymm0
++	vmovups	%ymm0, -202(%r8)
++.LBB0_371:
++	vmovups	-170(%rsi), %ymm0
++	vmovups	%ymm0, -170(%r8)
++	vmovups	-138(%rsi), %ymm0
++	vmovups	%ymm0, -138(%r8)
++	vmovups	-106(%rsi), %ymm0
++	vmovups	%ymm0, -106(%r8)
++.LBB0_372:
++	vmovups	-74(%rsi), %ymm0
++	vmovups	%ymm0, -74(%r8)
++.LBB0_373:
++	vmovups	-42(%rsi), %ymm0
++	vmovups	%ymm0, -42(%r8)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%r8)
++	vzeroupper
++	retq
++.LBB0_374:
++	vmovups	-203(%rsi), %ymm0
++	vmovups	%ymm0, -203(%r8)
++.LBB0_375:
++	vmovups	-171(%rsi), %ymm0
++	vmovups	%ymm0, -171(%r8)
++	vmovups	-139(%rsi), %ymm0
++	vmovups	%ymm0, -139(%r8)
++	vmovups	-107(%rsi), %ymm0
++	vmovups	%ymm0, -107(%r8)
++.LBB0_376:
++	vmovups	-75(%rsi), %ymm0
++	vmovups	%ymm0, -75(%r8)
++.LBB0_377:
++	vmovups	-43(%rsi), %ymm0
++	vmovups	%ymm0, -43(%r8)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%r8)
++	vzeroupper
++	retq
++.LBB0_378:
++	vmovups	-204(%rsi), %ymm0
++	vmovups	%ymm0, -204(%r8)
++.LBB0_379:
++	vmovups	-172(%rsi), %ymm0
++	vmovups	%ymm0, -172(%r8)
++	vmovups	-140(%rsi), %ymm0
++	vmovups	%ymm0, -140(%r8)
++	vmovups	-108(%rsi), %ymm0
++	vmovups	%ymm0, -108(%r8)
++.LBB0_380:
++	vmovups	-76(%rsi), %ymm0
++	vmovups	%ymm0, -76(%r8)
++.LBB0_381:
++	vmovups	-44(%rsi), %ymm0
++	vmovups	%ymm0, -44(%r8)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%r8)
++	vzeroupper
++	retq
++.LBB0_382:
++	vmovups	-205(%rsi), %ymm0
++	vmovups	%ymm0, -205(%r8)
++.LBB0_383:
++	vmovups	-173(%rsi), %ymm0
++	vmovups	%ymm0, -173(%r8)
++	vmovups	-141(%rsi), %ymm0
++	vmovups	%ymm0, -141(%r8)
++	vmovups	-109(%rsi), %ymm0
++	vmovups	%ymm0, -109(%r8)
++.LBB0_384:
++	vmovups	-77(%rsi), %ymm0
++	vmovups	%ymm0, -77(%r8)
++.LBB0_385:
++	vmovups	-45(%rsi), %ymm0
++	vmovups	%ymm0, -45(%r8)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%r8)
++	vzeroupper
++	retq
++.LBB0_386:
++	vmovups	-206(%rsi), %ymm0
++	vmovups	%ymm0, -206(%r8)
++.LBB0_387:
++	vmovups	-174(%rsi), %ymm0
++	vmovups	%ymm0, -174(%r8)
++	vmovups	-142(%rsi), %ymm0
++	vmovups	%ymm0, -142(%r8)
++	vmovups	-110(%rsi), %ymm0
++	vmovups	%ymm0, -110(%r8)
++.LBB0_388:
++	vmovups	-78(%rsi), %ymm0
++	vmovups	%ymm0, -78(%r8)
++.LBB0_389:
++	vmovups	-46(%rsi), %ymm0
++	vmovups	%ymm0, -46(%r8)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%r8)
++	vzeroupper
++	retq
++.LBB0_390:
++	vmovups	-207(%rsi), %ymm0
++	vmovups	%ymm0, -207(%r8)
++.LBB0_391:
++	vmovups	-175(%rsi), %ymm0
++	vmovups	%ymm0, -175(%r8)
++	vmovups	-143(%rsi), %ymm0
++	vmovups	%ymm0, -143(%r8)
++	vmovups	-111(%rsi), %ymm0
++	vmovups	%ymm0, -111(%r8)
++.LBB0_392:
++	vmovups	-79(%rsi), %ymm0
++	vmovups	%ymm0, -79(%r8)
++.LBB0_393:
++	vmovups	-47(%rsi), %ymm0
++	vmovups	%ymm0, -47(%r8)
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%r8)
++	vzeroupper
++	retq
++.LBB0_394:
++	vmovups	-208(%rsi), %ymm0
++	vmovups	%ymm0, -208(%r8)
++.LBB0_395:
++	vmovups	-176(%rsi), %ymm0
++	vmovups	%ymm0, -176(%r8)
++.LBB0_308:
++	vmovups	-144(%rsi), %ymm0
++	vmovups	%ymm0, -144(%r8)
++	vmovups	-112(%rsi), %ymm0
++	vmovups	%ymm0, -112(%r8)
++.LBB0_309:
++	vmovups	-80(%rsi), %ymm0
++	vmovups	%ymm0, -80(%r8)
++.LBB0_310:
++	vmovups	-48(%rsi), %ymm0
++	vmovups	%ymm0, -48(%r8)
++.LBB0_311:
++	vmovups	-16(%rsi), %xmm0
++	vmovups	%xmm0, -16(%r8)
++	vzeroupper
++	retq
++.LBB0_396:
++	vmovups	-209(%rsi), %ymm0
++	vmovups	%ymm0, -209(%r8)
++.LBB0_397:
++	vmovups	-177(%rsi), %ymm0
++	vmovups	%ymm0, -177(%r8)
++	vmovups	-145(%rsi), %ymm0
++	vmovups	%ymm0, -145(%r8)
++	vmovups	-113(%rsi), %ymm0
++	vmovups	%ymm0, -113(%r8)
++.LBB0_398:
++	vmovups	-81(%rsi), %ymm0
++	vmovups	%ymm0, -81(%r8)
++.LBB0_399:
++	vmovups	-49(%rsi), %ymm0
++	vmovups	%ymm0, -49(%r8)
++	jmp	.LBB0_525
++.LBB0_400:
++	vmovups	-210(%rsi), %ymm0
++	vmovups	%ymm0, -210(%r8)
++.LBB0_401:
++	vmovups	-178(%rsi), %ymm0
++	vmovups	%ymm0, -178(%r8)
++	vmovups	-146(%rsi), %ymm0
++	vmovups	%ymm0, -146(%r8)
++	vmovups	-114(%rsi), %ymm0
++	vmovups	%ymm0, -114(%r8)
++.LBB0_402:
++	vmovups	-82(%rsi), %ymm0
++	vmovups	%ymm0, -82(%r8)
++.LBB0_403:
++	vmovups	-50(%rsi), %ymm0
++	vmovups	%ymm0, -50(%r8)
++	jmp	.LBB0_525
++.LBB0_404:
++	vmovups	-211(%rsi), %ymm0
++	vmovups	%ymm0, -211(%r8)
++.LBB0_405:
++	vmovups	-179(%rsi), %ymm0
++	vmovups	%ymm0, -179(%r8)
++	vmovups	-147(%rsi), %ymm0
++	vmovups	%ymm0, -147(%r8)
++	vmovups	-115(%rsi), %ymm0
++	vmovups	%ymm0, -115(%r8)
++.LBB0_406:
++	vmovups	-83(%rsi), %ymm0
++	vmovups	%ymm0, -83(%r8)
++.LBB0_407:
++	vmovups	-51(%rsi), %ymm0
++	vmovups	%ymm0, -51(%r8)
++	jmp	.LBB0_525
++.LBB0_408:
++	vmovups	-212(%rsi), %ymm0
++	vmovups	%ymm0, -212(%r8)
++.LBB0_409:
++	vmovups	-180(%rsi), %ymm0
++	vmovups	%ymm0, -180(%r8)
++	vmovups	-148(%rsi), %ymm0
++	vmovups	%ymm0, -148(%r8)
++	vmovups	-116(%rsi), %ymm0
++	vmovups	%ymm0, -116(%r8)
++.LBB0_410:
++	vmovups	-84(%rsi), %ymm0
++	vmovups	%ymm0, -84(%r8)
++.LBB0_411:
++	vmovups	-52(%rsi), %ymm0
++	vmovups	%ymm0, -52(%r8)
++	jmp	.LBB0_525
++.LBB0_412:
++	vmovups	-213(%rsi), %ymm0
++	vmovups	%ymm0, -213(%r8)
++.LBB0_413:
++	vmovups	-181(%rsi), %ymm0
++	vmovups	%ymm0, -181(%r8)
++	vmovups	-149(%rsi), %ymm0
++	vmovups	%ymm0, -149(%r8)
++	vmovups	-117(%rsi), %ymm0
++	vmovups	%ymm0, -117(%r8)
++.LBB0_414:
++	vmovups	-85(%rsi), %ymm0
++	vmovups	%ymm0, -85(%r8)
++.LBB0_415:
++	vmovups	-53(%rsi), %ymm0
++	vmovups	%ymm0, -53(%r8)
++	jmp	.LBB0_525
++.LBB0_416:
++	vmovups	-214(%rsi), %ymm0
++	vmovups	%ymm0, -214(%r8)
++.LBB0_417:
++	vmovups	-182(%rsi), %ymm0
++	vmovups	%ymm0, -182(%r8)
++	vmovups	-150(%rsi), %ymm0
++	vmovups	%ymm0, -150(%r8)
++	vmovups	-118(%rsi), %ymm0
++	vmovups	%ymm0, -118(%r8)
++.LBB0_418:
++	vmovups	-86(%rsi), %ymm0
++	vmovups	%ymm0, -86(%r8)
++.LBB0_419:
++	vmovups	-54(%rsi), %ymm0
++	vmovups	%ymm0, -54(%r8)
++	jmp	.LBB0_525
++.LBB0_420:
++	vmovups	-215(%rsi), %ymm0
++	vmovups	%ymm0, -215(%r8)
++.LBB0_421:
++	vmovups	-183(%rsi), %ymm0
++	vmovups	%ymm0, -183(%r8)
++	vmovups	-151(%rsi), %ymm0
++	vmovups	%ymm0, -151(%r8)
++	vmovups	-119(%rsi), %ymm0
++	vmovups	%ymm0, -119(%r8)
++.LBB0_422:
++	vmovups	-87(%rsi), %ymm0
++	vmovups	%ymm0, -87(%r8)
++.LBB0_423:
++	vmovups	-55(%rsi), %ymm0
++	vmovups	%ymm0, -55(%r8)
++	jmp	.LBB0_525
++.LBB0_424:
++	vmovups	-216(%rsi), %ymm0
++	vmovups	%ymm0, -216(%r8)
++.LBB0_425:
++	vmovups	-184(%rsi), %ymm0
++	vmovups	%ymm0, -184(%r8)
++	vmovups	-152(%rsi), %ymm0
++	vmovups	%ymm0, -152(%r8)
++	vmovups	-120(%rsi), %ymm0
++	vmovups	%ymm0, -120(%r8)
++.LBB0_426:
++	vmovups	-88(%rsi), %ymm0
++	vmovups	%ymm0, -88(%r8)
++.LBB0_427:
++	vmovups	-56(%rsi), %ymm0
++	vmovups	%ymm0, -56(%r8)
++	jmp	.LBB0_525
++.LBB0_428:
++	vmovups	-217(%rsi), %ymm0
++	vmovups	%ymm0, -217(%r8)
++.LBB0_429:
++	vmovups	-185(%rsi), %ymm0
++	vmovups	%ymm0, -185(%r8)
++	vmovups	-153(%rsi), %ymm0
++	vmovups	%ymm0, -153(%r8)
++	vmovups	-121(%rsi), %ymm0
++	vmovups	%ymm0, -121(%r8)
++.LBB0_430:
++	vmovups	-89(%rsi), %ymm0
++	vmovups	%ymm0, -89(%r8)
++.LBB0_431:
++	vmovups	-57(%rsi), %ymm0
++	vmovups	%ymm0, -57(%r8)
++	jmp	.LBB0_525
++.LBB0_432:
++	vmovups	-218(%rsi), %ymm0
++	vmovups	%ymm0, -218(%r8)
++.LBB0_433:
++	vmovups	-186(%rsi), %ymm0
++	vmovups	%ymm0, -186(%r8)
++	vmovups	-154(%rsi), %ymm0
++	vmovups	%ymm0, -154(%r8)
++	vmovups	-122(%rsi), %ymm0
++	vmovups	%ymm0, -122(%r8)
++.LBB0_434:
++	vmovups	-90(%rsi), %ymm0
++	vmovups	%ymm0, -90(%r8)
++.LBB0_435:
++	vmovups	-58(%rsi), %ymm0
++	vmovups	%ymm0, -58(%r8)
++	jmp	.LBB0_525
++.LBB0_436:
++	vmovups	-219(%rsi), %ymm0
++	vmovups	%ymm0, -219(%r8)
++.LBB0_437:
++	vmovups	-187(%rsi), %ymm0
++	vmovups	%ymm0, -187(%r8)
++	vmovups	-155(%rsi), %ymm0
++	vmovups	%ymm0, -155(%r8)
++	vmovups	-123(%rsi), %ymm0
++	vmovups	%ymm0, -123(%r8)
++.LBB0_438:
++	vmovups	-91(%rsi), %ymm0
++	vmovups	%ymm0, -91(%r8)
++.LBB0_439:
++	vmovups	-59(%rsi), %ymm0
++	vmovups	%ymm0, -59(%r8)
++	jmp	.LBB0_525
++.LBB0_440:
++	vmovups	-220(%rsi), %ymm0
++	vmovups	%ymm0, -220(%r8)
++.LBB0_441:
++	vmovups	-188(%rsi), %ymm0
++	vmovups	%ymm0, -188(%r8)
++	vmovups	-156(%rsi), %ymm0
++	vmovups	%ymm0, -156(%r8)
++	vmovups	-124(%rsi), %ymm0
++	vmovups	%ymm0, -124(%r8)
++.LBB0_442:
++	vmovups	-92(%rsi), %ymm0
++	vmovups	%ymm0, -92(%r8)
++.LBB0_443:
++	vmovups	-60(%rsi), %ymm0
++	vmovups	%ymm0, -60(%r8)
++	jmp	.LBB0_525
++.LBB0_444:
++	vmovups	-221(%rsi), %ymm0
++	vmovups	%ymm0, -221(%r8)
++.LBB0_445:
++	vmovups	-189(%rsi), %ymm0
++	vmovups	%ymm0, -189(%r8)
++	vmovups	-157(%rsi), %ymm0
++	vmovups	%ymm0, -157(%r8)
++	vmovups	-125(%rsi), %ymm0
++	vmovups	%ymm0, -125(%r8)
++.LBB0_446:
++	vmovups	-93(%rsi), %ymm0
++	vmovups	%ymm0, -93(%r8)
++.LBB0_447:
++	vmovups	-61(%rsi), %ymm0
++	vmovups	%ymm0, -61(%r8)
++	jmp	.LBB0_525
++.LBB0_448:
++	vmovups	-222(%rsi), %ymm0
++	vmovups	%ymm0, -222(%r8)
++.LBB0_449:
++	vmovups	-190(%rsi), %ymm0
++	vmovups	%ymm0, -190(%r8)
++	vmovups	-158(%rsi), %ymm0
++	vmovups	%ymm0, -158(%r8)
++	vmovups	-126(%rsi), %ymm0
++	vmovups	%ymm0, -126(%r8)
++.LBB0_450:
++	vmovups	-94(%rsi), %ymm0
++	vmovups	%ymm0, -94(%r8)
++.LBB0_451:
++	vmovups	-62(%rsi), %ymm0
++	vmovups	%ymm0, -62(%r8)
++	jmp	.LBB0_525
++.LBB0_452:
++	vmovups	-223(%rsi), %ymm0
++	vmovups	%ymm0, -223(%r8)
++.LBB0_453:
++	vmovups	-191(%rsi), %ymm0
++	vmovups	%ymm0, -191(%r8)
++	vmovups	-159(%rsi), %ymm0
++	vmovups	%ymm0, -159(%r8)
++	vmovups	-127(%rsi), %ymm0
++	vmovups	%ymm0, -127(%r8)
++.LBB0_454:
++	vmovups	-95(%rsi), %ymm0
++	vmovups	%ymm0, -95(%r8)
++.LBB0_455:
++	vmovups	-63(%rsi), %ymm0
++	vmovups	%ymm0, -63(%r8)
++	jmp	.LBB0_525
++.LBB0_456:
++	vmovups	-225(%rsi), %ymm0
++	vmovups	%ymm0, -225(%r8)
++	vmovups	-193(%rsi), %ymm0
++	vmovups	%ymm0, -193(%r8)
++	vmovups	-161(%rsi), %ymm0
++	vmovups	%ymm0, -161(%r8)
++	vmovups	-129(%rsi), %ymm0
++	vmovups	%ymm0, -129(%r8)
++.LBB0_457:
++	vmovups	-97(%rsi), %ymm0
++	vmovups	%ymm0, -97(%r8)
++	vmovups	-65(%rsi), %ymm0
++	vmovups	%ymm0, -65(%r8)
++	jmp	.LBB0_524
++.LBB0_458:
++	vmovups	-226(%rsi), %ymm0
++	vmovups	%ymm0, -226(%r8)
++	vmovups	-194(%rsi), %ymm0
++	vmovups	%ymm0, -194(%r8)
++	vmovups	-162(%rsi), %ymm0
++	vmovups	%ymm0, -162(%r8)
++	vmovups	-130(%rsi), %ymm0
++	vmovups	%ymm0, -130(%r8)
++.LBB0_459:
++	vmovups	-98(%rsi), %ymm0
++	vmovups	%ymm0, -98(%r8)
++	vmovups	-66(%rsi), %ymm0
++	vmovups	%ymm0, -66(%r8)
++	jmp	.LBB0_524
++.LBB0_460:
++	vmovups	-227(%rsi), %ymm0
++	vmovups	%ymm0, -227(%r8)
++	vmovups	-195(%rsi), %ymm0
++	vmovups	%ymm0, -195(%r8)
++	vmovups	-163(%rsi), %ymm0
++	vmovups	%ymm0, -163(%r8)
++	vmovups	-131(%rsi), %ymm0
++	vmovups	%ymm0, -131(%r8)
++.LBB0_461:
++	vmovups	-99(%rsi), %ymm0
++	vmovups	%ymm0, -99(%r8)
++	vmovups	-67(%rsi), %ymm0
++	vmovups	%ymm0, -67(%r8)
++	jmp	.LBB0_524
++.LBB0_462:
++	vmovups	-228(%rsi), %ymm0
++	vmovups	%ymm0, -228(%r8)
++	vmovups	-196(%rsi), %ymm0
++	vmovups	%ymm0, -196(%r8)
++	vmovups	-164(%rsi), %ymm0
++	vmovups	%ymm0, -164(%r8)
++	vmovups	-132(%rsi), %ymm0
++	vmovups	%ymm0, -132(%r8)
++.LBB0_463:
++	vmovups	-100(%rsi), %ymm0
++	vmovups	%ymm0, -100(%r8)
++	vmovups	-68(%rsi), %ymm0
++	vmovups	%ymm0, -68(%r8)
++	jmp	.LBB0_524
++.LBB0_464:
++	vmovups	-229(%rsi), %ymm0
++	vmovups	%ymm0, -229(%r8)
++	vmovups	-197(%rsi), %ymm0
++	vmovups	%ymm0, -197(%r8)
++	vmovups	-165(%rsi), %ymm0
++	vmovups	%ymm0, -165(%r8)
++	vmovups	-133(%rsi), %ymm0
++	vmovups	%ymm0, -133(%r8)
++.LBB0_465:
++	vmovups	-101(%rsi), %ymm0
++	vmovups	%ymm0, -101(%r8)
++	vmovups	-69(%rsi), %ymm0
++	vmovups	%ymm0, -69(%r8)
++	jmp	.LBB0_524
++.LBB0_466:
++	vmovups	-230(%rsi), %ymm0
++	vmovups	%ymm0, -230(%r8)
++	vmovups	-198(%rsi), %ymm0
++	vmovups	%ymm0, -198(%r8)
++	vmovups	-166(%rsi), %ymm0
++	vmovups	%ymm0, -166(%r8)
++	vmovups	-134(%rsi), %ymm0
++	vmovups	%ymm0, -134(%r8)
++.LBB0_467:
++	vmovups	-102(%rsi), %ymm0
++	vmovups	%ymm0, -102(%r8)
++	vmovups	-70(%rsi), %ymm0
++	vmovups	%ymm0, -70(%r8)
++	jmp	.LBB0_524
++.LBB0_468:
++	vmovups	-231(%rsi), %ymm0
++	vmovups	%ymm0, -231(%r8)
++	vmovups	-199(%rsi), %ymm0
++	vmovups	%ymm0, -199(%r8)
++	vmovups	-167(%rsi), %ymm0
++	vmovups	%ymm0, -167(%r8)
++	vmovups	-135(%rsi), %ymm0
++	vmovups	%ymm0, -135(%r8)
++.LBB0_469:
++	vmovups	-103(%rsi), %ymm0
++	vmovups	%ymm0, -103(%r8)
++	vmovups	-71(%rsi), %ymm0
++	vmovups	%ymm0, -71(%r8)
++	jmp	.LBB0_524
++.LBB0_470:
++	vmovups	-232(%rsi), %ymm0
++	vmovups	%ymm0, -232(%r8)
++	vmovups	-200(%rsi), %ymm0
++	vmovups	%ymm0, -200(%r8)
++	vmovups	-168(%rsi), %ymm0
++	vmovups	%ymm0, -168(%r8)
++	vmovups	-136(%rsi), %ymm0
++	vmovups	%ymm0, -136(%r8)
++.LBB0_471:
++	vmovups	-104(%rsi), %ymm0
++	vmovups	%ymm0, -104(%r8)
++	vmovups	-72(%rsi), %ymm0
++	vmovups	%ymm0, -72(%r8)
++	jmp	.LBB0_524
++.LBB0_472:
++	vmovups	-233(%rsi), %ymm0
++	vmovups	%ymm0, -233(%r8)
++	vmovups	-201(%rsi), %ymm0
++	vmovups	%ymm0, -201(%r8)
++	vmovups	-169(%rsi), %ymm0
++	vmovups	%ymm0, -169(%r8)
++	vmovups	-137(%rsi), %ymm0
++	vmovups	%ymm0, -137(%r8)
++.LBB0_473:
++	vmovups	-105(%rsi), %ymm0
++	vmovups	%ymm0, -105(%r8)
++	vmovups	-73(%rsi), %ymm0
++	vmovups	%ymm0, -73(%r8)
++	jmp	.LBB0_524
++.LBB0_474:
++	vmovups	-234(%rsi), %ymm0
++	vmovups	%ymm0, -234(%r8)
++	vmovups	-202(%rsi), %ymm0
++	vmovups	%ymm0, -202(%r8)
++	vmovups	-170(%rsi), %ymm0
++	vmovups	%ymm0, -170(%r8)
++	vmovups	-138(%rsi), %ymm0
++	vmovups	%ymm0, -138(%r8)
++.LBB0_475:
++	vmovups	-106(%rsi), %ymm0
++	vmovups	%ymm0, -106(%r8)
++	vmovups	-74(%rsi), %ymm0
++	vmovups	%ymm0, -74(%r8)
++	jmp	.LBB0_524
++.LBB0_476:
++	vmovups	-235(%rsi), %ymm0
++	vmovups	%ymm0, -235(%r8)
++	vmovups	-203(%rsi), %ymm0
++	vmovups	%ymm0, -203(%r8)
++	vmovups	-171(%rsi), %ymm0
++	vmovups	%ymm0, -171(%r8)
++	vmovups	-139(%rsi), %ymm0
++	vmovups	%ymm0, -139(%r8)
++.LBB0_477:
++	vmovups	-107(%rsi), %ymm0
++	vmovups	%ymm0, -107(%r8)
++	vmovups	-75(%rsi), %ymm0
++	vmovups	%ymm0, -75(%r8)
++	jmp	.LBB0_524
++.LBB0_478:
++	vmovups	-236(%rsi), %ymm0
++	vmovups	%ymm0, -236(%r8)
++	vmovups	-204(%rsi), %ymm0
++	vmovups	%ymm0, -204(%r8)
++	vmovups	-172(%rsi), %ymm0
++	vmovups	%ymm0, -172(%r8)
++	vmovups	-140(%rsi), %ymm0
++	vmovups	%ymm0, -140(%r8)
++.LBB0_479:
++	vmovups	-108(%rsi), %ymm0
++	vmovups	%ymm0, -108(%r8)
++	vmovups	-76(%rsi), %ymm0
++	vmovups	%ymm0, -76(%r8)
++	jmp	.LBB0_524
++.LBB0_480:
++	vmovups	-237(%rsi), %ymm0
++	vmovups	%ymm0, -237(%r8)
++	vmovups	-205(%rsi), %ymm0
++	vmovups	%ymm0, -205(%r8)
++	vmovups	-173(%rsi), %ymm0
++	vmovups	%ymm0, -173(%r8)
++	vmovups	-141(%rsi), %ymm0
++	vmovups	%ymm0, -141(%r8)
++.LBB0_481:
++	vmovups	-109(%rsi), %ymm0
++	vmovups	%ymm0, -109(%r8)
++	vmovups	-77(%rsi), %ymm0
++	vmovups	%ymm0, -77(%r8)
++	jmp	.LBB0_524
++.LBB0_482:
++	vmovups	-238(%rsi), %ymm0
++	vmovups	%ymm0, -238(%r8)
++	vmovups	-206(%rsi), %ymm0
++	vmovups	%ymm0, -206(%r8)
++	vmovups	-174(%rsi), %ymm0
++	vmovups	%ymm0, -174(%r8)
++	vmovups	-142(%rsi), %ymm0
++	vmovups	%ymm0, -142(%r8)
++.LBB0_483:
++	vmovups	-110(%rsi), %ymm0
++	vmovups	%ymm0, -110(%r8)
++	vmovups	-78(%rsi), %ymm0
++	vmovups	%ymm0, -78(%r8)
++	jmp	.LBB0_524
++.LBB0_484:
++	vmovups	-239(%rsi), %ymm0
++	vmovups	%ymm0, -239(%r8)
++	vmovups	-207(%rsi), %ymm0
++	vmovups	%ymm0, -207(%r8)
++	vmovups	-175(%rsi), %ymm0
++	vmovups	%ymm0, -175(%r8)
++	vmovups	-143(%rsi), %ymm0
++	vmovups	%ymm0, -143(%r8)
++.LBB0_485:
++	vmovups	-111(%rsi), %ymm0
++	vmovups	%ymm0, -111(%r8)
++	vmovups	-79(%rsi), %ymm0
++	vmovups	%ymm0, -79(%r8)
++	jmp	.LBB0_524
++.LBB0_486:
++	vmovups	-240(%rsi), %ymm0
++	vmovups	%ymm0, -240(%r8)
++	vmovups	-208(%rsi), %ymm0
++	vmovups	%ymm0, -208(%r8)
++	vmovups	-176(%rsi), %ymm0
++	vmovups	%ymm0, -176(%r8)
++	vmovups	-144(%rsi), %ymm0
++	vmovups	%ymm0, -144(%r8)
++.LBB0_487:
++	vmovups	-112(%rsi), %ymm0
++	vmovups	%ymm0, -112(%r8)
++	vmovups	-80(%rsi), %ymm0
++	vmovups	%ymm0, -80(%r8)
++	jmp	.LBB0_524
++.LBB0_488:
++	vmovups	-241(%rsi), %ymm0
++	vmovups	%ymm0, -241(%r8)
++	vmovups	-209(%rsi), %ymm0
++	vmovups	%ymm0, -209(%r8)
++	vmovups	-177(%rsi), %ymm0
++	vmovups	%ymm0, -177(%r8)
++	vmovups	-145(%rsi), %ymm0
++	vmovups	%ymm0, -145(%r8)
++.LBB0_489:
++	vmovups	-113(%rsi), %ymm0
++	vmovups	%ymm0, -113(%r8)
++	vmovups	-81(%rsi), %ymm0
++	vmovups	%ymm0, -81(%r8)
++	jmp	.LBB0_524
++.LBB0_490:
++	vmovups	-242(%rsi), %ymm0
++	vmovups	%ymm0, -242(%r8)
++	vmovups	-210(%rsi), %ymm0
++	vmovups	%ymm0, -210(%r8)
++	vmovups	-178(%rsi), %ymm0
++	vmovups	%ymm0, -178(%r8)
++	vmovups	-146(%rsi), %ymm0
++	vmovups	%ymm0, -146(%r8)
++.LBB0_491:
++	vmovups	-114(%rsi), %ymm0
++	vmovups	%ymm0, -114(%r8)
++	vmovups	-82(%rsi), %ymm0
++	vmovups	%ymm0, -82(%r8)
++	jmp	.LBB0_524
++.LBB0_492:
++	vmovups	-243(%rsi), %ymm0
++	vmovups	%ymm0, -243(%r8)
++	vmovups	-211(%rsi), %ymm0
++	vmovups	%ymm0, -211(%r8)
++	vmovups	-179(%rsi), %ymm0
++	vmovups	%ymm0, -179(%r8)
++	vmovups	-147(%rsi), %ymm0
++	vmovups	%ymm0, -147(%r8)
++.LBB0_493:
++	vmovups	-115(%rsi), %ymm0
++	vmovups	%ymm0, -115(%r8)
++	vmovups	-83(%rsi), %ymm0
++	vmovups	%ymm0, -83(%r8)
++	jmp	.LBB0_524
++.LBB0_494:
++	vmovups	-244(%rsi), %ymm0
++	vmovups	%ymm0, -244(%r8)
++	vmovups	-212(%rsi), %ymm0
++	vmovups	%ymm0, -212(%r8)
++	vmovups	-180(%rsi), %ymm0
++	vmovups	%ymm0, -180(%r8)
++	vmovups	-148(%rsi), %ymm0
++	vmovups	%ymm0, -148(%r8)
++.LBB0_495:
++	vmovups	-116(%rsi), %ymm0
++	vmovups	%ymm0, -116(%r8)
++	vmovups	-84(%rsi), %ymm0
++	vmovups	%ymm0, -84(%r8)
++	jmp	.LBB0_524
++.LBB0_496:
++	vmovups	-245(%rsi), %ymm0
++	vmovups	%ymm0, -245(%r8)
++	vmovups	-213(%rsi), %ymm0
++	vmovups	%ymm0, -213(%r8)
++	vmovups	-181(%rsi), %ymm0
++	vmovups	%ymm0, -181(%r8)
++	vmovups	-149(%rsi), %ymm0
++	vmovups	%ymm0, -149(%r8)
++.LBB0_497:
++	vmovups	-117(%rsi), %ymm0
++	vmovups	%ymm0, -117(%r8)
++	vmovups	-85(%rsi), %ymm0
++	vmovups	%ymm0, -85(%r8)
++	jmp	.LBB0_524
++.LBB0_498:
++	vmovups	-246(%rsi), %ymm0
++	vmovups	%ymm0, -246(%r8)
++	vmovups	-214(%rsi), %ymm0
++	vmovups	%ymm0, -214(%r8)
++	vmovups	-182(%rsi), %ymm0
++	vmovups	%ymm0, -182(%r8)
++	vmovups	-150(%rsi), %ymm0
++	vmovups	%ymm0, -150(%r8)
++.LBB0_499:
++	vmovups	-118(%rsi), %ymm0
++	vmovups	%ymm0, -118(%r8)
++	vmovups	-86(%rsi), %ymm0
++	vmovups	%ymm0, -86(%r8)
++	jmp	.LBB0_524
++.LBB0_500:
++	vmovups	-247(%rsi), %ymm0
++	vmovups	%ymm0, -247(%r8)
++	vmovups	-215(%rsi), %ymm0
++	vmovups	%ymm0, -215(%r8)
++	vmovups	-183(%rsi), %ymm0
++	vmovups	%ymm0, -183(%r8)
++	vmovups	-151(%rsi), %ymm0
++	vmovups	%ymm0, -151(%r8)
++.LBB0_501:
++	vmovups	-119(%rsi), %ymm0
++	vmovups	%ymm0, -119(%r8)
++	vmovups	-87(%rsi), %ymm0
++	vmovups	%ymm0, -87(%r8)
++	jmp	.LBB0_524
++.LBB0_502:
++	vmovups	-248(%rsi), %ymm0
++	vmovups	%ymm0, -248(%r8)
++	vmovups	-216(%rsi), %ymm0
++	vmovups	%ymm0, -216(%r8)
++	vmovups	-184(%rsi), %ymm0
++	vmovups	%ymm0, -184(%r8)
++	vmovups	-152(%rsi), %ymm0
++	vmovups	%ymm0, -152(%r8)
++.LBB0_503:
++	vmovups	-120(%rsi), %ymm0
++	vmovups	%ymm0, -120(%r8)
++	vmovups	-88(%rsi), %ymm0
++	vmovups	%ymm0, -88(%r8)
++	jmp	.LBB0_524
++.LBB0_504:
++	vmovups	-249(%rsi), %ymm0
++	vmovups	%ymm0, -249(%r8)
++	vmovups	-217(%rsi), %ymm0
++	vmovups	%ymm0, -217(%r8)
++	vmovups	-185(%rsi), %ymm0
++	vmovups	%ymm0, -185(%r8)
++	vmovups	-153(%rsi), %ymm0
++	vmovups	%ymm0, -153(%r8)
++.LBB0_505:
++	vmovups	-121(%rsi), %ymm0
++	vmovups	%ymm0, -121(%r8)
++	vmovups	-89(%rsi), %ymm0
++	vmovups	%ymm0, -89(%r8)
++	jmp	.LBB0_524
++.LBB0_506:
++	vmovups	-250(%rsi), %ymm0
++	vmovups	%ymm0, -250(%r8)
++	vmovups	-218(%rsi), %ymm0
++	vmovups	%ymm0, -218(%r8)
++	vmovups	-186(%rsi), %ymm0
++	vmovups	%ymm0, -186(%r8)
++	vmovups	-154(%rsi), %ymm0
++	vmovups	%ymm0, -154(%r8)
++.LBB0_507:
++	vmovups	-122(%rsi), %ymm0
++	vmovups	%ymm0, -122(%r8)
++	vmovups	-90(%rsi), %ymm0
++	vmovups	%ymm0, -90(%r8)
++	jmp	.LBB0_524
++.LBB0_508:
++	vmovups	-251(%rsi), %ymm0
++	vmovups	%ymm0, -251(%r8)
++	vmovups	-219(%rsi), %ymm0
++	vmovups	%ymm0, -219(%r8)
++	vmovups	-187(%rsi), %ymm0
++	vmovups	%ymm0, -187(%r8)
++	vmovups	-155(%rsi), %ymm0
++	vmovups	%ymm0, -155(%r8)
++.LBB0_509:
++	vmovups	-123(%rsi), %ymm0
++	vmovups	%ymm0, -123(%r8)
++	vmovups	-91(%rsi), %ymm0
++	vmovups	%ymm0, -91(%r8)
++	jmp	.LBB0_524
++.LBB0_510:
++	vmovups	-252(%rsi), %ymm0
++	vmovups	%ymm0, -252(%r8)
++	vmovups	-220(%rsi), %ymm0
++	vmovups	%ymm0, -220(%r8)
++	vmovups	-188(%rsi), %ymm0
++	vmovups	%ymm0, -188(%r8)
++	vmovups	-156(%rsi), %ymm0
++	vmovups	%ymm0, -156(%r8)
++.LBB0_511:
++	vmovups	-124(%rsi), %ymm0
++	vmovups	%ymm0, -124(%r8)
++	vmovups	-92(%rsi), %ymm0
++	vmovups	%ymm0, -92(%r8)
++	jmp	.LBB0_524
++.LBB0_512:
++	vmovups	-253(%rsi), %ymm0
++	vmovups	%ymm0, -253(%r8)
++	vmovups	-221(%rsi), %ymm0
++	vmovups	%ymm0, -221(%r8)
++	vmovups	-189(%rsi), %ymm0
++	vmovups	%ymm0, -189(%r8)
++	vmovups	-157(%rsi), %ymm0
++	vmovups	%ymm0, -157(%r8)
++.LBB0_513:
++	vmovups	-125(%rsi), %ymm0
++	vmovups	%ymm0, -125(%r8)
++	vmovups	-93(%rsi), %ymm0
++	vmovups	%ymm0, -93(%r8)
++	jmp	.LBB0_524
++.LBB0_514:
++	vmovups	-254(%rsi), %ymm0
++	vmovups	%ymm0, -254(%r8)
++	vmovups	-222(%rsi), %ymm0
++	vmovups	%ymm0, -222(%r8)
++	vmovups	-190(%rsi), %ymm0
++	vmovups	%ymm0, -190(%r8)
++	vmovups	-158(%rsi), %ymm0
++	vmovups	%ymm0, -158(%r8)
++.LBB0_515:
++	vmovups	-126(%rsi), %ymm0
++	vmovups	%ymm0, -126(%r8)
++	vmovups	-94(%rsi), %ymm0
++	vmovups	%ymm0, -94(%r8)
++	jmp	.LBB0_524
++.LBB0_516:
++	vmovups	-255(%rsi), %ymm0
++	vmovups	%ymm0, -255(%r8)
++	vmovups	-223(%rsi), %ymm0
++	vmovups	%ymm0, -223(%r8)
++	vmovups	-191(%rsi), %ymm0
++	vmovups	%ymm0, -191(%r8)
++	vmovups	-159(%rsi), %ymm0
++	vmovups	%ymm0, -159(%r8)
++.LBB0_517:
++	vmovups	-127(%rsi), %ymm0
++	vmovups	%ymm0, -127(%r8)
++	vmovups	-95(%rsi), %ymm0
++	vmovups	%ymm0, -95(%r8)
++	jmp	.LBB0_524
++.LBB0_518:
++	vmovups	-256(%rsi), %ymm0
++	vmovups	%ymm0, -256(%r8)
++.LBB0_519:
++	vmovups	-224(%rsi), %ymm0
++	vmovups	%ymm0, -224(%r8)
++.LBB0_520:
++	vmovups	-192(%rsi), %ymm0
++	vmovups	%ymm0, -192(%r8)
++.LBB0_521:
++	vmovups	-160(%rsi), %ymm0
++	vmovups	%ymm0, -160(%r8)
++.LBB0_522:
++	vmovups	-128(%rsi), %ymm0
++	vmovups	%ymm0, -128(%r8)
++.LBB0_523:
++	vmovups	-96(%rsi), %ymm0
++	vmovups	%ymm0, -96(%r8)
++.LBB0_524:
++	vmovups	-64(%rsi), %ymm0
++	vmovups	%ymm0, -64(%r8)
++.LBB0_525:
++	vmovups	-32(%rsi), %ymm0
++	vmovups	%ymm0, -32(%r8)
++.LBB0_526:
++	vzeroupper
++	retq
++.Lfunc_end0:
++/*
++	.size	memcpy, .Lfunc_end0-memcpy
++	.cfi_endproc
++	.section	.rodata,"a",@progbits
++	.p2align	2
++*/
++	.cfi_endproc
++END(memcpy_avx2)
++
++.LJTI0_0:
++	.long	.LBB0_273-.LJTI0_0
++	.long	.LBB0_277-.LJTI0_0
++	.long	.LBB0_279-.LJTI0_0
++	.long	.LBB0_283-.LJTI0_0
++	.long	.LBB0_285-.LJTI0_0
++	.long	.LBB0_287-.LJTI0_0
++	.long	.LBB0_289-.LJTI0_0
++	.long	.LBB0_293-.LJTI0_0
++	.long	.LBB0_295-.LJTI0_0
++	.long	.LBB0_297-.LJTI0_0
++	.long	.LBB0_299-.LJTI0_0
++	.long	.LBB0_301-.LJTI0_0
++	.long	.LBB0_303-.LJTI0_0
++	.long	.LBB0_305-.LJTI0_0
++	.long	.LBB0_307-.LJTI0_0
++	.long	.LBB0_311-.LJTI0_0
++	.long	.LBB0_313-.LJTI0_0
++	.long	.LBB0_315-.LJTI0_0
++	.long	.LBB0_317-.LJTI0_0
++	.long	.LBB0_319-.LJTI0_0
++	.long	.LBB0_321-.LJTI0_0
++	.long	.LBB0_323-.LJTI0_0
++	.long	.LBB0_325-.LJTI0_0
++	.long	.LBB0_327-.LJTI0_0
++	.long	.LBB0_329-.LJTI0_0
++	.long	.LBB0_331-.LJTI0_0
++	.long	.LBB0_333-.LJTI0_0
++	.long	.LBB0_335-.LJTI0_0
++	.long	.LBB0_337-.LJTI0_0
++	.long	.LBB0_339-.LJTI0_0
++	.long	.LBB0_341-.LJTI0_0
++	.long	.LBB0_525-.LJTI0_0
++	.long	.LBB0_272-.LJTI0_0
++	.long	.LBB0_276-.LJTI0_0
++	.long	.LBB0_349-.LJTI0_0
++	.long	.LBB0_282-.LJTI0_0
++	.long	.LBB0_355-.LJTI0_0
++	.long	.LBB0_359-.LJTI0_0
++	.long	.LBB0_363-.LJTI0_0
++	.long	.LBB0_292-.LJTI0_0
++	.long	.LBB0_369-.LJTI0_0
++	.long	.LBB0_373-.LJTI0_0
++	.long	.LBB0_377-.LJTI0_0
++	.long	.LBB0_381-.LJTI0_0
++	.long	.LBB0_385-.LJTI0_0
++	.long	.LBB0_389-.LJTI0_0
++	.long	.LBB0_393-.LJTI0_0
++	.long	.LBB0_310-.LJTI0_0
++	.long	.LBB0_399-.LJTI0_0
++	.long	.LBB0_403-.LJTI0_0
++	.long	.LBB0_407-.LJTI0_0
++	.long	.LBB0_411-.LJTI0_0
++	.long	.LBB0_415-.LJTI0_0
++	.long	.LBB0_419-.LJTI0_0
++	.long	.LBB0_423-.LJTI0_0
++	.long	.LBB0_427-.LJTI0_0
++	.long	.LBB0_431-.LJTI0_0
++	.long	.LBB0_435-.LJTI0_0
++	.long	.LBB0_439-.LJTI0_0
++	.long	.LBB0_443-.LJTI0_0
++	.long	.LBB0_447-.LJTI0_0
++	.long	.LBB0_451-.LJTI0_0
++	.long	.LBB0_455-.LJTI0_0
++	.long	.LBB0_524-.LJTI0_0
++	.long	.LBB0_271-.LJTI0_0
++	.long	.LBB0_275-.LJTI0_0
++	.long	.LBB0_348-.LJTI0_0
++	.long	.LBB0_281-.LJTI0_0
++	.long	.LBB0_354-.LJTI0_0
++	.long	.LBB0_358-.LJTI0_0
++	.long	.LBB0_362-.LJTI0_0
++	.long	.LBB0_291-.LJTI0_0
++	.long	.LBB0_368-.LJTI0_0
++	.long	.LBB0_372-.LJTI0_0
++	.long	.LBB0_376-.LJTI0_0
++	.long	.LBB0_380-.LJTI0_0
++	.long	.LBB0_384-.LJTI0_0
++	.long	.LBB0_388-.LJTI0_0
++	.long	.LBB0_392-.LJTI0_0
++	.long	.LBB0_309-.LJTI0_0
++	.long	.LBB0_398-.LJTI0_0
++	.long	.LBB0_402-.LJTI0_0
++	.long	.LBB0_406-.LJTI0_0
++	.long	.LBB0_410-.LJTI0_0
++	.long	.LBB0_414-.LJTI0_0
++	.long	.LBB0_418-.LJTI0_0
++	.long	.LBB0_422-.LJTI0_0
++	.long	.LBB0_426-.LJTI0_0
++	.long	.LBB0_430-.LJTI0_0
++	.long	.LBB0_434-.LJTI0_0
++	.long	.LBB0_438-.LJTI0_0
++	.long	.LBB0_442-.LJTI0_0
++	.long	.LBB0_446-.LJTI0_0
++	.long	.LBB0_450-.LJTI0_0
++	.long	.LBB0_454-.LJTI0_0
++	.long	.LBB0_523-.LJTI0_0
++	.long	.LBB0_457-.LJTI0_0
++	.long	.LBB0_459-.LJTI0_0
++	.long	.LBB0_461-.LJTI0_0
++	.long	.LBB0_463-.LJTI0_0
++	.long	.LBB0_465-.LJTI0_0
++	.long	.LBB0_467-.LJTI0_0
++	.long	.LBB0_469-.LJTI0_0
++	.long	.LBB0_471-.LJTI0_0
++	.long	.LBB0_473-.LJTI0_0
++	.long	.LBB0_475-.LJTI0_0
++	.long	.LBB0_477-.LJTI0_0
++	.long	.LBB0_479-.LJTI0_0
++	.long	.LBB0_481-.LJTI0_0
++	.long	.LBB0_483-.LJTI0_0
++	.long	.LBB0_485-.LJTI0_0
++	.long	.LBB0_487-.LJTI0_0
++	.long	.LBB0_489-.LJTI0_0
++	.long	.LBB0_491-.LJTI0_0
++	.long	.LBB0_493-.LJTI0_0
++	.long	.LBB0_495-.LJTI0_0
++	.long	.LBB0_497-.LJTI0_0
++	.long	.LBB0_499-.LJTI0_0
++	.long	.LBB0_501-.LJTI0_0
++	.long	.LBB0_503-.LJTI0_0
++	.long	.LBB0_505-.LJTI0_0
++	.long	.LBB0_507-.LJTI0_0
++	.long	.LBB0_509-.LJTI0_0
++	.long	.LBB0_511-.LJTI0_0
++	.long	.LBB0_513-.LJTI0_0
++	.long	.LBB0_515-.LJTI0_0
++	.long	.LBB0_517-.LJTI0_0
++	.long	.LBB0_522-.LJTI0_0
++	.long	.LBB0_270-.LJTI0_0
++	.long	.LBB0_274-.LJTI0_0
++	.long	.LBB0_278-.LJTI0_0
++	.long	.LBB0_280-.LJTI0_0
++	.long	.LBB0_284-.LJTI0_0
++	.long	.LBB0_286-.LJTI0_0
++	.long	.LBB0_288-.LJTI0_0
++	.long	.LBB0_290-.LJTI0_0
++	.long	.LBB0_294-.LJTI0_0
++	.long	.LBB0_296-.LJTI0_0
++	.long	.LBB0_298-.LJTI0_0
++	.long	.LBB0_300-.LJTI0_0
++	.long	.LBB0_302-.LJTI0_0
++	.long	.LBB0_304-.LJTI0_0
++	.long	.LBB0_306-.LJTI0_0
++	.long	.LBB0_308-.LJTI0_0
++	.long	.LBB0_312-.LJTI0_0
++	.long	.LBB0_314-.LJTI0_0
++	.long	.LBB0_316-.LJTI0_0
++	.long	.LBB0_318-.LJTI0_0
++	.long	.LBB0_320-.LJTI0_0
++	.long	.LBB0_322-.LJTI0_0
++	.long	.LBB0_324-.LJTI0_0
++	.long	.LBB0_326-.LJTI0_0
++	.long	.LBB0_328-.LJTI0_0
++	.long	.LBB0_330-.LJTI0_0
++	.long	.LBB0_332-.LJTI0_0
++	.long	.LBB0_334-.LJTI0_0
++	.long	.LBB0_336-.LJTI0_0
++	.long	.LBB0_338-.LJTI0_0
++	.long	.LBB0_340-.LJTI0_0
++	.long	.LBB0_521-.LJTI0_0
++	.long	.LBB0_343-.LJTI0_0
++	.long	.LBB0_345-.LJTI0_0
++	.long	.LBB0_347-.LJTI0_0
++	.long	.LBB0_351-.LJTI0_0
++	.long	.LBB0_353-.LJTI0_0
++	.long	.LBB0_357-.LJTI0_0
++	.long	.LBB0_361-.LJTI0_0
++	.long	.LBB0_365-.LJTI0_0
++	.long	.LBB0_367-.LJTI0_0
++	.long	.LBB0_371-.LJTI0_0
++	.long	.LBB0_375-.LJTI0_0
++	.long	.LBB0_379-.LJTI0_0
++	.long	.LBB0_383-.LJTI0_0
++	.long	.LBB0_387-.LJTI0_0
++	.long	.LBB0_391-.LJTI0_0
++	.long	.LBB0_395-.LJTI0_0
++	.long	.LBB0_397-.LJTI0_0
++	.long	.LBB0_401-.LJTI0_0
++	.long	.LBB0_405-.LJTI0_0
++	.long	.LBB0_409-.LJTI0_0
++	.long	.LBB0_413-.LJTI0_0
++	.long	.LBB0_417-.LJTI0_0
++	.long	.LBB0_421-.LJTI0_0
++	.long	.LBB0_425-.LJTI0_0
++	.long	.LBB0_429-.LJTI0_0
++	.long	.LBB0_433-.LJTI0_0
++	.long	.LBB0_437-.LJTI0_0
++	.long	.LBB0_441-.LJTI0_0
++	.long	.LBB0_445-.LJTI0_0
++	.long	.LBB0_449-.LJTI0_0
++	.long	.LBB0_453-.LJTI0_0
++	.long	.LBB0_520-.LJTI0_0
++	.long	.LBB0_342-.LJTI0_0
++	.long	.LBB0_344-.LJTI0_0
++	.long	.LBB0_346-.LJTI0_0
++	.long	.LBB0_350-.LJTI0_0
++	.long	.LBB0_352-.LJTI0_0
++	.long	.LBB0_356-.LJTI0_0
++	.long	.LBB0_360-.LJTI0_0
++	.long	.LBB0_364-.LJTI0_0
++	.long	.LBB0_366-.LJTI0_0
++	.long	.LBB0_370-.LJTI0_0
++	.long	.LBB0_374-.LJTI0_0
++	.long	.LBB0_378-.LJTI0_0
++	.long	.LBB0_382-.LJTI0_0
++	.long	.LBB0_386-.LJTI0_0
++	.long	.LBB0_390-.LJTI0_0
++	.long	.LBB0_394-.LJTI0_0
++	.long	.LBB0_396-.LJTI0_0
++	.long	.LBB0_400-.LJTI0_0
++	.long	.LBB0_404-.LJTI0_0
++	.long	.LBB0_408-.LJTI0_0
++	.long	.LBB0_412-.LJTI0_0
++	.long	.LBB0_416-.LJTI0_0
++	.long	.LBB0_420-.LJTI0_0
++	.long	.LBB0_424-.LJTI0_0
++	.long	.LBB0_428-.LJTI0_0
++	.long	.LBB0_432-.LJTI0_0
++	.long	.LBB0_436-.LJTI0_0
++	.long	.LBB0_440-.LJTI0_0
++	.long	.LBB0_444-.LJTI0_0
++	.long	.LBB0_448-.LJTI0_0
++	.long	.LBB0_452-.LJTI0_0
++	.long	.LBB0_519-.LJTI0_0
++	.long	.LBB0_456-.LJTI0_0
++	.long	.LBB0_458-.LJTI0_0
++	.long	.LBB0_460-.LJTI0_0
++	.long	.LBB0_462-.LJTI0_0
++	.long	.LBB0_464-.LJTI0_0
++	.long	.LBB0_466-.LJTI0_0
++	.long	.LBB0_468-.LJTI0_0
++	.long	.LBB0_470-.LJTI0_0
++	.long	.LBB0_472-.LJTI0_0
++	.long	.LBB0_474-.LJTI0_0
++	.long	.LBB0_476-.LJTI0_0
++	.long	.LBB0_478-.LJTI0_0
++	.long	.LBB0_480-.LJTI0_0
++	.long	.LBB0_482-.LJTI0_0
++	.long	.LBB0_484-.LJTI0_0
++	.long	.LBB0_486-.LJTI0_0
++	.long	.LBB0_488-.LJTI0_0
++	.long	.LBB0_490-.LJTI0_0
++	.long	.LBB0_492-.LJTI0_0
++	.long	.LBB0_494-.LJTI0_0
++	.long	.LBB0_496-.LJTI0_0
++	.long	.LBB0_498-.LJTI0_0
++	.long	.LBB0_500-.LJTI0_0
++	.long	.LBB0_502-.LJTI0_0
++	.long	.LBB0_504-.LJTI0_0
++	.long	.LBB0_506-.LJTI0_0
++	.long	.LBB0_508-.LJTI0_0
++	.long	.LBB0_510-.LJTI0_0
++	.long	.LBB0_512-.LJTI0_0
++	.long	.LBB0_514-.LJTI0_0
++	.long	.LBB0_516-.LJTI0_0
++	.long	.LBB0_518-.LJTI0_0
++.LJTI0_1:
++	.long	.LBB0_6-.LJTI0_1
++	.long	.LBB0_10-.LJTI0_1
++	.long	.LBB0_12-.LJTI0_1
++	.long	.LBB0_16-.LJTI0_1
++	.long	.LBB0_18-.LJTI0_1
++	.long	.LBB0_20-.LJTI0_1
++	.long	.LBB0_22-.LJTI0_1
++	.long	.LBB0_26-.LJTI0_1
++	.long	.LBB0_28-.LJTI0_1
++	.long	.LBB0_30-.LJTI0_1
++	.long	.LBB0_32-.LJTI0_1
++	.long	.LBB0_34-.LJTI0_1
++	.long	.LBB0_36-.LJTI0_1
++	.long	.LBB0_38-.LJTI0_1
++	.long	.LBB0_40-.LJTI0_1
++	.long	.LBB0_44-.LJTI0_1
++	.long	.LBB0_46-.LJTI0_1
++	.long	.LBB0_48-.LJTI0_1
++	.long	.LBB0_50-.LJTI0_1
++	.long	.LBB0_52-.LJTI0_1
++	.long	.LBB0_54-.LJTI0_1
++	.long	.LBB0_56-.LJTI0_1
++	.long	.LBB0_58-.LJTI0_1
++	.long	.LBB0_60-.LJTI0_1
++	.long	.LBB0_62-.LJTI0_1
++	.long	.LBB0_64-.LJTI0_1
++	.long	.LBB0_66-.LJTI0_1
++	.long	.LBB0_68-.LJTI0_1
++	.long	.LBB0_70-.LJTI0_1
++	.long	.LBB0_72-.LJTI0_1
++	.long	.LBB0_74-.LJTI0_1
++	.long	.LBB0_258-.LJTI0_1
++	.long	.LBB0_5-.LJTI0_1
++	.long	.LBB0_9-.LJTI0_1
++	.long	.LBB0_82-.LJTI0_1
++	.long	.LBB0_15-.LJTI0_1
++	.long	.LBB0_88-.LJTI0_1
++	.long	.LBB0_92-.LJTI0_1
++	.long	.LBB0_96-.LJTI0_1
++	.long	.LBB0_25-.LJTI0_1
++	.long	.LBB0_102-.LJTI0_1
++	.long	.LBB0_106-.LJTI0_1
++	.long	.LBB0_110-.LJTI0_1
++	.long	.LBB0_114-.LJTI0_1
++	.long	.LBB0_118-.LJTI0_1
++	.long	.LBB0_122-.LJTI0_1
++	.long	.LBB0_126-.LJTI0_1
++	.long	.LBB0_43-.LJTI0_1
++	.long	.LBB0_132-.LJTI0_1
++	.long	.LBB0_136-.LJTI0_1
++	.long	.LBB0_140-.LJTI0_1
++	.long	.LBB0_144-.LJTI0_1
++	.long	.LBB0_148-.LJTI0_1
++	.long	.LBB0_152-.LJTI0_1
++	.long	.LBB0_156-.LJTI0_1
++	.long	.LBB0_160-.LJTI0_1
++	.long	.LBB0_164-.LJTI0_1
++	.long	.LBB0_168-.LJTI0_1
++	.long	.LBB0_172-.LJTI0_1
++	.long	.LBB0_176-.LJTI0_1
++	.long	.LBB0_180-.LJTI0_1
++	.long	.LBB0_184-.LJTI0_1
++	.long	.LBB0_188-.LJTI0_1
++	.long	.LBB0_257-.LJTI0_1
++	.long	.LBB0_4-.LJTI0_1
++	.long	.LBB0_8-.LJTI0_1
++	.long	.LBB0_81-.LJTI0_1
++	.long	.LBB0_14-.LJTI0_1
++	.long	.LBB0_87-.LJTI0_1
++	.long	.LBB0_91-.LJTI0_1
++	.long	.LBB0_95-.LJTI0_1
++	.long	.LBB0_24-.LJTI0_1
++	.long	.LBB0_101-.LJTI0_1
++	.long	.LBB0_105-.LJTI0_1
++	.long	.LBB0_109-.LJTI0_1
++	.long	.LBB0_113-.LJTI0_1
++	.long	.LBB0_117-.LJTI0_1
++	.long	.LBB0_121-.LJTI0_1
++	.long	.LBB0_125-.LJTI0_1
++	.long	.LBB0_42-.LJTI0_1
++	.long	.LBB0_131-.LJTI0_1
++	.long	.LBB0_135-.LJTI0_1
++	.long	.LBB0_139-.LJTI0_1
++	.long	.LBB0_143-.LJTI0_1
++	.long	.LBB0_147-.LJTI0_1
++	.long	.LBB0_151-.LJTI0_1
++	.long	.LBB0_155-.LJTI0_1
++	.long	.LBB0_159-.LJTI0_1
++	.long	.LBB0_163-.LJTI0_1
++	.long	.LBB0_167-.LJTI0_1
++	.long	.LBB0_171-.LJTI0_1
++	.long	.LBB0_175-.LJTI0_1
++	.long	.LBB0_179-.LJTI0_1
++	.long	.LBB0_183-.LJTI0_1
++	.long	.LBB0_187-.LJTI0_1
++	.long	.LBB0_256-.LJTI0_1
++	.long	.LBB0_190-.LJTI0_1
++	.long	.LBB0_192-.LJTI0_1
++	.long	.LBB0_194-.LJTI0_1
++	.long	.LBB0_196-.LJTI0_1
++	.long	.LBB0_198-.LJTI0_1
++	.long	.LBB0_200-.LJTI0_1
++	.long	.LBB0_202-.LJTI0_1
++	.long	.LBB0_204-.LJTI0_1
++	.long	.LBB0_206-.LJTI0_1
++	.long	.LBB0_208-.LJTI0_1
++	.long	.LBB0_210-.LJTI0_1
++	.long	.LBB0_212-.LJTI0_1
++	.long	.LBB0_214-.LJTI0_1
++	.long	.LBB0_216-.LJTI0_1
++	.long	.LBB0_218-.LJTI0_1
++	.long	.LBB0_220-.LJTI0_1
++	.long	.LBB0_222-.LJTI0_1
++	.long	.LBB0_224-.LJTI0_1
++	.long	.LBB0_226-.LJTI0_1
++	.long	.LBB0_228-.LJTI0_1
++	.long	.LBB0_230-.LJTI0_1
++	.long	.LBB0_232-.LJTI0_1
++	.long	.LBB0_234-.LJTI0_1
++	.long	.LBB0_236-.LJTI0_1
++	.long	.LBB0_238-.LJTI0_1
++	.long	.LBB0_240-.LJTI0_1
++	.long	.LBB0_242-.LJTI0_1
++	.long	.LBB0_244-.LJTI0_1
++	.long	.LBB0_246-.LJTI0_1
++	.long	.LBB0_248-.LJTI0_1
++	.long	.LBB0_250-.LJTI0_1
++	.long	.LBB0_255-.LJTI0_1
++	.long	.LBB0_3-.LJTI0_1
++	.long	.LBB0_7-.LJTI0_1
++	.long	.LBB0_11-.LJTI0_1
++	.long	.LBB0_13-.LJTI0_1
++	.long	.LBB0_17-.LJTI0_1
++	.long	.LBB0_19-.LJTI0_1
++	.long	.LBB0_21-.LJTI0_1
++	.long	.LBB0_23-.LJTI0_1
++	.long	.LBB0_27-.LJTI0_1
++	.long	.LBB0_29-.LJTI0_1
++	.long	.LBB0_31-.LJTI0_1
++	.long	.LBB0_33-.LJTI0_1
++	.long	.LBB0_35-.LJTI0_1
++	.long	.LBB0_37-.LJTI0_1
++	.long	.LBB0_39-.LJTI0_1
++	.long	.LBB0_41-.LJTI0_1
++	.long	.LBB0_45-.LJTI0_1
++	.long	.LBB0_47-.LJTI0_1
++	.long	.LBB0_49-.LJTI0_1
++	.long	.LBB0_51-.LJTI0_1
++	.long	.LBB0_53-.LJTI0_1
++	.long	.LBB0_55-.LJTI0_1
++	.long	.LBB0_57-.LJTI0_1
++	.long	.LBB0_59-.LJTI0_1
++	.long	.LBB0_61-.LJTI0_1
++	.long	.LBB0_63-.LJTI0_1
++	.long	.LBB0_65-.LJTI0_1
++	.long	.LBB0_67-.LJTI0_1
++	.long	.LBB0_69-.LJTI0_1
++	.long	.LBB0_71-.LJTI0_1
++	.long	.LBB0_73-.LJTI0_1
++	.long	.LBB0_254-.LJTI0_1
++	.long	.LBB0_76-.LJTI0_1
++	.long	.LBB0_78-.LJTI0_1
++	.long	.LBB0_80-.LJTI0_1
++	.long	.LBB0_84-.LJTI0_1
++	.long	.LBB0_86-.LJTI0_1
++	.long	.LBB0_90-.LJTI0_1
++	.long	.LBB0_94-.LJTI0_1
++	.long	.LBB0_98-.LJTI0_1
++	.long	.LBB0_100-.LJTI0_1
++	.long	.LBB0_104-.LJTI0_1
++	.long	.LBB0_108-.LJTI0_1
++	.long	.LBB0_112-.LJTI0_1
++	.long	.LBB0_116-.LJTI0_1
++	.long	.LBB0_120-.LJTI0_1
++	.long	.LBB0_124-.LJTI0_1
++	.long	.LBB0_128-.LJTI0_1
++	.long	.LBB0_130-.LJTI0_1
++	.long	.LBB0_134-.LJTI0_1
++	.long	.LBB0_138-.LJTI0_1
++	.long	.LBB0_142-.LJTI0_1
++	.long	.LBB0_146-.LJTI0_1
++	.long	.LBB0_150-.LJTI0_1
++	.long	.LBB0_154-.LJTI0_1
++	.long	.LBB0_158-.LJTI0_1
++	.long	.LBB0_162-.LJTI0_1
++	.long	.LBB0_166-.LJTI0_1
++	.long	.LBB0_170-.LJTI0_1
++	.long	.LBB0_174-.LJTI0_1
++	.long	.LBB0_178-.LJTI0_1
++	.long	.LBB0_182-.LJTI0_1
++	.long	.LBB0_186-.LJTI0_1
++	.long	.LBB0_253-.LJTI0_1
++	.long	.LBB0_75-.LJTI0_1
++	.long	.LBB0_77-.LJTI0_1
++	.long	.LBB0_79-.LJTI0_1
++	.long	.LBB0_83-.LJTI0_1
++	.long	.LBB0_85-.LJTI0_1
++	.long	.LBB0_89-.LJTI0_1
++	.long	.LBB0_93-.LJTI0_1
++	.long	.LBB0_97-.LJTI0_1
++	.long	.LBB0_99-.LJTI0_1
++	.long	.LBB0_103-.LJTI0_1
++	.long	.LBB0_107-.LJTI0_1
++	.long	.LBB0_111-.LJTI0_1
++	.long	.LBB0_115-.LJTI0_1
++	.long	.LBB0_119-.LJTI0_1
++	.long	.LBB0_123-.LJTI0_1
++	.long	.LBB0_127-.LJTI0_1
++	.long	.LBB0_129-.LJTI0_1
++	.long	.LBB0_133-.LJTI0_1
++	.long	.LBB0_137-.LJTI0_1
++	.long	.LBB0_141-.LJTI0_1
++	.long	.LBB0_145-.LJTI0_1
++	.long	.LBB0_149-.LJTI0_1
++	.long	.LBB0_153-.LJTI0_1
++	.long	.LBB0_157-.LJTI0_1
++	.long	.LBB0_161-.LJTI0_1
++	.long	.LBB0_165-.LJTI0_1
++	.long	.LBB0_169-.LJTI0_1
++	.long	.LBB0_173-.LJTI0_1
++	.long	.LBB0_177-.LJTI0_1
++	.long	.LBB0_181-.LJTI0_1
++	.long	.LBB0_185-.LJTI0_1
++	.long	.LBB0_252-.LJTI0_1
++	.long	.LBB0_189-.LJTI0_1
++	.long	.LBB0_191-.LJTI0_1
++	.long	.LBB0_193-.LJTI0_1
++	.long	.LBB0_195-.LJTI0_1
++	.long	.LBB0_197-.LJTI0_1
++	.long	.LBB0_199-.LJTI0_1
++	.long	.LBB0_201-.LJTI0_1
++	.long	.LBB0_203-.LJTI0_1
++	.long	.LBB0_205-.LJTI0_1
++	.long	.LBB0_207-.LJTI0_1
++	.long	.LBB0_209-.LJTI0_1
++	.long	.LBB0_211-.LJTI0_1
++	.long	.LBB0_213-.LJTI0_1
++	.long	.LBB0_215-.LJTI0_1
++	.long	.LBB0_217-.LJTI0_1
++	.long	.LBB0_219-.LJTI0_1
++	.long	.LBB0_221-.LJTI0_1
++	.long	.LBB0_223-.LJTI0_1
++	.long	.LBB0_225-.LJTI0_1
++	.long	.LBB0_227-.LJTI0_1
++	.long	.LBB0_229-.LJTI0_1
++	.long	.LBB0_231-.LJTI0_1
++	.long	.LBB0_233-.LJTI0_1
++	.long	.LBB0_235-.LJTI0_1
++	.long	.LBB0_237-.LJTI0_1
++	.long	.LBB0_239-.LJTI0_1
++	.long	.LBB0_241-.LJTI0_1
++	.long	.LBB0_243-.LJTI0_1
++	.long	.LBB0_245-.LJTI0_1
++	.long	.LBB0_247-.LJTI0_1
++	.long	.LBB0_249-.LJTI0_1
++	.long	.LBB0_251-.LJTI0_1
++                                        # -- End function
++/*
++	.ident	"Android (5484270 based on r353983c) clang version 9.0.3 (https://android.googlesource.com/toolchain/clang 745b335211bb9eadfa6aa6301f84715cee4b37c5) (https://android.googlesource.com/toolchain/llvm 60cf23e54e46c807513f7a36d0a7b777920b5881) (based on LLVM 9.0.3svn)"
++	.section	".note.GNU-stack","",@progbits
++	.addrsig*/
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-memmove-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-memmove-kbl.S
+new file mode 100644
+index 0000000..8730e78
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-memmove-kbl.S
+@@ -0,0 +1,409 @@
++/* memmove with AVX
++   Copyright (C) 2014 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library
++   <http://www.gnu.org/licenses/>.  */
++
++#include "cache.h"
++
++#ifndef MEMMOVE
++# define MEMMOVE  memmove_avx2
++#endif
++
++#ifndef L
++# define L(label)	.L##label
++#endif
++
++#ifndef cfi_startproc
++# define cfi_startproc	.cfi_startproc
++#endif
++
++#ifndef cfi_endproc
++# define cfi_endproc	.cfi_endproc
++#endif
++
++#ifndef cfi_rel_offset
++# define cfi_rel_offset(reg, off)	.cfi_rel_offset reg, off
++#endif
++
++#ifndef cfi_restore
++# define cfi_restore(reg)	.cfi_restore reg
++#endif
++
++#ifndef cfi_adjust_cfa_offset
++# define cfi_adjust_cfa_offset(off)	.cfi_adjust_cfa_offset off
++#endif
++
++#ifndef ENTRY
++# define ENTRY(name)		\
++	.type name,  @function;		\
++	.globl name;		\
++	.p2align 4;		\
++name:		\
++	cfi_startproc
++#endif
++
++#ifndef END
++# define END(name)		\
++	cfi_endproc;		\
++	.size name, .-name
++#endif
++
++#define CFI_PUSH(REG)		\
++	cfi_adjust_cfa_offset (4);		\
++	cfi_rel_offset (REG, 0)
++
++#define CFI_POP(REG)		\
++	cfi_adjust_cfa_offset (-4);		\
++	cfi_restore (REG)
++
++#define PUSH(REG)	push REG;
++#define POP(REG)	pop REG;
++
++#define ENTRANCE	PUSH (%rbx);
++#define RETURN_END	POP (%rbx); ret
++#define RETURN		RETURN_END;if not, see
++
++
++	.section .text.avx,"ax",@progbits
++ENTRY (MEMMOVE)
++	mov	%rdi, %rax
++	cmp	$256, %rdx
++	jae	L(256bytesormore)
++	cmp	$16, %dl
++	jb	L(less_16bytes)
++	cmp	$128, %dl
++	jb	L(less_128bytes)
++	vmovdqu (%rsi), %xmm0
++	lea	(%rsi, %rdx), %rcx
++	vmovdqu 0x10(%rsi), %xmm1
++	vmovdqu 0x20(%rsi), %xmm2
++	vmovdqu 0x30(%rsi), %xmm3
++	vmovdqu 0x40(%rsi), %xmm4
++	vmovdqu 0x50(%rsi), %xmm5
++	vmovdqu 0x60(%rsi), %xmm6
++	vmovdqu 0x70(%rsi), %xmm7
++	vmovdqu -0x80(%rcx), %xmm8
++	vmovdqu -0x70(%rcx), %xmm9
++	vmovdqu -0x60(%rcx), %xmm10
++	vmovdqu -0x50(%rcx), %xmm11
++	vmovdqu -0x40(%rcx), %xmm12
++	vmovdqu -0x30(%rcx), %xmm13
++	vmovdqu -0x20(%rcx), %xmm14
++	vmovdqu -0x10(%rcx), %xmm15
++	lea	(%rdi, %rdx), %rdx
++	vmovdqu %xmm0, (%rdi)
++	vmovdqu %xmm1, 0x10(%rdi)
++	vmovdqu %xmm2, 0x20(%rdi)
++	vmovdqu %xmm3, 0x30(%rdi)
++	vmovdqu %xmm4, 0x40(%rdi)
++	vmovdqu %xmm5, 0x50(%rdi)
++	vmovdqu %xmm6, 0x60(%rdi)
++	vmovdqu %xmm7, 0x70(%rdi)
++	vmovdqu %xmm8, -0x80(%rdx)
++	vmovdqu %xmm9, -0x70(%rdx)
++	vmovdqu %xmm10, -0x60(%rdx)
++	vmovdqu %xmm11, -0x50(%rdx)
++	vmovdqu %xmm12, -0x40(%rdx)
++	vmovdqu %xmm13, -0x30(%rdx)
++	vmovdqu %xmm14, -0x20(%rdx)
++	vmovdqu %xmm15, -0x10(%rdx)
++	ret
++	.p2align 4
++L(less_128bytes):
++	cmp	$64, %dl
++	jb	L(less_64bytes)
++	vmovdqu (%rsi), %xmm0
++	lea	(%rsi, %rdx), %rcx
++	vmovdqu 0x10(%rsi), %xmm1
++	vmovdqu 0x20(%rsi), %xmm2
++	lea	(%rdi, %rdx), %rdx
++	vmovdqu 0x30(%rsi), %xmm3
++	vmovdqu -0x40(%rcx), %xmm4
++	vmovdqu -0x30(%rcx), %xmm5
++	vmovdqu -0x20(%rcx), %xmm6
++	vmovdqu -0x10(%rcx), %xmm7
++	vmovdqu %xmm0, (%rdi)
++	vmovdqu %xmm1, 0x10(%rdi)
++	vmovdqu %xmm2, 0x20(%rdi)
++	vmovdqu %xmm3, 0x30(%rdi)
++	vmovdqu %xmm4, -0x40(%rdx)
++	vmovdqu %xmm5, -0x30(%rdx)
++	vmovdqu %xmm6, -0x20(%rdx)
++	vmovdqu %xmm7, -0x10(%rdx)
++	ret
++
++	.p2align 4
++L(less_64bytes):
++	cmp	$32, %dl
++	jb	L(less_32bytes)
++	vmovdqu (%rsi), %xmm0
++	vmovdqu 0x10(%rsi), %xmm1
++	vmovdqu -0x20(%rsi, %rdx), %xmm6
++	vmovdqu -0x10(%rsi, %rdx), %xmm7
++	vmovdqu %xmm0, (%rdi)
++	vmovdqu %xmm1, 0x10(%rdi)
++	vmovdqu %xmm6, -0x20(%rdi, %rdx)
++	vmovdqu %xmm7, -0x10(%rdi, %rdx)
++	ret
++
++	.p2align 4
++L(less_32bytes):
++	vmovdqu (%rsi), %xmm0
++	vmovdqu -0x10(%rsi, %rdx), %xmm7
++	vmovdqu %xmm0, (%rdi)
++	vmovdqu %xmm7, -0x10(%rdi, %rdx)
++	ret
++
++	.p2align 4
++L(less_16bytes):
++	cmp	$8, %dl
++	jb	L(less_8bytes)
++	movq -0x08(%rsi, %rdx),	%rcx
++	movq (%rsi),	%rsi
++	movq %rsi, (%rdi)
++	movq %rcx, -0x08(%rdi, %rdx)
++	ret
++
++	.p2align 4
++L(less_8bytes):
++	cmp	$4, %dl
++	jb	L(less_4bytes)
++	mov -0x04(%rsi, %rdx), %ecx
++	mov (%rsi),	%esi
++	mov %esi, (%rdi)
++	mov %ecx, -0x04(%rdi, %rdx)
++	ret
++
++L(less_4bytes):
++	cmp	$1, %dl
++	jbe	L(less_2bytes)
++	mov -0x02(%rsi, %rdx),	%cx
++	mov (%rsi),	%si
++	mov %si, (%rdi)
++	mov %cx, -0x02(%rdi, %rdx)
++	ret
++
++L(less_2bytes):
++	jb	L(less_0bytes)
++	mov	(%rsi), %cl
++	mov	%cl,	(%rdi)
++L(less_0bytes):
++	ret
++
++	.p2align 4
++L(256bytesormore):
++	mov	%rdi, %rcx
++	sub	%rsi, %rcx
++	cmp	%rdx, %rcx
++	jc	L(copy_backward)
++	cmp	$2048, %rdx
++	jae	L(gobble_data_movsb)
++	mov	%rax, %r8
++	lea	(%rsi, %rdx), %rcx
++	mov	%rdi, %r10
++	vmovdqu -0x80(%rcx), %xmm5
++	vmovdqu -0x70(%rcx), %xmm6
++	mov	$0x80, %rax
++	and	$-32, %rdi
++	add	$32, %rdi
++	vmovdqu -0x60(%rcx), %xmm7
++	vmovdqu -0x50(%rcx), %xmm8
++	mov	%rdi, %r11
++	sub	%r10, %r11
++	vmovdqu -0x40(%rcx), %xmm9
++	vmovdqu -0x30(%rcx), %xmm10
++	sub	%r11, %rdx
++	vmovdqu -0x20(%rcx), %xmm11
++	vmovdqu -0x10(%rcx), %xmm12
++	vmovdqu	(%rsi), %ymm4
++	add	%r11, %rsi
++	sub	%eax, %edx
++L(goble_128_loop):
++	vmovdqu (%rsi), %ymm0
++	vmovdqu 0x20(%rsi), %ymm1
++	vmovdqu 0x40(%rsi), %ymm2
++	vmovdqu 0x60(%rsi), %ymm3
++	add	%rax, %rsi
++	vmovdqa %ymm0, (%rdi)
++	vmovdqa %ymm1, 0x20(%rdi)
++	vmovdqa %ymm2, 0x40(%rdi)
++	vmovdqa %ymm3, 0x60(%rdi)
++	add	%rax, %rdi
++	sub	%eax, %edx
++	jae	L(goble_128_loop)
++	add	%eax, %edx
++	add	%rdi, %rdx
++	vmovdqu	%ymm4, (%r10)
++	vzeroupper
++	vmovdqu %xmm5, -0x80(%rdx)
++	vmovdqu %xmm6, -0x70(%rdx)
++	vmovdqu %xmm7, -0x60(%rdx)
++	vmovdqu %xmm8, -0x50(%rdx)
++	vmovdqu %xmm9, -0x40(%rdx)
++	vmovdqu %xmm10, -0x30(%rdx)
++	vmovdqu %xmm11, -0x20(%rdx)
++	vmovdqu %xmm12, -0x10(%rdx)
++	mov	%r8, %rax
++	ret
++
++	.p2align 4
++L(gobble_data_movsb):
++#ifdef SHARED_CACHE_SIZE_HALF
++	mov	$SHARED_CACHE_SIZE_HALF, %rcx
++#else
++	mov	__x86_shared_cache_size_half(%rip), %rcx
++#endif
++	shl	$3, %rcx
++	cmp	%rcx, %rdx
++	jae	L(gobble_big_data_fwd)
++	mov	%rdx, %rcx
++	mov	%rdx, %rcx
++	rep	movsb
++	ret
++
++	.p2align 4
++L(gobble_big_data_fwd):
++	lea	(%rsi, %rdx), %rcx
++	vmovdqu	(%rsi), %ymm4
++	vmovdqu -0x80(%rsi,%rdx), %xmm5
++	vmovdqu -0x70(%rcx), %xmm6
++	vmovdqu -0x60(%rcx), %xmm7
++	vmovdqu -0x50(%rcx), %xmm8
++	vmovdqu -0x40(%rcx), %xmm9
++	vmovdqu -0x30(%rcx), %xmm10
++	vmovdqu -0x20(%rcx), %xmm11
++	vmovdqu -0x10(%rcx), %xmm12
++	mov	%rdi, %r8
++	and	$-32, %rdi
++	add	$32, %rdi
++	mov	%rdi, %r10
++	sub	%r8, %r10
++	sub	%r10, %rdx
++	add	%r10, %rsi
++	lea	(%rdi, %rdx), %rcx
++	add	$-0x80, %rdx
++L(gobble_mem_fwd_loop):
++	prefetchnta 0x1c0(%rsi)
++	prefetchnta 0x280(%rsi)
++	vmovdqu	(%rsi), %ymm0
++	vmovdqu	0x20(%rsi), %ymm1
++	vmovdqu	0x40(%rsi), %ymm2
++	vmovdqu	0x60(%rsi), %ymm3
++	sub	$-0x80, %rsi
++	vmovntdq	%ymm0, (%rdi)
++	vmovntdq	%ymm1, 0x20(%rdi)
++	vmovntdq	%ymm2, 0x40(%rdi)
++	vmovntdq	%ymm3, 0x60(%rdi)
++	sub	$-0x80, %rdi
++	add	$-0x80, %rdx
++	jb	L(gobble_mem_fwd_loop)
++	sfence
++	vmovdqu	%ymm4, (%r8)
++	vzeroupper
++	vmovdqu %xmm5, -0x80(%rcx)
++	vmovdqu %xmm6, -0x70(%rcx)
++	vmovdqu %xmm7, -0x60(%rcx)
++	vmovdqu %xmm8, -0x50(%rcx)
++	vmovdqu %xmm9, -0x40(%rcx)
++	vmovdqu %xmm10, -0x30(%rcx)
++	vmovdqu %xmm11, -0x20(%rcx)
++	vmovdqu %xmm12, -0x10(%rcx)
++	ret
++
++	.p2align 4
++L(copy_backward):
++#ifdef SHARED_CACHE_SIZE_HALF
++	mov	$SHARED_CACHE_SIZE_HALF, %rcx
++#else
++	mov	__x86_shared_cache_size_half(%rip), %rcx
++#endif
++	shl	$3, %rcx
++	vmovdqu (%rsi), %xmm5
++	vmovdqu 0x10(%rsi), %xmm6
++	add	%rdx, %rdi
++	vmovdqu 0x20(%rsi), %xmm7
++	vmovdqu 0x30(%rsi), %xmm8
++	lea	-0x20(%rdi), %r10
++	mov %rdi, %r11
++	vmovdqu 0x40(%rsi), %xmm9
++	vmovdqu 0x50(%rsi), %xmm10
++	and	$0x1f, %r11
++	vmovdqu 0x60(%rsi), %xmm11
++	vmovdqu 0x70(%rsi), %xmm12
++	xor	%r11, %rdi
++	add	%rdx, %rsi
++	vmovdqu	-0x20(%rsi), %ymm4
++	sub	%r11, %rsi
++	sub	%r11, %rdx
++	cmp	%rcx, %rdx
++	ja	L(gobble_big_data_bwd)
++	add	$-0x80, %rdx
++L(gobble_mem_bwd_llc):
++	vmovdqu	-0x20(%rsi), %ymm0
++	vmovdqu	-0x40(%rsi), %ymm1
++	vmovdqu	-0x60(%rsi), %ymm2
++	vmovdqu	-0x80(%rsi), %ymm3
++	lea	-0x80(%rsi), %rsi
++	vmovdqa	%ymm0, -0x20(%rdi)
++	vmovdqa	%ymm1, -0x40(%rdi)
++	vmovdqa	%ymm2, -0x60(%rdi)
++	vmovdqa	%ymm3, -0x80(%rdi)
++	lea	-0x80(%rdi), %rdi
++	add	$-0x80, %rdx
++	jb	L(gobble_mem_bwd_llc)
++	vmovdqu	%ymm4, (%r10)
++	vzeroupper
++	vmovdqu %xmm5, (%rax)
++	vmovdqu %xmm6, 0x10(%rax)
++	vmovdqu %xmm7, 0x20(%rax)
++	vmovdqu %xmm8, 0x30(%rax)
++	vmovdqu %xmm9, 0x40(%rax)
++	vmovdqu %xmm10, 0x50(%rax)
++	vmovdqu %xmm11, 0x60(%rax)
++	vmovdqu %xmm12, 0x70(%rax)
++	ret
++
++	.p2align 4
++L(gobble_big_data_bwd):
++	add	$-0x80, %rdx
++L(gobble_mem_bwd_loop):
++	prefetchnta -0x1c0(%rsi)
++	prefetchnta -0x280(%rsi)
++	vmovdqu	-0x20(%rsi), %ymm0
++	vmovdqu	-0x40(%rsi), %ymm1
++	vmovdqu	-0x60(%rsi), %ymm2
++	vmovdqu	-0x80(%rsi), %ymm3
++	lea	-0x80(%rsi), %rsi
++	vmovntdq	%ymm0, -0x20(%rdi)
++	vmovntdq	%ymm1, -0x40(%rdi)
++	vmovntdq	%ymm2, -0x60(%rdi)
++	vmovntdq	%ymm3, -0x80(%rdi)
++	lea	-0x80(%rdi), %rdi
++	add	$-0x80, %rdx
++	jb	L(gobble_mem_bwd_loop)
++	sfence
++	vmovdqu	%ymm4, (%r10)
++	vzeroupper
++	vmovdqu %xmm5, (%rax)
++	vmovdqu %xmm6, 0x10(%rax)
++	vmovdqu %xmm7, 0x20(%rax)
++	vmovdqu %xmm8, 0x30(%rax)
++	vmovdqu %xmm9, 0x40(%rax)
++	vmovdqu %xmm10, 0x50(%rax)
++	vmovdqu %xmm11, 0x60(%rax)
++	vmovdqu %xmm12, 0x70(%rax)
++	ret
++END (MEMMOVE)
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-memrchr-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-memrchr-kbl.S
+new file mode 100644
+index 0000000..a958fb5
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-memrchr-kbl.S
+@@ -0,0 +1,408 @@
++/* memrchr optimized with AVX2.
++   Copyright (C) 2017-2019 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <http://www.gnu.org/licenses/>.  */
++
++#ifndef L
++# define L(label)       .L##label
++#endif
++
++#ifndef cfi_startproc
++# define cfi_startproc  .cfi_startproc
++#endif
++
++#ifndef cfi_endproc
++# define cfi_endproc    .cfi_endproc
++#endif
++
++#ifndef cfi_rel_offset
++# define cfi_rel_offset(reg, off)       .cfi_rel_offset reg, off
++#endif
++
++#ifndef cfi_restore
++# define cfi_restore(reg)       .cfi_restore reg
++#endif
++
++#ifndef cfi_adjust_cfa_offset
++# define cfi_adjust_cfa_offset(off)     .cfi_adjust_cfa_offset off
++#endif
++
++#ifndef ENTRY
++# define ENTRY(name)    \
++        .type name,  @function; \
++        .globl name;    \
++        .p2align 4;     \
++name:   \
++        cfi_startproc
++#endif
++
++#ifndef END
++# define END(name)      \
++        cfi_endproc;    \
++        .size name,     .-name
++#endif
++
++#define CFI_PUSH(REG)   \
++        cfi_adjust_cfa_offset (4);      \
++        cfi_rel_offset (REG, 0)
++
++#define CFI_POP(REG)    \
++        cfi_adjust_cfa_offset (-4);     \
++        cfi_restore (REG)
++
++#define PUSH(REG) pushl REG; CFI_PUSH (REG)
++#define POP(REG) popl REG; CFI_POP (REG)
++
++# ifndef MEMRCHR
++#  define MEMRCHR          memrchr_avx2
++# endif
++
++#ifndef VZEROUPPER
++#  define VZEROUPPER	vzeroupper
++# endif
++
++# define VEC_SIZE 32
++
++	.section .text.avx,"ax",@progbits
++ENTRY (MEMRCHR)
++	/* Broadcast CHAR to YMM0.  */
++	vmovd	%esi, %xmm0
++	vpbroadcastb %xmm0, %ymm0
++
++	sub	$VEC_SIZE, %rdx
++	jbe	L(last_vec_or_less)
++
++	add	%rdx, %rdi
++
++	/* Check the last VEC_SIZE bytes.  */
++	vpcmpeqb (%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(last_vec_x0)
++
++	subq	$(VEC_SIZE * 4), %rdi
++	movl	%edi, %ecx
++	andl	$(VEC_SIZE - 1), %ecx
++	jz	L(aligned_more)
++
++	/* Align data for aligned loads in the loop.  */
++	addq	$VEC_SIZE, %rdi
++	addq	$VEC_SIZE, %rdx
++	andq	$-VEC_SIZE, %rdi
++	subq	%rcx, %rdx
++
++	.p2align 4
++L(aligned_more):
++	subq	$(VEC_SIZE * 4), %rdx
++	jbe	L(last_4x_vec_or_less)
++
++	/* Check the last 4 * VEC_SIZE.  Only one VEC_SIZE at a time
++	   since data is only aligned to VEC_SIZE.  */
++	vpcmpeqb (VEC_SIZE * 3)(%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(last_vec_x3)
++
++	vpcmpeqb (VEC_SIZE * 2)(%rdi), %ymm0, %ymm2
++	vpmovmskb %ymm2, %eax
++	testl	%eax, %eax
++	jnz	L(last_vec_x2)
++
++	vpcmpeqb VEC_SIZE(%rdi), %ymm0, %ymm3
++	vpmovmskb %ymm3, %eax
++	testl	%eax, %eax
++	jnz	L(last_vec_x1)
++
++	vpcmpeqb (%rdi), %ymm0, %ymm4
++	vpmovmskb %ymm4, %eax
++	testl	%eax, %eax
++	jnz	L(last_vec_x0)
++
++	/* Align data to 4 * VEC_SIZE for loop with fewer branches.
++	   There are some overlaps with above if data isn't aligned
++	   to 4 * VEC_SIZE.  */
++	movl	%edi, %ecx
++	andl	$(VEC_SIZE * 4 - 1), %ecx
++	jz	L(loop_4x_vec)
++
++	addq	$(VEC_SIZE * 4), %rdi
++	addq	$(VEC_SIZE * 4), %rdx
++	andq	$-(VEC_SIZE * 4), %rdi
++	subq	%rcx, %rdx
++
++	.p2align 4
++L(loop_4x_vec):
++	/* Compare 4 * VEC at a time forward.  */
++	subq	$(VEC_SIZE * 4), %rdi
++	subq	$(VEC_SIZE * 4), %rdx
++	jbe	L(last_4x_vec_or_less)
++
++	vmovdqa	(%rdi), %ymm1
++	vmovdqa	VEC_SIZE(%rdi), %ymm2
++	vmovdqa	(VEC_SIZE * 2)(%rdi), %ymm3
++	vmovdqa	(VEC_SIZE * 3)(%rdi), %ymm4
++
++	vpcmpeqb %ymm1, %ymm0, %ymm1
++	vpcmpeqb %ymm2, %ymm0, %ymm2
++	vpcmpeqb %ymm3, %ymm0, %ymm3
++	vpcmpeqb %ymm4, %ymm0, %ymm4
++
++	vpor	%ymm1, %ymm2, %ymm5
++	vpor	%ymm3, %ymm4, %ymm6
++	vpor	%ymm5, %ymm6, %ymm5
++
++	vpmovmskb %ymm5, %eax
++	testl	%eax, %eax
++	jz	L(loop_4x_vec)
++
++	/* There is a match.  */
++	vpmovmskb %ymm4, %eax
++	testl	%eax, %eax
++	jnz	L(last_vec_x3)
++
++	vpmovmskb %ymm3, %eax
++	testl	%eax, %eax
++	jnz	L(last_vec_x2)
++
++	vpmovmskb %ymm2, %eax
++	testl	%eax, %eax
++	jnz	L(last_vec_x1)
++
++	vpmovmskb %ymm1, %eax
++	bsrl	%eax, %eax
++	addq	%rdi, %rax
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(last_4x_vec_or_less):
++	addl	$(VEC_SIZE * 4), %edx
++	cmpl	$(VEC_SIZE * 2), %edx
++	jbe	L(last_2x_vec)
++
++	vpcmpeqb (VEC_SIZE * 3)(%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(last_vec_x3)
++
++	vpcmpeqb (VEC_SIZE * 2)(%rdi), %ymm0, %ymm2
++	vpmovmskb %ymm2, %eax
++	testl	%eax, %eax
++	jnz	L(last_vec_x2)
++
++	vpcmpeqb VEC_SIZE(%rdi), %ymm0, %ymm3
++	vpmovmskb %ymm3, %eax
++	testl	%eax, %eax
++	jnz	L(last_vec_x1_check)
++	cmpl	$(VEC_SIZE * 3), %edx
++	jbe	L(zero)
++
++	vpcmpeqb (%rdi), %ymm0, %ymm4
++	vpmovmskb %ymm4, %eax
++	testl	%eax, %eax
++	jz	L(zero)
++	bsrl	%eax, %eax
++	subq	$(VEC_SIZE * 4), %rdx
++	addq	%rax, %rdx
++	jl	L(zero)
++	addq	%rdi, %rax
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(last_2x_vec):
++	vpcmpeqb (VEC_SIZE * 3)(%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(last_vec_x3_check)
++	cmpl	$VEC_SIZE, %edx
++	jbe	L(zero)
++
++	vpcmpeqb (VEC_SIZE * 2)(%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jz	L(zero)
++	bsrl	%eax, %eax
++	subq	$(VEC_SIZE * 2), %rdx
++	addq	%rax, %rdx
++	jl	L(zero)
++	addl	$(VEC_SIZE * 2), %eax
++	addq	%rdi, %rax
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(last_vec_x0):
++	bsrl	%eax, %eax
++	addq	%rdi, %rax
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(last_vec_x1):
++	bsrl	%eax, %eax
++	addl	$VEC_SIZE, %eax
++	addq	%rdi, %rax
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(last_vec_x2):
++	bsrl	%eax, %eax
++	addl	$(VEC_SIZE * 2), %eax
++	addq	%rdi, %rax
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(last_vec_x3):
++	bsrl	%eax, %eax
++	addl	$(VEC_SIZE * 3), %eax
++	addq	%rdi, %rax
++	ret
++
++	.p2align 4
++L(last_vec_x1_check):
++	bsrl	%eax, %eax
++	subq	$(VEC_SIZE * 3), %rdx
++	addq	%rax, %rdx
++	jl	L(zero)
++	addl	$VEC_SIZE, %eax
++	addq	%rdi, %rax
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(last_vec_x3_check):
++	bsrl	%eax, %eax
++	subq	$VEC_SIZE, %rdx
++	addq	%rax, %rdx
++	jl	L(zero)
++	addl	$(VEC_SIZE * 3), %eax
++	addq	%rdi, %rax
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(zero):
++	VZEROUPPER
++L(null):
++	xorl	%eax, %eax
++	ret
++
++	.p2align 4
++L(last_vec_or_less_aligned):
++	movl	%edx, %ecx
++
++	vpcmpeqb (%rdi), %ymm0, %ymm1
++
++	movl	$1, %edx
++	/* Support rdx << 32.  */
++	salq	%cl, %rdx
++	subq	$1, %rdx
++
++	vpmovmskb %ymm1, %eax
++
++	/* Remove the trailing bytes.  */
++	andl	%edx, %eax
++	testl	%eax, %eax
++	jz	L(zero)
++
++	bsrl	%eax, %eax
++	addq	%rdi, %rax
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(last_vec_or_less):
++	addl	$VEC_SIZE, %edx
++
++	/* Check for zero length.  */
++	testl	%edx, %edx
++	jz	L(null)
++
++	movl	%edi, %ecx
++	andl	$(VEC_SIZE - 1), %ecx
++	jz	L(last_vec_or_less_aligned)
++
++	movl	%ecx, %esi
++	movl	%ecx, %r8d
++	addl	%edx, %esi
++	andq	$-VEC_SIZE, %rdi
++
++	subl	$VEC_SIZE, %esi
++	ja	L(last_vec_2x_aligned)
++
++	/* Check the last VEC.  */
++	vpcmpeqb (%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++
++	/* Remove the leading and trailing bytes.  */
++	sarl	%cl, %eax
++	movl	%edx, %ecx
++
++	movl	$1, %edx
++	sall	%cl, %edx
++	subl	$1, %edx
++
++	andl	%edx, %eax
++	testl	%eax, %eax
++	jz	L(zero)
++
++	bsrl	%eax, %eax
++	addq	%rdi, %rax
++	addq	%r8, %rax
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(last_vec_2x_aligned):
++	movl	%esi, %ecx
++
++	/* Check the last VEC.  */
++	vpcmpeqb VEC_SIZE(%rdi), %ymm0, %ymm1
++
++	movl	$1, %edx
++	sall	%cl, %edx
++	subl	$1, %edx
++
++	vpmovmskb %ymm1, %eax
++
++	/* Remove the trailing bytes.  */
++	andl	%edx, %eax
++
++	testl	%eax, %eax
++	jnz	L(last_vec_x1)
++
++	/* Check the second last VEC.  */
++	vpcmpeqb (%rdi), %ymm0, %ymm1
++
++	movl	%r8d, %ecx
++
++	vpmovmskb %ymm1, %eax
++
++	/* Remove the leading bytes.  Must use unsigned right shift for
++	   bsrl below.  */
++	shrl	%cl, %eax
++	testl	%eax, %eax
++	jz	L(zero)
++
++	bsrl	%eax, %eax
++	addq	%rdi, %rax
++	addq	%r8, %rax
++	VZEROUPPER
++	ret
++END (MEMRCHR)
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-wmemset-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-wmemset-kbl.S
+new file mode 100644
+index 0000000..7c485cf
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-wmemset-kbl.S
+@@ -0,0 +1,140 @@
++/*
++Copyright (C) 2019 The Android Open Source Project
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions
++are met:
++ * Redistributions of source code must retain the above copyright
++   notice, this list of conditions and the following disclaimer.
++ * Redistributions in binary form must reproduce the above copyright
++   notice, this list of conditions and the following disclaimer in
++   the documentation and/or other materials provided with the
++   distribution.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
++FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
++COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
++INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
++BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
++OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
++AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
++OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
++OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++SUCH DAMAGE.
++*/
++
++#include <private/bionic_asm.h>
++
++#ifndef WMEMSET
++ #define WMEMSET wmemset_avx2
++#endif
++
++        .section .text.avx2,"ax",@progbits
++
++ENTRY (WMEMSET)
++# BB#0:
++	testq	%rdx, %rdx
++	je	.LBB0_14
++# BB#1:
++	cmpq	$32, %rdx
++	jae	.LBB0_3
++# BB#2:
++	xorl	%r8d, %r8d
++	movq	%rdi, %rax
++	jmp	.LBB0_12
++.LBB0_3:
++	movq	%rdx, %r8
++	andq	$-32, %r8
++	vmovd	%esi, %xmm0
++	vpbroadcastd	%xmm0, %ymm0
++	leaq	-32(%r8), %rcx
++	movq	%rcx, %rax
++	shrq	$5, %rax
++	leal	1(%rax), %r9d
++	andl	$7, %r9d
++	cmpq	$224, %rcx
++	jae	.LBB0_5
++# BB#4:
++	xorl	%eax, %eax
++	testq	%r9, %r9
++	jne	.LBB0_8
++	jmp	.LBB0_10
++.LBB0_5:
++	leaq	992(%rdi), %rcx
++	leaq	-1(%r9), %r10
++	subq	%rax, %r10
++	xorl	%eax, %eax
++	.p2align	4, 0x90
++.LBB0_6:                                # =>This Inner Loop Header: Depth=1
++	vmovdqu	%ymm0, -992(%rcx,%rax,4)
++	vmovdqu	%ymm0, -960(%rcx,%rax,4)
++	vmovdqu	%ymm0, -928(%rcx,%rax,4)
++	vmovdqu	%ymm0, -896(%rcx,%rax,4)
++	vmovdqu	%ymm0, -864(%rcx,%rax,4)
++	vmovdqu	%ymm0, -832(%rcx,%rax,4)
++	vmovdqu	%ymm0, -800(%rcx,%rax,4)
++	vmovdqu	%ymm0, -768(%rcx,%rax,4)
++	vmovdqu	%ymm0, -736(%rcx,%rax,4)
++	vmovdqu	%ymm0, -704(%rcx,%rax,4)
++	vmovdqu	%ymm0, -672(%rcx,%rax,4)
++	vmovdqu	%ymm0, -640(%rcx,%rax,4)
++	vmovdqu	%ymm0, -608(%rcx,%rax,4)
++	vmovdqu	%ymm0, -576(%rcx,%rax,4)
++	vmovdqu	%ymm0, -544(%rcx,%rax,4)
++	vmovdqu	%ymm0, -512(%rcx,%rax,4)
++	vmovdqu	%ymm0, -480(%rcx,%rax,4)
++	vmovdqu	%ymm0, -448(%rcx,%rax,4)
++	vmovdqu	%ymm0, -416(%rcx,%rax,4)
++	vmovdqu	%ymm0, -384(%rcx,%rax,4)
++	vmovdqu	%ymm0, -352(%rcx,%rax,4)
++	vmovdqu	%ymm0, -320(%rcx,%rax,4)
++	vmovdqu	%ymm0, -288(%rcx,%rax,4)
++	vmovdqu	%ymm0, -256(%rcx,%rax,4)
++	vmovdqu	%ymm0, -224(%rcx,%rax,4)
++	vmovdqu	%ymm0, -192(%rcx,%rax,4)
++	vmovdqu	%ymm0, -160(%rcx,%rax,4)
++	vmovdqu	%ymm0, -128(%rcx,%rax,4)
++	vmovdqu	%ymm0, -96(%rcx,%rax,4)
++	vmovdqu	%ymm0, -64(%rcx,%rax,4)
++	vmovdqu	%ymm0, -32(%rcx,%rax,4)
++	vmovdqu	%ymm0, (%rcx,%rax,4)
++	addq	$256, %rax              # imm = 0x100
++	addq	$8, %r10
++	jne	.LBB0_6
++# BB#7:
++	testq	%r9, %r9
++	je	.LBB0_10
++.LBB0_8:
++	leaq	(%rdi,%rax,4), %rax
++	addq	$96, %rax
++	negq	%r9
++	.p2align	4, 0x90
++.LBB0_9:                                # =>This Inner Loop Header: Depth=1
++	vmovdqu	%ymm0, -96(%rax)
++	vmovdqu	%ymm0, -64(%rax)
++	vmovdqu	%ymm0, -32(%rax)
++	vmovdqu	%ymm0, (%rax)
++	subq	$-128, %rax
++	addq	$1, %r9
++	jne	.LBB0_9
++.LBB0_10:
++	cmpq	%rdx, %r8
++	je	.LBB0_14
++# BB#11:
++	leaq	(%rdi,%r8,4), %rax
++.LBB0_12:
++	subq	%r8, %rdx
++	.p2align	4, 0x90
++.LBB0_13:                               # =>This Inner Loop Header: Depth=1
++	movl	%esi, (%rax)
++	addq	$4, %rax
++	addq	$-1, %rdx
++	jne	.LBB0_13
++.LBB0_14:
++	movq	%rdi, %rax
++	vzeroupper
++	retq
++END(WMEMSET)
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-memcpy-slm.s b/libc/arch-x86_64/silvermont/string/sse2-memcpy-slm.s
+new file mode 100644
+index 0000000..2965b23
+--- /dev/null
++++ b/libc/arch-x86_64/silvermont/string/sse2-memcpy-slm.s
+@@ -0,0 +1,1374 @@
++	.text
++	.file	"FastMemcpy_avx_sse2.c"
++	.globl	memcpy_sse2                  # -- Begin function memcpy
++	.p2align	4, 0x90
++	.type	memcpy_sse2,@function
++
++
++
++memcpy_sse2:                                 # @memcpy
++	.cfi_startproc
++
++# %bb.0:
++	movq	%rdi, %rax
++	cmpq	$128, %rdx
++	ja	.LBB0_129
++# %bb.1:
++	leaq	-1(%rdx), %rdi
++	cmpq	$127, %rdi
++	ja	.LBB0_145
++# %bb.2:
++	leaq	.LJTI0_1(%rip), %r8
++	leaq	(%rax,%rdx), %rcx
++	addq	%rdx, %rsi
++	movslq	(%r8,%rdi,4), %rdi
++	addq	%r8, %rdi
++	jmpq	*%rdi
++.LBB0_129:
++	movl	%eax, %edi
++	negl	%edi
++	andq	$15, %rdi
++	je	.LBB0_130
++# %bb.131:
++	movups	(%rsi), %xmm0
++	leaq	(%rax,%rdi), %rcx
++	addq	%rdi, %rsi
++	subq	%rdi, %rdx
++	movups	%xmm0, (%rax)
++	cmpq	$2097152, %rdx          # imm = 0x200000
++	ja	.LBB0_137
++.LBB0_133:
++	cmpq	$128, %rdx
++	jb	.LBB0_141
++# %bb.134:
++	movq	%rdx, %rdi
++	.p2align	4, 0x90
++.LBB0_135:                              # =>This Inner Loop Header: Depth=1
++	movups	(%rsi), %xmm0
++	movups	16(%rsi), %xmm1
++	movups	32(%rsi), %xmm2
++	movups	48(%rsi), %xmm3
++	movups	64(%rsi), %xmm4
++	movups	80(%rsi), %xmm5
++	movups	96(%rsi), %xmm6
++	movups	112(%rsi), %xmm7
++	prefetchnta	256(%rsi)
++	addq	$-128, %rdi
++	subq	$-128, %rsi
++	movaps	%xmm0, (%rcx)
++	movaps	%xmm1, 16(%rcx)
++	movaps	%xmm2, 32(%rcx)
++	movaps	%xmm3, 48(%rcx)
++	movaps	%xmm4, 64(%rcx)
++	movaps	%xmm5, 80(%rcx)
++	movaps	%xmm6, 96(%rcx)
++	movaps	%xmm7, 112(%rcx)
++	subq	$-128, %rcx
++	cmpq	$127, %rdi
++	ja	.LBB0_135
++# %bb.136:
++	andl	$127, %edx
++	leaq	-1(%rdx), %rdi
++	cmpq	$127, %rdi
++	jbe	.LBB0_142
++	jmp	.LBB0_145
++.LBB0_130:
++	movq	%rax, %rcx
++	cmpq	$2097152, %rdx          # imm = 0x200000
++	jbe	.LBB0_133
++.LBB0_137:
++	prefetchnta	(%rsi)
++	movq	%rdx, %rdi
++	testb	$15, %sil
++	je	.LBB0_139
++	.p2align	4, 0x90
++.LBB0_138:                              # =>This Inner Loop Header: Depth=1
++	movups	(%rsi), %xmm0
++	movups	16(%rsi), %xmm1
++	movups	32(%rsi), %xmm2
++	movups	48(%rsi), %xmm3
++	movups	64(%rsi), %xmm4
++	movups	80(%rsi), %xmm5
++	movups	96(%rsi), %xmm6
++	movups	112(%rsi), %xmm7
++	prefetchnta	256(%rsi)
++	addq	$-128, %rdi
++	subq	$-128, %rsi
++	movntps	%xmm0, (%rcx)
++	movntps	%xmm1, 16(%rcx)
++	movntps	%xmm2, 32(%rcx)
++	movntps	%xmm3, 48(%rcx)
++	movntps	%xmm4, 64(%rcx)
++	movntps	%xmm5, 80(%rcx)
++	movntps	%xmm6, 96(%rcx)
++	movntps	%xmm7, 112(%rcx)
++	subq	$-128, %rcx
++	cmpq	$127, %rdi
++	ja	.LBB0_138
++	jmp	.LBB0_140
++	.p2align	4, 0x90
++.LBB0_139:                              # =>This Inner Loop Header: Depth=1
++	movaps	(%rsi), %xmm0
++	movaps	16(%rsi), %xmm1
++	movaps	32(%rsi), %xmm2
++	movaps	48(%rsi), %xmm3
++	movaps	64(%rsi), %xmm4
++	movaps	80(%rsi), %xmm5
++	movaps	96(%rsi), %xmm6
++	movaps	112(%rsi), %xmm7
++	prefetchnta	256(%rsi)
++	addq	$-128, %rdi
++	subq	$-128, %rsi
++	movntps	%xmm0, (%rcx)
++	movntps	%xmm1, 16(%rcx)
++	movntps	%xmm2, 32(%rcx)
++	movntps	%xmm3, 48(%rcx)
++	movntps	%xmm4, 64(%rcx)
++	movntps	%xmm5, 80(%rcx)
++	movntps	%xmm6, 96(%rcx)
++	movntps	%xmm7, 112(%rcx)
++	subq	$-128, %rcx
++	cmpq	$127, %rdi
++	ja	.LBB0_139
++.LBB0_140:
++	andl	$127, %edx
++	sfence
++.LBB0_141:
++	leaq	-1(%rdx), %rdi
++	cmpq	$127, %rdi
++	ja	.LBB0_145
++.LBB0_142:
++	leaq	.LJTI0_0(%rip), %r8
++	addq	%rdx, %rcx
++	addq	%rdx, %rsi
++	movslq	(%r8,%rdi,4), %rdi
++	addq	%r8, %rdi
++	jmpq	*%rdi
++.LBB0_143:
++	movups	-64(%rsi), %xmm0
++	movups	-48(%rsi), %xmm1
++	movups	-32(%rsi), %xmm2
++	movups	-16(%rsi), %xmm3
++	movups	%xmm0, -64(%rcx)
++	movups	%xmm1, -48(%rcx)
++	movups	%xmm2, -32(%rcx)
++	movups	%xmm3, -16(%rcx)
++	retq
++.LBB0_3:
++	movups	-65(%rsi), %xmm0
++	movups	-49(%rsi), %xmm1
++	movups	-33(%rsi), %xmm2
++	movups	-17(%rsi), %xmm3
++	movups	%xmm0, -65(%rcx)
++	movups	%xmm1, -49(%rcx)
++	movups	%xmm2, -33(%rcx)
++	movups	%xmm3, -17(%rcx)
++	movb	-1(%rsi), %dl
++	movb	%dl, -1(%rcx)
++	retq
++.LBB0_5:
++	movups	-66(%rsi), %xmm0
++	movups	-50(%rsi), %xmm1
++	movups	-34(%rsi), %xmm2
++	movups	-18(%rsi), %xmm3
++	movups	%xmm0, -66(%rcx)
++	movups	%xmm1, -50(%rcx)
++	movups	%xmm2, -34(%rcx)
++	movups	%xmm3, -18(%rcx)
++	movzwl	-2(%rsi), %edx
++	movw	%dx, -2(%rcx)
++	retq
++.LBB0_7:
++	movups	-67(%rsi), %xmm0
++	movups	-51(%rsi), %xmm1
++	movups	-35(%rsi), %xmm2
++	movups	-19(%rsi), %xmm3
++	movups	%xmm0, -67(%rcx)
++	movups	%xmm1, -51(%rcx)
++	movups	%xmm2, -35(%rcx)
++	movups	%xmm3, -19(%rcx)
++	jmp	.LBB0_8
++.LBB0_9:
++	movups	-68(%rsi), %xmm0
++	movups	-52(%rsi), %xmm1
++	movups	-36(%rsi), %xmm2
++	movups	-20(%rsi), %xmm3
++	movups	%xmm0, -68(%rcx)
++	movups	%xmm1, -52(%rcx)
++	movups	%xmm2, -36(%rcx)
++	movups	%xmm3, -20(%rcx)
++	movl	-4(%rsi), %edx
++	movl	%edx, -4(%rcx)
++	retq
++.LBB0_11:
++	movups	-69(%rsi), %xmm0
++	movups	-53(%rsi), %xmm1
++	movups	-37(%rsi), %xmm2
++	movups	-21(%rsi), %xmm3
++	movups	%xmm0, -69(%rcx)
++	movups	%xmm1, -53(%rcx)
++	movups	%xmm2, -37(%rcx)
++	movups	%xmm3, -21(%rcx)
++	jmp	.LBB0_12
++.LBB0_13:
++	movups	-70(%rsi), %xmm0
++	movups	-54(%rsi), %xmm1
++	movups	-38(%rsi), %xmm2
++	movups	-22(%rsi), %xmm3
++	movups	%xmm0, -70(%rcx)
++	movups	%xmm1, -54(%rcx)
++	movups	%xmm2, -38(%rcx)
++	movups	%xmm3, -22(%rcx)
++	jmp	.LBB0_14
++.LBB0_15:
++	movups	-71(%rsi), %xmm0
++	movups	-55(%rsi), %xmm1
++	movups	-39(%rsi), %xmm2
++	movups	-23(%rsi), %xmm3
++	movups	%xmm0, -71(%rcx)
++	movups	%xmm1, -55(%rcx)
++	movups	%xmm2, -39(%rcx)
++	movups	%xmm3, -23(%rcx)
++	jmp	.LBB0_16
++.LBB0_17:
++	movups	-72(%rsi), %xmm0
++	movups	-56(%rsi), %xmm1
++	movups	-40(%rsi), %xmm2
++	movups	-24(%rsi), %xmm3
++	movups	%xmm0, -72(%rcx)
++	movups	%xmm1, -56(%rcx)
++	movups	%xmm2, -40(%rcx)
++	movups	%xmm3, -24(%rcx)
++	movq	-8(%rsi), %rdx
++	movq	%rdx, -8(%rcx)
++	retq
++.LBB0_19:
++	movups	-73(%rsi), %xmm0
++	movups	-57(%rsi), %xmm1
++	movups	-41(%rsi), %xmm2
++	movups	-25(%rsi), %xmm3
++	movups	%xmm0, -73(%rcx)
++	movups	%xmm1, -57(%rcx)
++	movups	%xmm2, -41(%rcx)
++	movups	%xmm3, -25(%rcx)
++	jmp	.LBB0_20
++.LBB0_21:
++	movups	-74(%rsi), %xmm0
++	movups	-58(%rsi), %xmm1
++	movups	-42(%rsi), %xmm2
++	movups	-26(%rsi), %xmm3
++	movups	%xmm0, -74(%rcx)
++	movups	%xmm1, -58(%rcx)
++	movups	%xmm2, -42(%rcx)
++	movups	%xmm3, -26(%rcx)
++	jmp	.LBB0_22
++.LBB0_23:
++	movups	-75(%rsi), %xmm0
++	movups	-59(%rsi), %xmm1
++	movups	-43(%rsi), %xmm2
++	movups	-27(%rsi), %xmm3
++	movups	%xmm0, -75(%rcx)
++	movups	%xmm1, -59(%rcx)
++	movups	%xmm2, -43(%rcx)
++	movups	%xmm3, -27(%rcx)
++	jmp	.LBB0_24
++.LBB0_25:
++	movups	-76(%rsi), %xmm0
++	movups	-60(%rsi), %xmm1
++	movups	-44(%rsi), %xmm2
++	movups	-28(%rsi), %xmm3
++	movups	%xmm0, -76(%rcx)
++	movups	%xmm1, -60(%rcx)
++	movups	%xmm2, -44(%rcx)
++	movups	%xmm3, -28(%rcx)
++	jmp	.LBB0_26
++.LBB0_27:
++	movups	-77(%rsi), %xmm0
++	movups	-61(%rsi), %xmm1
++	movups	-45(%rsi), %xmm2
++	movups	-29(%rsi), %xmm3
++	movups	%xmm0, -77(%rcx)
++	movups	%xmm1, -61(%rcx)
++	movups	%xmm2, -45(%rcx)
++	movups	%xmm3, -29(%rcx)
++	jmp	.LBB0_28
++.LBB0_29:
++	movups	-78(%rsi), %xmm0
++	movups	-62(%rsi), %xmm1
++	movups	-46(%rsi), %xmm2
++	movups	-30(%rsi), %xmm3
++	movups	%xmm0, -78(%rcx)
++	movups	%xmm1, -62(%rcx)
++	movups	%xmm2, -46(%rcx)
++	movups	%xmm3, -30(%rcx)
++	jmp	.LBB0_30
++.LBB0_31:
++	movups	-79(%rsi), %xmm0
++	movups	-63(%rsi), %xmm1
++	movups	-47(%rsi), %xmm2
++	movups	-31(%rsi), %xmm3
++	movups	%xmm0, -79(%rcx)
++	movups	%xmm1, -63(%rcx)
++	movups	%xmm2, -47(%rcx)
++	movups	%xmm3, -31(%rcx)
++	jmp	.LBB0_32
++.LBB0_33:
++	movups	-80(%rsi), %xmm0
++	movups	-64(%rsi), %xmm1
++	movups	-48(%rsi), %xmm2
++	movups	-32(%rsi), %xmm3
++	movups	%xmm0, -80(%rcx)
++	movups	%xmm1, -64(%rcx)
++	movups	%xmm2, -48(%rcx)
++	movups	%xmm3, -32(%rcx)
++	movups	-16(%rsi), %xmm0
++	movups	%xmm0, -16(%rcx)
++	retq
++.LBB0_35:
++	movups	-81(%rsi), %xmm0
++	movups	-65(%rsi), %xmm1
++	movups	-49(%rsi), %xmm2
++	movups	-33(%rsi), %xmm3
++	movups	%xmm0, -81(%rcx)
++	movups	%xmm1, -65(%rcx)
++	movups	%xmm2, -49(%rcx)
++	movups	%xmm3, -33(%rcx)
++	jmp	.LBB0_36
++.LBB0_37:
++	movups	-82(%rsi), %xmm0
++	movups	-66(%rsi), %xmm1
++	movups	-50(%rsi), %xmm2
++	movups	-34(%rsi), %xmm3
++	movups	%xmm0, -82(%rcx)
++	movups	%xmm1, -66(%rcx)
++	movups	%xmm2, -50(%rcx)
++	movups	%xmm3, -34(%rcx)
++	jmp	.LBB0_38
++.LBB0_39:
++	movups	-83(%rsi), %xmm0
++	movups	-67(%rsi), %xmm1
++	movups	-51(%rsi), %xmm2
++	movups	-35(%rsi), %xmm3
++	movups	%xmm0, -83(%rcx)
++	movups	%xmm1, -67(%rcx)
++	movups	%xmm2, -51(%rcx)
++	movups	%xmm3, -35(%rcx)
++	jmp	.LBB0_40
++.LBB0_41:
++	movups	-84(%rsi), %xmm0
++	movups	-68(%rsi), %xmm1
++	movups	-52(%rsi), %xmm2
++	movups	-36(%rsi), %xmm3
++	movups	%xmm0, -84(%rcx)
++	movups	%xmm1, -68(%rcx)
++	movups	%xmm2, -52(%rcx)
++	movups	%xmm3, -36(%rcx)
++	jmp	.LBB0_42
++.LBB0_43:
++	movups	-85(%rsi), %xmm0
++	movups	-69(%rsi), %xmm1
++	movups	-53(%rsi), %xmm2
++	movups	-37(%rsi), %xmm3
++	movups	%xmm0, -85(%rcx)
++	movups	%xmm1, -69(%rcx)
++	movups	%xmm2, -53(%rcx)
++	movups	%xmm3, -37(%rcx)
++	jmp	.LBB0_44
++.LBB0_45:
++	movups	-86(%rsi), %xmm0
++	movups	-70(%rsi), %xmm1
++	movups	-54(%rsi), %xmm2
++	movups	-38(%rsi), %xmm3
++	movups	%xmm0, -86(%rcx)
++	movups	%xmm1, -70(%rcx)
++	movups	%xmm2, -54(%rcx)
++	movups	%xmm3, -38(%rcx)
++	jmp	.LBB0_46
++.LBB0_47:
++	movups	-87(%rsi), %xmm0
++	movups	-71(%rsi), %xmm1
++	movups	-55(%rsi), %xmm2
++	movups	-39(%rsi), %xmm3
++	movups	%xmm0, -87(%rcx)
++	movups	%xmm1, -71(%rcx)
++	movups	%xmm2, -55(%rcx)
++	movups	%xmm3, -39(%rcx)
++	jmp	.LBB0_48
++.LBB0_49:
++	movups	-88(%rsi), %xmm0
++	movups	-72(%rsi), %xmm1
++	movups	-56(%rsi), %xmm2
++	movups	-40(%rsi), %xmm3
++	movups	%xmm0, -88(%rcx)
++	movups	%xmm1, -72(%rcx)
++	movups	%xmm2, -56(%rcx)
++	movups	%xmm3, -40(%rcx)
++	jmp	.LBB0_50
++.LBB0_51:
++	movups	-89(%rsi), %xmm0
++	movups	-73(%rsi), %xmm1
++	movups	-57(%rsi), %xmm2
++	movups	-41(%rsi), %xmm3
++	movups	%xmm0, -89(%rcx)
++	movups	%xmm1, -73(%rcx)
++	movups	%xmm2, -57(%rcx)
++	movups	%xmm3, -41(%rcx)
++	jmp	.LBB0_52
++.LBB0_53:
++	movups	-90(%rsi), %xmm0
++	movups	-74(%rsi), %xmm1
++	movups	-58(%rsi), %xmm2
++	movups	-42(%rsi), %xmm3
++	movups	%xmm0, -90(%rcx)
++	movups	%xmm1, -74(%rcx)
++	movups	%xmm2, -58(%rcx)
++	movups	%xmm3, -42(%rcx)
++	jmp	.LBB0_54
++.LBB0_55:
++	movups	-91(%rsi), %xmm0
++	movups	-75(%rsi), %xmm1
++	movups	-59(%rsi), %xmm2
++	movups	-43(%rsi), %xmm3
++	movups	%xmm0, -91(%rcx)
++	movups	%xmm1, -75(%rcx)
++	movups	%xmm2, -59(%rcx)
++	movups	%xmm3, -43(%rcx)
++	jmp	.LBB0_56
++.LBB0_57:
++	movups	-92(%rsi), %xmm0
++	movups	-76(%rsi), %xmm1
++	movups	-60(%rsi), %xmm2
++	movups	-44(%rsi), %xmm3
++	movups	%xmm0, -92(%rcx)
++	movups	%xmm1, -76(%rcx)
++	movups	%xmm2, -60(%rcx)
++	movups	%xmm3, -44(%rcx)
++	jmp	.LBB0_58
++.LBB0_59:
++	movups	-93(%rsi), %xmm0
++	movups	-77(%rsi), %xmm1
++	movups	-61(%rsi), %xmm2
++	movups	-45(%rsi), %xmm3
++	movups	%xmm0, -93(%rcx)
++	movups	%xmm1, -77(%rcx)
++	movups	%xmm2, -61(%rcx)
++	movups	%xmm3, -45(%rcx)
++	jmp	.LBB0_60
++.LBB0_61:
++	movups	-94(%rsi), %xmm0
++	movups	-78(%rsi), %xmm1
++	movups	-62(%rsi), %xmm2
++	movups	-46(%rsi), %xmm3
++	movups	%xmm0, -94(%rcx)
++	movups	%xmm1, -78(%rcx)
++	movups	%xmm2, -62(%rcx)
++	movups	%xmm3, -46(%rcx)
++	jmp	.LBB0_62
++.LBB0_63:
++	movups	-95(%rsi), %xmm0
++	movups	-79(%rsi), %xmm1
++	movups	-63(%rsi), %xmm2
++	movups	-47(%rsi), %xmm3
++	movups	%xmm0, -95(%rcx)
++	movups	%xmm1, -79(%rcx)
++	movups	%xmm2, -63(%rcx)
++	movups	%xmm3, -47(%rcx)
++	jmp	.LBB0_64
++.LBB0_65:
++	movups	-96(%rsi), %xmm0
++	movups	-80(%rsi), %xmm1
++	movups	-64(%rsi), %xmm2
++	movups	-48(%rsi), %xmm3
++	movups	%xmm0, -96(%rcx)
++	movups	%xmm1, -80(%rcx)
++	movups	%xmm2, -64(%rcx)
++	movups	%xmm3, -48(%rcx)
++.LBB0_66:
++	movups	-32(%rsi), %xmm0
++	movups	-16(%rsi), %xmm1
++	movups	%xmm0, -32(%rcx)
++	movups	%xmm1, -16(%rcx)
++	retq
++.LBB0_67:
++	movups	-97(%rsi), %xmm0
++	movups	-81(%rsi), %xmm1
++	movups	-65(%rsi), %xmm2
++	movups	-49(%rsi), %xmm3
++	movups	%xmm0, -97(%rcx)
++	movups	%xmm1, -81(%rcx)
++	movups	%xmm2, -65(%rcx)
++	movups	%xmm3, -49(%rcx)
++.LBB0_68:
++	movups	-33(%rsi), %xmm0
++	movups	-17(%rsi), %xmm1
++	movups	%xmm0, -33(%rcx)
++	movups	%xmm1, -17(%rcx)
++	movb	-1(%rsi), %dl
++	movb	%dl, -1(%rcx)
++	retq
++.LBB0_69:
++	movups	-98(%rsi), %xmm0
++	movups	-82(%rsi), %xmm1
++	movups	-66(%rsi), %xmm2
++	movups	-50(%rsi), %xmm3
++	movups	%xmm0, -98(%rcx)
++	movups	%xmm1, -82(%rcx)
++	movups	%xmm2, -66(%rcx)
++	movups	%xmm3, -50(%rcx)
++.LBB0_70:
++	movups	-34(%rsi), %xmm0
++	movups	-18(%rsi), %xmm1
++	movups	%xmm0, -34(%rcx)
++	movups	%xmm1, -18(%rcx)
++	movzwl	-2(%rsi), %edx
++	movw	%dx, -2(%rcx)
++	retq
++.LBB0_71:
++	movups	-99(%rsi), %xmm0
++	movups	-83(%rsi), %xmm1
++	movups	-67(%rsi), %xmm2
++	movups	-51(%rsi), %xmm3
++	movups	%xmm0, -99(%rcx)
++	movups	%xmm1, -83(%rcx)
++	movups	%xmm2, -67(%rcx)
++	movups	%xmm3, -51(%rcx)
++.LBB0_72:
++	movups	-35(%rsi), %xmm0
++	movups	-19(%rsi), %xmm1
++	movups	%xmm0, -35(%rcx)
++	movups	%xmm1, -19(%rcx)
++	jmp	.LBB0_8
++.LBB0_73:
++	movups	-100(%rsi), %xmm0
++	movups	-84(%rsi), %xmm1
++	movups	-68(%rsi), %xmm2
++	movups	-52(%rsi), %xmm3
++	movups	%xmm0, -100(%rcx)
++	movups	%xmm1, -84(%rcx)
++	movups	%xmm2, -68(%rcx)
++	movups	%xmm3, -52(%rcx)
++.LBB0_74:
++	movups	-36(%rsi), %xmm0
++	movups	-20(%rsi), %xmm1
++	movups	%xmm0, -36(%rcx)
++	movups	%xmm1, -20(%rcx)
++	movl	-4(%rsi), %edx
++	movl	%edx, -4(%rcx)
++	retq
++.LBB0_75:
++	movups	-101(%rsi), %xmm0
++	movups	-85(%rsi), %xmm1
++	movups	-69(%rsi), %xmm2
++	movups	-53(%rsi), %xmm3
++	movups	%xmm0, -101(%rcx)
++	movups	%xmm1, -85(%rcx)
++	movups	%xmm2, -69(%rcx)
++	movups	%xmm3, -53(%rcx)
++.LBB0_76:
++	movups	-37(%rsi), %xmm0
++	movups	-21(%rsi), %xmm1
++	movups	%xmm0, -37(%rcx)
++	movups	%xmm1, -21(%rcx)
++	jmp	.LBB0_12
++.LBB0_77:
++	movups	-102(%rsi), %xmm0
++	movups	-86(%rsi), %xmm1
++	movups	-70(%rsi), %xmm2
++	movups	-54(%rsi), %xmm3
++	movups	%xmm0, -102(%rcx)
++	movups	%xmm1, -86(%rcx)
++	movups	%xmm2, -70(%rcx)
++	movups	%xmm3, -54(%rcx)
++.LBB0_78:
++	movups	-38(%rsi), %xmm0
++	movups	-22(%rsi), %xmm1
++	movups	%xmm0, -38(%rcx)
++	movups	%xmm1, -22(%rcx)
++	jmp	.LBB0_14
++.LBB0_79:
++	movups	-103(%rsi), %xmm0
++	movups	-87(%rsi), %xmm1
++	movups	-71(%rsi), %xmm2
++	movups	-55(%rsi), %xmm3
++	movups	%xmm0, -103(%rcx)
++	movups	%xmm1, -87(%rcx)
++	movups	%xmm2, -71(%rcx)
++	movups	%xmm3, -55(%rcx)
++.LBB0_80:
++	movups	-39(%rsi), %xmm0
++	movups	-23(%rsi), %xmm1
++	movups	%xmm0, -39(%rcx)
++	movups	%xmm1, -23(%rcx)
++	jmp	.LBB0_16
++.LBB0_81:
++	movups	-104(%rsi), %xmm0
++	movups	-88(%rsi), %xmm1
++	movups	-72(%rsi), %xmm2
++	movups	-56(%rsi), %xmm3
++	movups	%xmm0, -104(%rcx)
++	movups	%xmm1, -88(%rcx)
++	movups	%xmm2, -72(%rcx)
++	movups	%xmm3, -56(%rcx)
++.LBB0_82:
++	movups	-40(%rsi), %xmm0
++	movups	-24(%rsi), %xmm1
++	movups	%xmm0, -40(%rcx)
++	movups	%xmm1, -24(%rcx)
++	movq	-8(%rsi), %rdx
++	movq	%rdx, -8(%rcx)
++	retq
++.LBB0_83:
++	movups	-105(%rsi), %xmm0
++	movups	-89(%rsi), %xmm1
++	movups	-73(%rsi), %xmm2
++	movups	-57(%rsi), %xmm3
++	movups	%xmm0, -105(%rcx)
++	movups	%xmm1, -89(%rcx)
++	movups	%xmm2, -73(%rcx)
++	movups	%xmm3, -57(%rcx)
++.LBB0_84:
++	movups	-41(%rsi), %xmm0
++	movups	-25(%rsi), %xmm1
++	movups	%xmm0, -41(%rcx)
++	movups	%xmm1, -25(%rcx)
++.LBB0_20:
++	movq	-9(%rsi), %rdx
++	movq	%rdx, -9(%rcx)
++.LBB0_4:
++	movb	-1(%rsi), %dl
++	movb	%dl, -1(%rcx)
++	retq
++.LBB0_85:
++	movups	-106(%rsi), %xmm0
++	movups	-90(%rsi), %xmm1
++	movups	-74(%rsi), %xmm2
++	movups	-58(%rsi), %xmm3
++	movups	%xmm0, -106(%rcx)
++	movups	%xmm1, -90(%rcx)
++	movups	%xmm2, -74(%rcx)
++	movups	%xmm3, -58(%rcx)
++.LBB0_86:
++	movups	-42(%rsi), %xmm0
++	movups	-26(%rsi), %xmm1
++	movups	%xmm0, -42(%rcx)
++	movups	%xmm1, -26(%rcx)
++.LBB0_22:
++	movq	-10(%rsi), %rdx
++	movq	%rdx, -10(%rcx)
++.LBB0_6:
++	movzwl	-2(%rsi), %edx
++	movw	%dx, -2(%rcx)
++	retq
++.LBB0_87:
++	movups	-107(%rsi), %xmm0
++	movups	-91(%rsi), %xmm1
++	movups	-75(%rsi), %xmm2
++	movups	-59(%rsi), %xmm3
++	movups	%xmm0, -107(%rcx)
++	movups	%xmm1, -91(%rcx)
++	movups	%xmm2, -75(%rcx)
++	movups	%xmm3, -59(%rcx)
++.LBB0_88:
++	movups	-43(%rsi), %xmm0
++	movups	-27(%rsi), %xmm1
++	movups	%xmm0, -43(%rcx)
++	movups	%xmm1, -27(%rcx)
++.LBB0_24:
++	movq	-11(%rsi), %rdx
++	movq	%rdx, -11(%rcx)
++.LBB0_10:
++	movl	-4(%rsi), %edx
++	movl	%edx, -4(%rcx)
++	retq
++.LBB0_89:
++	movups	-108(%rsi), %xmm0
++	movups	-92(%rsi), %xmm1
++	movups	-76(%rsi), %xmm2
++	movups	-60(%rsi), %xmm3
++	movups	%xmm0, -108(%rcx)
++	movups	%xmm1, -92(%rcx)
++	movups	%xmm2, -76(%rcx)
++	movups	%xmm3, -60(%rcx)
++.LBB0_90:
++	movups	-44(%rsi), %xmm0
++	movups	-28(%rsi), %xmm1
++	movups	%xmm0, -44(%rcx)
++	movups	%xmm1, -28(%rcx)
++.LBB0_26:
++	movq	-12(%rsi), %rdx
++	movq	%rdx, -12(%rcx)
++	movl	-4(%rsi), %edx
++	movl	%edx, -4(%rcx)
++	retq
++.LBB0_91:
++	movups	-109(%rsi), %xmm0
++	movups	-93(%rsi), %xmm1
++	movups	-77(%rsi), %xmm2
++	movups	-61(%rsi), %xmm3
++	movups	%xmm0, -109(%rcx)
++	movups	%xmm1, -93(%rcx)
++	movups	%xmm2, -77(%rcx)
++	movups	%xmm3, -61(%rcx)
++.LBB0_92:
++	movups	-45(%rsi), %xmm0
++	movups	-29(%rsi), %xmm1
++	movups	%xmm0, -45(%rcx)
++	movups	%xmm1, -29(%rcx)
++.LBB0_28:
++	movq	-13(%rsi), %rdx
++	movq	%rdx, -13(%rcx)
++	jmp	.LBB0_12
++.LBB0_93:
++	movups	-110(%rsi), %xmm0
++	movups	-94(%rsi), %xmm1
++	movups	-78(%rsi), %xmm2
++	movups	-62(%rsi), %xmm3
++	movups	%xmm0, -110(%rcx)
++	movups	%xmm1, -94(%rcx)
++	movups	%xmm2, -78(%rcx)
++	movups	%xmm3, -62(%rcx)
++.LBB0_94:
++	movups	-46(%rsi), %xmm0
++	movups	-30(%rsi), %xmm1
++	movups	%xmm0, -46(%rcx)
++	movups	%xmm1, -30(%rcx)
++.LBB0_30:
++	movq	-14(%rsi), %rdx
++	movq	%rdx, -14(%rcx)
++.LBB0_18:
++	movq	-8(%rsi), %rdx
++	movq	%rdx, -8(%rcx)
++	retq
++.LBB0_95:
++	movups	-111(%rsi), %xmm0
++	movups	-95(%rsi), %xmm1
++	movups	-79(%rsi), %xmm2
++	movups	-63(%rsi), %xmm3
++	movups	%xmm0, -111(%rcx)
++	movups	%xmm1, -95(%rcx)
++	movups	%xmm2, -79(%rcx)
++	movups	%xmm3, -63(%rcx)
++.LBB0_96:
++	movups	-47(%rsi), %xmm0
++	movups	-31(%rsi), %xmm1
++	movups	%xmm0, -47(%rcx)
++	movups	%xmm1, -31(%rcx)
++.LBB0_32:
++	movq	-15(%rsi), %rdx
++	movq	%rdx, -15(%rcx)
++	movq	-8(%rsi), %rdx
++	movq	%rdx, -8(%rcx)
++	retq
++.LBB0_97:
++	movups	-112(%rsi), %xmm0
++	movups	-96(%rsi), %xmm1
++	movups	-80(%rsi), %xmm2
++	movups	-64(%rsi), %xmm3
++	movups	%xmm0, -112(%rcx)
++	movups	%xmm1, -96(%rcx)
++	movups	%xmm2, -80(%rcx)
++	movups	%xmm3, -64(%rcx)
++.LBB0_98:
++	movups	-48(%rsi), %xmm0
++	movups	-32(%rsi), %xmm1
++	movups	%xmm0, -48(%rcx)
++	movups	%xmm1, -32(%rcx)
++	movups	-16(%rsi), %xmm0
++	movups	%xmm0, -16(%rcx)
++	retq
++.LBB0_99:
++	movups	-113(%rsi), %xmm0
++	movups	-97(%rsi), %xmm1
++	movups	-81(%rsi), %xmm2
++	movups	-65(%rsi), %xmm3
++	movups	%xmm0, -113(%rcx)
++	movups	%xmm1, -97(%rcx)
++	movups	%xmm2, -81(%rcx)
++	movups	%xmm3, -65(%rcx)
++.LBB0_100:
++	movups	-49(%rsi), %xmm0
++	movups	-33(%rsi), %xmm1
++	movups	%xmm0, -49(%rcx)
++	movups	%xmm1, -33(%rcx)
++.LBB0_36:
++	movups	-17(%rsi), %xmm0
++	movups	%xmm0, -17(%rcx)
++	movb	-1(%rsi), %dl
++	movb	%dl, -1(%rcx)
++	retq
++.LBB0_101:
++	movups	-114(%rsi), %xmm0
++	movups	-98(%rsi), %xmm1
++	movups	-82(%rsi), %xmm2
++	movups	-66(%rsi), %xmm3
++	movups	%xmm0, -114(%rcx)
++	movups	%xmm1, -98(%rcx)
++	movups	%xmm2, -82(%rcx)
++	movups	%xmm3, -66(%rcx)
++.LBB0_102:
++	movups	-50(%rsi), %xmm0
++	movups	-34(%rsi), %xmm1
++	movups	%xmm0, -50(%rcx)
++	movups	%xmm1, -34(%rcx)
++.LBB0_38:
++	movups	-18(%rsi), %xmm0
++	movups	%xmm0, -18(%rcx)
++	movzwl	-2(%rsi), %edx
++	movw	%dx, -2(%rcx)
++	retq
++.LBB0_103:
++	movups	-115(%rsi), %xmm0
++	movups	-99(%rsi), %xmm1
++	movups	-83(%rsi), %xmm2
++	movups	-67(%rsi), %xmm3
++	movups	%xmm0, -115(%rcx)
++	movups	%xmm1, -99(%rcx)
++	movups	%xmm2, -83(%rcx)
++	movups	%xmm3, -67(%rcx)
++.LBB0_104:
++	movups	-51(%rsi), %xmm0
++	movups	-35(%rsi), %xmm1
++	movups	%xmm0, -51(%rcx)
++	movups	%xmm1, -35(%rcx)
++.LBB0_40:
++	movups	-19(%rsi), %xmm0
++	movups	%xmm0, -19(%rcx)
++.LBB0_8:
++	movzwl	-3(%rsi), %edx
++	movw	%dx, -3(%rcx)
++	movb	-1(%rsi), %dl
++	movb	%dl, -1(%rcx)
++	retq
++.LBB0_105:
++	movups	-116(%rsi), %xmm0
++	movups	-100(%rsi), %xmm1
++	movups	-84(%rsi), %xmm2
++	movups	-68(%rsi), %xmm3
++	movups	%xmm0, -116(%rcx)
++	movups	%xmm1, -100(%rcx)
++	movups	%xmm2, -84(%rcx)
++	movups	%xmm3, -68(%rcx)
++.LBB0_106:
++	movups	-52(%rsi), %xmm0
++	movups	-36(%rsi), %xmm1
++	movups	%xmm0, -52(%rcx)
++	movups	%xmm1, -36(%rcx)
++.LBB0_42:
++	movups	-20(%rsi), %xmm0
++	movups	%xmm0, -20(%rcx)
++	movl	-4(%rsi), %edx
++	movl	%edx, -4(%rcx)
++	retq
++.LBB0_107:
++	movups	-117(%rsi), %xmm0
++	movups	-101(%rsi), %xmm1
++	movups	-85(%rsi), %xmm2
++	movups	-69(%rsi), %xmm3
++	movups	%xmm0, -117(%rcx)
++	movups	%xmm1, -101(%rcx)
++	movups	%xmm2, -85(%rcx)
++	movups	%xmm3, -69(%rcx)
++.LBB0_108:
++	movups	-53(%rsi), %xmm0
++	movups	-37(%rsi), %xmm1
++	movups	%xmm0, -53(%rcx)
++	movups	%xmm1, -37(%rcx)
++.LBB0_44:
++	movups	-21(%rsi), %xmm0
++	movups	%xmm0, -21(%rcx)
++.LBB0_12:
++	movl	-5(%rsi), %edx
++	movl	%edx, -5(%rcx)
++	movb	-1(%rsi), %dl
++	movb	%dl, -1(%rcx)
++	retq
++.LBB0_109:
++	movups	-118(%rsi), %xmm0
++	movups	-102(%rsi), %xmm1
++	movups	-86(%rsi), %xmm2
++	movups	-70(%rsi), %xmm3
++	movups	%xmm0, -118(%rcx)
++	movups	%xmm1, -102(%rcx)
++	movups	%xmm2, -86(%rcx)
++	movups	%xmm3, -70(%rcx)
++.LBB0_110:
++	movups	-54(%rsi), %xmm0
++	movups	-38(%rsi), %xmm1
++	movups	%xmm0, -54(%rcx)
++	movups	%xmm1, -38(%rcx)
++.LBB0_46:
++	movups	-22(%rsi), %xmm0
++	movups	%xmm0, -22(%rcx)
++.LBB0_14:
++	movl	-6(%rsi), %edx
++	movl	%edx, -6(%rcx)
++	movzwl	-2(%rsi), %edx
++	movw	%dx, -2(%rcx)
++	retq
++.LBB0_111:
++	movups	-119(%rsi), %xmm0
++	movups	-103(%rsi), %xmm1
++	movups	-87(%rsi), %xmm2
++	movups	-71(%rsi), %xmm3
++	movups	%xmm0, -119(%rcx)
++	movups	%xmm1, -103(%rcx)
++	movups	%xmm2, -87(%rcx)
++	movups	%xmm3, -71(%rcx)
++.LBB0_112:
++	movups	-55(%rsi), %xmm0
++	movups	-39(%rsi), %xmm1
++	movups	%xmm0, -55(%rcx)
++	movups	%xmm1, -39(%rcx)
++.LBB0_48:
++	movups	-23(%rsi), %xmm0
++	movups	%xmm0, -23(%rcx)
++.LBB0_16:
++	movl	-7(%rsi), %edx
++	movl	%edx, -7(%rcx)
++	movl	-4(%rsi), %edx
++	movl	%edx, -4(%rcx)
++	retq
++.LBB0_113:
++	movups	-120(%rsi), %xmm0
++	movups	-104(%rsi), %xmm1
++	movups	-88(%rsi), %xmm2
++	movups	-72(%rsi), %xmm3
++	movups	%xmm0, -120(%rcx)
++	movups	%xmm1, -104(%rcx)
++	movups	%xmm2, -88(%rcx)
++	movups	%xmm3, -72(%rcx)
++.LBB0_114:
++	movups	-56(%rsi), %xmm0
++	movups	-40(%rsi), %xmm1
++	movups	%xmm0, -56(%rcx)
++	movups	%xmm1, -40(%rcx)
++.LBB0_50:
++	movups	-24(%rsi), %xmm0
++	movups	%xmm0, -24(%rcx)
++.LBB0_34:
++	movups	-16(%rsi), %xmm0
++	movups	%xmm0, -16(%rcx)
++	retq
++.LBB0_115:
++	movups	-121(%rsi), %xmm0
++	movups	-105(%rsi), %xmm1
++	movups	-89(%rsi), %xmm2
++	movups	-73(%rsi), %xmm3
++	movups	%xmm0, -121(%rcx)
++	movups	%xmm1, -105(%rcx)
++	movups	%xmm2, -89(%rcx)
++	movups	%xmm3, -73(%rcx)
++.LBB0_116:
++	movups	-57(%rsi), %xmm0
++	movups	-41(%rsi), %xmm1
++	movups	%xmm0, -57(%rcx)
++	movups	%xmm1, -41(%rcx)
++.LBB0_52:
++	movups	-25(%rsi), %xmm0
++	movups	%xmm0, -25(%rcx)
++	movups	-16(%rsi), %xmm0
++	movups	%xmm0, -16(%rcx)
++	retq
++.LBB0_117:
++	movups	-122(%rsi), %xmm0
++	movups	-106(%rsi), %xmm1
++	movups	-90(%rsi), %xmm2
++	movups	-74(%rsi), %xmm3
++	movups	%xmm0, -122(%rcx)
++	movups	%xmm1, -106(%rcx)
++	movups	%xmm2, -90(%rcx)
++	movups	%xmm3, -74(%rcx)
++.LBB0_118:
++	movups	-58(%rsi), %xmm0
++	movups	-42(%rsi), %xmm1
++	movups	%xmm0, -58(%rcx)
++	movups	%xmm1, -42(%rcx)
++.LBB0_54:
++	movups	-26(%rsi), %xmm0
++	movups	%xmm0, -26(%rcx)
++	movups	-16(%rsi), %xmm0
++	movups	%xmm0, -16(%rcx)
++	retq
++.LBB0_119:
++	movups	-123(%rsi), %xmm0
++	movups	-107(%rsi), %xmm1
++	movups	-91(%rsi), %xmm2
++	movups	-75(%rsi), %xmm3
++	movups	%xmm0, -123(%rcx)
++	movups	%xmm1, -107(%rcx)
++	movups	%xmm2, -91(%rcx)
++	movups	%xmm3, -75(%rcx)
++.LBB0_120:
++	movups	-59(%rsi), %xmm0
++	movups	-43(%rsi), %xmm1
++	movups	%xmm0, -59(%rcx)
++	movups	%xmm1, -43(%rcx)
++.LBB0_56:
++	movups	-27(%rsi), %xmm0
++	movups	%xmm0, -27(%rcx)
++	movups	-16(%rsi), %xmm0
++	movups	%xmm0, -16(%rcx)
++	retq
++.LBB0_121:
++	movups	-124(%rsi), %xmm0
++	movups	-108(%rsi), %xmm1
++	movups	-92(%rsi), %xmm2
++	movups	-76(%rsi), %xmm3
++	movups	%xmm0, -124(%rcx)
++	movups	%xmm1, -108(%rcx)
++	movups	%xmm2, -92(%rcx)
++	movups	%xmm3, -76(%rcx)
++.LBB0_122:
++	movups	-60(%rsi), %xmm0
++	movups	-44(%rsi), %xmm1
++	movups	%xmm0, -60(%rcx)
++	movups	%xmm1, -44(%rcx)
++.LBB0_58:
++	movups	-28(%rsi), %xmm0
++	movups	%xmm0, -28(%rcx)
++	movups	-16(%rsi), %xmm0
++	movups	%xmm0, -16(%rcx)
++	retq
++.LBB0_123:
++	movups	-125(%rsi), %xmm0
++	movups	-109(%rsi), %xmm1
++	movups	-93(%rsi), %xmm2
++	movups	-77(%rsi), %xmm3
++	movups	%xmm0, -125(%rcx)
++	movups	%xmm1, -109(%rcx)
++	movups	%xmm2, -93(%rcx)
++	movups	%xmm3, -77(%rcx)
++.LBB0_124:
++	movups	-61(%rsi), %xmm0
++	movups	-45(%rsi), %xmm1
++	movups	%xmm0, -61(%rcx)
++	movups	%xmm1, -45(%rcx)
++.LBB0_60:
++	movups	-29(%rsi), %xmm0
++	movups	%xmm0, -29(%rcx)
++	movups	-16(%rsi), %xmm0
++	movups	%xmm0, -16(%rcx)
++	retq
++.LBB0_125:
++	movups	-126(%rsi), %xmm0
++	movups	-110(%rsi), %xmm1
++	movups	-94(%rsi), %xmm2
++	movups	-78(%rsi), %xmm3
++	movups	%xmm0, -126(%rcx)
++	movups	%xmm1, -110(%rcx)
++	movups	%xmm2, -94(%rcx)
++	movups	%xmm3, -78(%rcx)
++.LBB0_126:
++	movups	-62(%rsi), %xmm0
++	movups	-46(%rsi), %xmm1
++	movups	%xmm0, -62(%rcx)
++	movups	%xmm1, -46(%rcx)
++.LBB0_62:
++	movups	-30(%rsi), %xmm0
++	movups	%xmm0, -30(%rcx)
++	movups	-16(%rsi), %xmm0
++	movups	%xmm0, -16(%rcx)
++	retq
++.LBB0_127:
++	movups	-127(%rsi), %xmm0
++	movups	-111(%rsi), %xmm1
++	movups	-95(%rsi), %xmm2
++	movups	-79(%rsi), %xmm3
++	movups	%xmm0, -127(%rcx)
++	movups	%xmm1, -111(%rcx)
++	movups	%xmm2, -95(%rcx)
++	movups	%xmm3, -79(%rcx)
++.LBB0_128:
++	movups	-63(%rsi), %xmm0
++	movups	-47(%rsi), %xmm1
++	movups	%xmm0, -63(%rcx)
++	movups	%xmm1, -47(%rcx)
++.LBB0_64:
++	movups	-31(%rsi), %xmm0
++	movups	%xmm0, -31(%rcx)
++	movups	-16(%rsi), %xmm0
++	movups	%xmm0, -16(%rcx)
++	retq
++.LBB0_144:
++	movups	-128(%rsi), %xmm0
++	movups	-112(%rsi), %xmm1
++	movups	-96(%rsi), %xmm2
++	movups	-80(%rsi), %xmm3
++	movups	-64(%rsi), %xmm4
++	movups	-48(%rsi), %xmm5
++	movups	-32(%rsi), %xmm6
++	movups	-16(%rsi), %xmm7
++	movups	%xmm0, -128(%rcx)
++	movups	%xmm1, -112(%rcx)
++	movups	%xmm2, -96(%rcx)
++	movups	%xmm3, -80(%rcx)
++	movups	%xmm4, -64(%rcx)
++	movups	%xmm5, -48(%rcx)
++	movups	%xmm6, -32(%rcx)
++	movups	%xmm7, -16(%rcx)
++.LBB0_145:
++	retq
++.Lfunc_end0:
++	.size	memcpy, .Lfunc_end0-memcpy
++	.cfi_endproc
++	.section	.rodata,"a",@progbits
++	.p2align	2
++.LJTI0_0:
++	.long	.LBB0_4-.LJTI0_0
++	.long	.LBB0_6-.LJTI0_0
++	.long	.LBB0_8-.LJTI0_0
++	.long	.LBB0_10-.LJTI0_0
++	.long	.LBB0_12-.LJTI0_0
++	.long	.LBB0_14-.LJTI0_0
++	.long	.LBB0_16-.LJTI0_0
++	.long	.LBB0_18-.LJTI0_0
++	.long	.LBB0_20-.LJTI0_0
++	.long	.LBB0_22-.LJTI0_0
++	.long	.LBB0_24-.LJTI0_0
++	.long	.LBB0_26-.LJTI0_0
++	.long	.LBB0_28-.LJTI0_0
++	.long	.LBB0_30-.LJTI0_0
++	.long	.LBB0_32-.LJTI0_0
++	.long	.LBB0_34-.LJTI0_0
++	.long	.LBB0_36-.LJTI0_0
++	.long	.LBB0_38-.LJTI0_0
++	.long	.LBB0_40-.LJTI0_0
++	.long	.LBB0_42-.LJTI0_0
++	.long	.LBB0_44-.LJTI0_0
++	.long	.LBB0_46-.LJTI0_0
++	.long	.LBB0_48-.LJTI0_0
++	.long	.LBB0_50-.LJTI0_0
++	.long	.LBB0_52-.LJTI0_0
++	.long	.LBB0_54-.LJTI0_0
++	.long	.LBB0_56-.LJTI0_0
++	.long	.LBB0_58-.LJTI0_0
++	.long	.LBB0_60-.LJTI0_0
++	.long	.LBB0_62-.LJTI0_0
++	.long	.LBB0_64-.LJTI0_0
++	.long	.LBB0_66-.LJTI0_0
++	.long	.LBB0_68-.LJTI0_0
++	.long	.LBB0_70-.LJTI0_0
++	.long	.LBB0_72-.LJTI0_0
++	.long	.LBB0_74-.LJTI0_0
++	.long	.LBB0_76-.LJTI0_0
++	.long	.LBB0_78-.LJTI0_0
++	.long	.LBB0_80-.LJTI0_0
++	.long	.LBB0_82-.LJTI0_0
++	.long	.LBB0_84-.LJTI0_0
++	.long	.LBB0_86-.LJTI0_0
++	.long	.LBB0_88-.LJTI0_0
++	.long	.LBB0_90-.LJTI0_0
++	.long	.LBB0_92-.LJTI0_0
++	.long	.LBB0_94-.LJTI0_0
++	.long	.LBB0_96-.LJTI0_0
++	.long	.LBB0_98-.LJTI0_0
++	.long	.LBB0_100-.LJTI0_0
++	.long	.LBB0_102-.LJTI0_0
++	.long	.LBB0_104-.LJTI0_0
++	.long	.LBB0_106-.LJTI0_0
++	.long	.LBB0_108-.LJTI0_0
++	.long	.LBB0_110-.LJTI0_0
++	.long	.LBB0_112-.LJTI0_0
++	.long	.LBB0_114-.LJTI0_0
++	.long	.LBB0_116-.LJTI0_0
++	.long	.LBB0_118-.LJTI0_0
++	.long	.LBB0_120-.LJTI0_0
++	.long	.LBB0_122-.LJTI0_0
++	.long	.LBB0_124-.LJTI0_0
++	.long	.LBB0_126-.LJTI0_0
++	.long	.LBB0_128-.LJTI0_0
++	.long	.LBB0_143-.LJTI0_0
++	.long	.LBB0_3-.LJTI0_0
++	.long	.LBB0_5-.LJTI0_0
++	.long	.LBB0_7-.LJTI0_0
++	.long	.LBB0_9-.LJTI0_0
++	.long	.LBB0_11-.LJTI0_0
++	.long	.LBB0_13-.LJTI0_0
++	.long	.LBB0_15-.LJTI0_0
++	.long	.LBB0_17-.LJTI0_0
++	.long	.LBB0_19-.LJTI0_0
++	.long	.LBB0_21-.LJTI0_0
++	.long	.LBB0_23-.LJTI0_0
++	.long	.LBB0_25-.LJTI0_0
++	.long	.LBB0_27-.LJTI0_0
++	.long	.LBB0_29-.LJTI0_0
++	.long	.LBB0_31-.LJTI0_0
++	.long	.LBB0_33-.LJTI0_0
++	.long	.LBB0_35-.LJTI0_0
++	.long	.LBB0_37-.LJTI0_0
++	.long	.LBB0_39-.LJTI0_0
++	.long	.LBB0_41-.LJTI0_0
++	.long	.LBB0_43-.LJTI0_0
++	.long	.LBB0_45-.LJTI0_0
++	.long	.LBB0_47-.LJTI0_0
++	.long	.LBB0_49-.LJTI0_0
++	.long	.LBB0_51-.LJTI0_0
++	.long	.LBB0_53-.LJTI0_0
++	.long	.LBB0_55-.LJTI0_0
++	.long	.LBB0_57-.LJTI0_0
++	.long	.LBB0_59-.LJTI0_0
++	.long	.LBB0_61-.LJTI0_0
++	.long	.LBB0_63-.LJTI0_0
++	.long	.LBB0_65-.LJTI0_0
++	.long	.LBB0_67-.LJTI0_0
++	.long	.LBB0_69-.LJTI0_0
++	.long	.LBB0_71-.LJTI0_0
++	.long	.LBB0_73-.LJTI0_0
++	.long	.LBB0_75-.LJTI0_0
++	.long	.LBB0_77-.LJTI0_0
++	.long	.LBB0_79-.LJTI0_0
++	.long	.LBB0_81-.LJTI0_0
++	.long	.LBB0_83-.LJTI0_0
++	.long	.LBB0_85-.LJTI0_0
++	.long	.LBB0_87-.LJTI0_0
++	.long	.LBB0_89-.LJTI0_0
++	.long	.LBB0_91-.LJTI0_0
++	.long	.LBB0_93-.LJTI0_0
++	.long	.LBB0_95-.LJTI0_0
++	.long	.LBB0_97-.LJTI0_0
++	.long	.LBB0_99-.LJTI0_0
++	.long	.LBB0_101-.LJTI0_0
++	.long	.LBB0_103-.LJTI0_0
++	.long	.LBB0_105-.LJTI0_0
++	.long	.LBB0_107-.LJTI0_0
++	.long	.LBB0_109-.LJTI0_0
++	.long	.LBB0_111-.LJTI0_0
++	.long	.LBB0_113-.LJTI0_0
++	.long	.LBB0_115-.LJTI0_0
++	.long	.LBB0_117-.LJTI0_0
++	.long	.LBB0_119-.LJTI0_0
++	.long	.LBB0_121-.LJTI0_0
++	.long	.LBB0_123-.LJTI0_0
++	.long	.LBB0_125-.LJTI0_0
++	.long	.LBB0_127-.LJTI0_0
++	.long	.LBB0_144-.LJTI0_0
++.LJTI0_1:
++	.long	.LBB0_4-.LJTI0_1
++	.long	.LBB0_6-.LJTI0_1
++	.long	.LBB0_8-.LJTI0_1
++	.long	.LBB0_10-.LJTI0_1
++	.long	.LBB0_12-.LJTI0_1
++	.long	.LBB0_14-.LJTI0_1
++	.long	.LBB0_16-.LJTI0_1
++	.long	.LBB0_18-.LJTI0_1
++	.long	.LBB0_20-.LJTI0_1
++	.long	.LBB0_22-.LJTI0_1
++	.long	.LBB0_24-.LJTI0_1
++	.long	.LBB0_26-.LJTI0_1
++	.long	.LBB0_28-.LJTI0_1
++	.long	.LBB0_30-.LJTI0_1
++	.long	.LBB0_32-.LJTI0_1
++	.long	.LBB0_34-.LJTI0_1
++	.long	.LBB0_36-.LJTI0_1
++	.long	.LBB0_38-.LJTI0_1
++	.long	.LBB0_40-.LJTI0_1
++	.long	.LBB0_42-.LJTI0_1
++	.long	.LBB0_44-.LJTI0_1
++	.long	.LBB0_46-.LJTI0_1
++	.long	.LBB0_48-.LJTI0_1
++	.long	.LBB0_50-.LJTI0_1
++	.long	.LBB0_52-.LJTI0_1
++	.long	.LBB0_54-.LJTI0_1
++	.long	.LBB0_56-.LJTI0_1
++	.long	.LBB0_58-.LJTI0_1
++	.long	.LBB0_60-.LJTI0_1
++	.long	.LBB0_62-.LJTI0_1
++	.long	.LBB0_64-.LJTI0_1
++	.long	.LBB0_66-.LJTI0_1
++	.long	.LBB0_68-.LJTI0_1
++	.long	.LBB0_70-.LJTI0_1
++	.long	.LBB0_72-.LJTI0_1
++	.long	.LBB0_74-.LJTI0_1
++	.long	.LBB0_76-.LJTI0_1
++	.long	.LBB0_78-.LJTI0_1
++	.long	.LBB0_80-.LJTI0_1
++	.long	.LBB0_82-.LJTI0_1
++	.long	.LBB0_84-.LJTI0_1
++	.long	.LBB0_86-.LJTI0_1
++	.long	.LBB0_88-.LJTI0_1
++	.long	.LBB0_90-.LJTI0_1
++	.long	.LBB0_92-.LJTI0_1
++	.long	.LBB0_94-.LJTI0_1
++	.long	.LBB0_96-.LJTI0_1
++	.long	.LBB0_98-.LJTI0_1
++	.long	.LBB0_100-.LJTI0_1
++	.long	.LBB0_102-.LJTI0_1
++	.long	.LBB0_104-.LJTI0_1
++	.long	.LBB0_106-.LJTI0_1
++	.long	.LBB0_108-.LJTI0_1
++	.long	.LBB0_110-.LJTI0_1
++	.long	.LBB0_112-.LJTI0_1
++	.long	.LBB0_114-.LJTI0_1
++	.long	.LBB0_116-.LJTI0_1
++	.long	.LBB0_118-.LJTI0_1
++	.long	.LBB0_120-.LJTI0_1
++	.long	.LBB0_122-.LJTI0_1
++	.long	.LBB0_124-.LJTI0_1
++	.long	.LBB0_126-.LJTI0_1
++	.long	.LBB0_128-.LJTI0_1
++	.long	.LBB0_143-.LJTI0_1
++	.long	.LBB0_3-.LJTI0_1
++	.long	.LBB0_5-.LJTI0_1
++	.long	.LBB0_7-.LJTI0_1
++	.long	.LBB0_9-.LJTI0_1
++	.long	.LBB0_11-.LJTI0_1
++	.long	.LBB0_13-.LJTI0_1
++	.long	.LBB0_15-.LJTI0_1
++	.long	.LBB0_17-.LJTI0_1
++	.long	.LBB0_19-.LJTI0_1
++	.long	.LBB0_21-.LJTI0_1
++	.long	.LBB0_23-.LJTI0_1
++	.long	.LBB0_25-.LJTI0_1
++	.long	.LBB0_27-.LJTI0_1
++	.long	.LBB0_29-.LJTI0_1
++	.long	.LBB0_31-.LJTI0_1
++	.long	.LBB0_33-.LJTI0_1
++	.long	.LBB0_35-.LJTI0_1
++	.long	.LBB0_37-.LJTI0_1
++	.long	.LBB0_39-.LJTI0_1
++	.long	.LBB0_41-.LJTI0_1
++	.long	.LBB0_43-.LJTI0_1
++	.long	.LBB0_45-.LJTI0_1
++	.long	.LBB0_47-.LJTI0_1
++	.long	.LBB0_49-.LJTI0_1
++	.long	.LBB0_51-.LJTI0_1
++	.long	.LBB0_53-.LJTI0_1
++	.long	.LBB0_55-.LJTI0_1
++	.long	.LBB0_57-.LJTI0_1
++	.long	.LBB0_59-.LJTI0_1
++	.long	.LBB0_61-.LJTI0_1
++	.long	.LBB0_63-.LJTI0_1
++	.long	.LBB0_65-.LJTI0_1
++	.long	.LBB0_67-.LJTI0_1
++	.long	.LBB0_69-.LJTI0_1
++	.long	.LBB0_71-.LJTI0_1
++	.long	.LBB0_73-.LJTI0_1
++	.long	.LBB0_75-.LJTI0_1
++	.long	.LBB0_77-.LJTI0_1
++	.long	.LBB0_79-.LJTI0_1
++	.long	.LBB0_81-.LJTI0_1
++	.long	.LBB0_83-.LJTI0_1
++	.long	.LBB0_85-.LJTI0_1
++	.long	.LBB0_87-.LJTI0_1
++	.long	.LBB0_89-.LJTI0_1
++	.long	.LBB0_91-.LJTI0_1
++	.long	.LBB0_93-.LJTI0_1
++	.long	.LBB0_95-.LJTI0_1
++	.long	.LBB0_97-.LJTI0_1
++	.long	.LBB0_99-.LJTI0_1
++	.long	.LBB0_101-.LJTI0_1
++	.long	.LBB0_103-.LJTI0_1
++	.long	.LBB0_105-.LJTI0_1
++	.long	.LBB0_107-.LJTI0_1
++	.long	.LBB0_109-.LJTI0_1
++	.long	.LBB0_111-.LJTI0_1
++	.long	.LBB0_113-.LJTI0_1
++	.long	.LBB0_115-.LJTI0_1
++	.long	.LBB0_117-.LJTI0_1
++	.long	.LBB0_119-.LJTI0_1
++	.long	.LBB0_121-.LJTI0_1
++	.long	.LBB0_123-.LJTI0_1
++	.long	.LBB0_125-.LJTI0_1
++	.long	.LBB0_127-.LJTI0_1
++	.long	.LBB0_144-.LJTI0_1
++                                        # -- End function
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-memmove-slm.S b/libc/arch-x86_64/silvermont/string/sse2-memmove-slm.S
+new file mode 100644
+index 0000000..7024f49
+--- /dev/null
++++ b/libc/arch-x86_64/silvermont/string/sse2-memmove-slm.S
+@@ -0,0 +1,518 @@
++/*
++Copyright (c) 2014, Intel Corporation
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++    * Redistributions of source code must retain the above copyright notice,
++    * this list of conditions and the following disclaimer.
++
++    * Redistributions in binary form must reproduce the above copyright notice,
++    * this list of conditions and the following disclaimer in the documentation
++    * and/or other materials provided with the distribution.
++
++    * Neither the name of Intel Corporation nor the names of its contributors
++    * may be used to endorse or promote products derived from this software
++    * without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
++ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
++WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
++ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
++ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++#include "cache.h"
++
++#ifndef MEMMOVE
++# define MEMMOVE		memmove_generic
++#endif
++
++#ifndef L
++# define L(label)	.L##label
++#endif
++
++#ifndef cfi_startproc
++# define cfi_startproc	.cfi_startproc
++#endif
++
++#ifndef cfi_endproc
++# define cfi_endproc	.cfi_endproc
++#endif
++
++#ifndef cfi_rel_offset
++# define cfi_rel_offset(reg, off)	.cfi_rel_offset reg, off
++#endif
++
++#ifndef cfi_restore
++# define cfi_restore(reg)	.cfi_restore reg
++#endif
++
++#ifndef cfi_adjust_cfa_offset
++# define cfi_adjust_cfa_offset(off)	.cfi_adjust_cfa_offset off
++#endif
++
++#ifndef ENTRY
++# define ENTRY(name)		\
++	.type name,  @function;		\
++	.globl name;		\
++	.p2align 4;		\
++name:		\
++	cfi_startproc
++#endif
++
++#ifndef ALIAS_SYMBOL
++# define ALIAS_SYMBOL(alias, original) \
++	.globl alias; \
++	.equ alias, original
++#endif
++
++#ifndef END
++# define END(name)		\
++	cfi_endproc;		\
++	.size name, .-name
++#endif
++
++#define CFI_PUSH(REG)		\
++	cfi_adjust_cfa_offset (4);		\
++	cfi_rel_offset (REG, 0)
++
++#define CFI_POP(REG)		\
++	cfi_adjust_cfa_offset (-4);		\
++	cfi_restore (REG)
++
++#define PUSH(REG)	push REG;
++#define POP(REG)	pop REG;
++
++#define ENTRANCE	PUSH (%rbx);
++#define RETURN_END	POP (%rbx); ret
++#define RETURN		RETURN_END;
++
++	.section .text.sse2,"ax",@progbits
++ENTRY (MEMMOVE)
++	ENTRANCE
++	mov	%rdi, %rax
++
++/* Check whether we should copy backward or forward.  */
++	cmp	%rsi, %rdi
++	je	L(mm_return)
++	jg	L(mm_len_0_or_more_backward)
++
++/* Now do checks for lengths. We do [0..16], [0..32], [0..64], [0..128]
++	separately.  */
++	cmp	$16, %rdx
++	jbe	L(mm_len_0_16_bytes_forward)
++
++	cmp	$32, %rdx
++	ja	L(mm_len_32_or_more_forward)
++
++/* Copy [0..32] and return.  */
++	movdqu	(%rsi), %xmm0
++	movdqu	-16(%rsi, %rdx), %xmm1
++	movdqu	%xmm0, (%rdi)
++	movdqu	%xmm1, -16(%rdi, %rdx)
++	jmp	L(mm_return)
++
++L(mm_len_32_or_more_forward):
++	cmp	$64, %rdx
++	ja	L(mm_len_64_or_more_forward)
++
++/* Copy [0..64] and return.  */
++	movdqu	(%rsi), %xmm0
++	movdqu	16(%rsi), %xmm1
++	movdqu	-16(%rsi, %rdx), %xmm2
++	movdqu	-32(%rsi, %rdx), %xmm3
++	movdqu	%xmm0, (%rdi)
++	movdqu	%xmm1, 16(%rdi)
++	movdqu	%xmm2, -16(%rdi, %rdx)
++	movdqu	%xmm3, -32(%rdi, %rdx)
++	jmp	L(mm_return)
++
++L(mm_len_64_or_more_forward):
++	cmp	$128, %rdx
++	ja	L(mm_len_128_or_more_forward)
++
++/* Copy [0..128] and return.  */
++	movdqu	(%rsi), %xmm0
++	movdqu	16(%rsi), %xmm1
++	movdqu	32(%rsi), %xmm2
++	movdqu	48(%rsi), %xmm3
++	movdqu	-64(%rsi, %rdx), %xmm4
++	movdqu	-48(%rsi, %rdx), %xmm5
++	movdqu	-32(%rsi, %rdx), %xmm6
++	movdqu	-16(%rsi, %rdx), %xmm7
++	movdqu	%xmm0, (%rdi)
++	movdqu	%xmm1, 16(%rdi)
++	movdqu	%xmm2, 32(%rdi)
++	movdqu	%xmm3, 48(%rdi)
++	movdqu	%xmm4, -64(%rdi, %rdx)
++	movdqu	%xmm5, -48(%rdi, %rdx)
++	movdqu	%xmm6, -32(%rdi, %rdx)
++	movdqu	%xmm7, -16(%rdi, %rdx)
++	jmp	L(mm_return)
++
++L(mm_len_128_or_more_forward):
++/* Aligning the address of destination.  */
++/*  save first unaligned 64 bytes */
++	movdqu	(%rsi), %xmm0
++	movdqu	16(%rsi), %xmm1
++	movdqu	32(%rsi), %xmm2
++	movdqu	48(%rsi), %xmm3
++
++	lea	64(%rdi), %r8
++	and	$-64, %r8  /* r8 now aligned to next 64 byte boundary */
++	sub	%rdi, %rsi /* rsi = src - dst = diff */
++
++	movdqu	(%r8, %rsi), %xmm4
++	movdqu	16(%r8, %rsi), %xmm5
++	movdqu	32(%r8, %rsi), %xmm6
++	movdqu	48(%r8, %rsi), %xmm7
++
++	movdqu	%xmm0, (%rdi)
++	movdqu	%xmm1, 16(%rdi)
++	movdqu	%xmm2, 32(%rdi)
++	movdqu	%xmm3, 48(%rdi)
++	movdqa	%xmm4, (%r8)
++	movaps	%xmm5, 16(%r8)
++	movaps	%xmm6, 32(%r8)
++	movaps	%xmm7, 48(%r8)
++	add	$64, %r8
++
++	lea	(%rdi, %rdx), %rbx
++	and	$-64, %rbx
++	cmp	%r8, %rbx
++	jbe	L(mm_copy_remaining_forward)
++
++	cmp	$SHARED_CACHE_SIZE_HALF, %rdx
++	jae	L(mm_large_page_loop_forward)
++
++	.p2align 4
++L(mm_main_loop_forward):
++
++	prefetcht0 128(%r8, %rsi)
++
++	movdqu	(%r8, %rsi), %xmm0
++	movdqu	16(%r8, %rsi), %xmm1
++	movdqu	32(%r8, %rsi), %xmm2
++	movdqu	48(%r8, %rsi), %xmm3
++	movdqa	%xmm0, (%r8)
++	movaps	%xmm1, 16(%r8)
++	movaps	%xmm2, 32(%r8)
++	movaps	%xmm3, 48(%r8)
++	lea	64(%r8), %r8
++	cmp	%r8, %rbx
++	ja	L(mm_main_loop_forward)
++
++L(mm_copy_remaining_forward):
++	add	%rdi, %rdx
++	sub	%r8, %rdx
++/* We copied all up till %rdi position in the dst.
++	In %rdx now is how many bytes are left to copy.
++	Now we need to advance %r8. */
++	lea	(%r8, %rsi), %r9
++
++L(mm_remaining_0_64_bytes_forward):
++	cmp	$32, %rdx
++	ja	L(mm_remaining_33_64_bytes_forward)
++	cmp	$16, %rdx
++	ja	L(mm_remaining_17_32_bytes_forward)
++	test	%rdx, %rdx
++	.p2align 4,,2
++	je	L(mm_return)
++
++	cmpb	$8, %dl
++	ja	L(mm_remaining_9_16_bytes_forward)
++	cmpb	$4, %dl
++	.p2align 4,,5
++	ja	L(mm_remaining_5_8_bytes_forward)
++	cmpb	$2, %dl
++	.p2align 4,,1
++	ja	L(mm_remaining_3_4_bytes_forward)
++	movzbl	-1(%r9,%rdx), %esi
++	movzbl	(%r9), %ebx
++	movb	%sil, -1(%r8,%rdx)
++	movb	%bl, (%r8)
++	jmp	L(mm_return)
++
++L(mm_remaining_33_64_bytes_forward):
++	movdqu	(%r9), %xmm0
++	movdqu	16(%r9), %xmm1
++	movdqu	-32(%r9, %rdx), %xmm2
++	movdqu	-16(%r9, %rdx), %xmm3
++	movdqu	%xmm0, (%r8)
++	movdqu	%xmm1, 16(%r8)
++	movdqu	%xmm2, -32(%r8, %rdx)
++	movdqu	%xmm3, -16(%r8, %rdx)
++	jmp	L(mm_return)
++
++L(mm_remaining_17_32_bytes_forward):
++	movdqu	(%r9), %xmm0
++	movdqu	-16(%r9, %rdx), %xmm1
++	movdqu	%xmm0, (%r8)
++	movdqu	%xmm1, -16(%r8, %rdx)
++	jmp	L(mm_return)
++
++L(mm_remaining_5_8_bytes_forward):
++	movl	(%r9), %esi
++	movl	-4(%r9,%rdx), %ebx
++	movl	%esi, (%r8)
++	movl	%ebx, -4(%r8,%rdx)
++	jmp	L(mm_return)
++
++L(mm_remaining_9_16_bytes_forward):
++	mov	(%r9), %rsi
++	mov	-8(%r9, %rdx), %rbx
++	mov	%rsi, (%r8)
++	mov	%rbx, -8(%r8, %rdx)
++	jmp	L(mm_return)
++
++L(mm_remaining_3_4_bytes_forward):
++	movzwl	-2(%r9,%rdx), %esi
++	movzwl	(%r9), %ebx
++	movw	%si, -2(%r8,%rdx)
++	movw	%bx, (%r8)
++	jmp	L(mm_return)
++
++L(mm_len_0_16_bytes_forward):
++	testb	$24, %dl
++	jne	L(mm_len_9_16_bytes_forward)
++	testb	$4, %dl
++	.p2align 4,,5
++	jne	L(mm_len_5_8_bytes_forward)
++	test	%rdx, %rdx
++	.p2align 4,,2
++	je	L(mm_return)
++	testb	$2, %dl
++	.p2align 4,,1
++	jne	L(mm_len_2_4_bytes_forward)
++	movzbl	-1(%rsi,%rdx), %ebx
++	movzbl	(%rsi), %esi
++	movb	%bl, -1(%rdi,%rdx)
++	movb	%sil, (%rdi)
++	jmp	L(mm_return)
++
++L(mm_len_2_4_bytes_forward):
++	movzwl	-2(%rsi,%rdx), %ebx
++	movzwl	(%rsi), %esi
++	movw	%bx, -2(%rdi,%rdx)
++	movw	%si, (%rdi)
++	jmp	L(mm_return)
++
++L(mm_len_5_8_bytes_forward):
++	movl	(%rsi), %ebx
++	movl	-4(%rsi,%rdx), %esi
++	movl	%ebx, (%rdi)
++	movl	%esi, -4(%rdi,%rdx)
++	jmp	L(mm_return)
++
++L(mm_len_9_16_bytes_forward):
++	mov	(%rsi), %rbx
++	mov	-8(%rsi, %rdx), %rsi
++	mov	%rbx, (%rdi)
++	mov	%rsi, -8(%rdi, %rdx)
++	jmp	L(mm_return)
++
++L(mm_recalc_len):
++/* Compute in %rdx how many bytes are left to copy after
++	the main loop stops.  */
++	mov 	%rbx, %rdx
++	sub 	%rdi, %rdx
++/* The code for copying backwards.  */
++L(mm_len_0_or_more_backward):
++
++/* Now do checks for lengths. We do [0..16], [16..32], [32..64], [64..128]
++	separately.  */
++	cmp	$16, %rdx
++	jbe	L(mm_len_0_16_bytes_backward)
++
++	cmp	$32, %rdx
++	ja	L(mm_len_32_or_more_backward)
++
++/* Copy [0..32] and return.  */
++	movdqu	(%rsi), %xmm0
++	movdqu	-16(%rsi, %rdx), %xmm1
++	movdqu	%xmm0, (%rdi)
++	movdqu	%xmm1, -16(%rdi, %rdx)
++	jmp	L(mm_return)
++
++L(mm_len_32_or_more_backward):
++	cmp	$64, %rdx
++	ja	L(mm_len_64_or_more_backward)
++
++/* Copy [0..64] and return.  */
++	movdqu	(%rsi), %xmm0
++	movdqu	16(%rsi), %xmm1
++	movdqu	-16(%rsi, %rdx), %xmm2
++	movdqu	-32(%rsi, %rdx), %xmm3
++	movdqu	%xmm0, (%rdi)
++	movdqu	%xmm1, 16(%rdi)
++	movdqu	%xmm2, -16(%rdi, %rdx)
++	movdqu	%xmm3, -32(%rdi, %rdx)
++	jmp	L(mm_return)
++
++L(mm_len_64_or_more_backward):
++	cmp	$128, %rdx
++	ja	L(mm_len_128_or_more_backward)
++
++/* Copy [0..128] and return.  */
++	movdqu	(%rsi), %xmm0
++	movdqu	16(%rsi), %xmm1
++	movdqu	32(%rsi), %xmm2
++	movdqu	48(%rsi), %xmm3
++	movdqu	-64(%rsi, %rdx), %xmm4
++	movdqu	-48(%rsi, %rdx), %xmm5
++	movdqu	-32(%rsi, %rdx), %xmm6
++	movdqu	-16(%rsi, %rdx), %xmm7
++	movdqu	%xmm0, (%rdi)
++	movdqu	%xmm1, 16(%rdi)
++	movdqu	%xmm2, 32(%rdi)
++	movdqu	%xmm3, 48(%rdi)
++	movdqu	%xmm4, -64(%rdi, %rdx)
++	movdqu	%xmm5, -48(%rdi, %rdx)
++	movdqu	%xmm6, -32(%rdi, %rdx)
++	movdqu	%xmm7, -16(%rdi, %rdx)
++	jmp	L(mm_return)
++
++L(mm_len_128_or_more_backward):
++/* Aligning the address of destination. We need to save
++	16 bits from the source in order not to overwrite them.  */
++	movdqu	-16(%rsi, %rdx), %xmm0
++	movdqu	-32(%rsi, %rdx), %xmm1
++	movdqu	-48(%rsi, %rdx), %xmm2
++	movdqu	-64(%rsi, %rdx), %xmm3
++
++	lea	(%rdi, %rdx), %r9
++	and	$-64, %r9 /* r9 = aligned dst */
++
++	mov	%rsi, %r8
++	sub	%rdi, %r8 /* r8 = src - dst, diff */
++
++	movdqu	-16(%r9, %r8), %xmm4
++	movdqu	-32(%r9, %r8), %xmm5
++	movdqu	-48(%r9, %r8), %xmm6
++	movdqu	-64(%r9, %r8), %xmm7
++
++	movdqu	%xmm0, -16(%rdi, %rdx)
++	movdqu	%xmm1, -32(%rdi, %rdx)
++	movdqu	%xmm2, -48(%rdi, %rdx)
++	movdqu	%xmm3, -64(%rdi, %rdx)
++	movdqa	%xmm4, -16(%r9)
++	movaps	%xmm5, -32(%r9)
++	movaps	%xmm6, -48(%r9)
++	movaps	%xmm7, -64(%r9)
++	lea	-64(%r9), %r9
++
++	lea	64(%rdi), %rbx
++	and	$-64, %rbx
++
++	cmp	%r9, %rbx
++	jae	L(mm_recalc_len)
++
++	cmp	$SHARED_CACHE_SIZE_HALF, %rdx
++	jae	L(mm_large_page_loop_backward)
++
++	.p2align 4
++L(mm_main_loop_backward):
++
++	prefetcht0 -128(%r9, %r8)
++
++	movdqu	-64(%r9, %r8), %xmm0
++	movdqu	-48(%r9, %r8), %xmm1
++	movdqu	-32(%r9, %r8), %xmm2
++	movdqu	-16(%r9, %r8), %xmm3
++	movdqa	%xmm0, -64(%r9)
++	movaps	%xmm1, -48(%r9)
++	movaps	%xmm2, -32(%r9)
++	movaps	%xmm3, -16(%r9)
++	lea	-64(%r9), %r9
++	cmp	%r9, %rbx
++	jb	L(mm_main_loop_backward)
++	jmp	L(mm_recalc_len)
++
++/* Copy [0..16] and return.  */
++L(mm_len_0_16_bytes_backward):
++	testb	$24, %dl
++	jnz	L(mm_len_9_16_bytes_backward)
++	testb	$4, %dl
++	.p2align 4,,5
++	jnz	L(mm_len_5_8_bytes_backward)
++	test	%rdx, %rdx
++	.p2align 4,,2
++	je	L(mm_return)
++	testb	$2, %dl
++	.p2align 4,,1
++	jne	L(mm_len_3_4_bytes_backward)
++	movzbl	-1(%rsi,%rdx), %ebx
++	movzbl	(%rsi), %ecx
++	movb	%bl, -1(%rdi,%rdx)
++	movb	%cl, (%rdi)
++	jmp	L(mm_return)
++
++L(mm_len_3_4_bytes_backward):
++	movzwl	-2(%rsi,%rdx), %ebx
++	movzwl	(%rsi), %ecx
++	movw	%bx, -2(%rdi,%rdx)
++	movw	%cx, (%rdi)
++	jmp	L(mm_return)
++
++L(mm_len_9_16_bytes_backward):
++	movl	-4(%rsi,%rdx), %ebx
++	movl	-8(%rsi,%rdx), %ecx
++	movl	%ebx, -4(%rdi,%rdx)
++	movl	%ecx, -8(%rdi,%rdx)
++	sub	$8, %rdx
++	jmp	L(mm_len_0_16_bytes_backward)
++
++L(mm_len_5_8_bytes_backward):
++	movl	(%rsi), %ebx
++	movl	-4(%rsi,%rdx), %ecx
++	movl	%ebx, (%rdi)
++	movl	%ecx, -4(%rdi,%rdx)
++
++L(mm_return):
++	RETURN
++
++/* Big length copy forward part.  */
++
++	.p2align 4
++L(mm_large_page_loop_forward):
++	movdqu	(%r8, %rsi), %xmm0
++	movdqu	16(%r8, %rsi), %xmm1
++	movdqu	32(%r8, %rsi), %xmm2
++	movdqu	48(%r8, %rsi), %xmm3
++	movntdq	%xmm0, (%r8)
++	movntdq	%xmm1, 16(%r8)
++	movntdq	%xmm2, 32(%r8)
++	movntdq	%xmm3, 48(%r8)
++	lea 	64(%r8), %r8
++	cmp	%r8, %rbx
++	ja	L(mm_large_page_loop_forward)
++	sfence
++	jmp	L(mm_copy_remaining_forward)
++
++/* Big length copy backward part.  */
++	.p2align 4
++L(mm_large_page_loop_backward):
++	movdqu	-64(%r9, %r8), %xmm0
++	movdqu	-48(%r9, %r8), %xmm1
++	movdqu	-32(%r9, %r8), %xmm2
++	movdqu	-16(%r9, %r8), %xmm3
++	movntdq	%xmm0, -64(%r9)
++	movntdq	%xmm1, -48(%r9)
++	movntdq	%xmm2, -32(%r9)
++	movntdq	%xmm3, -16(%r9)
++	lea 	-64(%r9), %r9
++	cmp	%r9, %rbx
++	jb	L(mm_large_page_loop_backward)
++	sfence
++	jmp	L(mm_recalc_len)
++
++END (MEMMOVE)
++
++//ALIAS_SYMBOL(memcpy, MEMMOVE)
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-memset-slm.S b/libc/arch-x86_64/silvermont/string/sse2-memset-slm.S
+new file mode 100644
+index 0000000..3999cef
+--- /dev/null
++++ b/libc/arch-x86_64/silvermont/string/sse2-memset-slm.S
+@@ -0,0 +1,152 @@
++/*
++Copyright (c) 2014, Intel Corporation
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++    * Redistributions of source code must retain the above copyright notice,
++    * this list of conditions and the following disclaimer.
++
++    * Redistributions in binary form must reproduce the above copyright notice,
++    * this list of conditions and the following disclaimer in the documentation
++    * and/or other materials provided with the distribution.
++
++    * Neither the name of Intel Corporation nor the names of its contributors
++    * may be used to endorse or promote products derived from this software
++    * without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
++ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
++WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
++ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
++ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++#include <private/bionic_asm.h>
++
++#include "cache.h"
++
++#ifndef L
++# define L(label)	.L##label
++#endif
++
++#ifndef ALIGN
++# define ALIGN(n)	.p2align n
++#endif
++
++#ifndef MEMSET
++# define MEMSET        memset
++#endif
++
++ENTRY(__memset_chk)
++  # %rdi = dst, %rsi = byte, %rdx = n, %rcx = dst_len
++  cmp %rcx, %rdx
++  ja __memset_chk_fail
++  // Fall through to memset...
++END(__memset_chk)
++
++
++	.section .text.sse2,"ax",@progbits
++ENTRY(MEMSET)
++	movq	%rdi, %rax
++	and	$0xff, %rsi
++	mov	$0x0101010101010101, %rcx
++	imul	%rsi, %rcx
++	cmpq	$16, %rdx
++	jae	L(16bytesormore)
++	testb	$8, %dl
++	jnz	L(8_15bytes)
++	testb	$4, %dl
++	jnz	L(4_7bytes)
++	testb	$2, %dl
++	jnz	L(2_3bytes)
++	testb	$1, %dl
++	jz	L(return)
++	movb	%cl, (%rdi)
++L(return):
++	ret
++
++L(8_15bytes):
++	movq	%rcx, (%rdi)
++	movq	%rcx, -8(%rdi, %rdx)
++	ret
++
++L(4_7bytes):
++	movl	%ecx, (%rdi)
++	movl	%ecx, -4(%rdi, %rdx)
++	ret
++
++L(2_3bytes):
++	movw	%cx, (%rdi)
++	movw	%cx, -2(%rdi, %rdx)
++	ret
++
++	ALIGN (4)
++L(16bytesormore):
++	movd	%rcx, %xmm0
++	pshufd	$0, %xmm0, %xmm0
++	movdqu	%xmm0, (%rdi)
++	movdqu	%xmm0, -16(%rdi, %rdx)
++	cmpq	$32, %rdx
++	jbe	L(32bytesless)
++	movdqu	%xmm0, 16(%rdi)
++	movdqu	%xmm0, -32(%rdi, %rdx)
++	cmpq	$64, %rdx
++	jbe	L(64bytesless)
++	movdqu	%xmm0, 32(%rdi)
++	movdqu	%xmm0, 48(%rdi)
++	movdqu	%xmm0, -64(%rdi, %rdx)
++	movdqu	%xmm0, -48(%rdi, %rdx)
++	cmpq	$128, %rdx
++	ja	L(128bytesmore)
++L(32bytesless):
++L(64bytesless):
++	ret
++
++	ALIGN (4)
++L(128bytesmore):
++	leaq	64(%rdi), %rcx
++	andq	$-64, %rcx
++	movq	%rdx, %r8
++	addq	%rdi, %rdx
++	andq	$-64, %rdx
++	cmpq	%rcx, %rdx
++	je	L(return)
++
++#ifdef SHARED_CACHE_SIZE
++	cmp	$SHARED_CACHE_SIZE, %r8
++#else
++	cmp	__x86_64_shared_cache_size(%rip), %r8
++#endif
++	ja	L(128bytesmore_nt)
++
++	ALIGN (4)
++L(128bytesmore_normal):
++	movdqa	%xmm0, (%rcx)
++	movaps	%xmm0, 0x10(%rcx)
++	movaps	%xmm0, 0x20(%rcx)
++	movaps	%xmm0, 0x30(%rcx)
++	addq	$64, %rcx
++	cmpq	%rcx, %rdx
++	jne	L(128bytesmore_normal)
++	ret
++
++	ALIGN (4)
++L(128bytesmore_nt):
++	movntdq	%xmm0, (%rcx)
++	movntdq	%xmm0, 0x10(%rcx)
++	movntdq	%xmm0, 0x20(%rcx)
++	movntdq	%xmm0, 0x30(%rcx)
++	leaq	64(%rcx), %rcx
++	cmpq	%rcx, %rdx
++	jne	L(128bytesmore_nt)
++	sfence
++	ret
++
++END(MEMSET)
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-stpcpy-slm.S b/libc/arch-x86_64/silvermont/string/sse2-stpcpy-slm.S
+new file mode 100644
+index 0000000..0ad2d44
+--- /dev/null
++++ b/libc/arch-x86_64/silvermont/string/sse2-stpcpy-slm.S
+@@ -0,0 +1,33 @@
++/*
++Copyright (c) 2014, Intel Corporation
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++    * Redistributions of source code must retain the above copyright notice,
++    * this list of conditions and the following disclaimer.
++
++    * Redistributions in binary form must reproduce the above copyright notice,
++    * this list of conditions and the following disclaimer in the documentation
++    * and/or other materials provided with the distribution.
++
++    * Neither the name of Intel Corporation nor the names of its contributors
++    * may be used to endorse or promote products derived from this software
++    * without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
++ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
++WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
++ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
++ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++#define USE_AS_STPCPY
++#define STRCPY		stpcpy
++#include "sse2-strcpy-slm.S"
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-stpncpy-slm.S b/libc/arch-x86_64/silvermont/string/sse2-stpncpy-slm.S
+new file mode 100644
+index 0000000..3066685
+--- /dev/null
++++ b/libc/arch-x86_64/silvermont/string/sse2-stpncpy-slm.S
+@@ -0,0 +1,34 @@
++/*
++Copyright (c) 2014, Intel Corporation
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++    * Redistributions of source code must retain the above copyright notice,
++    * this list of conditions and the following disclaimer.
++
++    * Redistributions in binary form must reproduce the above copyright notice,
++    * this list of conditions and the following disclaimer in the documentation
++    * and/or other materials provided with the distribution.
++
++    * Neither the name of Intel Corporation nor the names of its contributors
++    * may be used to endorse or promote products derived from this software
++    * without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
++ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
++WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
++ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
++ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++#define USE_AS_STRNCPY
++#define USE_AS_STPCPY
++#define STRCPY		stpncpy
++#include "sse2-strcpy-slm.S"
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-strcat-slm.S b/libc/arch-x86_64/silvermont/string/sse2-strcat-slm.S
+new file mode 100644
+index 0000000..dd8207f
+--- /dev/null
++++ b/libc/arch-x86_64/silvermont/string/sse2-strcat-slm.S
+@@ -0,0 +1,87 @@
++/*
++Copyright (c) 2014, Intel Corporation
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++    * Redistributions of source code must retain the above copyright notice,
++    * this list of conditions and the following disclaimer.
++
++    * Redistributions in binary form must reproduce the above copyright notice,
++    * this list of conditions and the following disclaimer in the documentation
++    * and/or other materials provided with the distribution.
++
++    * Neither the name of Intel Corporation nor the names of its contributors
++    * may be used to endorse or promote products derived from this software
++    * without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
++ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
++WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
++ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
++ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++#ifndef STRCAT
++# define STRCAT		strcat
++#endif
++
++#ifndef L
++# define L(label)		.L##label
++#endif
++
++#ifndef cfi_startproc
++# define cfi_startproc		 .cfi_startproc
++#endif
++
++#ifndef cfi_endproc
++# define cfi_endproc		.cfi_endproc
++#endif
++
++#ifndef ENTRY
++# define ENTRY(name)		\
++	.type name,  @function;		\
++	.globl name;		\
++	.p2align 4;		\
++name:		\
++	cfi_startproc
++#endif
++
++#ifndef END
++# define END(name)		\
++	cfi_endproc;		\
++	.size name, .-name
++#endif
++
++#define USE_AS_STRCAT
++
++.text
++ENTRY (STRCAT)
++	mov	%rdi, %r9
++#ifdef USE_AS_STRNCAT
++	mov	%rdx, %r8
++#endif
++
++#define RETURN jmp L(Strcpy)
++#include "sse2-strlen-slm.S"
++
++#undef RETURN
++#define RETURN ret
++
++L(Strcpy):
++	lea	(%r9, %rax), %rdi
++	mov	%rsi, %rcx
++	mov	%r9, %rax	/* save result */
++
++#ifdef USE_AS_STRNCAT
++	test	%r8, %r8
++	jz	L(ExitZero)
++# define USE_AS_STRNCPY
++#endif
++#include "sse2-strcpy-slm.S"
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-strcpy-slm.S b/libc/arch-x86_64/silvermont/string/sse2-strcpy-slm.S
+new file mode 100644
+index 0000000..3e146bf
+--- /dev/null
++++ b/libc/arch-x86_64/silvermont/string/sse2-strcpy-slm.S
+@@ -0,0 +1,1921 @@
++/*
++Copyright (c) 2014, Intel Corporation
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++    * Redistributions of source code must retain the above copyright notice,
++    * this list of conditions and the following disclaimer.
++
++    * Redistributions in binary form must reproduce the above copyright notice,
++    * this list of conditions and the following disclaimer in the documentation
++    * and/or other materials provided with the distribution.
++
++    * Neither the name of Intel Corporation nor the names of its contributors
++    * may be used to endorse or promote products derived from this software
++    * without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
++ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
++WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
++ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
++ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++#ifndef USE_AS_STRCAT
++
++# ifndef STRCPY
++#  define STRCPY	strcpy
++# endif
++
++# ifndef L
++#  define L(label)	.L##label
++# endif
++
++# ifndef cfi_startproc
++#  define cfi_startproc	.cfi_startproc
++# endif
++
++# ifndef cfi_endproc
++#  define cfi_endproc	.cfi_endproc
++# endif
++
++# ifndef ENTRY
++#  define ENTRY(name)	\
++	.type name, @function;	\
++	.globl name;	\
++	.p2align 4;	\
++name:	\
++	cfi_startproc
++# endif
++
++# ifndef END
++#  define END(name)	\
++	cfi_endproc;	\
++	.size name, .-name
++# endif
++
++#endif
++
++#define JMPTBL(I, B)	I - B
++#define BRANCH_TO_JMPTBL_ENTRY(TABLE, INDEX, SCALE)	\
++	lea	TABLE(%rip), %r11;	\
++	movslq	(%r11, INDEX, SCALE), %rcx;	\
++	lea	(%r11, %rcx), %rcx;	\
++	jmp	*%rcx
++
++#ifndef USE_AS_STRCAT
++
++# define RETURN ret
++
++.text
++ENTRY (STRCPY)
++# ifdef USE_AS_STRNCPY
++	mov	%rdx, %r8
++	test	%r8, %r8
++	jz	L(ExitZero)
++# endif
++	mov	%rsi, %rcx
++# ifndef USE_AS_STPCPY
++	mov	%rdi, %rax      /* save result */
++# endif
++
++#endif
++	and	$63, %rcx
++	cmp	$32, %rcx
++	jbe	L(SourceStringAlignmentLess32)
++
++	and	$-16, %rsi
++	and	$15, %rcx
++	pxor	%xmm0, %xmm0
++	pxor	%xmm1, %xmm1
++
++	pcmpeqb	(%rsi), %xmm1
++	pmovmskb %xmm1, %rdx
++	shr	%cl, %rdx
++#ifdef USE_AS_STRNCPY
++# if defined USE_AS_STPCPY || defined USE_AS_STRCAT
++	mov	$16, %r10
++	sub	%rcx, %r10
++	cmp	%r10, %r8
++# else
++	mov	$17, %r10
++	sub	%rcx, %r10
++	cmp	%r10, %r8
++# endif
++	jbe	L(CopyFrom1To16BytesTailCase2OrCase3)
++#endif
++	test	%rdx, %rdx
++	jnz	L(CopyFrom1To16BytesTail)
++
++	pcmpeqb	16(%rsi), %xmm0
++	pmovmskb %xmm0, %rdx
++#ifdef USE_AS_STRNCPY
++	add	$16, %r10
++	cmp	%r10, %r8
++	jbe	L(CopyFrom1To32BytesCase2OrCase3)
++#endif
++	test	%rdx, %rdx
++	jnz	L(CopyFrom1To32Bytes)
++
++	movdqu	(%rsi, %rcx), %xmm1   /* copy 16 bytes */
++	movdqu	%xmm1, (%rdi)
++
++/* If source adress alignment != destination adress alignment */
++	.p2align 4
++L(Unalign16Both):
++	sub	%rcx, %rdi
++#ifdef USE_AS_STRNCPY
++	add	%rcx, %r8
++#endif
++	mov	$16, %rcx
++	movdqa	(%rsi, %rcx), %xmm1
++	movaps	16(%rsi, %rcx), %xmm2
++	movdqu	%xmm1, (%rdi, %rcx)
++	pcmpeqb	%xmm2, %xmm0
++	pmovmskb %xmm0, %rdx
++	add	$16, %rcx
++#ifdef USE_AS_STRNCPY
++	sub	$48, %r8
++	jbe	L(CopyFrom1To16BytesCase2OrCase3)
++#endif
++	test	%rdx, %rdx
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	jnz	L(CopyFrom1To16BytesUnalignedXmm2)
++#else
++	jnz	L(CopyFrom1To16Bytes)
++#endif
++
++	movaps	16(%rsi, %rcx), %xmm3
++	movdqu	%xmm2, (%rdi, %rcx)
++	pcmpeqb	%xmm3, %xmm0
++	pmovmskb %xmm0, %rdx
++	add	$16, %rcx
++#ifdef USE_AS_STRNCPY
++	sub	$16, %r8
++	jbe	L(CopyFrom1To16BytesCase2OrCase3)
++#endif
++	test	%rdx, %rdx
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	jnz	L(CopyFrom1To16BytesUnalignedXmm3)
++#else
++	jnz	L(CopyFrom1To16Bytes)
++#endif
++
++	movaps	16(%rsi, %rcx), %xmm4
++	movdqu	%xmm3, (%rdi, %rcx)
++	pcmpeqb	%xmm4, %xmm0
++	pmovmskb %xmm0, %rdx
++	add	$16, %rcx
++#ifdef USE_AS_STRNCPY
++	sub	$16, %r8
++	jbe	L(CopyFrom1To16BytesCase2OrCase3)
++#endif
++	test	%rdx, %rdx
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	jnz	L(CopyFrom1To16BytesUnalignedXmm4)
++#else
++	jnz	L(CopyFrom1To16Bytes)
++#endif
++
++	movaps	16(%rsi, %rcx), %xmm1
++	movdqu	%xmm4, (%rdi, %rcx)
++	pcmpeqb	%xmm1, %xmm0
++	pmovmskb %xmm0, %rdx
++	add	$16, %rcx
++#ifdef USE_AS_STRNCPY
++	sub	$16, %r8
++	jbe	L(CopyFrom1To16BytesCase2OrCase3)
++#endif
++	test	%rdx, %rdx
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	jnz	L(CopyFrom1To16BytesUnalignedXmm1)
++#else
++	jnz	L(CopyFrom1To16Bytes)
++#endif
++
++	movaps	16(%rsi, %rcx), %xmm2
++	movdqu	%xmm1, (%rdi, %rcx)
++	pcmpeqb	%xmm2, %xmm0
++	pmovmskb %xmm0, %rdx
++	add	$16, %rcx
++#ifdef USE_AS_STRNCPY
++	sub	$16, %r8
++	jbe	L(CopyFrom1To16BytesCase2OrCase3)
++#endif
++	test	%rdx, %rdx
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	jnz	L(CopyFrom1To16BytesUnalignedXmm2)
++#else
++	jnz	L(CopyFrom1To16Bytes)
++#endif
++
++	movaps	16(%rsi, %rcx), %xmm3
++	movdqu	%xmm2, (%rdi, %rcx)
++	pcmpeqb	%xmm3, %xmm0
++	pmovmskb %xmm0, %rdx
++	add	$16, %rcx
++#ifdef USE_AS_STRNCPY
++	sub	$16, %r8
++	jbe	L(CopyFrom1To16BytesCase2OrCase3)
++#endif
++	test	%rdx, %rdx
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	jnz	L(CopyFrom1To16BytesUnalignedXmm3)
++#else
++	jnz	L(CopyFrom1To16Bytes)
++#endif
++
++	movdqu	%xmm3, (%rdi, %rcx)
++	mov	%rsi, %rdx
++	lea	16(%rsi, %rcx), %rsi
++	and	$-0x40, %rsi
++	sub	%rsi, %rdx
++	sub	%rdx, %rdi
++#ifdef USE_AS_STRNCPY
++	lea	128(%r8, %rdx), %r8
++#endif
++L(Unaligned64Loop):
++	movaps	(%rsi), %xmm2
++	movaps	%xmm2, %xmm4
++	movaps	16(%rsi), %xmm5
++	movaps	32(%rsi), %xmm3
++	movaps	%xmm3, %xmm6
++	movaps	48(%rsi), %xmm7
++	pminub	%xmm5, %xmm2
++	pminub	%xmm7, %xmm3
++	pminub	%xmm2, %xmm3
++	pcmpeqb	%xmm0, %xmm3
++	pmovmskb %xmm3, %rdx
++#ifdef USE_AS_STRNCPY
++	sub	$64, %r8
++	jbe	L(UnalignedLeaveCase2OrCase3)
++#endif
++	test	%rdx, %rdx
++	jnz	L(Unaligned64Leave)
++
++L(Unaligned64Loop_start):
++	add	$64, %rdi
++	add	$64, %rsi
++	movdqu	%xmm4, -64(%rdi)
++	movaps	(%rsi), %xmm2
++	movdqa	%xmm2, %xmm4
++	movdqu	%xmm5, -48(%rdi)
++	movaps	16(%rsi), %xmm5
++	pminub	%xmm5, %xmm2
++	movaps	32(%rsi), %xmm3
++	movdqu	%xmm6, -32(%rdi)
++	movaps	%xmm3, %xmm6
++	movdqu	%xmm7, -16(%rdi)
++	movaps	48(%rsi), %xmm7
++	pminub	%xmm7, %xmm3
++	pminub	%xmm2, %xmm3
++	pcmpeqb	%xmm0, %xmm3
++	pmovmskb %xmm3, %rdx
++#ifdef USE_AS_STRNCPY
++	sub	$64, %r8
++	jbe	L(UnalignedLeaveCase2OrCase3)
++#endif
++	test	%rdx, %rdx
++	jz	L(Unaligned64Loop_start)
++
++L(Unaligned64Leave):
++	pxor	%xmm1, %xmm1
++
++	pcmpeqb	%xmm4, %xmm0
++	pcmpeqb	%xmm5, %xmm1
++	pmovmskb %xmm0, %rdx
++	pmovmskb %xmm1, %rcx
++	test	%rdx, %rdx
++	jnz	L(CopyFrom1To16BytesUnaligned_0)
++	test	%rcx, %rcx
++	jnz	L(CopyFrom1To16BytesUnaligned_16)
++
++	pcmpeqb	%xmm6, %xmm0
++	pcmpeqb	%xmm7, %xmm1
++	pmovmskb %xmm0, %rdx
++	pmovmskb %xmm1, %rcx
++	test	%rdx, %rdx
++	jnz	L(CopyFrom1To16BytesUnaligned_32)
++
++	bsf	%rcx, %rdx
++	movdqu	%xmm4, (%rdi)
++	movdqu	%xmm5, 16(%rdi)
++	movdqu	%xmm6, 32(%rdi)
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++# ifdef USE_AS_STPCPY
++	lea	48(%rdi, %rdx), %rax
++# endif
++	movdqu	%xmm7, 48(%rdi)
++	add	$15, %r8
++	sub	%rdx, %r8
++	lea	49(%rdi, %rdx), %rdi
++	jmp	L(StrncpyFillTailWithZero)
++#else
++	add	$48, %rsi
++	add	$48, %rdi
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
++#endif
++
++/* If source adress alignment == destination adress alignment */
++
++L(SourceStringAlignmentLess32):
++	pxor	%xmm0, %xmm0
++	movdqu	(%rsi), %xmm1
++	movdqu	16(%rsi), %xmm2
++	pcmpeqb	%xmm1, %xmm0
++	pmovmskb %xmm0, %rdx
++
++#ifdef USE_AS_STRNCPY
++# if defined USE_AS_STPCPY || defined USE_AS_STRCAT
++	cmp	$16, %r8
++# else
++	cmp	$17, %r8
++# endif
++	jbe	L(CopyFrom1To16BytesTail1Case2OrCase3)
++#endif
++	test	%rdx, %rdx
++	jnz	L(CopyFrom1To16BytesTail1)
++
++	pcmpeqb	%xmm2, %xmm0
++	movdqu	%xmm1, (%rdi)
++	pmovmskb %xmm0, %rdx
++
++#ifdef USE_AS_STRNCPY
++# if defined USE_AS_STPCPY || defined USE_AS_STRCAT
++	cmp	$32, %r8
++# else
++	cmp	$33, %r8
++# endif
++	jbe	L(CopyFrom1To32Bytes1Case2OrCase3)
++#endif
++	test	%rdx, %rdx
++	jnz	L(CopyFrom1To32Bytes1)
++
++	and	$15, %rcx
++	and	$-16, %rsi
++
++	jmp	L(Unalign16Both)
++
++/*------End of main part with loops---------------------*/
++
++/* Case1 */
++
++#if (!defined USE_AS_STRNCPY) || (defined USE_AS_STRCAT)
++	.p2align 4
++L(CopyFrom1To16Bytes):
++	add	%rcx, %rdi
++	add	%rcx, %rsi
++	bsf	%rdx, %rdx
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
++#endif
++	.p2align 4
++L(CopyFrom1To16BytesTail):
++	add	%rcx, %rsi
++	bsf	%rdx, %rdx
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
++
++	.p2align 4
++L(CopyFrom1To32Bytes1):
++	add	$16, %rsi
++	add	$16, %rdi
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$16, %r8
++#endif
++L(CopyFrom1To16BytesTail1):
++	bsf	%rdx, %rdx
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
++
++	.p2align 4
++L(CopyFrom1To32Bytes):
++	bsf	%rdx, %rdx
++	add	%rcx, %rsi
++	add	$16, %rdx
++	sub	%rcx, %rdx
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
++
++	.p2align 4
++L(CopyFrom1To16BytesUnaligned_0):
++	bsf	%rdx, %rdx
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++# ifdef USE_AS_STPCPY
++	lea	(%rdi, %rdx), %rax
++# endif
++	movdqu	%xmm4, (%rdi)
++	add	$63, %r8
++	sub	%rdx, %r8
++	lea	1(%rdi, %rdx), %rdi
++	jmp	L(StrncpyFillTailWithZero)
++#else
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
++#endif
++
++	.p2align 4
++L(CopyFrom1To16BytesUnaligned_16):
++	bsf	%rcx, %rdx
++	movdqu	%xmm4, (%rdi)
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++# ifdef USE_AS_STPCPY
++	lea	16(%rdi, %rdx), %rax
++# endif
++	movdqu	%xmm5, 16(%rdi)
++	add	$47, %r8
++	sub	%rdx, %r8
++	lea	17(%rdi, %rdx), %rdi
++	jmp	L(StrncpyFillTailWithZero)
++#else
++	add	$16, %rsi
++	add	$16, %rdi
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
++#endif
++
++	.p2align 4
++L(CopyFrom1To16BytesUnaligned_32):
++	bsf	%rdx, %rdx
++	movdqu	%xmm4, (%rdi)
++	movdqu	%xmm5, 16(%rdi)
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++# ifdef USE_AS_STPCPY
++	lea	32(%rdi, %rdx), %rax
++# endif
++	movdqu	%xmm6, 32(%rdi)
++	add	$31, %r8
++	sub	%rdx, %r8
++	lea	33(%rdi, %rdx), %rdi
++	jmp	L(StrncpyFillTailWithZero)
++#else
++	add	$32, %rsi
++	add	$32, %rdi
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
++#endif
++
++#ifdef USE_AS_STRNCPY
++# ifndef USE_AS_STRCAT 
++	.p2align 4
++L(CopyFrom1To16BytesUnalignedXmm6):
++	movdqu	%xmm6, (%rdi, %rcx)
++	jmp	L(CopyFrom1To16BytesXmmExit)
++
++	.p2align 4
++L(CopyFrom1To16BytesUnalignedXmm5):
++	movdqu	%xmm5, (%rdi, %rcx)
++	jmp	L(CopyFrom1To16BytesXmmExit)
++
++	.p2align 4
++L(CopyFrom1To16BytesUnalignedXmm4):
++	movdqu	%xmm4, (%rdi, %rcx)
++	jmp	L(CopyFrom1To16BytesXmmExit)
++
++	.p2align 4
++L(CopyFrom1To16BytesUnalignedXmm3):
++	movdqu	%xmm3, (%rdi, %rcx)
++	jmp	L(CopyFrom1To16BytesXmmExit)
++
++	.p2align 4
++L(CopyFrom1To16BytesUnalignedXmm1):
++	movdqu	%xmm1, (%rdi, %rcx)
++	jmp	L(CopyFrom1To16BytesXmmExit)
++# endif
++
++	.p2align 4
++L(CopyFrom1To16BytesExit):
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
++
++/* Case2 */
++
++	.p2align 4
++L(CopyFrom1To16BytesCase2):
++	add	$16, %r8
++	add	%rcx, %rdi
++	add	%rcx, %rsi
++	bsf	%rdx, %rdx
++	cmp	%r8, %rdx
++	jb	L(CopyFrom1To16BytesExit)
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
++
++	.p2align 4
++L(CopyFrom1To32BytesCase2):
++	add	%rcx, %rsi
++	bsf	%rdx, %rdx
++	add	$16, %rdx
++	sub	%rcx, %rdx
++	cmp	%r8, %rdx
++	jb	L(CopyFrom1To16BytesExit)
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
++
++L(CopyFrom1To16BytesTailCase2):
++	add	%rcx, %rsi
++	bsf	%rdx, %rdx
++	cmp	%r8, %rdx
++	jb	L(CopyFrom1To16BytesExit)
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
++
++L(CopyFrom1To16BytesTail1Case2):
++	bsf	%rdx, %rdx
++	cmp	%r8, %rdx
++	jb	L(CopyFrom1To16BytesExit)
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
++
++/* Case2 or Case3,  Case3 */
++
++	.p2align 4
++L(CopyFrom1To16BytesCase2OrCase3):
++	test	%rdx, %rdx
++	jnz	L(CopyFrom1To16BytesCase2)
++L(CopyFrom1To16BytesCase3):
++	add	$16, %r8
++	add	%rcx, %rdi
++	add	%rcx, %rsi
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
++
++	.p2align 4
++L(CopyFrom1To32BytesCase2OrCase3):
++	test	%rdx, %rdx
++	jnz	L(CopyFrom1To32BytesCase2)
++	add	%rcx, %rsi
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
++
++	.p2align 4
++L(CopyFrom1To16BytesTailCase2OrCase3):
++	test	%rdx, %rdx
++	jnz	L(CopyFrom1To16BytesTailCase2)
++	add	%rcx, %rsi
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
++
++	.p2align 4
++L(CopyFrom1To32Bytes1Case2OrCase3):
++	add	$16, %rdi
++	add	$16, %rsi
++	sub	$16, %r8
++L(CopyFrom1To16BytesTail1Case2OrCase3):
++	test	%rdx, %rdx
++	jnz	L(CopyFrom1To16BytesTail1Case2)
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
++
++#endif
++
++/*------------End labels regarding with copying 1-16 bytes--and 1-32 bytes----*/
++
++	.p2align 4
++L(Exit1):
++	mov	%dh, (%rdi)
++#ifdef USE_AS_STPCPY
++	lea	(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$1, %r8
++	lea	1(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit2):
++	mov	(%rsi), %dx
++	mov	%dx, (%rdi)
++#ifdef USE_AS_STPCPY
++	lea	1(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$2, %r8
++	lea	2(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit3):
++	mov	(%rsi), %cx
++	mov	%cx, (%rdi)
++	mov	%dh, 2(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	2(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$3, %r8
++	lea	3(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit4):
++	mov	(%rsi), %edx
++	mov	%edx, (%rdi)
++#ifdef USE_AS_STPCPY
++	lea	3(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$4, %r8
++	lea	4(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit5):
++	mov	(%rsi), %ecx
++	mov	%dh, 4(%rdi)
++	mov	%ecx, (%rdi)
++#ifdef USE_AS_STPCPY
++	lea	4(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$5, %r8
++	lea	5(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit6):
++	mov	(%rsi), %ecx
++	mov	4(%rsi), %dx
++	mov	%ecx, (%rdi)
++	mov	%dx, 4(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	5(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$6, %r8
++	lea	6(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit7):
++	mov	(%rsi), %ecx
++	mov	3(%rsi), %edx
++	mov	%ecx, (%rdi)
++	mov	%edx, 3(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	6(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$7, %r8
++	lea	7(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit8):
++	mov	(%rsi), %rdx
++	mov	%rdx, (%rdi)
++#ifdef USE_AS_STPCPY
++	lea	7(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$8, %r8
++	lea	8(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit9):
++	mov	(%rsi), %rcx
++	mov	%dh, 8(%rdi)
++	mov	%rcx, (%rdi)
++#ifdef USE_AS_STPCPY
++	lea	8(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$9, %r8
++	lea	9(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit10):
++	mov	(%rsi), %rcx
++	mov	8(%rsi), %dx
++	mov	%rcx, (%rdi)
++	mov	%dx, 8(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	9(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$10, %r8
++	lea	10(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit11):
++	mov	(%rsi), %rcx
++	mov	7(%rsi), %edx
++	mov	%rcx, (%rdi)
++	mov	%edx, 7(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	10(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$11, %r8
++	lea	11(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit12):
++	mov	(%rsi), %rcx
++	mov	8(%rsi), %edx
++	mov	%rcx, (%rdi)
++	mov	%edx, 8(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	11(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$12, %r8
++	lea	12(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit13):
++	mov	(%rsi), %rcx
++	mov	5(%rsi), %rdx
++	mov	%rcx, (%rdi)
++	mov	%rdx, 5(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	12(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$13, %r8
++	lea	13(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit14):
++	mov	(%rsi), %rcx
++	mov	6(%rsi), %rdx
++	mov	%rcx, (%rdi)
++	mov	%rdx, 6(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	13(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$14, %r8
++	lea	14(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit15):
++	mov	(%rsi), %rcx
++	mov	7(%rsi), %rdx
++	mov	%rcx, (%rdi)
++	mov	%rdx, 7(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	14(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$15, %r8
++	lea	15(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit16):
++	movdqu	(%rsi), %xmm0
++	movdqu	%xmm0, (%rdi)
++#ifdef USE_AS_STPCPY
++	lea	15(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$16, %r8
++	lea	16(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit17):
++	movdqu	(%rsi), %xmm0
++	movdqu	%xmm0, (%rdi)
++	mov	%dh, 16(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	16(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$17, %r8
++	lea	17(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit18):
++	movdqu	(%rsi), %xmm0
++	mov	16(%rsi), %cx
++	movdqu	%xmm0, (%rdi)
++	mov	%cx, 16(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	17(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$18, %r8
++	lea	18(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit19):
++	movdqu	(%rsi), %xmm0
++	mov	15(%rsi), %ecx
++	movdqu	%xmm0, (%rdi)
++	mov	%ecx, 15(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	18(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$19, %r8
++	lea	19(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit20):
++	movdqu	(%rsi), %xmm0
++	mov	16(%rsi), %ecx
++	movdqu	%xmm0, (%rdi)
++	mov	%ecx, 16(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	19(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$20, %r8
++	lea	20(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit21):
++	movdqu	(%rsi), %xmm0
++	mov	16(%rsi), %ecx
++	movdqu	%xmm0, (%rdi)
++	mov	%ecx, 16(%rdi)
++	mov	%dh, 20(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	20(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$21, %r8
++	lea	21(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit22):
++	movdqu	(%rsi), %xmm0
++	mov	14(%rsi), %rcx
++	movdqu	%xmm0, (%rdi)
++	mov	%rcx, 14(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	21(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$22, %r8
++	lea	22(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit23):
++	movdqu	(%rsi), %xmm0
++	mov	15(%rsi), %rcx
++	movdqu	%xmm0, (%rdi)
++	mov	%rcx, 15(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	22(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$23, %r8
++	lea	23(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit24):
++	movdqu	(%rsi), %xmm0
++	mov	16(%rsi), %rcx
++	movdqu	%xmm0, (%rdi)
++	mov	%rcx, 16(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	23(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$24, %r8
++	lea	24(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit25):
++	movdqu	(%rsi), %xmm0
++	mov	16(%rsi), %rcx
++	movdqu	%xmm0, (%rdi)
++	mov	%rcx, 16(%rdi)
++	mov	%dh, 24(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	24(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$25, %r8
++	lea	25(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit26):
++	movdqu	(%rsi), %xmm0
++	mov	16(%rsi), %rdx
++	mov	24(%rsi), %cx
++	movdqu	%xmm0, (%rdi)
++	mov	%rdx, 16(%rdi)
++	mov	%cx, 24(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	25(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$26, %r8
++	lea	26(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit27):
++	movdqu	(%rsi), %xmm0
++	mov	16(%rsi), %rdx
++	mov	23(%rsi), %ecx
++	movdqu	%xmm0, (%rdi)
++	mov	%rdx, 16(%rdi)
++	mov	%ecx, 23(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	26(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$27, %r8
++	lea	27(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit28):
++	movdqu	(%rsi), %xmm0
++	mov	16(%rsi), %rdx
++	mov	24(%rsi), %ecx
++	movdqu	%xmm0, (%rdi)
++	mov	%rdx, 16(%rdi)
++	mov	%ecx, 24(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	27(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$28, %r8
++	lea	28(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit29):
++	movdqu	(%rsi), %xmm0
++	movdqu	13(%rsi), %xmm2
++	movdqu	%xmm0, (%rdi)
++	movdqu	%xmm2, 13(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	28(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$29, %r8
++	lea	29(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit30):
++	movdqu	(%rsi), %xmm0
++	movdqu	14(%rsi), %xmm2
++	movdqu	%xmm0, (%rdi)
++	movdqu	%xmm2, 14(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	29(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$30, %r8
++	lea	30(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit31):
++	movdqu	(%rsi), %xmm0
++	movdqu	15(%rsi), %xmm2
++	movdqu	%xmm0, (%rdi)
++	movdqu	%xmm2, 15(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	30(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$31, %r8
++	lea	31(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++	.p2align 4
++L(Exit32):
++	movdqu	(%rsi), %xmm0
++	movdqu	16(%rsi), %xmm2
++	movdqu	%xmm0, (%rdi)
++	movdqu	%xmm2, 16(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	31(%rdi), %rax
++#endif
++#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$32, %r8
++	lea	32(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++#endif
++	RETURN
++
++#ifdef USE_AS_STRNCPY
++
++	.p2align 4
++L(StrncpyExit0):
++#ifdef USE_AS_STPCPY
++	mov	%rdi, %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, (%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit1):
++	mov	(%rsi), %dl
++	mov	%dl, (%rdi)
++#ifdef USE_AS_STPCPY
++	lea	1(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 1(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit2):
++	mov	(%rsi), %dx
++	mov	%dx, (%rdi)
++#ifdef USE_AS_STPCPY
++	lea	2(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 2(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit3):
++	mov	(%rsi), %cx
++	mov	2(%rsi), %dl
++	mov	%cx, (%rdi)
++	mov	%dl, 2(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	3(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 3(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit4):
++	mov	(%rsi), %edx
++	mov	%edx, (%rdi)
++#ifdef USE_AS_STPCPY
++	lea	4(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 4(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit5):
++	mov	(%rsi), %ecx
++	mov	4(%rsi), %dl
++	mov	%ecx, (%rdi)
++	mov	%dl, 4(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	5(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 5(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit6):
++	mov	(%rsi), %ecx
++	mov	4(%rsi), %dx
++	mov	%ecx, (%rdi)
++	mov	%dx, 4(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	6(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 6(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit7):
++	mov	(%rsi), %ecx
++	mov	3(%rsi), %edx
++	mov	%ecx, (%rdi)
++	mov	%edx, 3(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	7(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 7(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit8):
++	mov	(%rsi), %rdx
++	mov	%rdx, (%rdi)
++#ifdef USE_AS_STPCPY
++	lea	8(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 8(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit9):
++	mov	(%rsi), %rcx
++	mov	8(%rsi), %dl
++	mov	%rcx, (%rdi)
++	mov	%dl, 8(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	9(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 9(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit10):
++	mov	(%rsi), %rcx
++	mov	8(%rsi), %dx
++	mov	%rcx, (%rdi)
++	mov	%dx, 8(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	10(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 10(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit11):
++	mov	(%rsi), %rcx
++	mov	7(%rsi), %edx
++	mov	%rcx, (%rdi)
++	mov	%edx, 7(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	11(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 11(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit12):
++	mov	(%rsi), %rcx
++	mov	8(%rsi), %edx
++	mov	%rcx, (%rdi)
++	mov	%edx, 8(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	12(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 12(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit13):
++	mov	(%rsi), %rcx
++	mov	5(%rsi), %rdx
++	mov	%rcx, (%rdi)
++	mov	%rdx, 5(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	13(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 13(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit14):
++	mov	(%rsi), %rcx
++	mov	6(%rsi), %rdx
++	mov	%rcx, (%rdi)
++	mov	%rdx, 6(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	14(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 14(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit15):
++	mov	(%rsi), %rcx
++	mov	7(%rsi), %rdx
++	mov	%rcx, (%rdi)
++	mov	%rdx, 7(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	15(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 15(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit16):
++	movdqu	(%rsi), %xmm0
++	movdqu	%xmm0, (%rdi)
++#ifdef USE_AS_STPCPY
++	lea	16(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 16(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit17):
++	movdqu	(%rsi), %xmm0
++	mov	16(%rsi), %cl
++	movdqu	%xmm0, (%rdi)
++	mov	%cl, 16(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	17(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 17(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit18):
++	movdqu	(%rsi), %xmm0
++	mov	16(%rsi), %cx
++	movdqu	%xmm0, (%rdi)
++	mov	%cx, 16(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	18(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 18(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit19):
++	movdqu	(%rsi), %xmm0
++	mov	15(%rsi), %ecx
++	movdqu	%xmm0, (%rdi)
++	mov	%ecx, 15(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	19(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 19(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit20):
++	movdqu	(%rsi), %xmm0
++	mov	16(%rsi), %ecx
++	movdqu	%xmm0, (%rdi)
++	mov	%ecx, 16(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	20(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 20(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit21):
++	movdqu	(%rsi), %xmm0
++	mov	16(%rsi), %ecx
++	mov	20(%rsi), %dl
++	movdqu	%xmm0, (%rdi)
++	mov	%ecx, 16(%rdi)
++	mov	%dl, 20(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	21(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 21(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit22):
++	movdqu	(%rsi), %xmm0
++	mov	14(%rsi), %rcx
++	movdqu	%xmm0, (%rdi)
++	mov	%rcx, 14(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	22(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 22(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit23):
++	movdqu	(%rsi), %xmm0
++	mov	15(%rsi), %rcx
++	movdqu	%xmm0, (%rdi)
++	mov	%rcx, 15(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	23(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 23(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit24):
++	movdqu	(%rsi), %xmm0
++	mov	16(%rsi), %rcx
++	movdqu	%xmm0, (%rdi)
++	mov	%rcx, 16(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	24(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 24(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit25):
++	movdqu	(%rsi), %xmm0
++	mov	16(%rsi), %rdx
++	mov	24(%rsi), %cl
++	movdqu	%xmm0, (%rdi)
++	mov	%rdx, 16(%rdi)
++	mov	%cl, 24(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	25(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 25(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit26):
++	movdqu	(%rsi), %xmm0
++	mov	16(%rsi), %rdx
++	mov	24(%rsi), %cx
++	movdqu	%xmm0, (%rdi)
++	mov	%rdx, 16(%rdi)
++	mov	%cx, 24(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	26(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 26(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit27):
++	movdqu	(%rsi), %xmm0
++	mov	16(%rsi), %rdx
++	mov	23(%rsi), %ecx
++	movdqu	%xmm0, (%rdi)
++	mov	%rdx, 16(%rdi)
++	mov	%ecx, 23(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	27(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 27(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit28):
++	movdqu	(%rsi), %xmm0
++	mov	16(%rsi), %rdx
++	mov	24(%rsi), %ecx
++	movdqu	%xmm0, (%rdi)
++	mov	%rdx, 16(%rdi)
++	mov	%ecx, 24(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	28(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 28(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit29):
++	movdqu	(%rsi), %xmm0
++	movdqu	13(%rsi), %xmm2
++	movdqu	%xmm0, (%rdi)
++	movdqu	%xmm2, 13(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	29(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 29(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit30):
++	movdqu	(%rsi), %xmm0
++	movdqu	14(%rsi), %xmm2
++	movdqu	%xmm0, (%rdi)
++	movdqu	%xmm2, 14(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	30(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 30(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit31):
++	movdqu	(%rsi), %xmm0
++	movdqu	15(%rsi), %xmm2
++	movdqu	%xmm0, (%rdi)
++	movdqu	%xmm2, 15(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	31(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 31(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit32):
++	movdqu	(%rsi), %xmm0
++	movdqu	16(%rsi), %xmm2
++	movdqu	%xmm0, (%rdi)
++	movdqu	%xmm2, 16(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	32(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 32(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(StrncpyExit33):
++	movdqu	(%rsi), %xmm0
++	movdqu	16(%rsi), %xmm2
++	mov	32(%rsi), %cl
++	movdqu	%xmm0, (%rdi)
++	movdqu	%xmm2, 16(%rdi)
++	mov	%cl, 32(%rdi)
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 33(%rdi)
++#endif
++	RETURN
++
++#ifndef USE_AS_STRCAT
++
++	.p2align 4
++L(Fill0):
++	RETURN
++
++	.p2align 4
++L(Fill1):
++	mov	%dl, (%rdi)
++	RETURN
++
++	.p2align 4
++L(Fill2):
++	mov	%dx, (%rdi)
++	RETURN
++
++	.p2align 4
++L(Fill3):
++	mov	%edx, -1(%rdi)
++	RETURN
++
++	.p2align 4
++L(Fill4):
++	mov	%edx, (%rdi)
++	RETURN
++
++	.p2align 4
++L(Fill5):
++	mov	%edx, (%rdi)
++	mov	%dl, 4(%rdi)
++	RETURN
++
++	.p2align 4
++L(Fill6):
++	mov	%edx, (%rdi)
++	mov	%dx, 4(%rdi)
++	RETURN
++
++	.p2align 4
++L(Fill7):
++	mov	%rdx, -1(%rdi)
++	RETURN
++
++	.p2align 4
++L(Fill8):
++	mov	%rdx, (%rdi)
++	RETURN
++
++	.p2align 4
++L(Fill9):
++	mov	%rdx, (%rdi)
++	mov	%dl, 8(%rdi)
++	RETURN
++
++	.p2align 4
++L(Fill10):
++	mov	%rdx, (%rdi)
++	mov	%dx, 8(%rdi)
++	RETURN
++
++	.p2align 4
++L(Fill11):
++	mov	%rdx, (%rdi)
++	mov	%edx, 7(%rdi)
++	RETURN
++
++	.p2align 4
++L(Fill12):
++	mov	%rdx, (%rdi)
++	mov	%edx, 8(%rdi)
++	RETURN
++
++	.p2align 4
++L(Fill13):
++	mov	%rdx, (%rdi)
++	mov	%rdx, 5(%rdi)
++	RETURN
++
++	.p2align 4
++L(Fill14):
++	mov	%rdx, (%rdi)
++	mov	%rdx, 6(%rdi)
++	RETURN
++
++	.p2align 4
++L(Fill15):
++	movdqu	%xmm0, -1(%rdi)
++	RETURN
++
++	.p2align 4
++L(Fill16):
++	movdqu	%xmm0, (%rdi)
++	RETURN
++
++	.p2align 4
++L(CopyFrom1To16BytesUnalignedXmm2):
++	movdqu	%xmm2, (%rdi, %rcx)
++
++	.p2align 4
++L(CopyFrom1To16BytesXmmExit):
++	bsf	%rdx, %rdx
++	add	$15, %r8
++	add	%rcx, %rdi
++#ifdef USE_AS_STPCPY
++	lea	(%rdi, %rdx), %rax
++#endif
++	sub	%rdx, %r8
++	lea	1(%rdi, %rdx), %rdi
++
++	.p2align 4
++L(StrncpyFillTailWithZero):
++	pxor	%xmm0, %xmm0
++	xor	%rdx, %rdx
++	sub	$16, %r8
++	jbe	L(StrncpyFillExit)
++
++	movdqu	%xmm0, (%rdi)
++	add	$16, %rdi
++
++	mov	%rdi, %rsi
++	and	$0xf, %rsi
++	sub	%rsi, %rdi
++	add	%rsi, %r8
++	sub	$64, %r8
++	jb	L(StrncpyFillLess64)
++
++L(StrncpyFillLoopMovdqa):
++	movdqa	%xmm0, (%rdi)
++	movdqa	%xmm0, 16(%rdi)
++	movdqa	%xmm0, 32(%rdi)
++	movdqa	%xmm0, 48(%rdi)
++	add	$64, %rdi
++	sub	$64, %r8
++	jae	L(StrncpyFillLoopMovdqa)
++
++L(StrncpyFillLess64):
++	add	$32, %r8
++	jl	L(StrncpyFillLess32)
++	movdqa	%xmm0, (%rdi)
++	movdqa	%xmm0, 16(%rdi)
++	add	$32, %rdi
++	sub	$16, %r8
++	jl	L(StrncpyFillExit)
++	movdqa	%xmm0, (%rdi)
++	add	$16, %rdi
++	BRANCH_TO_JMPTBL_ENTRY (L(FillTable), %r8, 4)
++
++L(StrncpyFillLess32):
++	add	$16, %r8
++	jl	L(StrncpyFillExit)
++	movdqa	%xmm0, (%rdi)
++	add	$16, %rdi
++	BRANCH_TO_JMPTBL_ENTRY (L(FillTable), %r8, 4)
++
++L(StrncpyFillExit):
++	add	$16, %r8
++	BRANCH_TO_JMPTBL_ENTRY (L(FillTable), %r8, 4)
++
++/* end of ifndef USE_AS_STRCAT */
++#endif
++
++	.p2align 4
++L(UnalignedLeaveCase2OrCase3):
++	test	%rdx, %rdx
++	jnz	L(Unaligned64LeaveCase2)
++L(Unaligned64LeaveCase3):
++	lea	64(%r8), %rcx
++	and	$-16, %rcx
++	add	$48, %r8
++	jl	L(CopyFrom1To16BytesCase3)
++	movdqu	%xmm4, (%rdi)
++	sub	$16, %r8
++	jb	L(CopyFrom1To16BytesCase3)
++	movdqu	%xmm5, 16(%rdi)
++	sub	$16, %r8
++	jb	L(CopyFrom1To16BytesCase3)
++	movdqu	%xmm6, 32(%rdi)
++	sub	$16, %r8
++	jb	L(CopyFrom1To16BytesCase3)
++	movdqu	%xmm7, 48(%rdi)
++#ifdef USE_AS_STPCPY
++	lea	64(%rdi), %rax
++#endif
++#ifdef USE_AS_STRCAT
++	xor	%ch, %ch
++	movb	%ch, 64(%rdi)
++#endif
++	RETURN
++
++	.p2align 4
++L(Unaligned64LeaveCase2):
++	xor	%rcx, %rcx
++	pcmpeqb	%xmm4, %xmm0
++	pmovmskb %xmm0, %rdx
++	add	$48, %r8
++	jle	L(CopyFrom1To16BytesCase2OrCase3)
++	test	%rdx, %rdx
++#ifndef USE_AS_STRCAT
++	jnz	L(CopyFrom1To16BytesUnalignedXmm4)
++#else
++	jnz	L(CopyFrom1To16Bytes)
++#endif
++	pcmpeqb	%xmm5, %xmm0
++	pmovmskb %xmm0, %rdx
++	movdqu	%xmm4, (%rdi)
++	add	$16, %rcx
++	sub	$16, %r8
++	jbe	L(CopyFrom1To16BytesCase2OrCase3)
++	test	%rdx, %rdx
++#ifndef USE_AS_STRCAT
++	jnz	L(CopyFrom1To16BytesUnalignedXmm5)
++#else
++	jnz	L(CopyFrom1To16Bytes)
++#endif
++
++	pcmpeqb	%xmm6, %xmm0
++	pmovmskb %xmm0, %rdx
++	movdqu	%xmm5, 16(%rdi)
++	add	$16, %rcx
++	sub	$16, %r8
++	jbe	L(CopyFrom1To16BytesCase2OrCase3)
++	test	%rdx, %rdx
++#ifndef USE_AS_STRCAT
++	jnz	L(CopyFrom1To16BytesUnalignedXmm6)
++#else
++	jnz	L(CopyFrom1To16Bytes)
++#endif
++
++	pcmpeqb	%xmm7, %xmm0
++	pmovmskb %xmm0, %rdx
++	movdqu	%xmm6, 32(%rdi)
++	lea	16(%rdi, %rcx), %rdi
++	lea	16(%rsi, %rcx), %rsi
++	bsf	%rdx, %rdx
++	cmp	%r8, %rdx
++	jb	L(CopyFrom1To16BytesExit)
++	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
++
++	.p2align 4
++L(ExitZero):
++#ifndef USE_AS_STRCAT
++	mov	%rdi, %rax
++#endif
++	RETURN
++
++#endif
++
++#ifndef USE_AS_STRCAT
++END (STRCPY)
++#else
++END (STRCAT)
++#endif
++	.p2align 4
++	.section .rodata
++L(ExitTable):
++	.int	JMPTBL(L(Exit1), L(ExitTable))
++	.int	JMPTBL(L(Exit2), L(ExitTable))
++	.int	JMPTBL(L(Exit3), L(ExitTable))
++	.int	JMPTBL(L(Exit4), L(ExitTable))
++	.int	JMPTBL(L(Exit5), L(ExitTable))
++	.int	JMPTBL(L(Exit6), L(ExitTable))
++	.int	JMPTBL(L(Exit7), L(ExitTable))
++	.int	JMPTBL(L(Exit8), L(ExitTable))
++	.int	JMPTBL(L(Exit9), L(ExitTable))
++	.int	JMPTBL(L(Exit10), L(ExitTable))
++	.int	JMPTBL(L(Exit11), L(ExitTable))
++	.int	JMPTBL(L(Exit12), L(ExitTable))
++	.int	JMPTBL(L(Exit13), L(ExitTable))
++	.int	JMPTBL(L(Exit14), L(ExitTable))
++	.int	JMPTBL(L(Exit15), L(ExitTable))
++	.int	JMPTBL(L(Exit16), L(ExitTable))
++	.int	JMPTBL(L(Exit17), L(ExitTable))
++	.int	JMPTBL(L(Exit18), L(ExitTable))
++	.int	JMPTBL(L(Exit19), L(ExitTable))
++	.int	JMPTBL(L(Exit20), L(ExitTable))
++	.int	JMPTBL(L(Exit21), L(ExitTable))
++	.int	JMPTBL(L(Exit22), L(ExitTable))
++	.int	JMPTBL(L(Exit23), L(ExitTable))
++	.int	JMPTBL(L(Exit24), L(ExitTable))
++	.int	JMPTBL(L(Exit25), L(ExitTable))
++	.int	JMPTBL(L(Exit26), L(ExitTable))
++	.int	JMPTBL(L(Exit27), L(ExitTable))
++	.int	JMPTBL(L(Exit28), L(ExitTable))
++	.int	JMPTBL(L(Exit29), L(ExitTable))
++	.int	JMPTBL(L(Exit30), L(ExitTable))
++	.int	JMPTBL(L(Exit31), L(ExitTable))
++	.int	JMPTBL(L(Exit32), L(ExitTable))
++#ifdef USE_AS_STRNCPY
++L(ExitStrncpyTable):
++	.int	JMPTBL(L(StrncpyExit0), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit1), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit2), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit3), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit4), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit5), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit6), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit7), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit8), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit9), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit10), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit11), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit12), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit13), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit14), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit15), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit16), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit17), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit18), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit19), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit20), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit21), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit22), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit23), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit24), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit25), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit26), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit27), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit28), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit29), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit30), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit31), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit32), L(ExitStrncpyTable))
++	.int	JMPTBL(L(StrncpyExit33), L(ExitStrncpyTable))
++# ifndef USE_AS_STRCAT
++	.p2align 4
++L(FillTable):
++	.int	JMPTBL(L(Fill0), L(FillTable))
++	.int	JMPTBL(L(Fill1), L(FillTable))
++	.int	JMPTBL(L(Fill2), L(FillTable))
++	.int	JMPTBL(L(Fill3), L(FillTable))
++	.int	JMPTBL(L(Fill4), L(FillTable))
++	.int	JMPTBL(L(Fill5), L(FillTable))
++	.int	JMPTBL(L(Fill6), L(FillTable))
++	.int	JMPTBL(L(Fill7), L(FillTable))
++	.int	JMPTBL(L(Fill8), L(FillTable))
++	.int	JMPTBL(L(Fill9), L(FillTable))
++	.int	JMPTBL(L(Fill10), L(FillTable))
++	.int	JMPTBL(L(Fill11), L(FillTable))
++	.int	JMPTBL(L(Fill12), L(FillTable))
++	.int	JMPTBL(L(Fill13), L(FillTable))
++	.int	JMPTBL(L(Fill14), L(FillTable))
++	.int	JMPTBL(L(Fill15), L(FillTable))
++	.int	JMPTBL(L(Fill16), L(FillTable))
++# endif
++#endif
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-strlen-slm.S b/libc/arch-x86_64/silvermont/string/sse2-strlen-slm.S
+new file mode 100644
+index 0000000..3772fe7
+--- /dev/null
++++ b/libc/arch-x86_64/silvermont/string/sse2-strlen-slm.S
+@@ -0,0 +1,294 @@
++/*
++Copyright (c) 2014, Intel Corporation
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++    * Redistributions of source code must retain the above copyright notice,
++    * this list of conditions and the following disclaimer.
++
++    * Redistributions in binary form must reproduce the above copyright notice,
++    * this list of conditions and the following disclaimer in the documentation
++    * and/or other materials provided with the distribution.
++
++    * Neither the name of Intel Corporation nor the names of its contributors
++    * may be used to endorse or promote products derived from this software
++    * without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
++ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
++WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
++ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
++ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++#ifndef USE_AS_STRCAT
++
++#ifndef STRLEN
++# define STRLEN		strlen
++#endif
++
++#ifndef L
++# define L(label)	.L##label
++#endif
++
++#ifndef cfi_startproc
++# define cfi_startproc			.cfi_startproc
++#endif
++
++#ifndef cfi_endproc
++# define cfi_endproc			.cfi_endproc
++#endif
++
++#ifndef ENTRY
++# define ENTRY(name)			\
++	.type name,  @function; 	\
++	.globl name;			\
++	.p2align 4;			\
++name:					\
++	cfi_startproc
++#endif
++
++#ifndef END
++# define END(name)			\
++	cfi_endproc;			\
++	.size name, .-name
++#endif
++#define RETURN ret
++	.section .text.sse2,"ax",@progbits
++ENTRY (STRLEN)
++/* end ifndef USE_AS_STRCAT */
++#endif
++	xor	%rax, %rax
++	mov	%edi, %ecx
++	and	$0x3f, %ecx
++	pxor	%xmm0, %xmm0
++	cmp	$0x30, %ecx
++	ja	L(next)
++	movdqu	(%rdi), %xmm1
++	pcmpeqb	%xmm1, %xmm0
++	pmovmskb %xmm0, %edx
++	test	%edx, %edx
++	jnz	L(exit_less16)
++	mov	%rdi, %rax
++	and	$-16, %rax
++	jmp	L(align16_start)
++L(next):
++	mov	%rdi, %rax
++	and	$-16, %rax
++	pcmpeqb	(%rax), %xmm0
++	mov	$-1, %r10d
++	sub	%rax, %rcx
++	shl	%cl, %r10d
++	pmovmskb %xmm0, %edx
++	and	%r10d, %edx
++	jnz	L(exit)
++L(align16_start):
++	pxor	%xmm0, %xmm0
++	pxor	%xmm1, %xmm1
++	pxor	%xmm2, %xmm2
++	pxor	%xmm3, %xmm3
++	pcmpeqb	16(%rax), %xmm0
++	pmovmskb %xmm0, %edx
++	test	%edx, %edx
++	jnz	L(exit16)
++
++	pcmpeqb	32(%rax), %xmm1
++	pmovmskb %xmm1, %edx
++	test	%edx, %edx
++	jnz	L(exit32)
++
++	pcmpeqb	48(%rax), %xmm2
++	pmovmskb %xmm2, %edx
++	test	%edx, %edx
++	jnz	L(exit48)
++
++	pcmpeqb	64(%rax), %xmm3
++	pmovmskb %xmm3, %edx
++	test	%edx, %edx
++	jnz	L(exit64)
++
++	pcmpeqb	80(%rax), %xmm0
++	add	$64, %rax
++	pmovmskb %xmm0, %edx
++	test	%edx, %edx
++	jnz	L(exit16)
++
++	pcmpeqb	32(%rax), %xmm1
++	pmovmskb %xmm1, %edx
++	test	%edx, %edx
++	jnz	L(exit32)
++
++	pcmpeqb	48(%rax), %xmm2
++	pmovmskb %xmm2, %edx
++	test	%edx, %edx
++	jnz	L(exit48)
++
++	pcmpeqb	64(%rax), %xmm3
++	pmovmskb %xmm3, %edx
++	test	%edx, %edx
++	jnz	L(exit64)
++
++	pcmpeqb	80(%rax), %xmm0
++	add	$64, %rax
++	pmovmskb %xmm0, %edx
++	test	%edx, %edx
++	jnz	L(exit16)
++
++	pcmpeqb	32(%rax), %xmm1
++	pmovmskb %xmm1, %edx
++	test	%edx, %edx
++	jnz	L(exit32)
++
++	pcmpeqb	48(%rax), %xmm2
++	pmovmskb %xmm2, %edx
++	test	%edx, %edx
++	jnz	L(exit48)
++
++	pcmpeqb	64(%rax), %xmm3
++	pmovmskb %xmm3, %edx
++	test	%edx, %edx
++	jnz	L(exit64)
++	
++	pcmpeqb	80(%rax), %xmm0
++	add	$64, %rax
++	pmovmskb %xmm0, %edx
++	test	%edx, %edx
++	jnz	L(exit16)
++
++	pcmpeqb	32(%rax), %xmm1
++	pmovmskb %xmm1, %edx
++	test	%edx, %edx
++	jnz	L(exit32)
++
++	pcmpeqb	48(%rax), %xmm2
++	pmovmskb %xmm2, %edx
++	test	%edx, %edx
++	jnz	L(exit48)
++
++	pcmpeqb	64(%rax), %xmm3
++	pmovmskb %xmm3, %edx
++	test	%edx, %edx
++	jnz	L(exit64)
++	
++
++	test	$0x3f, %rax
++	jz	L(align64_loop)
++
++	pcmpeqb	80(%rax), %xmm0
++	add	$80, %rax
++	pmovmskb %xmm0, %edx
++	test	%edx, %edx
++	jnz	L(exit)
++
++	test	$0x3f, %rax
++	jz	L(align64_loop)
++
++	pcmpeqb	16(%rax), %xmm1
++	add	$16, %rax
++	pmovmskb %xmm1, %edx
++	test	%edx, %edx
++	jnz	L(exit)
++
++	test	$0x3f, %rax
++	jz	L(align64_loop)
++
++	pcmpeqb	16(%rax), %xmm2
++	add	$16, %rax
++	pmovmskb %xmm2, %edx
++	test	%edx, %edx
++	jnz	L(exit)
++
++	test	$0x3f, %rax
++	jz	L(align64_loop)
++
++	pcmpeqb	16(%rax), %xmm3
++	add	$16, %rax
++	pmovmskb %xmm3, %edx
++	test	%edx, %edx
++	jnz	L(exit)
++
++	add	$16, %rax
++	.p2align 4
++	L(align64_loop):
++	movaps	(%rax),	%xmm4
++	pminub	16(%rax), 	%xmm4
++	movaps	32(%rax), 	%xmm5
++	pminub	48(%rax), 	%xmm5
++	add	$64, 	%rax
++	pminub	%xmm4,	%xmm5
++	pcmpeqb	%xmm0,	%xmm5
++	pmovmskb %xmm5,	%edx
++	test	%edx,	%edx
++	jz	L(align64_loop)
++
++
++	pcmpeqb	-64(%rax), %xmm0
++	sub	$80, 	%rax
++	pmovmskb %xmm0, %edx
++	test	%edx, %edx
++	jnz	L(exit16)
++
++	pcmpeqb	32(%rax), %xmm1
++	pmovmskb %xmm1, %edx
++	test	%edx, %edx
++	jnz	L(exit32)
++
++	pcmpeqb	48(%rax), %xmm2
++	pmovmskb %xmm2, %edx
++	test	%edx, %edx
++	jnz	L(exit48)
++
++	pcmpeqb	64(%rax), %xmm3
++	pmovmskb %xmm3, %edx
++	sub	%rdi, %rax
++	bsf	%rdx, %rdx
++	add	%rdx, %rax
++	add	$64, %rax
++	RETURN
++
++	.p2align 4
++L(exit):
++	sub	%rdi, %rax
++L(exit_less16):
++	bsf	%rdx, %rdx
++	add	%rdx, %rax
++	RETURN
++	.p2align 4
++L(exit16):
++	sub	%rdi, %rax
++	bsf	%rdx, %rdx
++	add	%rdx, %rax
++	add	$16, %rax
++	RETURN
++	.p2align 4
++L(exit32):
++	sub	%rdi, %rax
++	bsf	%rdx, %rdx
++	add	%rdx, %rax
++	add	$32, %rax
++	RETURN
++	.p2align 4
++L(exit48):
++	sub	%rdi, %rax
++	bsf	%rdx, %rdx
++	add	%rdx, %rax
++	add	$48, %rax
++	RETURN
++	.p2align 4
++L(exit64):
++	sub	%rdi, %rax
++	bsf	%rdx, %rdx
++	add	%rdx, %rax
++	add	$64, %rax
++#ifndef USE_AS_STRCAT
++	RETURN
++
++END (STRLEN)
++#endif
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-strncat-slm.S b/libc/arch-x86_64/silvermont/string/sse2-strncat-slm.S
+new file mode 100644
+index 0000000..6b4a430
+--- /dev/null
++++ b/libc/arch-x86_64/silvermont/string/sse2-strncat-slm.S
+@@ -0,0 +1,33 @@
++/*
++Copyright (c) 2014, Intel Corporation
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++    * Redistributions of source code must retain the above copyright notice,
++    * this list of conditions and the following disclaimer.
++
++    * Redistributions in binary form must reproduce the above copyright notice,
++    * this list of conditions and the following disclaimer in the documentation
++    * and/or other materials provided with the distribution.
++
++    * Neither the name of Intel Corporation nor the names of its contributors
++    * may be used to endorse or promote products derived from this software
++    * without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
++ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
++WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
++ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
++ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++#define USE_AS_STRNCAT
++#define STRCAT		strncat
++#include "sse2-strcat-slm.S"
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-strncpy-slm.S b/libc/arch-x86_64/silvermont/string/sse2-strncpy-slm.S
+new file mode 100644
+index 0000000..594e78f
+--- /dev/null
++++ b/libc/arch-x86_64/silvermont/string/sse2-strncpy-slm.S
+@@ -0,0 +1,33 @@
++/*
++Copyright (c) 2014, Intel Corporation
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++    * Redistributions of source code must retain the above copyright notice,
++    * this list of conditions and the following disclaimer.
++
++    * Redistributions in binary form must reproduce the above copyright notice,
++    * this list of conditions and the following disclaimer in the documentation
++    * and/or other materials provided with the distribution.
++
++    * Neither the name of Intel Corporation nor the names of its contributors
++    * may be used to endorse or promote products derived from this software
++    * without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
++ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
++WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
++ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
++ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++#define USE_AS_STRNCPY
++#define STRCPY		strncpy
++#include "sse2-strcpy-slm.S"
+diff --git a/libc/arch-x86_64/silvermont/string/sse4-memcmp-slm.S b/libc/arch-x86_64/silvermont/string/sse4-memcmp-slm.S
+new file mode 100644
+index 0000000..6cfcd76
+--- /dev/null
++++ b/libc/arch-x86_64/silvermont/string/sse4-memcmp-slm.S
+@@ -0,0 +1,1799 @@
++/*
++Copyright (c) 2014, Intel Corporation
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++    * Redistributions of source code must retain the above copyright notice,
++    * this list of conditions and the following disclaimer.
++
++    * Redistributions in binary form must reproduce the above copyright notice,
++    * this list of conditions and the following disclaimer in the documentation
++    * and/or other materials provided with the distribution.
++
++    * Neither the name of Intel Corporation nor the names of its contributors
++    * may be used to endorse or promote products derived from this software
++    * without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
++ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
++WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
++ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
++ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++#include "cache.h"
++
++#ifndef MEMCMP
++# define MEMCMP		memcmp_generic
++#endif
++
++#ifndef L
++# define L(label)	.L##label
++#endif
++
++#ifndef ALIGN
++# define ALIGN(n)	.p2align n
++#endif
++
++#ifndef cfi_startproc
++# define cfi_startproc			.cfi_startproc
++#endif
++
++#ifndef cfi_endproc
++# define cfi_endproc			.cfi_endproc
++#endif
++
++#ifndef ENTRY
++# define ENTRY(name)			\
++	.type name,  @function; 	\
++	.globl name;			\
++	.p2align 4;			\
++name:					\
++	cfi_startproc
++#endif
++
++#ifndef END
++# define END(name)			\
++	cfi_endproc;			\
++	.size name, .-name
++#endif
++
++#ifndef ALIGN
++# define ALIGN(n)	.p2align n
++#endif
++
++#define JMPTBL(I, B)	(I - B)
++
++#define BRANCH_TO_JMPTBL_ENTRY(TABLE, INDEX, SCALE)		\
++  lea		TABLE(%rip), %r11;				\
++  movslq	(%r11, INDEX, SCALE), %rcx;			\
++  add		%r11, %rcx;					\
++  jmp		*%rcx;						\
++  ud2
++
++	.section .text.sse4.1,"ax",@progbits
++ENTRY (MEMCMP)
++#ifdef USE_AS_WMEMCMP
++	shl	$2, %rdx
++#endif
++	pxor	%xmm0, %xmm0
++	cmp	$79, %rdx
++	ja	L(79bytesormore)
++#ifndef USE_AS_WMEMCMP
++	cmp	$1, %rdx
++	je	L(firstbyte)
++#endif
++	add	%rdx, %rsi
++	add	%rdx, %rdi
++	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
++
++#ifndef USE_AS_WMEMCMP
++	ALIGN (4)
++L(firstbyte):
++	movzbl	(%rdi), %eax
++	movzbl	(%rsi), %ecx
++	sub	%ecx, %eax
++	ret
++#endif
++
++	ALIGN (4)
++L(79bytesormore):
++	movdqu	(%rsi), %xmm1
++	movdqu	(%rdi), %xmm2
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(16bytesin256)
++	mov	%rsi, %rcx
++	and	$-16, %rsi
++	add	$16, %rsi
++	sub	%rsi, %rcx
++
++	sub	%rcx, %rdi
++	add	%rcx, %rdx
++	test	$0xf, %rdi
++	jz	L(2aligned)
++
++	cmp	$128, %rdx
++	ja	L(128bytesormore)
++L(less128bytes):
++	sub	$64, %rdx
++
++	movdqu	(%rdi), %xmm2
++	pxor	(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(16bytesin256)
++
++	movdqu	16(%rdi), %xmm2
++	pxor	16(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(32bytesin256)
++
++	movdqu	32(%rdi), %xmm2
++	pxor	32(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(48bytesin256)
++
++	movdqu	48(%rdi), %xmm2
++	pxor	48(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(64bytesin256)
++	cmp	$32, %rdx
++	jb	L(less32bytesin64)
++
++	movdqu	64(%rdi), %xmm2
++	pxor	64(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(80bytesin256)
++
++	movdqu	80(%rdi), %xmm2
++	pxor	80(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(96bytesin256)
++	sub	$32, %rdx
++	add	$32, %rdi
++	add	$32, %rsi
++L(less32bytesin64):
++	add	$64, %rdi
++	add	$64, %rsi
++	add	%rdx, %rsi
++	add	%rdx, %rdi
++	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
++
++L(128bytesormore):
++	cmp	$512, %rdx
++	ja	L(512bytesormore)
++	cmp	$256, %rdx
++	ja	L(less512bytes)
++L(less256bytes):
++	sub	$128, %rdx
++
++	movdqu	(%rdi), %xmm2
++	pxor	(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(16bytesin256)
++
++	movdqu	16(%rdi), %xmm2
++	pxor	16(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(32bytesin256)
++
++	movdqu	32(%rdi), %xmm2
++	pxor	32(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(48bytesin256)
++
++	movdqu	48(%rdi), %xmm2
++	pxor	48(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(64bytesin256)
++
++	movdqu	64(%rdi), %xmm2
++	pxor	64(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(80bytesin256)
++
++	movdqu	80(%rdi), %xmm2
++	pxor	80(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(96bytesin256)
++
++	movdqu	96(%rdi), %xmm2
++	pxor	96(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(112bytesin256)
++
++	movdqu	112(%rdi), %xmm2
++	pxor	112(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(128bytesin256)
++
++	add	$128, %rsi
++	add	$128, %rdi
++
++	cmp	$64, %rdx
++	jae	L(less128bytes)
++
++	cmp	$32, %rdx
++	jb	L(less32bytesin128)
++
++	movdqu	(%rdi), %xmm2
++	pxor	(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(16bytesin256)
++
++	movdqu	16(%rdi), %xmm2
++	pxor	16(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(32bytesin256)
++	sub	$32, %rdx
++	add	$32, %rdi
++	add	$32, %rsi
++L(less32bytesin128):
++	add	%rdx, %rsi
++	add	%rdx, %rdi
++	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
++
++L(less512bytes):
++	sub	$256, %rdx
++	movdqu	(%rdi), %xmm2
++	pxor	(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(16bytesin256)
++
++	movdqu	16(%rdi), %xmm2
++	pxor	16(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(32bytesin256)
++
++	movdqu	32(%rdi), %xmm2
++	pxor	32(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(48bytesin256)
++
++	movdqu	48(%rdi), %xmm2
++	pxor	48(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(64bytesin256)
++
++	movdqu	64(%rdi), %xmm2
++	pxor	64(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(80bytesin256)
++
++	movdqu	80(%rdi), %xmm2
++	pxor	80(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(96bytesin256)
++
++	movdqu	96(%rdi), %xmm2
++	pxor	96(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(112bytesin256)
++
++	movdqu	112(%rdi), %xmm2
++	pxor	112(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(128bytesin256)
++
++	movdqu	128(%rdi), %xmm2
++	pxor	128(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(144bytesin256)
++
++	movdqu	144(%rdi), %xmm2
++	pxor	144(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(160bytesin256)
++
++	movdqu	160(%rdi), %xmm2
++	pxor	160(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(176bytesin256)
++
++	movdqu	176(%rdi), %xmm2
++	pxor	176(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(192bytesin256)
++
++	movdqu	192(%rdi), %xmm2
++	pxor	192(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(208bytesin256)
++
++	movdqu	208(%rdi), %xmm2
++	pxor	208(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(224bytesin256)
++
++	movdqu	224(%rdi), %xmm2
++	pxor	224(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(240bytesin256)
++
++	movdqu	240(%rdi), %xmm2
++	pxor	240(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(256bytesin256)
++
++	add	$256, %rsi
++	add	$256, %rdi
++
++	cmp	$128, %rdx
++	jae	L(less256bytes)
++
++	cmp	$64, %rdx
++	jae	L(less128bytes)
++
++	cmp	$32, %rdx
++	jb	L(less32bytesin256)
++
++	movdqu	(%rdi), %xmm2
++	pxor	(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(16bytesin256)
++
++	movdqu	16(%rdi), %xmm2
++	pxor	16(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(32bytesin256)
++	sub	$32, %rdx
++	add	$32, %rdi
++	add	$32, %rsi
++L(less32bytesin256):
++	add	%rdx, %rsi
++	add	%rdx, %rdi
++	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
++
++	ALIGN (4)
++L(512bytesormore):
++#ifdef DATA_CACHE_SIZE_HALF
++	mov	$DATA_CACHE_SIZE_HALF, %r8
++#else
++	mov	__x86_64_data_cache_size_half(%rip), %r8
++#endif
++	mov	%r8, %r9
++	shr	$1, %r8
++	add	%r9, %r8
++	cmp	%r8, %rdx
++	ja	L(L2_L3_cache_unaglined)
++	sub	$64, %rdx
++	ALIGN (4)
++L(64bytesormore_loop):
++	movdqu	(%rdi), %xmm2
++	pxor	(%rsi), %xmm2
++	movdqa	%xmm2, %xmm1
++
++	movdqu	16(%rdi), %xmm3
++	pxor	16(%rsi), %xmm3
++	por	%xmm3, %xmm1
++
++	movdqu	32(%rdi), %xmm4
++	pxor	32(%rsi), %xmm4
++	por	%xmm4, %xmm1
++
++	movdqu	48(%rdi), %xmm5
++	pxor	48(%rsi), %xmm5
++	por	%xmm5, %xmm1
++
++	ptest	%xmm1, %xmm0
++	jnc	L(64bytesormore_loop_end)
++	add	$64, %rsi
++	add	$64, %rdi
++	sub	$64, %rdx
++	jae	L(64bytesormore_loop)
++
++	add	$64, %rdx
++	add	%rdx, %rsi
++	add	%rdx, %rdi
++	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
++
++L(L2_L3_cache_unaglined):
++	sub	$64, %rdx
++	ALIGN (4)
++L(L2_L3_unaligned_128bytes_loop):
++	prefetchnta 0x1c0(%rdi)
++	prefetchnta 0x1c0(%rsi)
++	movdqu	(%rdi), %xmm2
++	pxor	(%rsi), %xmm2
++	movdqa	%xmm2, %xmm1
++
++	movdqu	16(%rdi), %xmm3
++	pxor	16(%rsi), %xmm3
++	por	%xmm3, %xmm1
++
++	movdqu	32(%rdi), %xmm4
++	pxor	32(%rsi), %xmm4
++	por	%xmm4, %xmm1
++
++	movdqu	48(%rdi), %xmm5
++	pxor	48(%rsi), %xmm5
++	por	%xmm5, %xmm1
++
++	ptest	%xmm1, %xmm0
++	jnc	L(64bytesormore_loop_end)
++	add	$64, %rsi
++	add	$64, %rdi
++	sub	$64, %rdx
++	jae	L(L2_L3_unaligned_128bytes_loop)
++
++	add	$64, %rdx
++	add	%rdx, %rsi
++	add	%rdx, %rdi
++	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
++
++/*
++ * This case is for machines which are sensitive for unaligned instructions.
++ */
++	ALIGN (4)
++L(2aligned):
++	cmp	$128, %rdx
++	ja	L(128bytesormorein2aligned)
++L(less128bytesin2aligned):
++	sub	$64, %rdx
++
++	movdqa	(%rdi), %xmm2
++	pxor	(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(16bytesin256)
++
++	movdqa	16(%rdi), %xmm2
++	pxor	16(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(32bytesin256)
++
++	movdqa	32(%rdi), %xmm2
++	pxor	32(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(48bytesin256)
++
++	movdqa	48(%rdi), %xmm2
++	pxor	48(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(64bytesin256)
++	cmp	$32, %rdx
++	jb	L(less32bytesin64in2alinged)
++
++	movdqa	64(%rdi), %xmm2
++	pxor	64(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(80bytesin256)
++
++	movdqa	80(%rdi), %xmm2
++	pxor	80(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(96bytesin256)
++	sub	$32, %rdx
++	add	$32, %rdi
++	add	$32, %rsi
++L(less32bytesin64in2alinged):
++	add	$64, %rdi
++	add	$64, %rsi
++	add	%rdx, %rsi
++	add	%rdx, %rdi
++	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
++
++	ALIGN (4)
++L(128bytesormorein2aligned):
++	cmp	$512, %rdx
++	ja	L(512bytesormorein2aligned)
++	cmp	$256, %rdx
++	ja	L(256bytesormorein2aligned)
++L(less256bytesin2alinged):
++	sub	$128, %rdx
++
++	movdqa	(%rdi), %xmm2
++	pxor	(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(16bytesin256)
++
++	movdqa	16(%rdi), %xmm2
++	pxor	16(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(32bytesin256)
++
++	movdqa	32(%rdi), %xmm2
++	pxor	32(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(48bytesin256)
++
++	movdqa	48(%rdi), %xmm2
++	pxor	48(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(64bytesin256)
++
++	movdqa	64(%rdi), %xmm2
++	pxor	64(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(80bytesin256)
++
++	movdqa	80(%rdi), %xmm2
++	pxor	80(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(96bytesin256)
++
++	movdqa	96(%rdi), %xmm2
++	pxor	96(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(112bytesin256)
++
++	movdqa	112(%rdi), %xmm2
++	pxor	112(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(128bytesin256)
++
++	add	$128, %rsi
++	add	$128, %rdi
++
++	cmp	$64, %rdx
++	jae	L(less128bytesin2aligned)
++
++	cmp	$32, %rdx
++	jb	L(less32bytesin128in2aligned)
++
++	movdqu	(%rdi), %xmm2
++	pxor	(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(16bytesin256)
++
++	movdqu	16(%rdi), %xmm2
++	pxor	16(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(32bytesin256)
++	sub	$32, %rdx
++	add	$32, %rdi
++	add	$32, %rsi
++L(less32bytesin128in2aligned):
++	add	%rdx, %rsi
++	add	%rdx, %rdi
++	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
++
++	ALIGN (4)
++L(256bytesormorein2aligned):
++
++	sub	$256, %rdx
++	movdqa	(%rdi), %xmm2
++	pxor	(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(16bytesin256)
++
++	movdqa	16(%rdi), %xmm2
++	pxor	16(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(32bytesin256)
++
++	movdqa	32(%rdi), %xmm2
++	pxor	32(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(48bytesin256)
++
++	movdqa	48(%rdi), %xmm2
++	pxor	48(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(64bytesin256)
++
++	movdqa	64(%rdi), %xmm2
++	pxor	64(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(80bytesin256)
++
++	movdqa	80(%rdi), %xmm2
++	pxor	80(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(96bytesin256)
++
++	movdqa	96(%rdi), %xmm2
++	pxor	96(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(112bytesin256)
++
++	movdqa	112(%rdi), %xmm2
++	pxor	112(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(128bytesin256)
++
++	movdqa	128(%rdi), %xmm2
++	pxor	128(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(144bytesin256)
++
++	movdqa	144(%rdi), %xmm2
++	pxor	144(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(160bytesin256)
++
++	movdqa	160(%rdi), %xmm2
++	pxor	160(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(176bytesin256)
++
++	movdqa	176(%rdi), %xmm2
++	pxor	176(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(192bytesin256)
++
++	movdqa	192(%rdi), %xmm2
++	pxor	192(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(208bytesin256)
++
++	movdqa	208(%rdi), %xmm2
++	pxor	208(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(224bytesin256)
++
++	movdqa	224(%rdi), %xmm2
++	pxor	224(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(240bytesin256)
++
++	movdqa	240(%rdi), %xmm2
++	pxor	240(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(256bytesin256)
++
++	add	$256, %rsi
++	add	$256, %rdi
++
++	cmp	$128, %rdx
++	jae	L(less256bytesin2alinged)
++
++	cmp	$64, %rdx
++	jae	L(less128bytesin2aligned)
++
++	cmp	$32, %rdx
++	jb	L(less32bytesin256in2alinged)
++
++	movdqa	(%rdi), %xmm2
++	pxor	(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(16bytesin256)
++
++	movdqa	16(%rdi), %xmm2
++	pxor	16(%rsi), %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(32bytesin256)
++	sub	$32, %rdx
++	add	$32, %rdi
++	add	$32, %rsi
++L(less32bytesin256in2alinged):
++	add	%rdx, %rsi
++	add	%rdx, %rdi
++	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
++
++	ALIGN (4)
++L(512bytesormorein2aligned):
++#ifdef DATA_CACHE_SIZE_HALF
++	mov	$DATA_CACHE_SIZE_HALF, %r8
++#else
++	mov	__x86_64_data_cache_size_half(%rip), %r8
++#endif
++	mov	%r8, %r9
++	shr	$1, %r8
++	add	%r9, %r8
++	cmp	%r8, %rdx
++	ja	L(L2_L3_cache_aglined)
++
++	sub	$64, %rdx
++	ALIGN (4)
++L(64bytesormore_loopin2aligned):
++	movdqa	(%rdi), %xmm2
++	pxor	(%rsi), %xmm2
++	movdqa	%xmm2, %xmm1
++
++	movdqa	16(%rdi), %xmm3
++	pxor	16(%rsi), %xmm3
++	por	%xmm3, %xmm1
++
++	movdqa	32(%rdi), %xmm4
++	pxor	32(%rsi), %xmm4
++	por	%xmm4, %xmm1
++
++	movdqa	48(%rdi), %xmm5
++	pxor	48(%rsi), %xmm5
++	por	%xmm5, %xmm1
++
++	ptest	%xmm1, %xmm0
++	jnc	L(64bytesormore_loop_end)
++	add	$64, %rsi
++	add	$64, %rdi
++	sub	$64, %rdx
++	jae	L(64bytesormore_loopin2aligned)
++
++	add	$64, %rdx
++	add	%rdx, %rsi
++	add	%rdx, %rdi
++	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
++L(L2_L3_cache_aglined):
++	sub	$64, %rdx
++	ALIGN (4)
++L(L2_L3_aligned_128bytes_loop):
++	prefetchnta 0x1c0(%rdi)
++	prefetchnta 0x1c0(%rsi)
++	movdqa	(%rdi), %xmm2
++	pxor	(%rsi), %xmm2
++	movdqa	%xmm2, %xmm1
++
++	movdqa	16(%rdi), %xmm3
++	pxor	16(%rsi), %xmm3
++	por	%xmm3, %xmm1
++
++	movdqa	32(%rdi), %xmm4
++	pxor	32(%rsi), %xmm4
++	por	%xmm4, %xmm1
++
++	movdqa	48(%rdi), %xmm5
++	pxor	48(%rsi), %xmm5
++	por	%xmm5, %xmm1
++
++	ptest	%xmm1, %xmm0
++	jnc	L(64bytesormore_loop_end)
++	add	$64, %rsi
++	add	$64, %rdi
++	sub	$64, %rdx
++	jae	L(L2_L3_aligned_128bytes_loop)
++
++	add	$64, %rdx
++	add	%rdx, %rsi
++	add	%rdx, %rdi
++	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
++
++
++	ALIGN (4)
++L(64bytesormore_loop_end):
++	add	$16, %rdi
++	add	$16, %rsi
++	ptest	%xmm2, %xmm0
++	jnc	L(16bytes)
++
++	add	$16, %rdi
++	add	$16, %rsi
++	ptest	%xmm3, %xmm0
++	jnc	L(16bytes)
++
++	add	$16, %rdi
++	add	$16, %rsi
++	ptest	%xmm4, %xmm0
++	jnc	L(16bytes)
++
++	add	$16, %rdi
++	add	$16, %rsi
++	jmp	L(16bytes)
++
++L(256bytesin256):
++	add	$256, %rdi
++	add	$256, %rsi
++	jmp	L(16bytes)
++L(240bytesin256):
++	add	$240, %rdi
++	add	$240, %rsi
++	jmp	L(16bytes)
++L(224bytesin256):
++	add	$224, %rdi
++	add	$224, %rsi
++	jmp	L(16bytes)
++L(208bytesin256):
++	add	$208, %rdi
++	add	$208, %rsi
++	jmp	L(16bytes)
++L(192bytesin256):
++	add	$192, %rdi
++	add	$192, %rsi
++	jmp	L(16bytes)
++L(176bytesin256):
++	add	$176, %rdi
++	add	$176, %rsi
++	jmp	L(16bytes)
++L(160bytesin256):
++	add	$160, %rdi
++	add	$160, %rsi
++	jmp	L(16bytes)
++L(144bytesin256):
++	add	$144, %rdi
++	add	$144, %rsi
++	jmp	L(16bytes)
++L(128bytesin256):
++	add	$128, %rdi
++	add	$128, %rsi
++	jmp	L(16bytes)
++L(112bytesin256):
++	add	$112, %rdi
++	add	$112, %rsi
++	jmp	L(16bytes)
++L(96bytesin256):
++	add	$96, %rdi
++	add	$96, %rsi
++	jmp	L(16bytes)
++L(80bytesin256):
++	add	$80, %rdi
++	add	$80, %rsi
++	jmp	L(16bytes)
++L(64bytesin256):
++	add	$64, %rdi
++	add	$64, %rsi
++	jmp	L(16bytes)
++L(48bytesin256):
++	add	$16, %rdi
++	add	$16, %rsi
++L(32bytesin256):
++	add	$16, %rdi
++	add	$16, %rsi
++L(16bytesin256):
++	add	$16, %rdi
++	add	$16, %rsi
++L(16bytes):
++	mov	-16(%rdi), %rax
++	mov	-16(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++L(8bytes):
++	mov	-8(%rdi), %rax
++	mov	-8(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	xor	%eax, %eax
++	ret
++
++	ALIGN (4)
++L(12bytes):
++	mov	-12(%rdi), %rax
++	mov	-12(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++L(4bytes):
++	mov	-4(%rsi), %ecx
++	mov	-4(%rdi), %eax
++	cmp	%eax, %ecx
++	jne	L(diffin4bytes)
++L(0bytes):
++	xor	%eax, %eax
++	ret
++
++#ifndef USE_AS_WMEMCMP
++/* unreal case for wmemcmp */
++	ALIGN (4)
++L(65bytes):
++	movdqu	-65(%rdi), %xmm1
++	movdqu	-65(%rsi), %xmm2
++	mov	$-65, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(49bytes):
++	movdqu	-49(%rdi), %xmm1
++	movdqu	-49(%rsi), %xmm2
++	mov	$-49, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(33bytes):
++	movdqu	-33(%rdi), %xmm1
++	movdqu	-33(%rsi), %xmm2
++	mov	$-33, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(17bytes):
++	mov	-17(%rdi), %rax
++	mov	-17(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++L(9bytes):
++	mov	-9(%rdi), %rax
++	mov	-9(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	movzbl	-1(%rdi), %eax
++	movzbl	-1(%rsi), %edx
++	sub	%edx, %eax
++	ret
++
++	ALIGN (4)
++L(13bytes):
++	mov	-13(%rdi), %rax
++	mov	-13(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	mov	-8(%rdi), %rax
++	mov	-8(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	xor	%eax, %eax
++	ret
++
++	ALIGN (4)
++L(5bytes):
++	mov	-5(%rdi), %eax
++	mov	-5(%rsi), %ecx
++	cmp	%eax, %ecx
++	jne	L(diffin4bytes)
++	movzbl	-1(%rdi), %eax
++	movzbl	-1(%rsi), %edx
++	sub	%edx, %eax
++	ret
++
++	ALIGN (4)
++L(66bytes):
++	movdqu	-66(%rdi), %xmm1
++	movdqu	-66(%rsi), %xmm2
++	mov	$-66, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(50bytes):
++	movdqu	-50(%rdi), %xmm1
++	movdqu	-50(%rsi), %xmm2
++	mov	$-50, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(34bytes):
++	movdqu	-34(%rdi), %xmm1
++	movdqu	-34(%rsi), %xmm2
++	mov	$-34, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(18bytes):
++	mov	-18(%rdi), %rax
++	mov	-18(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++L(10bytes):
++	mov	-10(%rdi), %rax
++	mov	-10(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	movzwl	-2(%rdi), %eax
++	movzwl	-2(%rsi), %ecx
++	cmp	%cl, %al
++	jne	L(end)
++	and	$0xffff, %eax
++	and	$0xffff, %ecx
++	sub	%ecx, %eax
++	ret
++
++	ALIGN (4)
++L(14bytes):
++	mov	-14(%rdi), %rax
++	mov	-14(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	mov	-8(%rdi), %rax
++	mov	-8(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	xor	%eax, %eax
++	ret
++
++	ALIGN (4)
++L(6bytes):
++	mov	-6(%rdi), %eax
++	mov	-6(%rsi), %ecx
++	cmp	%eax, %ecx
++	jne	L(diffin4bytes)
++L(2bytes):
++	movzwl	-2(%rsi), %ecx
++	movzwl	-2(%rdi), %eax
++	cmp	%cl, %al
++	jne	L(end)
++	and	$0xffff, %eax
++	and	$0xffff, %ecx
++	sub	%ecx, %eax
++	ret
++
++	ALIGN (4)
++L(67bytes):
++	movdqu	-67(%rdi), %xmm2
++	movdqu	-67(%rsi), %xmm1
++	mov	$-67, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(51bytes):
++	movdqu	-51(%rdi), %xmm2
++	movdqu	-51(%rsi), %xmm1
++	mov	$-51, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(35bytes):
++	movdqu	-35(%rsi), %xmm1
++	movdqu	-35(%rdi), %xmm2
++	mov	$-35, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(19bytes):
++	mov	-19(%rdi), %rax
++	mov	-19(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++L(11bytes):
++	mov	-11(%rdi), %rax
++	mov	-11(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	mov	-4(%rdi), %eax
++	mov	-4(%rsi), %ecx
++	cmp	%eax, %ecx
++	jne	L(diffin4bytes)
++	xor	%eax, %eax
++	ret
++
++	ALIGN (4)
++L(15bytes):
++	mov	-15(%rdi), %rax
++	mov	-15(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	mov	-8(%rdi), %rax
++	mov	-8(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	xor	%eax, %eax
++	ret
++
++	ALIGN (4)
++L(7bytes):
++	mov	-7(%rdi), %eax
++	mov	-7(%rsi), %ecx
++	cmp	%eax, %ecx
++	jne	L(diffin4bytes)
++	mov	-4(%rdi), %eax
++	mov	-4(%rsi), %ecx
++	cmp	%eax, %ecx
++	jne	L(diffin4bytes)
++	xor	%eax, %eax
++	ret
++
++	ALIGN (4)
++L(3bytes):
++	movzwl	-3(%rdi), %eax
++	movzwl	-3(%rsi), %ecx
++	cmp	%eax, %ecx
++	jne	L(diffin2bytes)
++L(1bytes):
++	movzbl	-1(%rdi), %eax
++	movzbl	-1(%rsi), %ecx
++	sub	%ecx, %eax
++	ret
++#endif
++
++	ALIGN (4)
++L(68bytes):
++	movdqu	-68(%rdi), %xmm2
++	movdqu	-68(%rsi), %xmm1
++	mov	$-68, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(52bytes):
++	movdqu	-52(%rdi), %xmm2
++	movdqu	-52(%rsi), %xmm1
++	mov	$-52, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(36bytes):
++	movdqu	-36(%rdi), %xmm2
++	movdqu	-36(%rsi), %xmm1
++	mov	$-36, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(20bytes):
++	movdqu	-20(%rdi), %xmm2
++	movdqu	-20(%rsi), %xmm1
++	mov	$-20, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++	mov	-4(%rdi), %eax
++	mov	-4(%rsi), %ecx
++	cmp	%eax, %ecx
++	jne	L(diffin4bytes)
++	xor	%eax, %eax
++	ret
++
++#ifndef USE_AS_WMEMCMP
++/* unreal cases for wmemcmp */
++	ALIGN (4)
++L(69bytes):
++	movdqu	-69(%rsi), %xmm1
++	movdqu	-69(%rdi), %xmm2
++	mov	$-69, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(53bytes):
++	movdqu	-53(%rsi), %xmm1
++	movdqu	-53(%rdi), %xmm2
++	mov	$-53, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(37bytes):
++	movdqu	-37(%rsi), %xmm1
++	movdqu	-37(%rdi), %xmm2
++	mov	$-37, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(21bytes):
++	movdqu	-21(%rsi), %xmm1
++	movdqu	-21(%rdi), %xmm2
++	mov	$-21, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++	mov	-8(%rdi), %rax
++	mov	-8(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	xor	%eax, %eax
++	ret
++
++	ALIGN (4)
++L(70bytes):
++	movdqu	-70(%rsi), %xmm1
++	movdqu	-70(%rdi), %xmm2
++	mov	$-70, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(54bytes):
++	movdqu	-54(%rsi), %xmm1
++	movdqu	-54(%rdi), %xmm2
++	mov	$-54, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(38bytes):
++	movdqu	-38(%rsi), %xmm1
++	movdqu	-38(%rdi), %xmm2
++	mov	$-38, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(22bytes):
++	movdqu	-22(%rsi), %xmm1
++	movdqu	-22(%rdi), %xmm2
++	mov	$-22, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++	mov	-8(%rdi), %rax
++	mov	-8(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	xor	%eax, %eax
++	ret
++
++	ALIGN (4)
++L(71bytes):
++	movdqu	-71(%rsi), %xmm1
++	movdqu	-71(%rdi), %xmm2
++	mov	$-71, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(55bytes):
++	movdqu	-55(%rdi), %xmm2
++	movdqu	-55(%rsi), %xmm1
++	mov	$-55, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(39bytes):
++	movdqu	-39(%rdi), %xmm2
++	movdqu	-39(%rsi), %xmm1
++	mov	$-39, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(23bytes):
++	movdqu	-23(%rdi), %xmm2
++	movdqu	-23(%rsi), %xmm1
++	mov	$-23, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++	mov	-8(%rdi), %rax
++	mov	-8(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	xor	%eax, %eax
++	ret
++#endif
++
++	ALIGN (4)
++L(72bytes):
++	movdqu	-72(%rsi), %xmm1
++	movdqu	-72(%rdi), %xmm2
++	mov	$-72, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(56bytes):
++	movdqu	-56(%rdi), %xmm2
++	movdqu	-56(%rsi), %xmm1
++	mov	$-56, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(40bytes):
++	movdqu	-40(%rdi), %xmm2
++	movdqu	-40(%rsi), %xmm1
++	mov	$-40, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(24bytes):
++	movdqu	-24(%rdi), %xmm2
++	movdqu	-24(%rsi), %xmm1
++	mov	$-24, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++	mov	-8(%rdi), %rax
++	mov	-8(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	xor	%eax, %eax
++	ret
++
++#ifndef USE_AS_WMEMCMP
++/* unreal cases for wmemcmp */
++	ALIGN (4)
++L(73bytes):
++	movdqu	-73(%rsi), %xmm1
++	movdqu	-73(%rdi), %xmm2
++	mov	$-73, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(57bytes):
++	movdqu	-57(%rdi), %xmm2
++	movdqu	-57(%rsi), %xmm1
++	mov	$-57, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(41bytes):
++	movdqu	-41(%rdi), %xmm2
++	movdqu	-41(%rsi), %xmm1
++	mov	$-41, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(25bytes):
++	movdqu	-25(%rdi), %xmm2
++	movdqu	-25(%rsi), %xmm1
++	mov	$-25, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++	mov	-9(%rdi), %rax
++	mov	-9(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	movzbl	-1(%rdi), %eax
++	movzbl	-1(%rsi), %ecx
++	sub	%ecx, %eax
++	ret
++
++	ALIGN (4)
++L(74bytes):
++	movdqu	-74(%rsi), %xmm1
++	movdqu	-74(%rdi), %xmm2
++	mov	$-74, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(58bytes):
++	movdqu	-58(%rdi), %xmm2
++	movdqu	-58(%rsi), %xmm1
++	mov	$-58, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(42bytes):
++	movdqu	-42(%rdi), %xmm2
++	movdqu	-42(%rsi), %xmm1
++	mov	$-42, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(26bytes):
++	movdqu	-26(%rdi), %xmm2
++	movdqu	-26(%rsi), %xmm1
++	mov	$-26, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++	mov	-10(%rdi), %rax
++	mov	-10(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	movzwl	-2(%rdi), %eax
++	movzwl	-2(%rsi), %ecx
++	jmp	L(diffin2bytes)
++
++	ALIGN (4)
++L(75bytes):
++	movdqu	-75(%rsi), %xmm1
++	movdqu	-75(%rdi), %xmm2
++	mov	$-75, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(59bytes):
++	movdqu	-59(%rdi), %xmm2
++	movdqu	-59(%rsi), %xmm1
++	mov	$-59, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(43bytes):
++	movdqu	-43(%rdi), %xmm2
++	movdqu	-43(%rsi), %xmm1
++	mov	$-43, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(27bytes):
++	movdqu	-27(%rdi), %xmm2
++	movdqu	-27(%rsi), %xmm1
++	mov	$-27, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++	mov	-11(%rdi), %rax
++	mov	-11(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	mov	-4(%rdi), %eax
++	mov	-4(%rsi), %ecx
++	cmp	%eax, %ecx
++	jne	L(diffin4bytes)
++	xor	%eax, %eax
++	ret
++#endif
++	ALIGN (4)
++L(76bytes):
++	movdqu	-76(%rsi), %xmm1
++	movdqu	-76(%rdi), %xmm2
++	mov	$-76, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(60bytes):
++	movdqu	-60(%rdi), %xmm2
++	movdqu	-60(%rsi), %xmm1
++	mov	$-60, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(44bytes):
++	movdqu	-44(%rdi), %xmm2
++	movdqu	-44(%rsi), %xmm1
++	mov	$-44, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(28bytes):
++	movdqu	-28(%rdi), %xmm2
++	movdqu	-28(%rsi), %xmm1
++	mov	$-28, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++	mov	-12(%rdi), %rax
++	mov	-12(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	mov	-4(%rdi), %eax
++	mov	-4(%rsi), %ecx
++	cmp	%eax, %ecx
++	jne	L(diffin4bytes)
++	xor	%eax, %eax
++	ret
++
++#ifndef USE_AS_WMEMCMP
++/* unreal cases for wmemcmp */
++	ALIGN (4)
++L(77bytes):
++	movdqu	-77(%rsi), %xmm1
++	movdqu	-77(%rdi), %xmm2
++	mov	$-77, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(61bytes):
++	movdqu	-61(%rdi), %xmm2
++	movdqu	-61(%rsi), %xmm1
++	mov	$-61, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(45bytes):
++	movdqu	-45(%rdi), %xmm2
++	movdqu	-45(%rsi), %xmm1
++	mov	$-45, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(29bytes):
++	movdqu	-29(%rdi), %xmm2
++	movdqu	-29(%rsi), %xmm1
++	mov	$-29, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++
++	mov	-13(%rdi), %rax
++	mov	-13(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++
++	mov	-8(%rdi), %rax
++	mov	-8(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	xor	%eax, %eax
++	ret
++
++	ALIGN (4)
++L(78bytes):
++	movdqu	-78(%rsi), %xmm1
++	movdqu	-78(%rdi), %xmm2
++	mov	$-78, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(62bytes):
++	movdqu	-62(%rdi), %xmm2
++	movdqu	-62(%rsi), %xmm1
++	mov	$-62, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(46bytes):
++	movdqu	-46(%rdi), %xmm2
++	movdqu	-46(%rsi), %xmm1
++	mov	$-46, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(30bytes):
++	movdqu	-30(%rdi), %xmm2
++	movdqu	-30(%rsi), %xmm1
++	mov	$-30, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++	mov	-14(%rdi), %rax
++	mov	-14(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	mov	-8(%rdi), %rax
++	mov	-8(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	xor	%eax, %eax
++	ret
++
++	ALIGN (4)
++L(79bytes):
++	movdqu	-79(%rsi), %xmm1
++	movdqu	-79(%rdi), %xmm2
++	mov	$-79, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(63bytes):
++	movdqu	-63(%rdi), %xmm2
++	movdqu	-63(%rsi), %xmm1
++	mov	$-63, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(47bytes):
++	movdqu	-47(%rdi), %xmm2
++	movdqu	-47(%rsi), %xmm1
++	mov	$-47, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(31bytes):
++	movdqu	-31(%rdi), %xmm2
++	movdqu	-31(%rsi), %xmm1
++	mov	$-31, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++	mov	-15(%rdi), %rax
++	mov	-15(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	mov	-8(%rdi), %rax
++	mov	-8(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	xor	%eax, %eax
++	ret
++#endif
++	ALIGN (4)
++L(64bytes):
++	movdqu	-64(%rdi), %xmm2
++	movdqu	-64(%rsi), %xmm1
++	mov	$-64, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(48bytes):
++	movdqu	-48(%rdi), %xmm2
++	movdqu	-48(%rsi), %xmm1
++	mov	$-48, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++L(32bytes):
++	movdqu	-32(%rdi), %xmm2
++	movdqu	-32(%rsi), %xmm1
++	mov	$-32, %dl
++	pxor	%xmm1, %xmm2
++	ptest	%xmm2, %xmm0
++	jnc	L(less16bytes)
++
++	mov	-16(%rdi), %rax
++	mov	-16(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++
++	mov	-8(%rdi), %rax
++	mov	-8(%rsi), %rcx
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	xor	%eax, %eax
++	ret
++
++/*
++ * Aligned 8 bytes to avoid 2 branch "taken" in one 16 alinged code block.
++ */
++	ALIGN (3)
++L(less16bytes):
++	movsbq	%dl, %rdx
++	mov	(%rsi, %rdx), %rcx
++	mov	(%rdi, %rdx), %rax
++	cmp	%rax, %rcx
++	jne	L(diffin8bytes)
++	mov	8(%rsi, %rdx), %rcx
++	mov	8(%rdi, %rdx), %rax
++L(diffin8bytes):
++	cmp	%eax, %ecx
++	jne	L(diffin4bytes)
++	shr	$32, %rcx
++	shr	$32, %rax
++
++#ifdef USE_AS_WMEMCMP
++/* for wmemcmp */
++	cmp	%eax, %ecx
++	jne	L(diffin4bytes)
++	xor	%eax, %eax
++	ret
++#endif
++
++L(diffin4bytes):
++#ifndef USE_AS_WMEMCMP
++	cmp	%cx, %ax
++	jne	L(diffin2bytes)
++	shr	$16, %ecx
++	shr	$16, %eax
++L(diffin2bytes):
++	cmp	%cl, %al
++	jne	L(end)
++	and	$0xffff, %eax
++	and	$0xffff, %ecx
++	sub	%ecx, %eax
++	ret
++#else
++
++/* for wmemcmp */
++	mov	$1, %eax
++	jl	L(nequal_bigger)
++	neg	%eax
++	ret
++
++	ALIGN (4)
++L(nequal_bigger):
++	ret
++
++L(unreal_case):
++	xor	%eax, %eax
++	ret
++#endif
++
++	ALIGN (4)
++L(end):
++	and	$0xff, %eax
++	and	$0xff, %ecx
++	sub	%ecx, %eax
++	ret
++
++END (MEMCMP)
++
++	.section .rodata.sse4.1,"a",@progbits
++	ALIGN (3)
++#ifndef USE_AS_WMEMCMP
++L(table_64bytes):
++	.int	JMPTBL (L(0bytes), L(table_64bytes))
++	.int	JMPTBL (L(1bytes), L(table_64bytes))
++	.int	JMPTBL (L(2bytes), L(table_64bytes))
++	.int	JMPTBL (L(3bytes), L(table_64bytes))
++	.int	JMPTBL (L(4bytes), L(table_64bytes))
++	.int	JMPTBL (L(5bytes), L(table_64bytes))
++	.int	JMPTBL (L(6bytes), L(table_64bytes))
++	.int	JMPTBL (L(7bytes), L(table_64bytes))
++	.int	JMPTBL (L(8bytes), L(table_64bytes))
++	.int	JMPTBL (L(9bytes), L(table_64bytes))
++	.int	JMPTBL (L(10bytes), L(table_64bytes))
++	.int	JMPTBL (L(11bytes), L(table_64bytes))
++	.int	JMPTBL (L(12bytes), L(table_64bytes))
++	.int	JMPTBL (L(13bytes), L(table_64bytes))
++	.int	JMPTBL (L(14bytes), L(table_64bytes))
++	.int	JMPTBL (L(15bytes), L(table_64bytes))
++	.int	JMPTBL (L(16bytes), L(table_64bytes))
++	.int	JMPTBL (L(17bytes), L(table_64bytes))
++	.int	JMPTBL (L(18bytes), L(table_64bytes))
++	.int	JMPTBL (L(19bytes), L(table_64bytes))
++	.int	JMPTBL (L(20bytes), L(table_64bytes))
++	.int	JMPTBL (L(21bytes), L(table_64bytes))
++	.int	JMPTBL (L(22bytes), L(table_64bytes))
++	.int	JMPTBL (L(23bytes), L(table_64bytes))
++	.int	JMPTBL (L(24bytes), L(table_64bytes))
++	.int	JMPTBL (L(25bytes), L(table_64bytes))
++	.int	JMPTBL (L(26bytes), L(table_64bytes))
++	.int	JMPTBL (L(27bytes), L(table_64bytes))
++	.int	JMPTBL (L(28bytes), L(table_64bytes))
++	.int	JMPTBL (L(29bytes), L(table_64bytes))
++	.int	JMPTBL (L(30bytes), L(table_64bytes))
++	.int	JMPTBL (L(31bytes), L(table_64bytes))
++	.int	JMPTBL (L(32bytes), L(table_64bytes))
++	.int	JMPTBL (L(33bytes), L(table_64bytes))
++	.int	JMPTBL (L(34bytes), L(table_64bytes))
++	.int	JMPTBL (L(35bytes), L(table_64bytes))
++	.int	JMPTBL (L(36bytes), L(table_64bytes))
++	.int	JMPTBL (L(37bytes), L(table_64bytes))
++	.int	JMPTBL (L(38bytes), L(table_64bytes))
++	.int	JMPTBL (L(39bytes), L(table_64bytes))
++	.int	JMPTBL (L(40bytes), L(table_64bytes))
++	.int	JMPTBL (L(41bytes), L(table_64bytes))
++	.int	JMPTBL (L(42bytes), L(table_64bytes))
++	.int	JMPTBL (L(43bytes), L(table_64bytes))
++	.int	JMPTBL (L(44bytes), L(table_64bytes))
++	.int	JMPTBL (L(45bytes), L(table_64bytes))
++	.int	JMPTBL (L(46bytes), L(table_64bytes))
++	.int	JMPTBL (L(47bytes), L(table_64bytes))
++	.int	JMPTBL (L(48bytes), L(table_64bytes))
++	.int	JMPTBL (L(49bytes), L(table_64bytes))
++	.int	JMPTBL (L(50bytes), L(table_64bytes))
++	.int	JMPTBL (L(51bytes), L(table_64bytes))
++	.int	JMPTBL (L(52bytes), L(table_64bytes))
++	.int	JMPTBL (L(53bytes), L(table_64bytes))
++	.int	JMPTBL (L(54bytes), L(table_64bytes))
++	.int	JMPTBL (L(55bytes), L(table_64bytes))
++	.int	JMPTBL (L(56bytes), L(table_64bytes))
++	.int	JMPTBL (L(57bytes), L(table_64bytes))
++	.int	JMPTBL (L(58bytes), L(table_64bytes))
++	.int	JMPTBL (L(59bytes), L(table_64bytes))
++	.int	JMPTBL (L(60bytes), L(table_64bytes))
++	.int	JMPTBL (L(61bytes), L(table_64bytes))
++	.int	JMPTBL (L(62bytes), L(table_64bytes))
++	.int	JMPTBL (L(63bytes), L(table_64bytes))
++	.int	JMPTBL (L(64bytes), L(table_64bytes))
++	.int	JMPTBL (L(65bytes), L(table_64bytes))
++	.int	JMPTBL (L(66bytes), L(table_64bytes))
++	.int	JMPTBL (L(67bytes), L(table_64bytes))
++	.int	JMPTBL (L(68bytes), L(table_64bytes))
++	.int	JMPTBL (L(69bytes), L(table_64bytes))
++	.int	JMPTBL (L(70bytes), L(table_64bytes))
++	.int	JMPTBL (L(71bytes), L(table_64bytes))
++	.int	JMPTBL (L(72bytes), L(table_64bytes))
++	.int	JMPTBL (L(73bytes), L(table_64bytes))
++	.int	JMPTBL (L(74bytes), L(table_64bytes))
++	.int	JMPTBL (L(75bytes), L(table_64bytes))
++	.int	JMPTBL (L(76bytes), L(table_64bytes))
++	.int	JMPTBL (L(77bytes), L(table_64bytes))
++	.int	JMPTBL (L(78bytes), L(table_64bytes))
++	.int	JMPTBL (L(79bytes), L(table_64bytes))
++#else
++L(table_64bytes):
++	.int	JMPTBL (L(0bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(4bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(8bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(12bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(16bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(20bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(24bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(28bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(32bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(36bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(40bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(44bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(48bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(52bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(56bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(60bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(64bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(68bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(72bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(76bytes), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++	.int	JMPTBL (L(unreal_case), L(table_64bytes))
++#endif
+diff --git a/libc/arch-x86_64/silvermont/string/ssse3-strcmp-slm.S b/libc/arch-x86_64/silvermont/string/ssse3-strcmp-slm.S
+new file mode 100644
+index 0000000..e8acd5b
+--- /dev/null
++++ b/libc/arch-x86_64/silvermont/string/ssse3-strcmp-slm.S
+@@ -0,0 +1,1925 @@
++/*
++Copyright (c) 2014, Intel Corporation
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++    * Redistributions of source code must retain the above copyright notice,
++    * this list of conditions and the following disclaimer.
++
++    * Redistributions in binary form must reproduce the above copyright notice,
++    * this list of conditions and the following disclaimer in the documentation
++    * and/or other materials provided with the distribution.
++
++    * Neither the name of Intel Corporation nor the names of its contributors
++    * may be used to endorse or promote products derived from this software
++    * without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
++ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
++WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
++ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
++ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++#ifdef USE_AS_STRNCMP
++/* Since the counter, %r11, is unsigned, we branch to strcmp_exitz
++   if the new counter > the old one or is 0.  */
++#define UPDATE_STRNCMP_COUNTER				\
++	/* calculate left number to compare */		\
++	lea	-16(%rcx, %r11), %r9;			\
++	cmp	%r9, %r11;				\
++	jb	L(strcmp_exitz);			\
++	test	%r9, %r9;				\
++	je	L(strcmp_exitz);			\
++	mov	%r9, %r11
++
++#else
++#define UPDATE_STRNCMP_COUNTER
++#ifndef STRCMP
++#define STRCMP		strcmp
++#endif
++#endif
++
++#ifndef L
++# define L(label)	.L##label
++#endif
++
++#ifndef cfi_startproc
++# define cfi_startproc			.cfi_startproc
++#endif
++
++#ifndef cfi_endproc
++# define cfi_endproc			.cfi_endproc
++#endif
++
++#ifndef ENTRY
++# define ENTRY(name)			\
++	.type name,  @function; 	\
++	.globl name;			\
++	.p2align 4;			\
++name:					\
++	cfi_startproc
++#endif
++
++#ifndef END
++# define END(name)			\
++	cfi_endproc;			\
++	.size name, .-name
++#endif
++#define RETURN ret
++	.section .text.ssse3,"ax",@progbits
++ENTRY (STRCMP)
++/*
++ * This implementation uses SSE to compare up to 16 bytes at a time.
++ */
++#ifdef USE_AS_STRNCMP
++	test	%rdx, %rdx
++	je	L(strcmp_exitz)
++	cmp	$1, %rdx
++	je	L(Byte0)
++	mov	%rdx, %r11
++#endif
++	mov	%esi, %ecx
++	mov	%edi, %eax
++/* Use 64bit AND here to avoid long NOP padding.  */
++	and	$0x3f, %rcx		/* rsi alignment in cache line */
++	and	$0x3f, %rax		/* rdi alignment in cache line */
++	cmp	$0x30, %ecx
++	ja	L(crosscache)	/* rsi: 16-byte load will cross cache line */
++	cmp	$0x30, %eax
++	ja	L(crosscache)	/* rdi: 16-byte load will cross cache line */
++	movlpd	(%rdi), %xmm1
++	movlpd	(%rsi), %xmm2
++	movhpd	8(%rdi), %xmm1
++	movhpd	8(%rsi), %xmm2
++	pxor	%xmm0, %xmm0		/* clear %xmm0 for null char checks */
++	pcmpeqb	%xmm1, %xmm0		/* Any null chars? */
++	pcmpeqb	%xmm2, %xmm1		/* compare first 16 bytes for equality */
++	psubb	%xmm0, %xmm1		/* packed sub of comparison results*/
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx		/* if first 16 bytes are same, edx == 0xffff */
++	jnz	L(less16bytes)	/* If not, find different value or null char */
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)	/* finish comparision */
++#endif
++	add	$16, %rsi		/* prepare to search next 16 bytes */
++	add	$16, %rdi		/* prepare to search next 16 bytes */
++
++	/*
++	 * Determine source and destination string offsets from 16-byte alignment.
++	 * Use relative offset difference between the two to determine which case
++	 * below to use.
++	 */
++	.p2align 4
++L(crosscache):
++	and	$0xfffffffffffffff0, %rsi	/* force %rsi is 16 byte aligned */
++	and	$0xfffffffffffffff0, %rdi	/* force %rdi is 16 byte aligned */
++	mov	$0xffff, %edx			/* for equivalent offset */
++	xor	%r8d, %r8d
++	and	$0xf, %ecx			/* offset of rsi */
++	and	$0xf, %eax			/* offset of rdi */
++	cmp	%eax, %ecx
++	je	L(ashr_0)			/* rsi and rdi relative offset same */
++	ja	L(bigger)
++	mov	%edx, %r8d			/* r8d is offset flag for exit tail */
++	xchg	%ecx, %eax
++	xchg	%rsi, %rdi
++L(bigger):
++	lea	15(%rax), %r9
++	sub	%rcx, %r9
++	lea	L(unaligned_table)(%rip), %r10
++	movslq	(%r10, %r9,4), %r9
++	lea	(%r10, %r9), %r10
++	jmp	*%r10				/* jump to corresponding case */
++
++/*
++ * The following cases will be handled by ashr_0
++ *  rcx(offset of rsi)  rax(offset of rdi)  relative offset  corresponding case
++ *        n(0~15)            n(0~15)           15(15+ n-n)         ashr_0
++ */
++	.p2align 4
++L(ashr_0):
++
++	movdqa	(%rsi), %xmm1
++	pxor	%xmm0, %xmm0			/* clear %xmm0 for null char check */
++	pcmpeqb	%xmm1, %xmm0			/* Any null chars? */
++	pcmpeqb	(%rdi), %xmm1			/* compare 16 bytes for equality */
++	psubb	%xmm0, %xmm1			/* packed sub of comparison results*/
++	pmovmskb %xmm1, %r9d
++	shr	%cl, %edx			/* adjust 0xffff for offset */
++	shr	%cl, %r9d			/* adjust for 16-byte offset */
++	sub	%r9d, %edx
++	/*
++	 * edx must be the same with r9d if in left byte (16-rcx) is equal to
++	 * the start from (16-rax) and no null char was seen.
++	 */
++	jne	L(less32bytes)		/* mismatch or null char */
++	UPDATE_STRNCMP_COUNTER
++	mov	$16, %rcx
++	mov	$16, %r9
++	pxor	%xmm0, %xmm0			/* clear xmm0, may have changed above */
++
++	/*
++	 * Now both strings are aligned at 16-byte boundary. Loop over strings
++	 * checking 32-bytes per iteration.
++	 */
++	.p2align 4
++L(loop_ashr_0):
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)		/* mismatch or null char seen */
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++	add	$16, %rcx
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++	add	$16, %rcx
++	jmp	L(loop_ashr_0)
++
++/*
++ * The following cases will be handled by ashr_1
++ * rcx(offset of rsi)  rax(offset of rdi)   relative offset   	corresponding case
++ *        n(15)            n -15            0(15 +(n-15) - n)         ashr_1
++ */
++	.p2align 4
++L(ashr_1):
++	pxor	%xmm0, %xmm0
++	movdqa	(%rdi), %xmm2
++	movdqa	(%rsi), %xmm1
++	pcmpeqb	%xmm1, %xmm0		/* Any null chars? */
++	pslldq	$15, %xmm2		/* shift first string to align with second */
++	pcmpeqb	%xmm1, %xmm2		/* compare 16 bytes for equality */
++	psubb	%xmm0, %xmm2		/* packed sub of comparison results*/
++	pmovmskb %xmm2, %r9d
++	shr	%cl, %edx		/* adjust 0xffff for offset */
++	shr	%cl, %r9d		/* adjust for 16-byte offset */
++	sub	%r9d, %edx
++	jnz	L(less32bytes)	/* mismatch or null char seen */
++	movdqa	(%rdi), %xmm3
++	UPDATE_STRNCMP_COUNTER
++
++	pxor	%xmm0, %xmm0
++	mov	$16, %rcx		/* index for loads*/
++	mov	$1, %r9d		/* byte position left over from less32bytes case */
++	/*
++	 * Setup %r10 value allows us to detect crossing a page boundary.
++	 * When %r10 goes positive we have crossed a page boundary and
++	 * need to do a nibble.
++	 */
++	lea	1(%rdi), %r10
++	and	$0xfff, %r10		/* offset into 4K page */
++	sub	$0x1000, %r10		/* subtract 4K pagesize */
++
++	.p2align 4
++L(loop_ashr_1):
++	add	$16, %r10
++	jg	L(nibble_ashr_1)	/* cross page boundary */
++
++L(gobble_ashr_1):
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4		 /* store for next cycle */
++
++	palignr $1, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++
++	add	$16, %r10
++	jg	L(nibble_ashr_1)	/* cross page boundary */
++
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4		/* store for next cycle */
++
++	palignr $1, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++	jmp	L(loop_ashr_1)
++
++	/*
++	 * Nibble avoids loads across page boundary. This is to avoid a potential
++	 * access into unmapped memory.
++	 */
++	.p2align 4
++L(nibble_ashr_1):
++	pcmpeqb	%xmm3, %xmm0		 /* check nibble for null char*/
++	pmovmskb %xmm0, %edx
++	test	$0xfffe, %edx
++	jnz	L(ashr_1_exittail)	/* find null char*/
++
++#ifdef USE_AS_STRNCMP
++	cmp	$14, %r11
++	jbe	L(ashr_1_exittail)
++#endif
++
++	pxor	%xmm0, %xmm0
++	sub	$0x1000, %r10		/* substract 4K from %r10 */
++	jmp	L(gobble_ashr_1)
++
++	/*
++	 * Once find null char, determine if there is a string mismatch
++	 * before the null char.
++	 */
++	.p2align 4
++L(ashr_1_exittail):
++	movdqa	(%rsi, %rcx), %xmm1
++	psrldq	$1, %xmm0
++	psrldq	$1, %xmm3
++	jmp	L(aftertail)
++
++/*
++ * The following cases will be handled by ashr_2
++ * rcx(offset of rsi)  rax(offset of rdi)   relative offset   	corresponding case
++ *        n(14~15)            n -14         1(15 +(n-14) - n)         ashr_2
++ */
++	.p2align 4
++L(ashr_2):
++	pxor	%xmm0, %xmm0
++	movdqa	(%rdi), %xmm2
++	movdqa	(%rsi), %xmm1
++	pcmpeqb	%xmm1, %xmm0
++	pslldq	$14, %xmm2
++	pcmpeqb	%xmm1, %xmm2
++	psubb	%xmm0, %xmm2
++	pmovmskb %xmm2, %r9d
++	shr	%cl, %edx
++	shr	%cl, %r9d
++	sub	%r9d, %edx
++	jnz	L(less32bytes)
++	movdqa	(%rdi), %xmm3
++	UPDATE_STRNCMP_COUNTER
++
++	pxor	%xmm0, %xmm0
++	mov	$16, %rcx	/* index for loads */
++	mov	$2, %r9d	/* byte position left over from less32bytes case */
++	/*
++	 * Setup %r10 value allows us to detect crossing a page boundary.
++	 * When %r10 goes positive we have crossed a page boundary and
++	 * need to do a nibble.
++	 */
++	lea	2(%rdi), %r10
++	and	$0xfff, %r10	/* offset into 4K page */
++	sub	$0x1000, %r10	/* subtract 4K pagesize */
++
++	.p2align 4
++L(loop_ashr_2):
++	add	$16, %r10
++	jg	L(nibble_ashr_2)
++
++L(gobble_ashr_2):
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $2, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++
++	add	$16, %r10
++	jg	L(nibble_ashr_2)	/* cross page boundary */
++
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $2, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++	jmp	L(loop_ashr_2)
++
++	.p2align 4
++L(nibble_ashr_2):
++	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
++	pmovmskb %xmm0, %edx
++	test	$0xfffc, %edx
++	jnz	L(ashr_2_exittail)
++
++#ifdef USE_AS_STRNCMP
++	cmp	$13, %r11
++	jbe	L(ashr_2_exittail)
++#endif
++
++	pxor	%xmm0, %xmm0
++	sub	$0x1000, %r10
++	jmp	L(gobble_ashr_2)
++
++	.p2align 4
++L(ashr_2_exittail):
++	movdqa	(%rsi, %rcx), %xmm1
++	psrldq	$2, %xmm0
++	psrldq	$2, %xmm3
++	jmp	L(aftertail)
++
++/*
++ * The following cases will be handled by ashr_3
++ *  rcx(offset of rsi)  rax(offset of rdi)  relative offset	 corresponding case
++ *        n(13~15)            n -13         2(15 +(n-13) - n)         ashr_3
++ */
++	.p2align 4
++L(ashr_3):
++	pxor	%xmm0, %xmm0
++	movdqa	(%rdi), %xmm2
++	movdqa	(%rsi), %xmm1
++	pcmpeqb	%xmm1, %xmm0
++	pslldq	$13, %xmm2
++	pcmpeqb	%xmm1, %xmm2
++	psubb	%xmm0, %xmm2
++	pmovmskb %xmm2, %r9d
++	shr	%cl, %edx
++	shr	%cl, %r9d
++	sub	%r9d, %edx
++	jnz	L(less32bytes)
++	movdqa	(%rdi), %xmm3
++
++	UPDATE_STRNCMP_COUNTER
++
++	pxor	%xmm0, %xmm0
++	mov	$16, %rcx	/* index for loads */
++	mov	$3, %r9d	/* byte position left over from less32bytes case */
++	/*
++	 * Setup %r10 value allows us to detect crossing a page boundary.
++	 * When %r10 goes positive we have crossed a page boundary and
++	 * need to do a nibble.
++	 */
++	lea	3(%rdi), %r10
++	and	$0xfff, %r10	/* offset into 4K page */
++	sub	$0x1000, %r10	/* subtract 4K pagesize */
++
++	.p2align 4
++L(loop_ashr_3):
++	add	$16, %r10
++	jg	L(nibble_ashr_3)
++
++L(gobble_ashr_3):
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $3, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++
++	add	$16, %r10
++	jg	L(nibble_ashr_3)	/* cross page boundary */
++
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $3, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++	jmp	L(loop_ashr_3)
++
++	.p2align 4
++L(nibble_ashr_3):
++	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
++	pmovmskb %xmm0, %edx
++	test	$0xfff8, %edx
++	jnz	L(ashr_3_exittail)
++
++#ifdef USE_AS_STRNCMP
++	cmp	$12, %r11
++	jbe	L(ashr_3_exittail)
++#endif
++
++	pxor	%xmm0, %xmm0
++	sub	$0x1000, %r10
++	jmp	L(gobble_ashr_3)
++
++	.p2align 4
++L(ashr_3_exittail):
++	movdqa	(%rsi, %rcx), %xmm1
++	psrldq	$3, %xmm0
++	psrldq	$3, %xmm3
++	jmp	L(aftertail)
++
++/*
++ * The following cases will be handled by ashr_4
++ *  rcx(offset of rsi)  rax(offset of rdi)  relative offset	 corresponding case
++ *        n(12~15)            n -12         3(15 +(n-12) - n)         ashr_4
++ */
++	.p2align 4
++L(ashr_4):
++	pxor	%xmm0, %xmm0
++	movdqa	(%rdi), %xmm2
++	movdqa	(%rsi), %xmm1
++	pcmpeqb	%xmm1, %xmm0
++	pslldq	$12, %xmm2
++	pcmpeqb	%xmm1, %xmm2
++	psubb	%xmm0, %xmm2
++	pmovmskb %xmm2, %r9d
++	shr	%cl, %edx
++	shr	%cl, %r9d
++	sub	%r9d, %edx
++	jnz	L(less32bytes)
++	movdqa	(%rdi), %xmm3
++
++	UPDATE_STRNCMP_COUNTER
++
++	pxor	%xmm0, %xmm0
++	mov	$16, %rcx	/* index for loads */
++	mov	$4, %r9d	/* byte position left over from less32bytes case */
++	/*
++	 * Setup %r10 value allows us to detect crossing a page boundary.
++	 * When %r10 goes positive we have crossed a page boundary and
++	 * need to do a nibble.
++	 */
++	lea	4(%rdi), %r10
++	and	$0xfff, %r10	/* offset into 4K page */
++	sub	$0x1000, %r10	/* subtract 4K pagesize */
++
++	.p2align 4
++L(loop_ashr_4):
++	add	$16, %r10
++	jg	L(nibble_ashr_4)
++
++L(gobble_ashr_4):
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $4, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++
++	add	$16, %r10
++	jg	L(nibble_ashr_4)	/* cross page boundary */
++
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $4, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++	jmp	L(loop_ashr_4)
++
++	.p2align 4
++L(nibble_ashr_4):
++	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
++	pmovmskb %xmm0, %edx
++	test	$0xfff0, %edx
++	jnz	L(ashr_4_exittail)
++
++#ifdef USE_AS_STRNCMP
++	cmp	$11, %r11
++	jbe	L(ashr_4_exittail)
++#endif
++
++	pxor	%xmm0, %xmm0
++	sub	$0x1000, %r10
++	jmp	L(gobble_ashr_4)
++
++	.p2align 4
++L(ashr_4_exittail):
++	movdqa	(%rsi, %rcx), %xmm1
++	psrldq	$4, %xmm0
++	psrldq	$4, %xmm3
++	jmp	L(aftertail)
++
++/*
++ * The following cases will be handled by ashr_5
++ *  rcx(offset of rsi)  rax(offset of rdi)        relative offset      corresponding case
++ *        n(11~15)          n - 11      	  4(15 +(n-11) - n)         ashr_5
++ */
++	.p2align 4
++L(ashr_5):
++	pxor	%xmm0, %xmm0
++	movdqa	(%rdi), %xmm2
++	movdqa	(%rsi), %xmm1
++	pcmpeqb	%xmm1, %xmm0
++	pslldq	$11, %xmm2
++	pcmpeqb	%xmm1, %xmm2
++	psubb	%xmm0, %xmm2
++	pmovmskb %xmm2, %r9d
++	shr	%cl, %edx
++	shr	%cl, %r9d
++	sub	%r9d, %edx
++	jnz	L(less32bytes)
++	movdqa	(%rdi), %xmm3
++
++	UPDATE_STRNCMP_COUNTER
++
++	pxor	%xmm0, %xmm0
++	mov	$16, %rcx	/* index for loads */
++	mov	$5, %r9d	/* byte position left over from less32bytes case */
++	/*
++	 * Setup %r10 value allows us to detect crossing a page boundary.
++	 * When %r10 goes positive we have crossed a page boundary and
++	 * need to do a nibble.
++	 */
++	lea	5(%rdi), %r10
++	and	$0xfff, %r10	/* offset into 4K page */
++	sub	$0x1000, %r10	/* subtract 4K pagesize */
++
++	.p2align 4
++L(loop_ashr_5):
++	add	$16, %r10
++	jg	L(nibble_ashr_5)
++
++L(gobble_ashr_5):
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $5, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++
++	add	$16, %r10
++	jg	L(nibble_ashr_5)	/* cross page boundary */
++
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $5, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++	jmp	L(loop_ashr_5)
++
++	.p2align 4
++L(nibble_ashr_5):
++	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
++	pmovmskb %xmm0, %edx
++	test	$0xffe0, %edx
++	jnz	L(ashr_5_exittail)
++
++#ifdef USE_AS_STRNCMP
++	cmp	$10, %r11
++	jbe	L(ashr_5_exittail)
++#endif
++
++	pxor	%xmm0, %xmm0
++	sub	$0x1000, %r10
++	jmp	L(gobble_ashr_5)
++
++	.p2align 4
++L(ashr_5_exittail):
++	movdqa	(%rsi, %rcx), %xmm1
++	psrldq	$5, %xmm0
++	psrldq	$5, %xmm3
++	jmp	L(aftertail)
++
++/*
++ * The following cases will be handled by ashr_6
++ *  rcx(offset of rsi)  rax(offset of rdi)        relative offset      corresponding case
++ *        n(10~15)          n - 10      	  5(15 +(n-10) - n)         ashr_6
++ */
++	.p2align 4
++L(ashr_6):
++	pxor	%xmm0, %xmm0
++	movdqa	(%rdi), %xmm2
++	movdqa	(%rsi), %xmm1
++	pcmpeqb	%xmm1, %xmm0
++	pslldq	$10, %xmm2
++	pcmpeqb	%xmm1, %xmm2
++	psubb	%xmm0, %xmm2
++	pmovmskb %xmm2, %r9d
++	shr	%cl, %edx
++	shr	%cl, %r9d
++	sub	%r9d, %edx
++	jnz	L(less32bytes)
++	movdqa	(%rdi), %xmm3
++
++	UPDATE_STRNCMP_COUNTER
++
++	pxor	%xmm0, %xmm0
++	mov	$16, %rcx	/* index for loads */
++	mov	$6, %r9d	/* byte position left over from less32bytes case */
++	/*
++	 * Setup %r10 value allows us to detect crossing a page boundary.
++	 * When %r10 goes positive we have crossed a page boundary and
++	 * need to do a nibble.
++	 */
++	lea	6(%rdi), %r10
++	and	$0xfff, %r10	/* offset into 4K page */
++	sub	$0x1000, %r10	/* subtract 4K pagesize */
++
++	.p2align 4
++L(loop_ashr_6):
++	add	$16, %r10
++	jg	L(nibble_ashr_6)
++
++L(gobble_ashr_6):
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $6, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++
++	add	$16, %r10
++	jg	L(nibble_ashr_6)	/* cross page boundary */
++
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $6, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++	jmp	L(loop_ashr_6)
++
++	.p2align 4
++L(nibble_ashr_6):
++	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
++	pmovmskb %xmm0, %edx
++	test	$0xffc0, %edx
++	jnz	L(ashr_6_exittail)
++
++#ifdef USE_AS_STRNCMP
++	cmp	$9, %r11
++	jbe	L(ashr_6_exittail)
++#endif
++
++	pxor	%xmm0, %xmm0
++	sub	$0x1000, %r10
++	jmp	L(gobble_ashr_6)
++
++	.p2align 4
++L(ashr_6_exittail):
++	movdqa	(%rsi, %rcx), %xmm1
++	psrldq	$6, %xmm0
++	psrldq	$6, %xmm3
++	jmp	L(aftertail)
++
++/*
++ * The following cases will be handled by ashr_7
++ *  rcx(offset of rsi)  rax(offset of rdi)        relative offset      corresponding case
++ *        n(9~15)          n - 9      	        6(15 +(n - 9) - n)         ashr_7
++ */
++	.p2align 4
++L(ashr_7):
++	pxor	%xmm0, %xmm0
++	movdqa	(%rdi), %xmm2
++	movdqa	(%rsi), %xmm1
++	pcmpeqb	%xmm1, %xmm0
++	pslldq	$9, %xmm2
++	pcmpeqb	%xmm1, %xmm2
++	psubb	%xmm0, %xmm2
++	pmovmskb %xmm2, %r9d
++	shr	%cl, %edx
++	shr	%cl, %r9d
++	sub	%r9d, %edx
++	jnz	L(less32bytes)
++	movdqa	(%rdi), %xmm3
++
++	UPDATE_STRNCMP_COUNTER
++
++	pxor	%xmm0, %xmm0
++	mov	$16, %rcx	/* index for loads */
++	mov	$7, %r9d	/* byte position left over from less32bytes case */
++	/*
++	 * Setup %r10 value allows us to detect crossing a page boundary.
++	 * When %r10 goes positive we have crossed a page boundary and
++	 * need to do a nibble.
++	 */
++	lea	7(%rdi), %r10
++	and	$0xfff, %r10	/* offset into 4K page */
++	sub	$0x1000, %r10	/* subtract 4K pagesize */
++
++	.p2align 4
++L(loop_ashr_7):
++	add	$16, %r10
++	jg	L(nibble_ashr_7)
++
++L(gobble_ashr_7):
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $7, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++
++	add	$16, %r10
++	jg	L(nibble_ashr_7)	/* cross page boundary */
++
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $7, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++	jmp	L(loop_ashr_7)
++
++	.p2align 4
++L(nibble_ashr_7):
++	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
++	pmovmskb %xmm0, %edx
++	test	$0xff80, %edx
++	jnz	L(ashr_7_exittail)
++
++#ifdef USE_AS_STRNCMP
++	cmp	$8, %r11
++	jbe	L(ashr_7_exittail)
++#endif
++
++	pxor	%xmm0, %xmm0
++	sub	$0x1000, %r10
++	jmp	L(gobble_ashr_7)
++
++	.p2align 4
++L(ashr_7_exittail):
++	movdqa	(%rsi, %rcx), %xmm1
++	psrldq	$7, %xmm0
++	psrldq	$7, %xmm3
++	jmp	L(aftertail)
++
++/*
++ *  The following cases will be handled by ashr_8
++ *  rcx(offset of rsi)  rax(offset of rdi)        relative offset	 corresponding case
++ *        n(8~15)          n - 8      	        7(15 +(n - 8) - n)         ashr_8
++ */
++	.p2align 4
++L(ashr_8):
++	pxor	%xmm0, %xmm0
++	movdqa	(%rdi), %xmm2
++	movdqa	(%rsi), %xmm1
++	pcmpeqb	%xmm1, %xmm0
++	pslldq	$8, %xmm2
++	pcmpeqb	%xmm1, %xmm2
++	psubb	%xmm0, %xmm2
++	pmovmskb %xmm2, %r9d
++	shr	%cl, %edx
++	shr	%cl, %r9d
++	sub	%r9d, %edx
++	jnz	L(less32bytes)
++	movdqa	(%rdi), %xmm3
++
++	UPDATE_STRNCMP_COUNTER
++
++	pxor	%xmm0, %xmm0
++	mov	$16, %rcx	/* index for loads */
++	mov	$8, %r9d	/* byte position left over from less32bytes case */
++	/*
++	 * Setup %r10 value allows us to detect crossing a page boundary.
++	 * When %r10 goes positive we have crossed a page boundary and
++	 * need to do a nibble.
++	 */
++	lea	8(%rdi), %r10
++	and	$0xfff, %r10	/* offset into 4K page */
++	sub	$0x1000, %r10	/* subtract 4K pagesize */
++
++	.p2align 4
++L(loop_ashr_8):
++	add	$16, %r10
++	jg	L(nibble_ashr_8)
++
++L(gobble_ashr_8):
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $8, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++
++	add	$16, %r10
++	jg	L(nibble_ashr_8)	/* cross page boundary */
++
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $8, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++	jmp	L(loop_ashr_8)
++
++	.p2align 4
++L(nibble_ashr_8):
++	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
++	pmovmskb %xmm0, %edx
++	test	$0xff00, %edx
++	jnz	L(ashr_8_exittail)
++
++#ifdef USE_AS_STRNCMP
++	cmp	$7, %r11
++	jbe	L(ashr_8_exittail)
++#endif
++
++	pxor	%xmm0, %xmm0
++	sub	$0x1000, %r10
++	jmp	L(gobble_ashr_8)
++
++	.p2align 4
++L(ashr_8_exittail):
++	movdqa	(%rsi, %rcx), %xmm1
++	psrldq	$8, %xmm0
++	psrldq	$8, %xmm3
++	jmp	L(aftertail)
++
++/*
++ *  The following cases will be handled by ashr_9
++ *  rcx(offset of rsi)  rax(offset of rdi)        relative offset	 corresponding case
++ *        n(7~15)          n - 7      	        8(15 +(n - 7) - n)         ashr_9
++ */
++	.p2align 4
++L(ashr_9):
++	pxor	%xmm0, %xmm0
++	movdqa	(%rdi), %xmm2
++	movdqa	(%rsi), %xmm1
++	pcmpeqb	%xmm1, %xmm0
++	pslldq	$7, %xmm2
++	pcmpeqb	%xmm1, %xmm2
++	psubb	%xmm0, %xmm2
++	pmovmskb %xmm2, %r9d
++	shr	%cl, %edx
++	shr	%cl, %r9d
++	sub	%r9d, %edx
++	jnz	L(less32bytes)
++	movdqa	(%rdi), %xmm3
++
++	UPDATE_STRNCMP_COUNTER
++
++	pxor	%xmm0, %xmm0
++	mov	$16, %rcx	/* index for loads */
++	mov	$9, %r9d	/* byte position left over from less32bytes case */
++	/*
++	 * Setup %r10 value allows us to detect crossing a page boundary.
++	 * When %r10 goes positive we have crossed a page boundary and
++	 * need to do a nibble.
++	 */
++	lea	9(%rdi), %r10
++	and	$0xfff, %r10	/* offset into 4K page */
++	sub	$0x1000, %r10	/* subtract 4K pagesize */
++
++	.p2align 4
++L(loop_ashr_9):
++	add	$16, %r10
++	jg	L(nibble_ashr_9)
++
++L(gobble_ashr_9):
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $9, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++
++	add	$16, %r10
++	jg	L(nibble_ashr_9)	/* cross page boundary */
++
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $9, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3		/* store for next cycle */
++	jmp	L(loop_ashr_9)
++
++	.p2align 4
++L(nibble_ashr_9):
++	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
++	pmovmskb %xmm0, %edx
++	test	$0xfe00, %edx
++	jnz	L(ashr_9_exittail)
++
++#ifdef USE_AS_STRNCMP
++	cmp	$6, %r11
++	jbe	L(ashr_9_exittail)
++#endif
++
++	pxor	%xmm0, %xmm0
++	sub	$0x1000, %r10
++	jmp	L(gobble_ashr_9)
++
++	.p2align 4
++L(ashr_9_exittail):
++	movdqa	(%rsi, %rcx), %xmm1
++	psrldq	$9, %xmm0
++	psrldq	$9, %xmm3
++	jmp	L(aftertail)
++
++/*
++ *  The following cases will be handled by ashr_10
++ *  rcx(offset of rsi)  rax(offset of rdi)        relative offset	 corresponding case
++ *        n(6~15)          n - 6      	        9(15 +(n - 6) - n)         ashr_10
++ */
++	.p2align 4
++L(ashr_10):
++	pxor	%xmm0, %xmm0
++	movdqa	(%rdi), %xmm2
++	movdqa	(%rsi), %xmm1
++	pcmpeqb	%xmm1, %xmm0
++	pslldq	$6, %xmm2
++	pcmpeqb	%xmm1, %xmm2
++	psubb	%xmm0, %xmm2
++	pmovmskb %xmm2, %r9d
++	shr	%cl, %edx
++	shr	%cl, %r9d
++	sub	%r9d, %edx
++	jnz	L(less32bytes)
++	movdqa	(%rdi), %xmm3
++
++	UPDATE_STRNCMP_COUNTER
++
++	pxor	%xmm0, %xmm0
++	mov	$16, %rcx	/* index for loads */
++	mov	$10, %r9d	/* byte position left over from less32bytes case */
++	/*
++	 * Setup %r10 value allows us to detect crossing a page boundary.
++	 * When %r10 goes positive we have crossed a page boundary and
++	 * need to do a nibble.
++	 */
++	lea	10(%rdi), %r10
++	and	$0xfff, %r10	/* offset into 4K page */
++	sub	$0x1000, %r10	/* subtract 4K pagesize */
++
++	.p2align 4
++L(loop_ashr_10):
++	add	$16, %r10
++	jg	L(nibble_ashr_10)
++
++L(gobble_ashr_10):
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $10, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++
++	add	$16, %r10
++	jg	L(nibble_ashr_10)	/* cross page boundary */
++
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $10, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++	jmp	L(loop_ashr_10)
++
++	.p2align 4
++L(nibble_ashr_10):
++	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
++	pmovmskb %xmm0, %edx
++	test	$0xfc00, %edx
++	jnz	L(ashr_10_exittail)
++
++#ifdef USE_AS_STRNCMP
++	cmp	$5, %r11
++	jbe	L(ashr_10_exittail)
++#endif
++
++	pxor	%xmm0, %xmm0
++	sub	$0x1000, %r10
++	jmp	L(gobble_ashr_10)
++
++	.p2align 4
++L(ashr_10_exittail):
++	movdqa	(%rsi, %rcx), %xmm1
++	psrldq	$10, %xmm0
++	psrldq	$10, %xmm3
++	jmp	L(aftertail)
++
++/*
++ *  The following cases will be handled by ashr_11
++ *  rcx(offset of rsi)  rax(offset of rdi)        relative offset	 corresponding case
++ *        n(5~15)          n - 5      	        10(15 +(n - 5) - n)         ashr_11
++ */
++	.p2align 4
++L(ashr_11):
++	pxor	%xmm0, %xmm0
++	movdqa	(%rdi), %xmm2
++	movdqa	(%rsi), %xmm1
++	pcmpeqb	%xmm1, %xmm0
++	pslldq	$5, %xmm2
++	pcmpeqb	%xmm1, %xmm2
++	psubb	%xmm0, %xmm2
++	pmovmskb %xmm2, %r9d
++	shr	%cl, %edx
++	shr	%cl, %r9d
++	sub	%r9d, %edx
++	jnz	L(less32bytes)
++	movdqa	(%rdi), %xmm3
++
++	UPDATE_STRNCMP_COUNTER
++
++	pxor	%xmm0, %xmm0
++	mov	$16, %rcx	/* index for loads */
++	mov	$11, %r9d	/* byte position left over from less32bytes case */
++	/*
++	 * Setup %r10 value allows us to detect crossing a page boundary.
++	 * When %r10 goes positive we have crossed a page boundary and
++	 * need to do a nibble.
++	 */
++	lea	11(%rdi), %r10
++	and	$0xfff, %r10	/* offset into 4K page */
++	sub	$0x1000, %r10	/* subtract 4K pagesize */
++
++	.p2align 4
++L(loop_ashr_11):
++	add	$16, %r10
++	jg	L(nibble_ashr_11)
++
++L(gobble_ashr_11):
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $11, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++
++	add	$16, %r10
++	jg	L(nibble_ashr_11)	/* cross page boundary */
++
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $11, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++	jmp	L(loop_ashr_11)
++
++	.p2align 4
++L(nibble_ashr_11):
++	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
++	pmovmskb %xmm0, %edx
++	test	$0xf800, %edx
++	jnz	L(ashr_11_exittail)
++
++#ifdef USE_AS_STRNCMP
++	cmp	$4, %r11
++	jbe	L(ashr_11_exittail)
++#endif
++
++	pxor	%xmm0, %xmm0
++	sub	$0x1000, %r10
++	jmp	L(gobble_ashr_11)
++
++	.p2align 4
++L(ashr_11_exittail):
++	movdqa	(%rsi, %rcx), %xmm1
++	psrldq	$11, %xmm0
++	psrldq	$11, %xmm3
++	jmp	L(aftertail)
++
++/*
++ *  The following cases will be handled by ashr_12
++ *  rcx(offset of rsi)  rax(offset of rdi)        relative offset	 corresponding case
++ *        n(4~15)          n - 4      	        11(15 +(n - 4) - n)         ashr_12
++ */
++	.p2align 4
++L(ashr_12):
++	pxor	%xmm0, %xmm0
++	movdqa	(%rdi), %xmm2
++	movdqa	(%rsi), %xmm1
++	pcmpeqb	%xmm1, %xmm0
++	pslldq	$4, %xmm2
++	pcmpeqb	%xmm1, %xmm2
++	psubb	%xmm0, %xmm2
++	pmovmskb %xmm2, %r9d
++	shr	%cl, %edx
++	shr	%cl, %r9d
++	sub	%r9d, %edx
++	jnz	L(less32bytes)
++	movdqa	(%rdi), %xmm3
++
++	UPDATE_STRNCMP_COUNTER
++
++	pxor	%xmm0, %xmm0
++	mov	$16, %rcx	/* index for loads */
++	mov	$12, %r9d	/* byte position left over from less32bytes case */
++	/*
++	 * Setup %r10 value allows us to detect crossing a page boundary.
++	 * When %r10 goes positive we have crossed a page boundary and
++	 * need to do a nibble.
++	 */
++	lea	12(%rdi), %r10
++	and	$0xfff, %r10	/* offset into 4K page */
++	sub	$0x1000, %r10	/* subtract 4K pagesize */
++
++	.p2align 4
++L(loop_ashr_12):
++	add	$16, %r10
++	jg	L(nibble_ashr_12)
++
++L(gobble_ashr_12):
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $12, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++
++	add	$16, %r10
++	jg	L(nibble_ashr_12)	/* cross page boundary */
++
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $12, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++	jmp	L(loop_ashr_12)
++
++	.p2align 4
++L(nibble_ashr_12):
++	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
++	pmovmskb %xmm0, %edx
++	test	$0xf000, %edx
++	jnz	L(ashr_12_exittail)
++
++#ifdef USE_AS_STRNCMP
++	cmp	$3, %r11
++	jbe	L(ashr_12_exittail)
++#endif
++
++	pxor	%xmm0, %xmm0
++	sub	$0x1000, %r10
++	jmp	L(gobble_ashr_12)
++
++	.p2align 4
++L(ashr_12_exittail):
++	movdqa	(%rsi, %rcx), %xmm1
++	psrldq	$12, %xmm0
++	psrldq	$12, %xmm3
++	jmp	L(aftertail)
++
++/*
++ *  The following cases will be handled by ashr_13
++ *  rcx(offset of rsi)  rax(offset of rdi)        relative offset	 corresponding case
++ *        n(3~15)          n - 3      	        12(15 +(n - 3) - n)         ashr_13
++ */
++	.p2align 4
++L(ashr_13):
++	pxor	%xmm0, %xmm0
++	movdqa	(%rdi), %xmm2
++	movdqa	(%rsi), %xmm1
++	pcmpeqb	%xmm1, %xmm0
++	pslldq	$3, %xmm2
++	pcmpeqb	%xmm1, %xmm2
++	psubb	%xmm0, %xmm2
++	pmovmskb %xmm2, %r9d
++	shr	%cl, %edx
++	shr	%cl, %r9d
++	sub	%r9d, %edx
++	jnz	L(less32bytes)
++	movdqa	(%rdi), %xmm3
++
++	UPDATE_STRNCMP_COUNTER
++
++	pxor	%xmm0, %xmm0
++	mov	$16, %rcx	/* index for loads */
++	mov	$13, %r9d	/* byte position left over from less32bytes case */
++	/*
++	 * Setup %r10 value allows us to detect crossing a page boundary.
++	 * When %r10 goes positive we have crossed a page boundary and
++	 * need to do a nibble.
++	 */
++	lea	13(%rdi), %r10
++	and	$0xfff, %r10	/* offset into 4K page */
++	sub	$0x1000, %r10	/* subtract 4K pagesize */
++
++	.p2align 4
++L(loop_ashr_13):
++	add	$16, %r10
++	jg	L(nibble_ashr_13)
++
++L(gobble_ashr_13):
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $13, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++
++	add	$16, %r10
++	jg	L(nibble_ashr_13)	/* cross page boundary */
++
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $13, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++	jmp	L(loop_ashr_13)
++
++	.p2align 4
++L(nibble_ashr_13):
++	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
++	pmovmskb %xmm0, %edx
++	test	$0xe000, %edx
++	jnz	L(ashr_13_exittail)
++
++#ifdef USE_AS_STRNCMP
++	cmp	$2, %r11
++	jbe	L(ashr_13_exittail)
++#endif
++
++	pxor	%xmm0, %xmm0
++	sub	$0x1000, %r10
++	jmp	L(gobble_ashr_13)
++
++	.p2align 4
++L(ashr_13_exittail):
++	movdqa	(%rsi, %rcx), %xmm1
++	psrldq  $13, %xmm0
++	psrldq  $13, %xmm3
++	jmp	L(aftertail)
++
++/*
++ *  The following cases will be handled by ashr_14
++ *  rcx(offset of rsi)  rax(offset of rdi)        relative offset	 corresponding case
++ *        n(2~15)          n - 2      	        13(15 +(n - 2) - n)         ashr_14
++ */
++	.p2align 4
++L(ashr_14):
++	pxor	%xmm0, %xmm0
++	movdqa	(%rdi), %xmm2
++	movdqa	(%rsi), %xmm1
++	pcmpeqb	%xmm1, %xmm0
++	pslldq  $2, %xmm2
++	pcmpeqb	%xmm1, %xmm2
++	psubb	%xmm0, %xmm2
++	pmovmskb %xmm2, %r9d
++	shr	%cl, %edx
++	shr	%cl, %r9d
++	sub	%r9d, %edx
++	jnz	L(less32bytes)
++	movdqa	(%rdi), %xmm3
++
++	UPDATE_STRNCMP_COUNTER
++
++	pxor	%xmm0, %xmm0
++	mov	$16, %rcx	/* index for loads */
++	mov	$14, %r9d	/* byte position left over from less32bytes case */
++	/*
++	 * Setup %r10 value allows us to detect crossing a page boundary.
++	 * When %r10 goes positive we have crossed a page boundary and
++	 * need to do a nibble.
++	 */
++	lea	14(%rdi), %r10
++	and	$0xfff, %r10	/* offset into 4K page */
++	sub	$0x1000, %r10	/* subtract 4K pagesize */
++
++	.p2align 4
++L(loop_ashr_14):
++	add	$16, %r10
++	jg	L(nibble_ashr_14)
++
++L(gobble_ashr_14):
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $14, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++
++	add	$16, %r10
++	jg	L(nibble_ashr_14)	/* cross page boundary */
++
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $14, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++	jmp	L(loop_ashr_14)
++
++	.p2align 4
++L(nibble_ashr_14):
++	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
++	pmovmskb %xmm0, %edx
++	test	$0xc000, %edx
++	jnz	L(ashr_14_exittail)
++
++#ifdef USE_AS_STRNCMP
++	cmp	$1, %r11
++	jbe	L(ashr_14_exittail)
++#endif
++
++	pxor	%xmm0, %xmm0
++	sub	$0x1000, %r10
++	jmp	L(gobble_ashr_14)
++
++	.p2align 4
++L(ashr_14_exittail):
++	movdqa	(%rsi, %rcx), %xmm1
++	psrldq	$14, %xmm0
++	psrldq	$14, %xmm3
++	jmp	L(aftertail)
++
++/*
++ *  The following cases will be handled by ashr_15
++ *  rcx(offset of rsi)  rax(offset of rdi)        relative offset	 corresponding case
++ *        n(1~15)          n - 1      	        14(15 +(n - 1) - n)         ashr_15
++ */
++	.p2align 4
++L(ashr_15):
++	pxor	%xmm0, %xmm0
++	movdqa	(%rdi), %xmm2
++	movdqa	(%rsi), %xmm1
++	pcmpeqb	%xmm1, %xmm0
++	pslldq	$1, %xmm2
++	pcmpeqb	%xmm1, %xmm2
++	psubb	%xmm0, %xmm2
++	pmovmskb %xmm2, %r9d
++	shr	%cl, %edx
++	shr	%cl, %r9d
++	sub	%r9d, %edx
++	jnz	L(less32bytes)
++
++	movdqa	(%rdi), %xmm3
++
++	UPDATE_STRNCMP_COUNTER
++
++	pxor	%xmm0, %xmm0
++	mov	$16, %rcx	/* index for loads */
++	mov	$15, %r9d	/* byte position left over from less32bytes case */
++	/*
++	 * Setup %r10 value allows us to detect crossing a page boundary.
++	 * When %r10 goes positive we have crossed a page boundary and
++	 * need to do a nibble.
++	 */
++	lea	15(%rdi), %r10
++	and	$0xfff, %r10	/* offset into 4K page */
++
++	sub	$0x1000, %r10	/* subtract 4K pagesize */
++
++	.p2align 4
++L(loop_ashr_15):
++	add	$16, %r10
++	jg	L(nibble_ashr_15)
++
++L(gobble_ashr_15):
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $15, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++
++	add	$16, %r10
++	jg	L(nibble_ashr_15)	/* cross page boundary */
++
++	movdqa	(%rsi, %rcx), %xmm1
++	movdqa	(%rdi, %rcx), %xmm2
++	movdqa	%xmm2, %xmm4
++
++	palignr $15, %xmm3, %xmm2        /* merge into one 16byte value */
++
++	pcmpeqb	%xmm1, %xmm0
++	pcmpeqb	%xmm2, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	sub	$0xffff, %edx
++	jnz	L(exit)
++
++#ifdef USE_AS_STRNCMP
++	sub	$16, %r11
++	jbe	L(strcmp_exitz)
++#endif
++
++	add	$16, %rcx
++	movdqa	%xmm4, %xmm3
++	jmp	L(loop_ashr_15)
++
++	.p2align 4
++L(nibble_ashr_15):
++	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
++	pmovmskb %xmm0, %edx
++	test	$0x8000, %edx
++	jnz	L(ashr_15_exittail)
++
++#ifdef USE_AS_STRNCMP
++	test	%r11, %r11
++	je	L(ashr_15_exittail)
++#endif
++
++	pxor	%xmm0, %xmm0
++	sub	$0x1000, %r10
++	jmp	L(gobble_ashr_15)
++
++	.p2align 4
++L(ashr_15_exittail):
++	movdqa	(%rsi, %rcx), %xmm1
++	psrldq	$15, %xmm3
++	psrldq	$15, %xmm0
++
++	.p2align 4
++L(aftertail):
++	pcmpeqb	%xmm3, %xmm1
++	psubb	%xmm0, %xmm1
++	pmovmskb %xmm1, %edx
++	not	%edx
++
++	.p2align 4
++L(exit):
++	lea	-16(%r9, %rcx), %rax	/* locate the exact offset for rdi */
++L(less32bytes):
++	lea	(%rdi, %rax), %rdi	/* locate the exact address for first operand(rdi) */
++	lea	(%rsi, %rcx), %rsi	/* locate the exact address for second operand(rsi) */
++	test	%r8d, %r8d
++	jz	L(ret)
++	xchg	%rsi, %rdi		/* recover original order according to flag(%r8d) */
++
++	.p2align 4
++L(ret):
++L(less16bytes):
++	bsf	%rdx, %rdx		/* find and store bit index in %rdx */
++
++#ifdef USE_AS_STRNCMP
++	sub	%rdx, %r11
++	jbe	L(strcmp_exitz)
++#endif
++	movzbl	(%rsi, %rdx), %ecx
++	movzbl	(%rdi, %rdx), %eax
++
++	sub	%ecx, %eax
++	ret
++
++L(strcmp_exitz):
++	xor	%eax, %eax
++	ret
++
++	.p2align 4
++L(Byte0):
++	movzbl	(%rsi), %ecx
++	movzbl	(%rdi), %eax
++
++	sub	%ecx, %eax
++	ret
++END (STRCMP)
++
++	.section .rodata,"a",@progbits
++	.p2align 3
++L(unaligned_table):
++	.int	L(ashr_1) - L(unaligned_table)
++	.int	L(ashr_2) - L(unaligned_table)
++	.int	L(ashr_3) - L(unaligned_table)
++	.int	L(ashr_4) - L(unaligned_table)
++	.int	L(ashr_5) - L(unaligned_table)
++	.int	L(ashr_6) - L(unaligned_table)
++	.int	L(ashr_7) - L(unaligned_table)
++	.int	L(ashr_8) - L(unaligned_table)
++	.int	L(ashr_9) - L(unaligned_table)
++	.int	L(ashr_10) - L(unaligned_table)
++	.int	L(ashr_11) - L(unaligned_table)
++	.int	L(ashr_12) - L(unaligned_table)
++	.int	L(ashr_13) - L(unaligned_table)
++	.int	L(ashr_14) - L(unaligned_table)
++	.int	L(ashr_15) - L(unaligned_table)
++	.int	L(ashr_0) - L(unaligned_table)
+diff --git a/libc/arch-x86_64/silvermont/string/ssse3-strncmp-slm.S b/libc/arch-x86_64/silvermont/string/ssse3-strncmp-slm.S
+new file mode 100644
+index 0000000..0e40775
+--- /dev/null
++++ b/libc/arch-x86_64/silvermont/string/ssse3-strncmp-slm.S
+@@ -0,0 +1,33 @@
++/*
++Copyright (c) 2014, Intel Corporation
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++    * Redistributions of source code must retain the above copyright notice,
++    * this list of conditions and the following disclaimer.
++
++    * Redistributions in binary form must reproduce the above copyright notice,
++    * this list of conditions and the following disclaimer in the documentation
++    * and/or other materials provided with the distribution.
++
++    * Neither the name of Intel Corporation nor the names of its contributors
++    * may be used to endorse or promote products derived from this software
++    * without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
++ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
++WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
++ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
++ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++#define USE_AS_STRNCMP
++#define STRCMP		strncmp
++#include "ssse3-strcmp-slm.S"
+diff --git a/libc/arch-x86_64/static_function_dispatch.S b/libc/arch-x86_64/static_function_dispatch.S
+new file mode 100644
+index 0000000..a30bb36
+--- /dev/null
++++ b/libc/arch-x86_64/static_function_dispatch.S
+@@ -0,0 +1,41 @@
++/*
++ * Copyright (C) 2018 The Android Open Source Project
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions
++ * are met:
++ *  * Redistributions of source code must retain the above copyright
++ *    notice, this list of conditions and the following disclaimer.
++ *  * Redistributions in binary form must reproduce the above copyright
++ *    notice, this list of conditions and the following disclaimer in
++ *    the documentation and/or other materials provided with the
++ *    distribution.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
++ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
++ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
++ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
++ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
++ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
++ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
++ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
++ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
++ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
++ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++ * SUCH DAMAGE.
++ */
++
++#include <private/bionic_asm.h>
++
++#define FUNCTION_DELEGATE(name, impl) \
++ENTRY(name); \
++    jmp impl; \
++END(name)
++
++FUNCTION_DELEGATE(memcmp, memcmp_generic)
++FUNCTION_DELEGATE(memcpy, memmove_generic)
++FUNCTION_DELEGATE(memmove, memmove_generic)
++FUNCTION_DELEGATE(memchr, memchr_openbsd)
++FUNCTION_DELEGATE(memrchr, memrchr_openbsd)
++FUNCTION_DELEGATE(wmemset, wmemset_freebsd)
+diff --git a/libc/arch-x86_64/string/avx2-wmemset-kbl.S b/libc/arch-x86_64/string/avx2-wmemset-kbl.S
+deleted file mode 100644
+index 7c485cf..0000000
+--- a/libc/arch-x86_64/string/avx2-wmemset-kbl.S
++++ /dev/null
+@@ -1,140 +0,0 @@
+-/*
+-Copyright (C) 2019 The Android Open Source Project
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions
+-are met:
+- * Redistributions of source code must retain the above copyright
+-   notice, this list of conditions and the following disclaimer.
+- * Redistributions in binary form must reproduce the above copyright
+-   notice, this list of conditions and the following disclaimer in
+-   the documentation and/or other materials provided with the
+-   distribution.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+-FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+-OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+-AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+-OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+-SUCH DAMAGE.
+-*/
+-
+-#include <private/bionic_asm.h>
+-
+-#ifndef WMEMSET
+- #define WMEMSET wmemset_avx2
+-#endif
+-
+-        .section .text.avx2,"ax",@progbits
+-
+-ENTRY (WMEMSET)
+-# BB#0:
+-	testq	%rdx, %rdx
+-	je	.LBB0_14
+-# BB#1:
+-	cmpq	$32, %rdx
+-	jae	.LBB0_3
+-# BB#2:
+-	xorl	%r8d, %r8d
+-	movq	%rdi, %rax
+-	jmp	.LBB0_12
+-.LBB0_3:
+-	movq	%rdx, %r8
+-	andq	$-32, %r8
+-	vmovd	%esi, %xmm0
+-	vpbroadcastd	%xmm0, %ymm0
+-	leaq	-32(%r8), %rcx
+-	movq	%rcx, %rax
+-	shrq	$5, %rax
+-	leal	1(%rax), %r9d
+-	andl	$7, %r9d
+-	cmpq	$224, %rcx
+-	jae	.LBB0_5
+-# BB#4:
+-	xorl	%eax, %eax
+-	testq	%r9, %r9
+-	jne	.LBB0_8
+-	jmp	.LBB0_10
+-.LBB0_5:
+-	leaq	992(%rdi), %rcx
+-	leaq	-1(%r9), %r10
+-	subq	%rax, %r10
+-	xorl	%eax, %eax
+-	.p2align	4, 0x90
+-.LBB0_6:                                # =>This Inner Loop Header: Depth=1
+-	vmovdqu	%ymm0, -992(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -960(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -928(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -896(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -864(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -832(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -800(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -768(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -736(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -704(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -672(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -640(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -608(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -576(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -544(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -512(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -480(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -448(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -416(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -384(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -352(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -320(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -288(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -256(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -224(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -192(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -160(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -128(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -96(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -64(%rcx,%rax,4)
+-	vmovdqu	%ymm0, -32(%rcx,%rax,4)
+-	vmovdqu	%ymm0, (%rcx,%rax,4)
+-	addq	$256, %rax              # imm = 0x100
+-	addq	$8, %r10
+-	jne	.LBB0_6
+-# BB#7:
+-	testq	%r9, %r9
+-	je	.LBB0_10
+-.LBB0_8:
+-	leaq	(%rdi,%rax,4), %rax
+-	addq	$96, %rax
+-	negq	%r9
+-	.p2align	4, 0x90
+-.LBB0_9:                                # =>This Inner Loop Header: Depth=1
+-	vmovdqu	%ymm0, -96(%rax)
+-	vmovdqu	%ymm0, -64(%rax)
+-	vmovdqu	%ymm0, -32(%rax)
+-	vmovdqu	%ymm0, (%rax)
+-	subq	$-128, %rax
+-	addq	$1, %r9
+-	jne	.LBB0_9
+-.LBB0_10:
+-	cmpq	%rdx, %r8
+-	je	.LBB0_14
+-# BB#11:
+-	leaq	(%rdi,%r8,4), %rax
+-.LBB0_12:
+-	subq	%r8, %rdx
+-	.p2align	4, 0x90
+-.LBB0_13:                               # =>This Inner Loop Header: Depth=1
+-	movl	%esi, (%rax)
+-	addq	$4, %rax
+-	addq	$-1, %rdx
+-	jne	.LBB0_13
+-.LBB0_14:
+-	movq	%rdi, %rax
+-	vzeroupper
+-	retq
+-END(WMEMSET)
+diff --git a/libc/arch-x86_64/string/cache.h b/libc/arch-x86_64/string/cache.h
+deleted file mode 100644
+index 4131509..0000000
+--- a/libc/arch-x86_64/string/cache.h
++++ /dev/null
+@@ -1,36 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-/* Values are optimized for Core Architecture */
+-#define SHARED_CACHE_SIZE (4096*1024)  /* Core Architecture L2 Cache */
+-#define DATA_CACHE_SIZE   (24*1024)    /* Core Architecture L1 Data Cache */
+-
+-#define SHARED_CACHE_SIZE_HALF (SHARED_CACHE_SIZE / 2)
+-#define DATA_CACHE_SIZE_HALF   (DATA_CACHE_SIZE / 2)
+diff --git a/libc/arch-x86_64/string/sse2-memcpy-slm.s b/libc/arch-x86_64/string/sse2-memcpy-slm.s
+deleted file mode 100644
+index 2844528..0000000
+--- a/libc/arch-x86_64/string/sse2-memcpy-slm.s
++++ /dev/null
+@@ -1,1374 +0,0 @@
+-	.text
+-	.file	"FastMemcpy_avx_sse2.c"
+-	.globl	memcpy                  # -- Begin function memcpy
+-	.p2align	4, 0x90
+-	.type	memcpy,@function
+-
+-
+-
+-memcpy:                                 # @memcpy
+-	.cfi_startproc
+-
+-# %bb.0:
+-	movq	%rdi, %rax
+-	cmpq	$128, %rdx
+-	ja	.LBB0_129
+-# %bb.1:
+-	leaq	-1(%rdx), %rdi
+-	cmpq	$127, %rdi
+-	ja	.LBB0_145
+-# %bb.2:
+-	leaq	.LJTI0_1(%rip), %r8
+-	leaq	(%rax,%rdx), %rcx
+-	addq	%rdx, %rsi
+-	movslq	(%r8,%rdi,4), %rdi
+-	addq	%r8, %rdi
+-	jmpq	*%rdi
+-.LBB0_129:
+-	movl	%eax, %edi
+-	negl	%edi
+-	andq	$15, %rdi
+-	je	.LBB0_130
+-# %bb.131:
+-	movups	(%rsi), %xmm0
+-	leaq	(%rax,%rdi), %rcx
+-	addq	%rdi, %rsi
+-	subq	%rdi, %rdx
+-	movups	%xmm0, (%rax)
+-	cmpq	$2097152, %rdx          # imm = 0x200000
+-	ja	.LBB0_137
+-.LBB0_133:
+-	cmpq	$128, %rdx
+-	jb	.LBB0_141
+-# %bb.134:
+-	movq	%rdx, %rdi
+-	.p2align	4, 0x90
+-.LBB0_135:                              # =>This Inner Loop Header: Depth=1
+-	movups	(%rsi), %xmm0
+-	movups	16(%rsi), %xmm1
+-	movups	32(%rsi), %xmm2
+-	movups	48(%rsi), %xmm3
+-	movups	64(%rsi), %xmm4
+-	movups	80(%rsi), %xmm5
+-	movups	96(%rsi), %xmm6
+-	movups	112(%rsi), %xmm7
+-	prefetchnta	256(%rsi)
+-	addq	$-128, %rdi
+-	subq	$-128, %rsi
+-	movaps	%xmm0, (%rcx)
+-	movaps	%xmm1, 16(%rcx)
+-	movaps	%xmm2, 32(%rcx)
+-	movaps	%xmm3, 48(%rcx)
+-	movaps	%xmm4, 64(%rcx)
+-	movaps	%xmm5, 80(%rcx)
+-	movaps	%xmm6, 96(%rcx)
+-	movaps	%xmm7, 112(%rcx)
+-	subq	$-128, %rcx
+-	cmpq	$127, %rdi
+-	ja	.LBB0_135
+-# %bb.136:
+-	andl	$127, %edx
+-	leaq	-1(%rdx), %rdi
+-	cmpq	$127, %rdi
+-	jbe	.LBB0_142
+-	jmp	.LBB0_145
+-.LBB0_130:
+-	movq	%rax, %rcx
+-	cmpq	$2097152, %rdx          # imm = 0x200000
+-	jbe	.LBB0_133
+-.LBB0_137:
+-	prefetchnta	(%rsi)
+-	movq	%rdx, %rdi
+-	testb	$15, %sil
+-	je	.LBB0_139
+-	.p2align	4, 0x90
+-.LBB0_138:                              # =>This Inner Loop Header: Depth=1
+-	movups	(%rsi), %xmm0
+-	movups	16(%rsi), %xmm1
+-	movups	32(%rsi), %xmm2
+-	movups	48(%rsi), %xmm3
+-	movups	64(%rsi), %xmm4
+-	movups	80(%rsi), %xmm5
+-	movups	96(%rsi), %xmm6
+-	movups	112(%rsi), %xmm7
+-	prefetchnta	256(%rsi)
+-	addq	$-128, %rdi
+-	subq	$-128, %rsi
+-	movntps	%xmm0, (%rcx)
+-	movntps	%xmm1, 16(%rcx)
+-	movntps	%xmm2, 32(%rcx)
+-	movntps	%xmm3, 48(%rcx)
+-	movntps	%xmm4, 64(%rcx)
+-	movntps	%xmm5, 80(%rcx)
+-	movntps	%xmm6, 96(%rcx)
+-	movntps	%xmm7, 112(%rcx)
+-	subq	$-128, %rcx
+-	cmpq	$127, %rdi
+-	ja	.LBB0_138
+-	jmp	.LBB0_140
+-	.p2align	4, 0x90
+-.LBB0_139:                              # =>This Inner Loop Header: Depth=1
+-	movaps	(%rsi), %xmm0
+-	movaps	16(%rsi), %xmm1
+-	movaps	32(%rsi), %xmm2
+-	movaps	48(%rsi), %xmm3
+-	movaps	64(%rsi), %xmm4
+-	movaps	80(%rsi), %xmm5
+-	movaps	96(%rsi), %xmm6
+-	movaps	112(%rsi), %xmm7
+-	prefetchnta	256(%rsi)
+-	addq	$-128, %rdi
+-	subq	$-128, %rsi
+-	movntps	%xmm0, (%rcx)
+-	movntps	%xmm1, 16(%rcx)
+-	movntps	%xmm2, 32(%rcx)
+-	movntps	%xmm3, 48(%rcx)
+-	movntps	%xmm4, 64(%rcx)
+-	movntps	%xmm5, 80(%rcx)
+-	movntps	%xmm6, 96(%rcx)
+-	movntps	%xmm7, 112(%rcx)
+-	subq	$-128, %rcx
+-	cmpq	$127, %rdi
+-	ja	.LBB0_139
+-.LBB0_140:
+-	andl	$127, %edx
+-	sfence
+-.LBB0_141:
+-	leaq	-1(%rdx), %rdi
+-	cmpq	$127, %rdi
+-	ja	.LBB0_145
+-.LBB0_142:
+-	leaq	.LJTI0_0(%rip), %r8
+-	addq	%rdx, %rcx
+-	addq	%rdx, %rsi
+-	movslq	(%r8,%rdi,4), %rdi
+-	addq	%r8, %rdi
+-	jmpq	*%rdi
+-.LBB0_143:
+-	movups	-64(%rsi), %xmm0
+-	movups	-48(%rsi), %xmm1
+-	movups	-32(%rsi), %xmm2
+-	movups	-16(%rsi), %xmm3
+-	movups	%xmm0, -64(%rcx)
+-	movups	%xmm1, -48(%rcx)
+-	movups	%xmm2, -32(%rcx)
+-	movups	%xmm3, -16(%rcx)
+-	retq
+-.LBB0_3:
+-	movups	-65(%rsi), %xmm0
+-	movups	-49(%rsi), %xmm1
+-	movups	-33(%rsi), %xmm2
+-	movups	-17(%rsi), %xmm3
+-	movups	%xmm0, -65(%rcx)
+-	movups	%xmm1, -49(%rcx)
+-	movups	%xmm2, -33(%rcx)
+-	movups	%xmm3, -17(%rcx)
+-	movb	-1(%rsi), %dl
+-	movb	%dl, -1(%rcx)
+-	retq
+-.LBB0_5:
+-	movups	-66(%rsi), %xmm0
+-	movups	-50(%rsi), %xmm1
+-	movups	-34(%rsi), %xmm2
+-	movups	-18(%rsi), %xmm3
+-	movups	%xmm0, -66(%rcx)
+-	movups	%xmm1, -50(%rcx)
+-	movups	%xmm2, -34(%rcx)
+-	movups	%xmm3, -18(%rcx)
+-	movzwl	-2(%rsi), %edx
+-	movw	%dx, -2(%rcx)
+-	retq
+-.LBB0_7:
+-	movups	-67(%rsi), %xmm0
+-	movups	-51(%rsi), %xmm1
+-	movups	-35(%rsi), %xmm2
+-	movups	-19(%rsi), %xmm3
+-	movups	%xmm0, -67(%rcx)
+-	movups	%xmm1, -51(%rcx)
+-	movups	%xmm2, -35(%rcx)
+-	movups	%xmm3, -19(%rcx)
+-	jmp	.LBB0_8
+-.LBB0_9:
+-	movups	-68(%rsi), %xmm0
+-	movups	-52(%rsi), %xmm1
+-	movups	-36(%rsi), %xmm2
+-	movups	-20(%rsi), %xmm3
+-	movups	%xmm0, -68(%rcx)
+-	movups	%xmm1, -52(%rcx)
+-	movups	%xmm2, -36(%rcx)
+-	movups	%xmm3, -20(%rcx)
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	retq
+-.LBB0_11:
+-	movups	-69(%rsi), %xmm0
+-	movups	-53(%rsi), %xmm1
+-	movups	-37(%rsi), %xmm2
+-	movups	-21(%rsi), %xmm3
+-	movups	%xmm0, -69(%rcx)
+-	movups	%xmm1, -53(%rcx)
+-	movups	%xmm2, -37(%rcx)
+-	movups	%xmm3, -21(%rcx)
+-	jmp	.LBB0_12
+-.LBB0_13:
+-	movups	-70(%rsi), %xmm0
+-	movups	-54(%rsi), %xmm1
+-	movups	-38(%rsi), %xmm2
+-	movups	-22(%rsi), %xmm3
+-	movups	%xmm0, -70(%rcx)
+-	movups	%xmm1, -54(%rcx)
+-	movups	%xmm2, -38(%rcx)
+-	movups	%xmm3, -22(%rcx)
+-	jmp	.LBB0_14
+-.LBB0_15:
+-	movups	-71(%rsi), %xmm0
+-	movups	-55(%rsi), %xmm1
+-	movups	-39(%rsi), %xmm2
+-	movups	-23(%rsi), %xmm3
+-	movups	%xmm0, -71(%rcx)
+-	movups	%xmm1, -55(%rcx)
+-	movups	%xmm2, -39(%rcx)
+-	movups	%xmm3, -23(%rcx)
+-	jmp	.LBB0_16
+-.LBB0_17:
+-	movups	-72(%rsi), %xmm0
+-	movups	-56(%rsi), %xmm1
+-	movups	-40(%rsi), %xmm2
+-	movups	-24(%rsi), %xmm3
+-	movups	%xmm0, -72(%rcx)
+-	movups	%xmm1, -56(%rcx)
+-	movups	%xmm2, -40(%rcx)
+-	movups	%xmm3, -24(%rcx)
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	retq
+-.LBB0_19:
+-	movups	-73(%rsi), %xmm0
+-	movups	-57(%rsi), %xmm1
+-	movups	-41(%rsi), %xmm2
+-	movups	-25(%rsi), %xmm3
+-	movups	%xmm0, -73(%rcx)
+-	movups	%xmm1, -57(%rcx)
+-	movups	%xmm2, -41(%rcx)
+-	movups	%xmm3, -25(%rcx)
+-	jmp	.LBB0_20
+-.LBB0_21:
+-	movups	-74(%rsi), %xmm0
+-	movups	-58(%rsi), %xmm1
+-	movups	-42(%rsi), %xmm2
+-	movups	-26(%rsi), %xmm3
+-	movups	%xmm0, -74(%rcx)
+-	movups	%xmm1, -58(%rcx)
+-	movups	%xmm2, -42(%rcx)
+-	movups	%xmm3, -26(%rcx)
+-	jmp	.LBB0_22
+-.LBB0_23:
+-	movups	-75(%rsi), %xmm0
+-	movups	-59(%rsi), %xmm1
+-	movups	-43(%rsi), %xmm2
+-	movups	-27(%rsi), %xmm3
+-	movups	%xmm0, -75(%rcx)
+-	movups	%xmm1, -59(%rcx)
+-	movups	%xmm2, -43(%rcx)
+-	movups	%xmm3, -27(%rcx)
+-	jmp	.LBB0_24
+-.LBB0_25:
+-	movups	-76(%rsi), %xmm0
+-	movups	-60(%rsi), %xmm1
+-	movups	-44(%rsi), %xmm2
+-	movups	-28(%rsi), %xmm3
+-	movups	%xmm0, -76(%rcx)
+-	movups	%xmm1, -60(%rcx)
+-	movups	%xmm2, -44(%rcx)
+-	movups	%xmm3, -28(%rcx)
+-	jmp	.LBB0_26
+-.LBB0_27:
+-	movups	-77(%rsi), %xmm0
+-	movups	-61(%rsi), %xmm1
+-	movups	-45(%rsi), %xmm2
+-	movups	-29(%rsi), %xmm3
+-	movups	%xmm0, -77(%rcx)
+-	movups	%xmm1, -61(%rcx)
+-	movups	%xmm2, -45(%rcx)
+-	movups	%xmm3, -29(%rcx)
+-	jmp	.LBB0_28
+-.LBB0_29:
+-	movups	-78(%rsi), %xmm0
+-	movups	-62(%rsi), %xmm1
+-	movups	-46(%rsi), %xmm2
+-	movups	-30(%rsi), %xmm3
+-	movups	%xmm0, -78(%rcx)
+-	movups	%xmm1, -62(%rcx)
+-	movups	%xmm2, -46(%rcx)
+-	movups	%xmm3, -30(%rcx)
+-	jmp	.LBB0_30
+-.LBB0_31:
+-	movups	-79(%rsi), %xmm0
+-	movups	-63(%rsi), %xmm1
+-	movups	-47(%rsi), %xmm2
+-	movups	-31(%rsi), %xmm3
+-	movups	%xmm0, -79(%rcx)
+-	movups	%xmm1, -63(%rcx)
+-	movups	%xmm2, -47(%rcx)
+-	movups	%xmm3, -31(%rcx)
+-	jmp	.LBB0_32
+-.LBB0_33:
+-	movups	-80(%rsi), %xmm0
+-	movups	-64(%rsi), %xmm1
+-	movups	-48(%rsi), %xmm2
+-	movups	-32(%rsi), %xmm3
+-	movups	%xmm0, -80(%rcx)
+-	movups	%xmm1, -64(%rcx)
+-	movups	%xmm2, -48(%rcx)
+-	movups	%xmm3, -32(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_35:
+-	movups	-81(%rsi), %xmm0
+-	movups	-65(%rsi), %xmm1
+-	movups	-49(%rsi), %xmm2
+-	movups	-33(%rsi), %xmm3
+-	movups	%xmm0, -81(%rcx)
+-	movups	%xmm1, -65(%rcx)
+-	movups	%xmm2, -49(%rcx)
+-	movups	%xmm3, -33(%rcx)
+-	jmp	.LBB0_36
+-.LBB0_37:
+-	movups	-82(%rsi), %xmm0
+-	movups	-66(%rsi), %xmm1
+-	movups	-50(%rsi), %xmm2
+-	movups	-34(%rsi), %xmm3
+-	movups	%xmm0, -82(%rcx)
+-	movups	%xmm1, -66(%rcx)
+-	movups	%xmm2, -50(%rcx)
+-	movups	%xmm3, -34(%rcx)
+-	jmp	.LBB0_38
+-.LBB0_39:
+-	movups	-83(%rsi), %xmm0
+-	movups	-67(%rsi), %xmm1
+-	movups	-51(%rsi), %xmm2
+-	movups	-35(%rsi), %xmm3
+-	movups	%xmm0, -83(%rcx)
+-	movups	%xmm1, -67(%rcx)
+-	movups	%xmm2, -51(%rcx)
+-	movups	%xmm3, -35(%rcx)
+-	jmp	.LBB0_40
+-.LBB0_41:
+-	movups	-84(%rsi), %xmm0
+-	movups	-68(%rsi), %xmm1
+-	movups	-52(%rsi), %xmm2
+-	movups	-36(%rsi), %xmm3
+-	movups	%xmm0, -84(%rcx)
+-	movups	%xmm1, -68(%rcx)
+-	movups	%xmm2, -52(%rcx)
+-	movups	%xmm3, -36(%rcx)
+-	jmp	.LBB0_42
+-.LBB0_43:
+-	movups	-85(%rsi), %xmm0
+-	movups	-69(%rsi), %xmm1
+-	movups	-53(%rsi), %xmm2
+-	movups	-37(%rsi), %xmm3
+-	movups	%xmm0, -85(%rcx)
+-	movups	%xmm1, -69(%rcx)
+-	movups	%xmm2, -53(%rcx)
+-	movups	%xmm3, -37(%rcx)
+-	jmp	.LBB0_44
+-.LBB0_45:
+-	movups	-86(%rsi), %xmm0
+-	movups	-70(%rsi), %xmm1
+-	movups	-54(%rsi), %xmm2
+-	movups	-38(%rsi), %xmm3
+-	movups	%xmm0, -86(%rcx)
+-	movups	%xmm1, -70(%rcx)
+-	movups	%xmm2, -54(%rcx)
+-	movups	%xmm3, -38(%rcx)
+-	jmp	.LBB0_46
+-.LBB0_47:
+-	movups	-87(%rsi), %xmm0
+-	movups	-71(%rsi), %xmm1
+-	movups	-55(%rsi), %xmm2
+-	movups	-39(%rsi), %xmm3
+-	movups	%xmm0, -87(%rcx)
+-	movups	%xmm1, -71(%rcx)
+-	movups	%xmm2, -55(%rcx)
+-	movups	%xmm3, -39(%rcx)
+-	jmp	.LBB0_48
+-.LBB0_49:
+-	movups	-88(%rsi), %xmm0
+-	movups	-72(%rsi), %xmm1
+-	movups	-56(%rsi), %xmm2
+-	movups	-40(%rsi), %xmm3
+-	movups	%xmm0, -88(%rcx)
+-	movups	%xmm1, -72(%rcx)
+-	movups	%xmm2, -56(%rcx)
+-	movups	%xmm3, -40(%rcx)
+-	jmp	.LBB0_50
+-.LBB0_51:
+-	movups	-89(%rsi), %xmm0
+-	movups	-73(%rsi), %xmm1
+-	movups	-57(%rsi), %xmm2
+-	movups	-41(%rsi), %xmm3
+-	movups	%xmm0, -89(%rcx)
+-	movups	%xmm1, -73(%rcx)
+-	movups	%xmm2, -57(%rcx)
+-	movups	%xmm3, -41(%rcx)
+-	jmp	.LBB0_52
+-.LBB0_53:
+-	movups	-90(%rsi), %xmm0
+-	movups	-74(%rsi), %xmm1
+-	movups	-58(%rsi), %xmm2
+-	movups	-42(%rsi), %xmm3
+-	movups	%xmm0, -90(%rcx)
+-	movups	%xmm1, -74(%rcx)
+-	movups	%xmm2, -58(%rcx)
+-	movups	%xmm3, -42(%rcx)
+-	jmp	.LBB0_54
+-.LBB0_55:
+-	movups	-91(%rsi), %xmm0
+-	movups	-75(%rsi), %xmm1
+-	movups	-59(%rsi), %xmm2
+-	movups	-43(%rsi), %xmm3
+-	movups	%xmm0, -91(%rcx)
+-	movups	%xmm1, -75(%rcx)
+-	movups	%xmm2, -59(%rcx)
+-	movups	%xmm3, -43(%rcx)
+-	jmp	.LBB0_56
+-.LBB0_57:
+-	movups	-92(%rsi), %xmm0
+-	movups	-76(%rsi), %xmm1
+-	movups	-60(%rsi), %xmm2
+-	movups	-44(%rsi), %xmm3
+-	movups	%xmm0, -92(%rcx)
+-	movups	%xmm1, -76(%rcx)
+-	movups	%xmm2, -60(%rcx)
+-	movups	%xmm3, -44(%rcx)
+-	jmp	.LBB0_58
+-.LBB0_59:
+-	movups	-93(%rsi), %xmm0
+-	movups	-77(%rsi), %xmm1
+-	movups	-61(%rsi), %xmm2
+-	movups	-45(%rsi), %xmm3
+-	movups	%xmm0, -93(%rcx)
+-	movups	%xmm1, -77(%rcx)
+-	movups	%xmm2, -61(%rcx)
+-	movups	%xmm3, -45(%rcx)
+-	jmp	.LBB0_60
+-.LBB0_61:
+-	movups	-94(%rsi), %xmm0
+-	movups	-78(%rsi), %xmm1
+-	movups	-62(%rsi), %xmm2
+-	movups	-46(%rsi), %xmm3
+-	movups	%xmm0, -94(%rcx)
+-	movups	%xmm1, -78(%rcx)
+-	movups	%xmm2, -62(%rcx)
+-	movups	%xmm3, -46(%rcx)
+-	jmp	.LBB0_62
+-.LBB0_63:
+-	movups	-95(%rsi), %xmm0
+-	movups	-79(%rsi), %xmm1
+-	movups	-63(%rsi), %xmm2
+-	movups	-47(%rsi), %xmm3
+-	movups	%xmm0, -95(%rcx)
+-	movups	%xmm1, -79(%rcx)
+-	movups	%xmm2, -63(%rcx)
+-	movups	%xmm3, -47(%rcx)
+-	jmp	.LBB0_64
+-.LBB0_65:
+-	movups	-96(%rsi), %xmm0
+-	movups	-80(%rsi), %xmm1
+-	movups	-64(%rsi), %xmm2
+-	movups	-48(%rsi), %xmm3
+-	movups	%xmm0, -96(%rcx)
+-	movups	%xmm1, -80(%rcx)
+-	movups	%xmm2, -64(%rcx)
+-	movups	%xmm3, -48(%rcx)
+-.LBB0_66:
+-	movups	-32(%rsi), %xmm0
+-	movups	-16(%rsi), %xmm1
+-	movups	%xmm0, -32(%rcx)
+-	movups	%xmm1, -16(%rcx)
+-	retq
+-.LBB0_67:
+-	movups	-97(%rsi), %xmm0
+-	movups	-81(%rsi), %xmm1
+-	movups	-65(%rsi), %xmm2
+-	movups	-49(%rsi), %xmm3
+-	movups	%xmm0, -97(%rcx)
+-	movups	%xmm1, -81(%rcx)
+-	movups	%xmm2, -65(%rcx)
+-	movups	%xmm3, -49(%rcx)
+-.LBB0_68:
+-	movups	-33(%rsi), %xmm0
+-	movups	-17(%rsi), %xmm1
+-	movups	%xmm0, -33(%rcx)
+-	movups	%xmm1, -17(%rcx)
+-	movb	-1(%rsi), %dl
+-	movb	%dl, -1(%rcx)
+-	retq
+-.LBB0_69:
+-	movups	-98(%rsi), %xmm0
+-	movups	-82(%rsi), %xmm1
+-	movups	-66(%rsi), %xmm2
+-	movups	-50(%rsi), %xmm3
+-	movups	%xmm0, -98(%rcx)
+-	movups	%xmm1, -82(%rcx)
+-	movups	%xmm2, -66(%rcx)
+-	movups	%xmm3, -50(%rcx)
+-.LBB0_70:
+-	movups	-34(%rsi), %xmm0
+-	movups	-18(%rsi), %xmm1
+-	movups	%xmm0, -34(%rcx)
+-	movups	%xmm1, -18(%rcx)
+-	movzwl	-2(%rsi), %edx
+-	movw	%dx, -2(%rcx)
+-	retq
+-.LBB0_71:
+-	movups	-99(%rsi), %xmm0
+-	movups	-83(%rsi), %xmm1
+-	movups	-67(%rsi), %xmm2
+-	movups	-51(%rsi), %xmm3
+-	movups	%xmm0, -99(%rcx)
+-	movups	%xmm1, -83(%rcx)
+-	movups	%xmm2, -67(%rcx)
+-	movups	%xmm3, -51(%rcx)
+-.LBB0_72:
+-	movups	-35(%rsi), %xmm0
+-	movups	-19(%rsi), %xmm1
+-	movups	%xmm0, -35(%rcx)
+-	movups	%xmm1, -19(%rcx)
+-	jmp	.LBB0_8
+-.LBB0_73:
+-	movups	-100(%rsi), %xmm0
+-	movups	-84(%rsi), %xmm1
+-	movups	-68(%rsi), %xmm2
+-	movups	-52(%rsi), %xmm3
+-	movups	%xmm0, -100(%rcx)
+-	movups	%xmm1, -84(%rcx)
+-	movups	%xmm2, -68(%rcx)
+-	movups	%xmm3, -52(%rcx)
+-.LBB0_74:
+-	movups	-36(%rsi), %xmm0
+-	movups	-20(%rsi), %xmm1
+-	movups	%xmm0, -36(%rcx)
+-	movups	%xmm1, -20(%rcx)
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	retq
+-.LBB0_75:
+-	movups	-101(%rsi), %xmm0
+-	movups	-85(%rsi), %xmm1
+-	movups	-69(%rsi), %xmm2
+-	movups	-53(%rsi), %xmm3
+-	movups	%xmm0, -101(%rcx)
+-	movups	%xmm1, -85(%rcx)
+-	movups	%xmm2, -69(%rcx)
+-	movups	%xmm3, -53(%rcx)
+-.LBB0_76:
+-	movups	-37(%rsi), %xmm0
+-	movups	-21(%rsi), %xmm1
+-	movups	%xmm0, -37(%rcx)
+-	movups	%xmm1, -21(%rcx)
+-	jmp	.LBB0_12
+-.LBB0_77:
+-	movups	-102(%rsi), %xmm0
+-	movups	-86(%rsi), %xmm1
+-	movups	-70(%rsi), %xmm2
+-	movups	-54(%rsi), %xmm3
+-	movups	%xmm0, -102(%rcx)
+-	movups	%xmm1, -86(%rcx)
+-	movups	%xmm2, -70(%rcx)
+-	movups	%xmm3, -54(%rcx)
+-.LBB0_78:
+-	movups	-38(%rsi), %xmm0
+-	movups	-22(%rsi), %xmm1
+-	movups	%xmm0, -38(%rcx)
+-	movups	%xmm1, -22(%rcx)
+-	jmp	.LBB0_14
+-.LBB0_79:
+-	movups	-103(%rsi), %xmm0
+-	movups	-87(%rsi), %xmm1
+-	movups	-71(%rsi), %xmm2
+-	movups	-55(%rsi), %xmm3
+-	movups	%xmm0, -103(%rcx)
+-	movups	%xmm1, -87(%rcx)
+-	movups	%xmm2, -71(%rcx)
+-	movups	%xmm3, -55(%rcx)
+-.LBB0_80:
+-	movups	-39(%rsi), %xmm0
+-	movups	-23(%rsi), %xmm1
+-	movups	%xmm0, -39(%rcx)
+-	movups	%xmm1, -23(%rcx)
+-	jmp	.LBB0_16
+-.LBB0_81:
+-	movups	-104(%rsi), %xmm0
+-	movups	-88(%rsi), %xmm1
+-	movups	-72(%rsi), %xmm2
+-	movups	-56(%rsi), %xmm3
+-	movups	%xmm0, -104(%rcx)
+-	movups	%xmm1, -88(%rcx)
+-	movups	%xmm2, -72(%rcx)
+-	movups	%xmm3, -56(%rcx)
+-.LBB0_82:
+-	movups	-40(%rsi), %xmm0
+-	movups	-24(%rsi), %xmm1
+-	movups	%xmm0, -40(%rcx)
+-	movups	%xmm1, -24(%rcx)
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	retq
+-.LBB0_83:
+-	movups	-105(%rsi), %xmm0
+-	movups	-89(%rsi), %xmm1
+-	movups	-73(%rsi), %xmm2
+-	movups	-57(%rsi), %xmm3
+-	movups	%xmm0, -105(%rcx)
+-	movups	%xmm1, -89(%rcx)
+-	movups	%xmm2, -73(%rcx)
+-	movups	%xmm3, -57(%rcx)
+-.LBB0_84:
+-	movups	-41(%rsi), %xmm0
+-	movups	-25(%rsi), %xmm1
+-	movups	%xmm0, -41(%rcx)
+-	movups	%xmm1, -25(%rcx)
+-.LBB0_20:
+-	movq	-9(%rsi), %rdx
+-	movq	%rdx, -9(%rcx)
+-.LBB0_4:
+-	movb	-1(%rsi), %dl
+-	movb	%dl, -1(%rcx)
+-	retq
+-.LBB0_85:
+-	movups	-106(%rsi), %xmm0
+-	movups	-90(%rsi), %xmm1
+-	movups	-74(%rsi), %xmm2
+-	movups	-58(%rsi), %xmm3
+-	movups	%xmm0, -106(%rcx)
+-	movups	%xmm1, -90(%rcx)
+-	movups	%xmm2, -74(%rcx)
+-	movups	%xmm3, -58(%rcx)
+-.LBB0_86:
+-	movups	-42(%rsi), %xmm0
+-	movups	-26(%rsi), %xmm1
+-	movups	%xmm0, -42(%rcx)
+-	movups	%xmm1, -26(%rcx)
+-.LBB0_22:
+-	movq	-10(%rsi), %rdx
+-	movq	%rdx, -10(%rcx)
+-.LBB0_6:
+-	movzwl	-2(%rsi), %edx
+-	movw	%dx, -2(%rcx)
+-	retq
+-.LBB0_87:
+-	movups	-107(%rsi), %xmm0
+-	movups	-91(%rsi), %xmm1
+-	movups	-75(%rsi), %xmm2
+-	movups	-59(%rsi), %xmm3
+-	movups	%xmm0, -107(%rcx)
+-	movups	%xmm1, -91(%rcx)
+-	movups	%xmm2, -75(%rcx)
+-	movups	%xmm3, -59(%rcx)
+-.LBB0_88:
+-	movups	-43(%rsi), %xmm0
+-	movups	-27(%rsi), %xmm1
+-	movups	%xmm0, -43(%rcx)
+-	movups	%xmm1, -27(%rcx)
+-.LBB0_24:
+-	movq	-11(%rsi), %rdx
+-	movq	%rdx, -11(%rcx)
+-.LBB0_10:
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	retq
+-.LBB0_89:
+-	movups	-108(%rsi), %xmm0
+-	movups	-92(%rsi), %xmm1
+-	movups	-76(%rsi), %xmm2
+-	movups	-60(%rsi), %xmm3
+-	movups	%xmm0, -108(%rcx)
+-	movups	%xmm1, -92(%rcx)
+-	movups	%xmm2, -76(%rcx)
+-	movups	%xmm3, -60(%rcx)
+-.LBB0_90:
+-	movups	-44(%rsi), %xmm0
+-	movups	-28(%rsi), %xmm1
+-	movups	%xmm0, -44(%rcx)
+-	movups	%xmm1, -28(%rcx)
+-.LBB0_26:
+-	movq	-12(%rsi), %rdx
+-	movq	%rdx, -12(%rcx)
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	retq
+-.LBB0_91:
+-	movups	-109(%rsi), %xmm0
+-	movups	-93(%rsi), %xmm1
+-	movups	-77(%rsi), %xmm2
+-	movups	-61(%rsi), %xmm3
+-	movups	%xmm0, -109(%rcx)
+-	movups	%xmm1, -93(%rcx)
+-	movups	%xmm2, -77(%rcx)
+-	movups	%xmm3, -61(%rcx)
+-.LBB0_92:
+-	movups	-45(%rsi), %xmm0
+-	movups	-29(%rsi), %xmm1
+-	movups	%xmm0, -45(%rcx)
+-	movups	%xmm1, -29(%rcx)
+-.LBB0_28:
+-	movq	-13(%rsi), %rdx
+-	movq	%rdx, -13(%rcx)
+-	jmp	.LBB0_12
+-.LBB0_93:
+-	movups	-110(%rsi), %xmm0
+-	movups	-94(%rsi), %xmm1
+-	movups	-78(%rsi), %xmm2
+-	movups	-62(%rsi), %xmm3
+-	movups	%xmm0, -110(%rcx)
+-	movups	%xmm1, -94(%rcx)
+-	movups	%xmm2, -78(%rcx)
+-	movups	%xmm3, -62(%rcx)
+-.LBB0_94:
+-	movups	-46(%rsi), %xmm0
+-	movups	-30(%rsi), %xmm1
+-	movups	%xmm0, -46(%rcx)
+-	movups	%xmm1, -30(%rcx)
+-.LBB0_30:
+-	movq	-14(%rsi), %rdx
+-	movq	%rdx, -14(%rcx)
+-.LBB0_18:
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	retq
+-.LBB0_95:
+-	movups	-111(%rsi), %xmm0
+-	movups	-95(%rsi), %xmm1
+-	movups	-79(%rsi), %xmm2
+-	movups	-63(%rsi), %xmm3
+-	movups	%xmm0, -111(%rcx)
+-	movups	%xmm1, -95(%rcx)
+-	movups	%xmm2, -79(%rcx)
+-	movups	%xmm3, -63(%rcx)
+-.LBB0_96:
+-	movups	-47(%rsi), %xmm0
+-	movups	-31(%rsi), %xmm1
+-	movups	%xmm0, -47(%rcx)
+-	movups	%xmm1, -31(%rcx)
+-.LBB0_32:
+-	movq	-15(%rsi), %rdx
+-	movq	%rdx, -15(%rcx)
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	retq
+-.LBB0_97:
+-	movups	-112(%rsi), %xmm0
+-	movups	-96(%rsi), %xmm1
+-	movups	-80(%rsi), %xmm2
+-	movups	-64(%rsi), %xmm3
+-	movups	%xmm0, -112(%rcx)
+-	movups	%xmm1, -96(%rcx)
+-	movups	%xmm2, -80(%rcx)
+-	movups	%xmm3, -64(%rcx)
+-.LBB0_98:
+-	movups	-48(%rsi), %xmm0
+-	movups	-32(%rsi), %xmm1
+-	movups	%xmm0, -48(%rcx)
+-	movups	%xmm1, -32(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_99:
+-	movups	-113(%rsi), %xmm0
+-	movups	-97(%rsi), %xmm1
+-	movups	-81(%rsi), %xmm2
+-	movups	-65(%rsi), %xmm3
+-	movups	%xmm0, -113(%rcx)
+-	movups	%xmm1, -97(%rcx)
+-	movups	%xmm2, -81(%rcx)
+-	movups	%xmm3, -65(%rcx)
+-.LBB0_100:
+-	movups	-49(%rsi), %xmm0
+-	movups	-33(%rsi), %xmm1
+-	movups	%xmm0, -49(%rcx)
+-	movups	%xmm1, -33(%rcx)
+-.LBB0_36:
+-	movups	-17(%rsi), %xmm0
+-	movups	%xmm0, -17(%rcx)
+-	movb	-1(%rsi), %dl
+-	movb	%dl, -1(%rcx)
+-	retq
+-.LBB0_101:
+-	movups	-114(%rsi), %xmm0
+-	movups	-98(%rsi), %xmm1
+-	movups	-82(%rsi), %xmm2
+-	movups	-66(%rsi), %xmm3
+-	movups	%xmm0, -114(%rcx)
+-	movups	%xmm1, -98(%rcx)
+-	movups	%xmm2, -82(%rcx)
+-	movups	%xmm3, -66(%rcx)
+-.LBB0_102:
+-	movups	-50(%rsi), %xmm0
+-	movups	-34(%rsi), %xmm1
+-	movups	%xmm0, -50(%rcx)
+-	movups	%xmm1, -34(%rcx)
+-.LBB0_38:
+-	movups	-18(%rsi), %xmm0
+-	movups	%xmm0, -18(%rcx)
+-	movzwl	-2(%rsi), %edx
+-	movw	%dx, -2(%rcx)
+-	retq
+-.LBB0_103:
+-	movups	-115(%rsi), %xmm0
+-	movups	-99(%rsi), %xmm1
+-	movups	-83(%rsi), %xmm2
+-	movups	-67(%rsi), %xmm3
+-	movups	%xmm0, -115(%rcx)
+-	movups	%xmm1, -99(%rcx)
+-	movups	%xmm2, -83(%rcx)
+-	movups	%xmm3, -67(%rcx)
+-.LBB0_104:
+-	movups	-51(%rsi), %xmm0
+-	movups	-35(%rsi), %xmm1
+-	movups	%xmm0, -51(%rcx)
+-	movups	%xmm1, -35(%rcx)
+-.LBB0_40:
+-	movups	-19(%rsi), %xmm0
+-	movups	%xmm0, -19(%rcx)
+-.LBB0_8:
+-	movzwl	-3(%rsi), %edx
+-	movw	%dx, -3(%rcx)
+-	movb	-1(%rsi), %dl
+-	movb	%dl, -1(%rcx)
+-	retq
+-.LBB0_105:
+-	movups	-116(%rsi), %xmm0
+-	movups	-100(%rsi), %xmm1
+-	movups	-84(%rsi), %xmm2
+-	movups	-68(%rsi), %xmm3
+-	movups	%xmm0, -116(%rcx)
+-	movups	%xmm1, -100(%rcx)
+-	movups	%xmm2, -84(%rcx)
+-	movups	%xmm3, -68(%rcx)
+-.LBB0_106:
+-	movups	-52(%rsi), %xmm0
+-	movups	-36(%rsi), %xmm1
+-	movups	%xmm0, -52(%rcx)
+-	movups	%xmm1, -36(%rcx)
+-.LBB0_42:
+-	movups	-20(%rsi), %xmm0
+-	movups	%xmm0, -20(%rcx)
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	retq
+-.LBB0_107:
+-	movups	-117(%rsi), %xmm0
+-	movups	-101(%rsi), %xmm1
+-	movups	-85(%rsi), %xmm2
+-	movups	-69(%rsi), %xmm3
+-	movups	%xmm0, -117(%rcx)
+-	movups	%xmm1, -101(%rcx)
+-	movups	%xmm2, -85(%rcx)
+-	movups	%xmm3, -69(%rcx)
+-.LBB0_108:
+-	movups	-53(%rsi), %xmm0
+-	movups	-37(%rsi), %xmm1
+-	movups	%xmm0, -53(%rcx)
+-	movups	%xmm1, -37(%rcx)
+-.LBB0_44:
+-	movups	-21(%rsi), %xmm0
+-	movups	%xmm0, -21(%rcx)
+-.LBB0_12:
+-	movl	-5(%rsi), %edx
+-	movl	%edx, -5(%rcx)
+-	movb	-1(%rsi), %dl
+-	movb	%dl, -1(%rcx)
+-	retq
+-.LBB0_109:
+-	movups	-118(%rsi), %xmm0
+-	movups	-102(%rsi), %xmm1
+-	movups	-86(%rsi), %xmm2
+-	movups	-70(%rsi), %xmm3
+-	movups	%xmm0, -118(%rcx)
+-	movups	%xmm1, -102(%rcx)
+-	movups	%xmm2, -86(%rcx)
+-	movups	%xmm3, -70(%rcx)
+-.LBB0_110:
+-	movups	-54(%rsi), %xmm0
+-	movups	-38(%rsi), %xmm1
+-	movups	%xmm0, -54(%rcx)
+-	movups	%xmm1, -38(%rcx)
+-.LBB0_46:
+-	movups	-22(%rsi), %xmm0
+-	movups	%xmm0, -22(%rcx)
+-.LBB0_14:
+-	movl	-6(%rsi), %edx
+-	movl	%edx, -6(%rcx)
+-	movzwl	-2(%rsi), %edx
+-	movw	%dx, -2(%rcx)
+-	retq
+-.LBB0_111:
+-	movups	-119(%rsi), %xmm0
+-	movups	-103(%rsi), %xmm1
+-	movups	-87(%rsi), %xmm2
+-	movups	-71(%rsi), %xmm3
+-	movups	%xmm0, -119(%rcx)
+-	movups	%xmm1, -103(%rcx)
+-	movups	%xmm2, -87(%rcx)
+-	movups	%xmm3, -71(%rcx)
+-.LBB0_112:
+-	movups	-55(%rsi), %xmm0
+-	movups	-39(%rsi), %xmm1
+-	movups	%xmm0, -55(%rcx)
+-	movups	%xmm1, -39(%rcx)
+-.LBB0_48:
+-	movups	-23(%rsi), %xmm0
+-	movups	%xmm0, -23(%rcx)
+-.LBB0_16:
+-	movl	-7(%rsi), %edx
+-	movl	%edx, -7(%rcx)
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	retq
+-.LBB0_113:
+-	movups	-120(%rsi), %xmm0
+-	movups	-104(%rsi), %xmm1
+-	movups	-88(%rsi), %xmm2
+-	movups	-72(%rsi), %xmm3
+-	movups	%xmm0, -120(%rcx)
+-	movups	%xmm1, -104(%rcx)
+-	movups	%xmm2, -88(%rcx)
+-	movups	%xmm3, -72(%rcx)
+-.LBB0_114:
+-	movups	-56(%rsi), %xmm0
+-	movups	-40(%rsi), %xmm1
+-	movups	%xmm0, -56(%rcx)
+-	movups	%xmm1, -40(%rcx)
+-.LBB0_50:
+-	movups	-24(%rsi), %xmm0
+-	movups	%xmm0, -24(%rcx)
+-.LBB0_34:
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_115:
+-	movups	-121(%rsi), %xmm0
+-	movups	-105(%rsi), %xmm1
+-	movups	-89(%rsi), %xmm2
+-	movups	-73(%rsi), %xmm3
+-	movups	%xmm0, -121(%rcx)
+-	movups	%xmm1, -105(%rcx)
+-	movups	%xmm2, -89(%rcx)
+-	movups	%xmm3, -73(%rcx)
+-.LBB0_116:
+-	movups	-57(%rsi), %xmm0
+-	movups	-41(%rsi), %xmm1
+-	movups	%xmm0, -57(%rcx)
+-	movups	%xmm1, -41(%rcx)
+-.LBB0_52:
+-	movups	-25(%rsi), %xmm0
+-	movups	%xmm0, -25(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_117:
+-	movups	-122(%rsi), %xmm0
+-	movups	-106(%rsi), %xmm1
+-	movups	-90(%rsi), %xmm2
+-	movups	-74(%rsi), %xmm3
+-	movups	%xmm0, -122(%rcx)
+-	movups	%xmm1, -106(%rcx)
+-	movups	%xmm2, -90(%rcx)
+-	movups	%xmm3, -74(%rcx)
+-.LBB0_118:
+-	movups	-58(%rsi), %xmm0
+-	movups	-42(%rsi), %xmm1
+-	movups	%xmm0, -58(%rcx)
+-	movups	%xmm1, -42(%rcx)
+-.LBB0_54:
+-	movups	-26(%rsi), %xmm0
+-	movups	%xmm0, -26(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_119:
+-	movups	-123(%rsi), %xmm0
+-	movups	-107(%rsi), %xmm1
+-	movups	-91(%rsi), %xmm2
+-	movups	-75(%rsi), %xmm3
+-	movups	%xmm0, -123(%rcx)
+-	movups	%xmm1, -107(%rcx)
+-	movups	%xmm2, -91(%rcx)
+-	movups	%xmm3, -75(%rcx)
+-.LBB0_120:
+-	movups	-59(%rsi), %xmm0
+-	movups	-43(%rsi), %xmm1
+-	movups	%xmm0, -59(%rcx)
+-	movups	%xmm1, -43(%rcx)
+-.LBB0_56:
+-	movups	-27(%rsi), %xmm0
+-	movups	%xmm0, -27(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_121:
+-	movups	-124(%rsi), %xmm0
+-	movups	-108(%rsi), %xmm1
+-	movups	-92(%rsi), %xmm2
+-	movups	-76(%rsi), %xmm3
+-	movups	%xmm0, -124(%rcx)
+-	movups	%xmm1, -108(%rcx)
+-	movups	%xmm2, -92(%rcx)
+-	movups	%xmm3, -76(%rcx)
+-.LBB0_122:
+-	movups	-60(%rsi), %xmm0
+-	movups	-44(%rsi), %xmm1
+-	movups	%xmm0, -60(%rcx)
+-	movups	%xmm1, -44(%rcx)
+-.LBB0_58:
+-	movups	-28(%rsi), %xmm0
+-	movups	%xmm0, -28(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_123:
+-	movups	-125(%rsi), %xmm0
+-	movups	-109(%rsi), %xmm1
+-	movups	-93(%rsi), %xmm2
+-	movups	-77(%rsi), %xmm3
+-	movups	%xmm0, -125(%rcx)
+-	movups	%xmm1, -109(%rcx)
+-	movups	%xmm2, -93(%rcx)
+-	movups	%xmm3, -77(%rcx)
+-.LBB0_124:
+-	movups	-61(%rsi), %xmm0
+-	movups	-45(%rsi), %xmm1
+-	movups	%xmm0, -61(%rcx)
+-	movups	%xmm1, -45(%rcx)
+-.LBB0_60:
+-	movups	-29(%rsi), %xmm0
+-	movups	%xmm0, -29(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_125:
+-	movups	-126(%rsi), %xmm0
+-	movups	-110(%rsi), %xmm1
+-	movups	-94(%rsi), %xmm2
+-	movups	-78(%rsi), %xmm3
+-	movups	%xmm0, -126(%rcx)
+-	movups	%xmm1, -110(%rcx)
+-	movups	%xmm2, -94(%rcx)
+-	movups	%xmm3, -78(%rcx)
+-.LBB0_126:
+-	movups	-62(%rsi), %xmm0
+-	movups	-46(%rsi), %xmm1
+-	movups	%xmm0, -62(%rcx)
+-	movups	%xmm1, -46(%rcx)
+-.LBB0_62:
+-	movups	-30(%rsi), %xmm0
+-	movups	%xmm0, -30(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_127:
+-	movups	-127(%rsi), %xmm0
+-	movups	-111(%rsi), %xmm1
+-	movups	-95(%rsi), %xmm2
+-	movups	-79(%rsi), %xmm3
+-	movups	%xmm0, -127(%rcx)
+-	movups	%xmm1, -111(%rcx)
+-	movups	%xmm2, -95(%rcx)
+-	movups	%xmm3, -79(%rcx)
+-.LBB0_128:
+-	movups	-63(%rsi), %xmm0
+-	movups	-47(%rsi), %xmm1
+-	movups	%xmm0, -63(%rcx)
+-	movups	%xmm1, -47(%rcx)
+-.LBB0_64:
+-	movups	-31(%rsi), %xmm0
+-	movups	%xmm0, -31(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_144:
+-	movups	-128(%rsi), %xmm0
+-	movups	-112(%rsi), %xmm1
+-	movups	-96(%rsi), %xmm2
+-	movups	-80(%rsi), %xmm3
+-	movups	-64(%rsi), %xmm4
+-	movups	-48(%rsi), %xmm5
+-	movups	-32(%rsi), %xmm6
+-	movups	-16(%rsi), %xmm7
+-	movups	%xmm0, -128(%rcx)
+-	movups	%xmm1, -112(%rcx)
+-	movups	%xmm2, -96(%rcx)
+-	movups	%xmm3, -80(%rcx)
+-	movups	%xmm4, -64(%rcx)
+-	movups	%xmm5, -48(%rcx)
+-	movups	%xmm6, -32(%rcx)
+-	movups	%xmm7, -16(%rcx)
+-.LBB0_145:
+-	retq
+-.Lfunc_end0:
+-	.size	memcpy, .Lfunc_end0-memcpy
+-	.cfi_endproc
+-	.section	.rodata,"a",@progbits
+-	.p2align	2
+-.LJTI0_0:
+-	.long	.LBB0_4-.LJTI0_0
+-	.long	.LBB0_6-.LJTI0_0
+-	.long	.LBB0_8-.LJTI0_0
+-	.long	.LBB0_10-.LJTI0_0
+-	.long	.LBB0_12-.LJTI0_0
+-	.long	.LBB0_14-.LJTI0_0
+-	.long	.LBB0_16-.LJTI0_0
+-	.long	.LBB0_18-.LJTI0_0
+-	.long	.LBB0_20-.LJTI0_0
+-	.long	.LBB0_22-.LJTI0_0
+-	.long	.LBB0_24-.LJTI0_0
+-	.long	.LBB0_26-.LJTI0_0
+-	.long	.LBB0_28-.LJTI0_0
+-	.long	.LBB0_30-.LJTI0_0
+-	.long	.LBB0_32-.LJTI0_0
+-	.long	.LBB0_34-.LJTI0_0
+-	.long	.LBB0_36-.LJTI0_0
+-	.long	.LBB0_38-.LJTI0_0
+-	.long	.LBB0_40-.LJTI0_0
+-	.long	.LBB0_42-.LJTI0_0
+-	.long	.LBB0_44-.LJTI0_0
+-	.long	.LBB0_46-.LJTI0_0
+-	.long	.LBB0_48-.LJTI0_0
+-	.long	.LBB0_50-.LJTI0_0
+-	.long	.LBB0_52-.LJTI0_0
+-	.long	.LBB0_54-.LJTI0_0
+-	.long	.LBB0_56-.LJTI0_0
+-	.long	.LBB0_58-.LJTI0_0
+-	.long	.LBB0_60-.LJTI0_0
+-	.long	.LBB0_62-.LJTI0_0
+-	.long	.LBB0_64-.LJTI0_0
+-	.long	.LBB0_66-.LJTI0_0
+-	.long	.LBB0_68-.LJTI0_0
+-	.long	.LBB0_70-.LJTI0_0
+-	.long	.LBB0_72-.LJTI0_0
+-	.long	.LBB0_74-.LJTI0_0
+-	.long	.LBB0_76-.LJTI0_0
+-	.long	.LBB0_78-.LJTI0_0
+-	.long	.LBB0_80-.LJTI0_0
+-	.long	.LBB0_82-.LJTI0_0
+-	.long	.LBB0_84-.LJTI0_0
+-	.long	.LBB0_86-.LJTI0_0
+-	.long	.LBB0_88-.LJTI0_0
+-	.long	.LBB0_90-.LJTI0_0
+-	.long	.LBB0_92-.LJTI0_0
+-	.long	.LBB0_94-.LJTI0_0
+-	.long	.LBB0_96-.LJTI0_0
+-	.long	.LBB0_98-.LJTI0_0
+-	.long	.LBB0_100-.LJTI0_0
+-	.long	.LBB0_102-.LJTI0_0
+-	.long	.LBB0_104-.LJTI0_0
+-	.long	.LBB0_106-.LJTI0_0
+-	.long	.LBB0_108-.LJTI0_0
+-	.long	.LBB0_110-.LJTI0_0
+-	.long	.LBB0_112-.LJTI0_0
+-	.long	.LBB0_114-.LJTI0_0
+-	.long	.LBB0_116-.LJTI0_0
+-	.long	.LBB0_118-.LJTI0_0
+-	.long	.LBB0_120-.LJTI0_0
+-	.long	.LBB0_122-.LJTI0_0
+-	.long	.LBB0_124-.LJTI0_0
+-	.long	.LBB0_126-.LJTI0_0
+-	.long	.LBB0_128-.LJTI0_0
+-	.long	.LBB0_143-.LJTI0_0
+-	.long	.LBB0_3-.LJTI0_0
+-	.long	.LBB0_5-.LJTI0_0
+-	.long	.LBB0_7-.LJTI0_0
+-	.long	.LBB0_9-.LJTI0_0
+-	.long	.LBB0_11-.LJTI0_0
+-	.long	.LBB0_13-.LJTI0_0
+-	.long	.LBB0_15-.LJTI0_0
+-	.long	.LBB0_17-.LJTI0_0
+-	.long	.LBB0_19-.LJTI0_0
+-	.long	.LBB0_21-.LJTI0_0
+-	.long	.LBB0_23-.LJTI0_0
+-	.long	.LBB0_25-.LJTI0_0
+-	.long	.LBB0_27-.LJTI0_0
+-	.long	.LBB0_29-.LJTI0_0
+-	.long	.LBB0_31-.LJTI0_0
+-	.long	.LBB0_33-.LJTI0_0
+-	.long	.LBB0_35-.LJTI0_0
+-	.long	.LBB0_37-.LJTI0_0
+-	.long	.LBB0_39-.LJTI0_0
+-	.long	.LBB0_41-.LJTI0_0
+-	.long	.LBB0_43-.LJTI0_0
+-	.long	.LBB0_45-.LJTI0_0
+-	.long	.LBB0_47-.LJTI0_0
+-	.long	.LBB0_49-.LJTI0_0
+-	.long	.LBB0_51-.LJTI0_0
+-	.long	.LBB0_53-.LJTI0_0
+-	.long	.LBB0_55-.LJTI0_0
+-	.long	.LBB0_57-.LJTI0_0
+-	.long	.LBB0_59-.LJTI0_0
+-	.long	.LBB0_61-.LJTI0_0
+-	.long	.LBB0_63-.LJTI0_0
+-	.long	.LBB0_65-.LJTI0_0
+-	.long	.LBB0_67-.LJTI0_0
+-	.long	.LBB0_69-.LJTI0_0
+-	.long	.LBB0_71-.LJTI0_0
+-	.long	.LBB0_73-.LJTI0_0
+-	.long	.LBB0_75-.LJTI0_0
+-	.long	.LBB0_77-.LJTI0_0
+-	.long	.LBB0_79-.LJTI0_0
+-	.long	.LBB0_81-.LJTI0_0
+-	.long	.LBB0_83-.LJTI0_0
+-	.long	.LBB0_85-.LJTI0_0
+-	.long	.LBB0_87-.LJTI0_0
+-	.long	.LBB0_89-.LJTI0_0
+-	.long	.LBB0_91-.LJTI0_0
+-	.long	.LBB0_93-.LJTI0_0
+-	.long	.LBB0_95-.LJTI0_0
+-	.long	.LBB0_97-.LJTI0_0
+-	.long	.LBB0_99-.LJTI0_0
+-	.long	.LBB0_101-.LJTI0_0
+-	.long	.LBB0_103-.LJTI0_0
+-	.long	.LBB0_105-.LJTI0_0
+-	.long	.LBB0_107-.LJTI0_0
+-	.long	.LBB0_109-.LJTI0_0
+-	.long	.LBB0_111-.LJTI0_0
+-	.long	.LBB0_113-.LJTI0_0
+-	.long	.LBB0_115-.LJTI0_0
+-	.long	.LBB0_117-.LJTI0_0
+-	.long	.LBB0_119-.LJTI0_0
+-	.long	.LBB0_121-.LJTI0_0
+-	.long	.LBB0_123-.LJTI0_0
+-	.long	.LBB0_125-.LJTI0_0
+-	.long	.LBB0_127-.LJTI0_0
+-	.long	.LBB0_144-.LJTI0_0
+-.LJTI0_1:
+-	.long	.LBB0_4-.LJTI0_1
+-	.long	.LBB0_6-.LJTI0_1
+-	.long	.LBB0_8-.LJTI0_1
+-	.long	.LBB0_10-.LJTI0_1
+-	.long	.LBB0_12-.LJTI0_1
+-	.long	.LBB0_14-.LJTI0_1
+-	.long	.LBB0_16-.LJTI0_1
+-	.long	.LBB0_18-.LJTI0_1
+-	.long	.LBB0_20-.LJTI0_1
+-	.long	.LBB0_22-.LJTI0_1
+-	.long	.LBB0_24-.LJTI0_1
+-	.long	.LBB0_26-.LJTI0_1
+-	.long	.LBB0_28-.LJTI0_1
+-	.long	.LBB0_30-.LJTI0_1
+-	.long	.LBB0_32-.LJTI0_1
+-	.long	.LBB0_34-.LJTI0_1
+-	.long	.LBB0_36-.LJTI0_1
+-	.long	.LBB0_38-.LJTI0_1
+-	.long	.LBB0_40-.LJTI0_1
+-	.long	.LBB0_42-.LJTI0_1
+-	.long	.LBB0_44-.LJTI0_1
+-	.long	.LBB0_46-.LJTI0_1
+-	.long	.LBB0_48-.LJTI0_1
+-	.long	.LBB0_50-.LJTI0_1
+-	.long	.LBB0_52-.LJTI0_1
+-	.long	.LBB0_54-.LJTI0_1
+-	.long	.LBB0_56-.LJTI0_1
+-	.long	.LBB0_58-.LJTI0_1
+-	.long	.LBB0_60-.LJTI0_1
+-	.long	.LBB0_62-.LJTI0_1
+-	.long	.LBB0_64-.LJTI0_1
+-	.long	.LBB0_66-.LJTI0_1
+-	.long	.LBB0_68-.LJTI0_1
+-	.long	.LBB0_70-.LJTI0_1
+-	.long	.LBB0_72-.LJTI0_1
+-	.long	.LBB0_74-.LJTI0_1
+-	.long	.LBB0_76-.LJTI0_1
+-	.long	.LBB0_78-.LJTI0_1
+-	.long	.LBB0_80-.LJTI0_1
+-	.long	.LBB0_82-.LJTI0_1
+-	.long	.LBB0_84-.LJTI0_1
+-	.long	.LBB0_86-.LJTI0_1
+-	.long	.LBB0_88-.LJTI0_1
+-	.long	.LBB0_90-.LJTI0_1
+-	.long	.LBB0_92-.LJTI0_1
+-	.long	.LBB0_94-.LJTI0_1
+-	.long	.LBB0_96-.LJTI0_1
+-	.long	.LBB0_98-.LJTI0_1
+-	.long	.LBB0_100-.LJTI0_1
+-	.long	.LBB0_102-.LJTI0_1
+-	.long	.LBB0_104-.LJTI0_1
+-	.long	.LBB0_106-.LJTI0_1
+-	.long	.LBB0_108-.LJTI0_1
+-	.long	.LBB0_110-.LJTI0_1
+-	.long	.LBB0_112-.LJTI0_1
+-	.long	.LBB0_114-.LJTI0_1
+-	.long	.LBB0_116-.LJTI0_1
+-	.long	.LBB0_118-.LJTI0_1
+-	.long	.LBB0_120-.LJTI0_1
+-	.long	.LBB0_122-.LJTI0_1
+-	.long	.LBB0_124-.LJTI0_1
+-	.long	.LBB0_126-.LJTI0_1
+-	.long	.LBB0_128-.LJTI0_1
+-	.long	.LBB0_143-.LJTI0_1
+-	.long	.LBB0_3-.LJTI0_1
+-	.long	.LBB0_5-.LJTI0_1
+-	.long	.LBB0_7-.LJTI0_1
+-	.long	.LBB0_9-.LJTI0_1
+-	.long	.LBB0_11-.LJTI0_1
+-	.long	.LBB0_13-.LJTI0_1
+-	.long	.LBB0_15-.LJTI0_1
+-	.long	.LBB0_17-.LJTI0_1
+-	.long	.LBB0_19-.LJTI0_1
+-	.long	.LBB0_21-.LJTI0_1
+-	.long	.LBB0_23-.LJTI0_1
+-	.long	.LBB0_25-.LJTI0_1
+-	.long	.LBB0_27-.LJTI0_1
+-	.long	.LBB0_29-.LJTI0_1
+-	.long	.LBB0_31-.LJTI0_1
+-	.long	.LBB0_33-.LJTI0_1
+-	.long	.LBB0_35-.LJTI0_1
+-	.long	.LBB0_37-.LJTI0_1
+-	.long	.LBB0_39-.LJTI0_1
+-	.long	.LBB0_41-.LJTI0_1
+-	.long	.LBB0_43-.LJTI0_1
+-	.long	.LBB0_45-.LJTI0_1
+-	.long	.LBB0_47-.LJTI0_1
+-	.long	.LBB0_49-.LJTI0_1
+-	.long	.LBB0_51-.LJTI0_1
+-	.long	.LBB0_53-.LJTI0_1
+-	.long	.LBB0_55-.LJTI0_1
+-	.long	.LBB0_57-.LJTI0_1
+-	.long	.LBB0_59-.LJTI0_1
+-	.long	.LBB0_61-.LJTI0_1
+-	.long	.LBB0_63-.LJTI0_1
+-	.long	.LBB0_65-.LJTI0_1
+-	.long	.LBB0_67-.LJTI0_1
+-	.long	.LBB0_69-.LJTI0_1
+-	.long	.LBB0_71-.LJTI0_1
+-	.long	.LBB0_73-.LJTI0_1
+-	.long	.LBB0_75-.LJTI0_1
+-	.long	.LBB0_77-.LJTI0_1
+-	.long	.LBB0_79-.LJTI0_1
+-	.long	.LBB0_81-.LJTI0_1
+-	.long	.LBB0_83-.LJTI0_1
+-	.long	.LBB0_85-.LJTI0_1
+-	.long	.LBB0_87-.LJTI0_1
+-	.long	.LBB0_89-.LJTI0_1
+-	.long	.LBB0_91-.LJTI0_1
+-	.long	.LBB0_93-.LJTI0_1
+-	.long	.LBB0_95-.LJTI0_1
+-	.long	.LBB0_97-.LJTI0_1
+-	.long	.LBB0_99-.LJTI0_1
+-	.long	.LBB0_101-.LJTI0_1
+-	.long	.LBB0_103-.LJTI0_1
+-	.long	.LBB0_105-.LJTI0_1
+-	.long	.LBB0_107-.LJTI0_1
+-	.long	.LBB0_109-.LJTI0_1
+-	.long	.LBB0_111-.LJTI0_1
+-	.long	.LBB0_113-.LJTI0_1
+-	.long	.LBB0_115-.LJTI0_1
+-	.long	.LBB0_117-.LJTI0_1
+-	.long	.LBB0_119-.LJTI0_1
+-	.long	.LBB0_121-.LJTI0_1
+-	.long	.LBB0_123-.LJTI0_1
+-	.long	.LBB0_125-.LJTI0_1
+-	.long	.LBB0_127-.LJTI0_1
+-	.long	.LBB0_144-.LJTI0_1
+-                                        # -- End function
+diff --git a/libc/arch-x86_64/string/sse2-memmove-slm.S b/libc/arch-x86_64/string/sse2-memmove-slm.S
+deleted file mode 100644
+index 99a5173..0000000
+--- a/libc/arch-x86_64/string/sse2-memmove-slm.S
++++ /dev/null
+@@ -1,516 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-#include "cache.h"
+-
+-#ifndef MEMMOVE
+-# define MEMMOVE		memmove
+-#endif
+-
+-#ifndef L
+-# define L(label)	.L##label
+-#endif
+-
+-#ifndef cfi_startproc
+-# define cfi_startproc	.cfi_startproc
+-#endif
+-
+-#ifndef cfi_endproc
+-# define cfi_endproc	.cfi_endproc
+-#endif
+-
+-#ifndef cfi_rel_offset
+-# define cfi_rel_offset(reg, off)	.cfi_rel_offset reg, off
+-#endif
+-
+-#ifndef cfi_restore
+-# define cfi_restore(reg)	.cfi_restore reg
+-#endif
+-
+-#ifndef cfi_adjust_cfa_offset
+-# define cfi_adjust_cfa_offset(off)	.cfi_adjust_cfa_offset off
+-#endif
+-
+-#ifndef ENTRY
+-# define ENTRY(name)		\
+-	.type name,  @function;		\
+-	.globl name;		\
+-	.p2align 4;		\
+-name:		\
+-	cfi_startproc
+-#endif
+-
+-#ifndef ALIAS_SYMBOL
+-# define ALIAS_SYMBOL(alias, original) \
+-	.globl alias; \
+-	.equ alias, original
+-#endif
+-
+-#ifndef END
+-# define END(name)		\
+-	cfi_endproc;		\
+-	.size name, .-name
+-#endif
+-
+-#define CFI_PUSH(REG)		\
+-	cfi_adjust_cfa_offset (4);		\
+-	cfi_rel_offset (REG, 0)
+-
+-#define CFI_POP(REG)		\
+-	cfi_adjust_cfa_offset (-4);		\
+-	cfi_restore (REG)
+-
+-#define PUSH(REG)	push REG;
+-#define POP(REG)	pop REG;
+-
+-#define ENTRANCE	PUSH (%rbx);
+-#define RETURN_END	POP (%rbx); ret
+-#define RETURN		RETURN_END;
+-
+-	.section .text.sse2,"ax",@progbits
+-ENTRY (MEMMOVE)
+-	ENTRANCE
+-	mov	%rdi, %rax
+-
+-/* Check whether we should copy backward or forward.  */
+-	cmp	%rsi, %rdi
+-	je	L(mm_return)
+-	jg	L(mm_len_0_or_more_backward)
+-
+-/* Now do checks for lengths. We do [0..16], [0..32], [0..64], [0..128]
+-	separately.  */
+-	cmp	$16, %rdx
+-	jbe	L(mm_len_0_16_bytes_forward)
+-
+-	cmp	$32, %rdx
+-	ja	L(mm_len_32_or_more_forward)
+-
+-/* Copy [0..32] and return.  */
+-	movdqu	(%rsi), %xmm0
+-	movdqu	-16(%rsi, %rdx), %xmm1
+-	movdqu	%xmm0, (%rdi)
+-	movdqu	%xmm1, -16(%rdi, %rdx)
+-	jmp	L(mm_return)
+-
+-L(mm_len_32_or_more_forward):
+-	cmp	$64, %rdx
+-	ja	L(mm_len_64_or_more_forward)
+-
+-/* Copy [0..64] and return.  */
+-	movdqu	(%rsi), %xmm0
+-	movdqu	16(%rsi), %xmm1
+-	movdqu	-16(%rsi, %rdx), %xmm2
+-	movdqu	-32(%rsi, %rdx), %xmm3
+-	movdqu	%xmm0, (%rdi)
+-	movdqu	%xmm1, 16(%rdi)
+-	movdqu	%xmm2, -16(%rdi, %rdx)
+-	movdqu	%xmm3, -32(%rdi, %rdx)
+-	jmp	L(mm_return)
+-
+-L(mm_len_64_or_more_forward):
+-	cmp	$128, %rdx
+-	ja	L(mm_len_128_or_more_forward)
+-
+-/* Copy [0..128] and return.  */
+-	movdqu	(%rsi), %xmm0
+-	movdqu	16(%rsi), %xmm1
+-	movdqu	32(%rsi), %xmm2
+-	movdqu	48(%rsi), %xmm3
+-	movdqu	-64(%rsi, %rdx), %xmm4
+-	movdqu	-48(%rsi, %rdx), %xmm5
+-	movdqu	-32(%rsi, %rdx), %xmm6
+-	movdqu	-16(%rsi, %rdx), %xmm7
+-	movdqu	%xmm0, (%rdi)
+-	movdqu	%xmm1, 16(%rdi)
+-	movdqu	%xmm2, 32(%rdi)
+-	movdqu	%xmm3, 48(%rdi)
+-	movdqu	%xmm4, -64(%rdi, %rdx)
+-	movdqu	%xmm5, -48(%rdi, %rdx)
+-	movdqu	%xmm6, -32(%rdi, %rdx)
+-	movdqu	%xmm7, -16(%rdi, %rdx)
+-	jmp	L(mm_return)
+-
+-L(mm_len_128_or_more_forward):
+-/* Aligning the address of destination.  */
+-/*  save first unaligned 64 bytes */
+-	movdqu	(%rsi), %xmm0
+-	movdqu	16(%rsi), %xmm1
+-	movdqu	32(%rsi), %xmm2
+-	movdqu	48(%rsi), %xmm3
+-
+-	lea	64(%rdi), %r8
+-	and	$-64, %r8  /* r8 now aligned to next 64 byte boundary */
+-	sub	%rdi, %rsi /* rsi = src - dst = diff */
+-
+-	movdqu	(%r8, %rsi), %xmm4
+-	movdqu	16(%r8, %rsi), %xmm5
+-	movdqu	32(%r8, %rsi), %xmm6
+-	movdqu	48(%r8, %rsi), %xmm7
+-
+-	movdqu	%xmm0, (%rdi)
+-	movdqu	%xmm1, 16(%rdi)
+-	movdqu	%xmm2, 32(%rdi)
+-	movdqu	%xmm3, 48(%rdi)
+-	movdqa	%xmm4, (%r8)
+-	movaps	%xmm5, 16(%r8)
+-	movaps	%xmm6, 32(%r8)
+-	movaps	%xmm7, 48(%r8)
+-	add	$64, %r8
+-
+-	lea	(%rdi, %rdx), %rbx
+-	and	$-64, %rbx
+-	cmp	%r8, %rbx
+-	jbe	L(mm_copy_remaining_forward)
+-
+-	cmp	$SHARED_CACHE_SIZE_HALF, %rdx
+-	jae	L(mm_large_page_loop_forward)
+-
+-	.p2align 4
+-L(mm_main_loop_forward):
+-
+-	prefetcht0 128(%r8, %rsi)
+-
+-	movdqu	(%r8, %rsi), %xmm0
+-	movdqu	16(%r8, %rsi), %xmm1
+-	movdqu	32(%r8, %rsi), %xmm2
+-	movdqu	48(%r8, %rsi), %xmm3
+-	movdqa	%xmm0, (%r8)
+-	movaps	%xmm1, 16(%r8)
+-	movaps	%xmm2, 32(%r8)
+-	movaps	%xmm3, 48(%r8)
+-	lea	64(%r8), %r8
+-	cmp	%r8, %rbx
+-	ja	L(mm_main_loop_forward)
+-
+-L(mm_copy_remaining_forward):
+-	add	%rdi, %rdx
+-	sub	%r8, %rdx
+-/* We copied all up till %rdi position in the dst.
+-	In %rdx now is how many bytes are left to copy.
+-	Now we need to advance %r8. */
+-	lea	(%r8, %rsi), %r9
+-
+-L(mm_remaining_0_64_bytes_forward):
+-	cmp	$32, %rdx
+-	ja	L(mm_remaining_33_64_bytes_forward)
+-	cmp	$16, %rdx
+-	ja	L(mm_remaining_17_32_bytes_forward)
+-	test	%rdx, %rdx
+-	.p2align 4,,2
+-	je	L(mm_return)
+-
+-	cmpb	$8, %dl
+-	ja	L(mm_remaining_9_16_bytes_forward)
+-	cmpb	$4, %dl
+-	.p2align 4,,5
+-	ja	L(mm_remaining_5_8_bytes_forward)
+-	cmpb	$2, %dl
+-	.p2align 4,,1
+-	ja	L(mm_remaining_3_4_bytes_forward)
+-	movzbl	-1(%r9,%rdx), %esi
+-	movzbl	(%r9), %ebx
+-	movb	%sil, -1(%r8,%rdx)
+-	movb	%bl, (%r8)
+-	jmp	L(mm_return)
+-
+-L(mm_remaining_33_64_bytes_forward):
+-	movdqu	(%r9), %xmm0
+-	movdqu	16(%r9), %xmm1
+-	movdqu	-32(%r9, %rdx), %xmm2
+-	movdqu	-16(%r9, %rdx), %xmm3
+-	movdqu	%xmm0, (%r8)
+-	movdqu	%xmm1, 16(%r8)
+-	movdqu	%xmm2, -32(%r8, %rdx)
+-	movdqu	%xmm3, -16(%r8, %rdx)
+-	jmp	L(mm_return)
+-
+-L(mm_remaining_17_32_bytes_forward):
+-	movdqu	(%r9), %xmm0
+-	movdqu	-16(%r9, %rdx), %xmm1
+-	movdqu	%xmm0, (%r8)
+-	movdqu	%xmm1, -16(%r8, %rdx)
+-	jmp	L(mm_return)
+-
+-L(mm_remaining_5_8_bytes_forward):
+-	movl	(%r9), %esi
+-	movl	-4(%r9,%rdx), %ebx
+-	movl	%esi, (%r8)
+-	movl	%ebx, -4(%r8,%rdx)
+-	jmp	L(mm_return)
+-
+-L(mm_remaining_9_16_bytes_forward):
+-	mov	(%r9), %rsi
+-	mov	-8(%r9, %rdx), %rbx
+-	mov	%rsi, (%r8)
+-	mov	%rbx, -8(%r8, %rdx)
+-	jmp	L(mm_return)
+-
+-L(mm_remaining_3_4_bytes_forward):
+-	movzwl	-2(%r9,%rdx), %esi
+-	movzwl	(%r9), %ebx
+-	movw	%si, -2(%r8,%rdx)
+-	movw	%bx, (%r8)
+-	jmp	L(mm_return)
+-
+-L(mm_len_0_16_bytes_forward):
+-	testb	$24, %dl
+-	jne	L(mm_len_9_16_bytes_forward)
+-	testb	$4, %dl
+-	.p2align 4,,5
+-	jne	L(mm_len_5_8_bytes_forward)
+-	test	%rdx, %rdx
+-	.p2align 4,,2
+-	je	L(mm_return)
+-	testb	$2, %dl
+-	.p2align 4,,1
+-	jne	L(mm_len_2_4_bytes_forward)
+-	movzbl	-1(%rsi,%rdx), %ebx
+-	movzbl	(%rsi), %esi
+-	movb	%bl, -1(%rdi,%rdx)
+-	movb	%sil, (%rdi)
+-	jmp	L(mm_return)
+-
+-L(mm_len_2_4_bytes_forward):
+-	movzwl	-2(%rsi,%rdx), %ebx
+-	movzwl	(%rsi), %esi
+-	movw	%bx, -2(%rdi,%rdx)
+-	movw	%si, (%rdi)
+-	jmp	L(mm_return)
+-
+-L(mm_len_5_8_bytes_forward):
+-	movl	(%rsi), %ebx
+-	movl	-4(%rsi,%rdx), %esi
+-	movl	%ebx, (%rdi)
+-	movl	%esi, -4(%rdi,%rdx)
+-	jmp	L(mm_return)
+-
+-L(mm_len_9_16_bytes_forward):
+-	mov	(%rsi), %rbx
+-	mov	-8(%rsi, %rdx), %rsi
+-	mov	%rbx, (%rdi)
+-	mov	%rsi, -8(%rdi, %rdx)
+-	jmp	L(mm_return)
+-
+-L(mm_recalc_len):
+-/* Compute in %rdx how many bytes are left to copy after
+-	the main loop stops.  */
+-	mov 	%rbx, %rdx
+-	sub 	%rdi, %rdx
+-/* The code for copying backwards.  */
+-L(mm_len_0_or_more_backward):
+-
+-/* Now do checks for lengths. We do [0..16], [16..32], [32..64], [64..128]
+-	separately.  */
+-	cmp	$16, %rdx
+-	jbe	L(mm_len_0_16_bytes_backward)
+-
+-	cmp	$32, %rdx
+-	ja	L(mm_len_32_or_more_backward)
+-
+-/* Copy [0..32] and return.  */
+-	movdqu	(%rsi), %xmm0
+-	movdqu	-16(%rsi, %rdx), %xmm1
+-	movdqu	%xmm0, (%rdi)
+-	movdqu	%xmm1, -16(%rdi, %rdx)
+-	jmp	L(mm_return)
+-
+-L(mm_len_32_or_more_backward):
+-	cmp	$64, %rdx
+-	ja	L(mm_len_64_or_more_backward)
+-
+-/* Copy [0..64] and return.  */
+-	movdqu	(%rsi), %xmm0
+-	movdqu	16(%rsi), %xmm1
+-	movdqu	-16(%rsi, %rdx), %xmm2
+-	movdqu	-32(%rsi, %rdx), %xmm3
+-	movdqu	%xmm0, (%rdi)
+-	movdqu	%xmm1, 16(%rdi)
+-	movdqu	%xmm2, -16(%rdi, %rdx)
+-	movdqu	%xmm3, -32(%rdi, %rdx)
+-	jmp	L(mm_return)
+-
+-L(mm_len_64_or_more_backward):
+-	cmp	$128, %rdx
+-	ja	L(mm_len_128_or_more_backward)
+-
+-/* Copy [0..128] and return.  */
+-	movdqu	(%rsi), %xmm0
+-	movdqu	16(%rsi), %xmm1
+-	movdqu	32(%rsi), %xmm2
+-	movdqu	48(%rsi), %xmm3
+-	movdqu	-64(%rsi, %rdx), %xmm4
+-	movdqu	-48(%rsi, %rdx), %xmm5
+-	movdqu	-32(%rsi, %rdx), %xmm6
+-	movdqu	-16(%rsi, %rdx), %xmm7
+-	movdqu	%xmm0, (%rdi)
+-	movdqu	%xmm1, 16(%rdi)
+-	movdqu	%xmm2, 32(%rdi)
+-	movdqu	%xmm3, 48(%rdi)
+-	movdqu	%xmm4, -64(%rdi, %rdx)
+-	movdqu	%xmm5, -48(%rdi, %rdx)
+-	movdqu	%xmm6, -32(%rdi, %rdx)
+-	movdqu	%xmm7, -16(%rdi, %rdx)
+-	jmp	L(mm_return)
+-
+-L(mm_len_128_or_more_backward):
+-/* Aligning the address of destination. We need to save
+-	16 bits from the source in order not to overwrite them.  */
+-	movdqu	-16(%rsi, %rdx), %xmm0
+-	movdqu	-32(%rsi, %rdx), %xmm1
+-	movdqu	-48(%rsi, %rdx), %xmm2
+-	movdqu	-64(%rsi, %rdx), %xmm3
+-
+-	lea	(%rdi, %rdx), %r9
+-	and	$-64, %r9 /* r9 = aligned dst */
+-
+-	mov	%rsi, %r8
+-	sub	%rdi, %r8 /* r8 = src - dst, diff */
+-
+-	movdqu	-16(%r9, %r8), %xmm4
+-	movdqu	-32(%r9, %r8), %xmm5
+-	movdqu	-48(%r9, %r8), %xmm6
+-	movdqu	-64(%r9, %r8), %xmm7
+-
+-	movdqu	%xmm0, -16(%rdi, %rdx)
+-	movdqu	%xmm1, -32(%rdi, %rdx)
+-	movdqu	%xmm2, -48(%rdi, %rdx)
+-	movdqu	%xmm3, -64(%rdi, %rdx)
+-	movdqa	%xmm4, -16(%r9)
+-	movaps	%xmm5, -32(%r9)
+-	movaps	%xmm6, -48(%r9)
+-	movaps	%xmm7, -64(%r9)
+-	lea	-64(%r9), %r9
+-
+-	lea	64(%rdi), %rbx
+-	and	$-64, %rbx
+-
+-	cmp	%r9, %rbx
+-	jae	L(mm_recalc_len)
+-
+-	cmp	$SHARED_CACHE_SIZE_HALF, %rdx
+-	jae	L(mm_large_page_loop_backward)
+-
+-	.p2align 4
+-L(mm_main_loop_backward):
+-
+-	prefetcht0 -128(%r9, %r8)
+-
+-	movdqu	-64(%r9, %r8), %xmm0
+-	movdqu	-48(%r9, %r8), %xmm1
+-	movdqu	-32(%r9, %r8), %xmm2
+-	movdqu	-16(%r9, %r8), %xmm3
+-	movdqa	%xmm0, -64(%r9)
+-	movaps	%xmm1, -48(%r9)
+-	movaps	%xmm2, -32(%r9)
+-	movaps	%xmm3, -16(%r9)
+-	lea	-64(%r9), %r9
+-	cmp	%r9, %rbx
+-	jb	L(mm_main_loop_backward)
+-	jmp	L(mm_recalc_len)
+-
+-/* Copy [0..16] and return.  */
+-L(mm_len_0_16_bytes_backward):
+-	testb	$24, %dl
+-	jnz	L(mm_len_9_16_bytes_backward)
+-	testb	$4, %dl
+-	.p2align 4,,5
+-	jnz	L(mm_len_5_8_bytes_backward)
+-	test	%rdx, %rdx
+-	.p2align 4,,2
+-	je	L(mm_return)
+-	testb	$2, %dl
+-	.p2align 4,,1
+-	jne	L(mm_len_3_4_bytes_backward)
+-	movzbl	-1(%rsi,%rdx), %ebx
+-	movzbl	(%rsi), %ecx
+-	movb	%bl, -1(%rdi,%rdx)
+-	movb	%cl, (%rdi)
+-	jmp	L(mm_return)
+-
+-L(mm_len_3_4_bytes_backward):
+-	movzwl	-2(%rsi,%rdx), %ebx
+-	movzwl	(%rsi), %ecx
+-	movw	%bx, -2(%rdi,%rdx)
+-	movw	%cx, (%rdi)
+-	jmp	L(mm_return)
+-
+-L(mm_len_9_16_bytes_backward):
+-	movl	-4(%rsi,%rdx), %ebx
+-	movl	-8(%rsi,%rdx), %ecx
+-	movl	%ebx, -4(%rdi,%rdx)
+-	movl	%ecx, -8(%rdi,%rdx)
+-	sub	$8, %rdx
+-	jmp	L(mm_len_0_16_bytes_backward)
+-
+-L(mm_len_5_8_bytes_backward):
+-	movl	(%rsi), %ebx
+-	movl	-4(%rsi,%rdx), %ecx
+-	movl	%ebx, (%rdi)
+-	movl	%ecx, -4(%rdi,%rdx)
+-
+-L(mm_return):
+-	RETURN
+-
+-/* Big length copy forward part.  */
+-
+-	.p2align 4
+-L(mm_large_page_loop_forward):
+-	movdqu	(%r8, %rsi), %xmm0
+-	movdqu	16(%r8, %rsi), %xmm1
+-	movdqu	32(%r8, %rsi), %xmm2
+-	movdqu	48(%r8, %rsi), %xmm3
+-	movntdq	%xmm0, (%r8)
+-	movntdq	%xmm1, 16(%r8)
+-	movntdq	%xmm2, 32(%r8)
+-	movntdq	%xmm3, 48(%r8)
+-	lea 	64(%r8), %r8
+-	cmp	%r8, %rbx
+-	ja	L(mm_large_page_loop_forward)
+-	sfence
+-	jmp	L(mm_copy_remaining_forward)
+-
+-/* Big length copy backward part.  */
+-	.p2align 4
+-L(mm_large_page_loop_backward):
+-	movdqu	-64(%r9, %r8), %xmm0
+-	movdqu	-48(%r9, %r8), %xmm1
+-	movdqu	-32(%r9, %r8), %xmm2
+-	movdqu	-16(%r9, %r8), %xmm3
+-	movntdq	%xmm0, -64(%r9)
+-	movntdq	%xmm1, -48(%r9)
+-	movntdq	%xmm2, -32(%r9)
+-	movntdq	%xmm3, -16(%r9)
+-	lea 	-64(%r9), %r9
+-	cmp	%r9, %rbx
+-	jb	L(mm_large_page_loop_backward)
+-	sfence
+-	jmp	L(mm_recalc_len)
+-
+-END (MEMMOVE)
+diff --git a/libc/arch-x86_64/string/sse2-memset-slm.S b/libc/arch-x86_64/string/sse2-memset-slm.S
+deleted file mode 100644
+index fc502c0..0000000
+--- a/libc/arch-x86_64/string/sse2-memset-slm.S
++++ /dev/null
+@@ -1,149 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-#include <private/bionic_asm.h>
+-
+-#include "cache.h"
+-
+-#ifndef L
+-# define L(label)	.L##label
+-#endif
+-
+-#ifndef ALIGN
+-# define ALIGN(n)	.p2align n
+-#endif
+-
+-
+-ENTRY(__memset_chk)
+-  # %rdi = dst, %rsi = byte, %rdx = n, %rcx = dst_len
+-  cmp %rcx, %rdx
+-  ja __memset_chk_fail
+-  // Fall through to memset...
+-END(__memset_chk)
+-
+-
+-	.section .text.sse2,"ax",@progbits
+-ENTRY(memset)
+-	movq	%rdi, %rax
+-	and	$0xff, %rsi
+-	mov	$0x0101010101010101, %rcx
+-	imul	%rsi, %rcx
+-	cmpq	$16, %rdx
+-	jae	L(16bytesormore)
+-	testb	$8, %dl
+-	jnz	L(8_15bytes)
+-	testb	$4, %dl
+-	jnz	L(4_7bytes)
+-	testb	$2, %dl
+-	jnz	L(2_3bytes)
+-	testb	$1, %dl
+-	jz	L(return)
+-	movb	%cl, (%rdi)
+-L(return):
+-	ret
+-
+-L(8_15bytes):
+-	movq	%rcx, (%rdi)
+-	movq	%rcx, -8(%rdi, %rdx)
+-	ret
+-
+-L(4_7bytes):
+-	movl	%ecx, (%rdi)
+-	movl	%ecx, -4(%rdi, %rdx)
+-	ret
+-
+-L(2_3bytes):
+-	movw	%cx, (%rdi)
+-	movw	%cx, -2(%rdi, %rdx)
+-	ret
+-
+-	ALIGN (4)
+-L(16bytesormore):
+-	movd	%rcx, %xmm0
+-	pshufd	$0, %xmm0, %xmm0
+-	movdqu	%xmm0, (%rdi)
+-	movdqu	%xmm0, -16(%rdi, %rdx)
+-	cmpq	$32, %rdx
+-	jbe	L(32bytesless)
+-	movdqu	%xmm0, 16(%rdi)
+-	movdqu	%xmm0, -32(%rdi, %rdx)
+-	cmpq	$64, %rdx
+-	jbe	L(64bytesless)
+-	movdqu	%xmm0, 32(%rdi)
+-	movdqu	%xmm0, 48(%rdi)
+-	movdqu	%xmm0, -64(%rdi, %rdx)
+-	movdqu	%xmm0, -48(%rdi, %rdx)
+-	cmpq	$128, %rdx
+-	ja	L(128bytesmore)
+-L(32bytesless):
+-L(64bytesless):
+-	ret
+-
+-	ALIGN (4)
+-L(128bytesmore):
+-	leaq	64(%rdi), %rcx
+-	andq	$-64, %rcx
+-	movq	%rdx, %r8
+-	addq	%rdi, %rdx
+-	andq	$-64, %rdx
+-	cmpq	%rcx, %rdx
+-	je	L(return)
+-
+-#ifdef SHARED_CACHE_SIZE
+-	cmp	$SHARED_CACHE_SIZE, %r8
+-#else
+-	cmp	__x86_64_shared_cache_size(%rip), %r8
+-#endif
+-	ja	L(128bytesmore_nt)
+-
+-	ALIGN (4)
+-L(128bytesmore_normal):
+-	movdqa	%xmm0, (%rcx)
+-	movaps	%xmm0, 0x10(%rcx)
+-	movaps	%xmm0, 0x20(%rcx)
+-	movaps	%xmm0, 0x30(%rcx)
+-	addq	$64, %rcx
+-	cmpq	%rcx, %rdx
+-	jne	L(128bytesmore_normal)
+-	ret
+-
+-	ALIGN (4)
+-L(128bytesmore_nt):
+-	movntdq	%xmm0, (%rcx)
+-	movntdq	%xmm0, 0x10(%rcx)
+-	movntdq	%xmm0, 0x20(%rcx)
+-	movntdq	%xmm0, 0x30(%rcx)
+-	leaq	64(%rcx), %rcx
+-	cmpq	%rcx, %rdx
+-	jne	L(128bytesmore_nt)
+-	sfence
+-	ret
+-
+-END(memset)
+diff --git a/libc/arch-x86_64/string/sse2-stpcpy-slm.S b/libc/arch-x86_64/string/sse2-stpcpy-slm.S
+deleted file mode 100644
+index 0ad2d44..0000000
+--- a/libc/arch-x86_64/string/sse2-stpcpy-slm.S
++++ /dev/null
+@@ -1,33 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-#define USE_AS_STPCPY
+-#define STRCPY		stpcpy
+-#include "sse2-strcpy-slm.S"
+diff --git a/libc/arch-x86_64/string/sse2-stpncpy-slm.S b/libc/arch-x86_64/string/sse2-stpncpy-slm.S
+deleted file mode 100644
+index 3066685..0000000
+--- a/libc/arch-x86_64/string/sse2-stpncpy-slm.S
++++ /dev/null
+@@ -1,34 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-#define USE_AS_STRNCPY
+-#define USE_AS_STPCPY
+-#define STRCPY		stpncpy
+-#include "sse2-strcpy-slm.S"
+diff --git a/libc/arch-x86_64/string/sse2-strcat-slm.S b/libc/arch-x86_64/string/sse2-strcat-slm.S
+deleted file mode 100644
+index dd8207f..0000000
+--- a/libc/arch-x86_64/string/sse2-strcat-slm.S
++++ /dev/null
+@@ -1,87 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-#ifndef STRCAT
+-# define STRCAT		strcat
+-#endif
+-
+-#ifndef L
+-# define L(label)		.L##label
+-#endif
+-
+-#ifndef cfi_startproc
+-# define cfi_startproc		 .cfi_startproc
+-#endif
+-
+-#ifndef cfi_endproc
+-# define cfi_endproc		.cfi_endproc
+-#endif
+-
+-#ifndef ENTRY
+-# define ENTRY(name)		\
+-	.type name,  @function;		\
+-	.globl name;		\
+-	.p2align 4;		\
+-name:		\
+-	cfi_startproc
+-#endif
+-
+-#ifndef END
+-# define END(name)		\
+-	cfi_endproc;		\
+-	.size name, .-name
+-#endif
+-
+-#define USE_AS_STRCAT
+-
+-.text
+-ENTRY (STRCAT)
+-	mov	%rdi, %r9
+-#ifdef USE_AS_STRNCAT
+-	mov	%rdx, %r8
+-#endif
+-
+-#define RETURN jmp L(Strcpy)
+-#include "sse2-strlen-slm.S"
+-
+-#undef RETURN
+-#define RETURN ret
+-
+-L(Strcpy):
+-	lea	(%r9, %rax), %rdi
+-	mov	%rsi, %rcx
+-	mov	%r9, %rax	/* save result */
+-
+-#ifdef USE_AS_STRNCAT
+-	test	%r8, %r8
+-	jz	L(ExitZero)
+-# define USE_AS_STRNCPY
+-#endif
+-#include "sse2-strcpy-slm.S"
+diff --git a/libc/arch-x86_64/string/sse2-strcpy-slm.S b/libc/arch-x86_64/string/sse2-strcpy-slm.S
+deleted file mode 100644
+index 3e146bf..0000000
+--- a/libc/arch-x86_64/string/sse2-strcpy-slm.S
++++ /dev/null
+@@ -1,1921 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-#ifndef USE_AS_STRCAT
+-
+-# ifndef STRCPY
+-#  define STRCPY	strcpy
+-# endif
+-
+-# ifndef L
+-#  define L(label)	.L##label
+-# endif
+-
+-# ifndef cfi_startproc
+-#  define cfi_startproc	.cfi_startproc
+-# endif
+-
+-# ifndef cfi_endproc
+-#  define cfi_endproc	.cfi_endproc
+-# endif
+-
+-# ifndef ENTRY
+-#  define ENTRY(name)	\
+-	.type name, @function;	\
+-	.globl name;	\
+-	.p2align 4;	\
+-name:	\
+-	cfi_startproc
+-# endif
+-
+-# ifndef END
+-#  define END(name)	\
+-	cfi_endproc;	\
+-	.size name, .-name
+-# endif
+-
+-#endif
+-
+-#define JMPTBL(I, B)	I - B
+-#define BRANCH_TO_JMPTBL_ENTRY(TABLE, INDEX, SCALE)	\
+-	lea	TABLE(%rip), %r11;	\
+-	movslq	(%r11, INDEX, SCALE), %rcx;	\
+-	lea	(%r11, %rcx), %rcx;	\
+-	jmp	*%rcx
+-
+-#ifndef USE_AS_STRCAT
+-
+-# define RETURN ret
+-
+-.text
+-ENTRY (STRCPY)
+-# ifdef USE_AS_STRNCPY
+-	mov	%rdx, %r8
+-	test	%r8, %r8
+-	jz	L(ExitZero)
+-# endif
+-	mov	%rsi, %rcx
+-# ifndef USE_AS_STPCPY
+-	mov	%rdi, %rax      /* save result */
+-# endif
+-
+-#endif
+-	and	$63, %rcx
+-	cmp	$32, %rcx
+-	jbe	L(SourceStringAlignmentLess32)
+-
+-	and	$-16, %rsi
+-	and	$15, %rcx
+-	pxor	%xmm0, %xmm0
+-	pxor	%xmm1, %xmm1
+-
+-	pcmpeqb	(%rsi), %xmm1
+-	pmovmskb %xmm1, %rdx
+-	shr	%cl, %rdx
+-#ifdef USE_AS_STRNCPY
+-# if defined USE_AS_STPCPY || defined USE_AS_STRCAT
+-	mov	$16, %r10
+-	sub	%rcx, %r10
+-	cmp	%r10, %r8
+-# else
+-	mov	$17, %r10
+-	sub	%rcx, %r10
+-	cmp	%r10, %r8
+-# endif
+-	jbe	L(CopyFrom1To16BytesTailCase2OrCase3)
+-#endif
+-	test	%rdx, %rdx
+-	jnz	L(CopyFrom1To16BytesTail)
+-
+-	pcmpeqb	16(%rsi), %xmm0
+-	pmovmskb %xmm0, %rdx
+-#ifdef USE_AS_STRNCPY
+-	add	$16, %r10
+-	cmp	%r10, %r8
+-	jbe	L(CopyFrom1To32BytesCase2OrCase3)
+-#endif
+-	test	%rdx, %rdx
+-	jnz	L(CopyFrom1To32Bytes)
+-
+-	movdqu	(%rsi, %rcx), %xmm1   /* copy 16 bytes */
+-	movdqu	%xmm1, (%rdi)
+-
+-/* If source adress alignment != destination adress alignment */
+-	.p2align 4
+-L(Unalign16Both):
+-	sub	%rcx, %rdi
+-#ifdef USE_AS_STRNCPY
+-	add	%rcx, %r8
+-#endif
+-	mov	$16, %rcx
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movaps	16(%rsi, %rcx), %xmm2
+-	movdqu	%xmm1, (%rdi, %rcx)
+-	pcmpeqb	%xmm2, %xmm0
+-	pmovmskb %xmm0, %rdx
+-	add	$16, %rcx
+-#ifdef USE_AS_STRNCPY
+-	sub	$48, %r8
+-	jbe	L(CopyFrom1To16BytesCase2OrCase3)
+-#endif
+-	test	%rdx, %rdx
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	jnz	L(CopyFrom1To16BytesUnalignedXmm2)
+-#else
+-	jnz	L(CopyFrom1To16Bytes)
+-#endif
+-
+-	movaps	16(%rsi, %rcx), %xmm3
+-	movdqu	%xmm2, (%rdi, %rcx)
+-	pcmpeqb	%xmm3, %xmm0
+-	pmovmskb %xmm0, %rdx
+-	add	$16, %rcx
+-#ifdef USE_AS_STRNCPY
+-	sub	$16, %r8
+-	jbe	L(CopyFrom1To16BytesCase2OrCase3)
+-#endif
+-	test	%rdx, %rdx
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	jnz	L(CopyFrom1To16BytesUnalignedXmm3)
+-#else
+-	jnz	L(CopyFrom1To16Bytes)
+-#endif
+-
+-	movaps	16(%rsi, %rcx), %xmm4
+-	movdqu	%xmm3, (%rdi, %rcx)
+-	pcmpeqb	%xmm4, %xmm0
+-	pmovmskb %xmm0, %rdx
+-	add	$16, %rcx
+-#ifdef USE_AS_STRNCPY
+-	sub	$16, %r8
+-	jbe	L(CopyFrom1To16BytesCase2OrCase3)
+-#endif
+-	test	%rdx, %rdx
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	jnz	L(CopyFrom1To16BytesUnalignedXmm4)
+-#else
+-	jnz	L(CopyFrom1To16Bytes)
+-#endif
+-
+-	movaps	16(%rsi, %rcx), %xmm1
+-	movdqu	%xmm4, (%rdi, %rcx)
+-	pcmpeqb	%xmm1, %xmm0
+-	pmovmskb %xmm0, %rdx
+-	add	$16, %rcx
+-#ifdef USE_AS_STRNCPY
+-	sub	$16, %r8
+-	jbe	L(CopyFrom1To16BytesCase2OrCase3)
+-#endif
+-	test	%rdx, %rdx
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	jnz	L(CopyFrom1To16BytesUnalignedXmm1)
+-#else
+-	jnz	L(CopyFrom1To16Bytes)
+-#endif
+-
+-	movaps	16(%rsi, %rcx), %xmm2
+-	movdqu	%xmm1, (%rdi, %rcx)
+-	pcmpeqb	%xmm2, %xmm0
+-	pmovmskb %xmm0, %rdx
+-	add	$16, %rcx
+-#ifdef USE_AS_STRNCPY
+-	sub	$16, %r8
+-	jbe	L(CopyFrom1To16BytesCase2OrCase3)
+-#endif
+-	test	%rdx, %rdx
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	jnz	L(CopyFrom1To16BytesUnalignedXmm2)
+-#else
+-	jnz	L(CopyFrom1To16Bytes)
+-#endif
+-
+-	movaps	16(%rsi, %rcx), %xmm3
+-	movdqu	%xmm2, (%rdi, %rcx)
+-	pcmpeqb	%xmm3, %xmm0
+-	pmovmskb %xmm0, %rdx
+-	add	$16, %rcx
+-#ifdef USE_AS_STRNCPY
+-	sub	$16, %r8
+-	jbe	L(CopyFrom1To16BytesCase2OrCase3)
+-#endif
+-	test	%rdx, %rdx
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	jnz	L(CopyFrom1To16BytesUnalignedXmm3)
+-#else
+-	jnz	L(CopyFrom1To16Bytes)
+-#endif
+-
+-	movdqu	%xmm3, (%rdi, %rcx)
+-	mov	%rsi, %rdx
+-	lea	16(%rsi, %rcx), %rsi
+-	and	$-0x40, %rsi
+-	sub	%rsi, %rdx
+-	sub	%rdx, %rdi
+-#ifdef USE_AS_STRNCPY
+-	lea	128(%r8, %rdx), %r8
+-#endif
+-L(Unaligned64Loop):
+-	movaps	(%rsi), %xmm2
+-	movaps	%xmm2, %xmm4
+-	movaps	16(%rsi), %xmm5
+-	movaps	32(%rsi), %xmm3
+-	movaps	%xmm3, %xmm6
+-	movaps	48(%rsi), %xmm7
+-	pminub	%xmm5, %xmm2
+-	pminub	%xmm7, %xmm3
+-	pminub	%xmm2, %xmm3
+-	pcmpeqb	%xmm0, %xmm3
+-	pmovmskb %xmm3, %rdx
+-#ifdef USE_AS_STRNCPY
+-	sub	$64, %r8
+-	jbe	L(UnalignedLeaveCase2OrCase3)
+-#endif
+-	test	%rdx, %rdx
+-	jnz	L(Unaligned64Leave)
+-
+-L(Unaligned64Loop_start):
+-	add	$64, %rdi
+-	add	$64, %rsi
+-	movdqu	%xmm4, -64(%rdi)
+-	movaps	(%rsi), %xmm2
+-	movdqa	%xmm2, %xmm4
+-	movdqu	%xmm5, -48(%rdi)
+-	movaps	16(%rsi), %xmm5
+-	pminub	%xmm5, %xmm2
+-	movaps	32(%rsi), %xmm3
+-	movdqu	%xmm6, -32(%rdi)
+-	movaps	%xmm3, %xmm6
+-	movdqu	%xmm7, -16(%rdi)
+-	movaps	48(%rsi), %xmm7
+-	pminub	%xmm7, %xmm3
+-	pminub	%xmm2, %xmm3
+-	pcmpeqb	%xmm0, %xmm3
+-	pmovmskb %xmm3, %rdx
+-#ifdef USE_AS_STRNCPY
+-	sub	$64, %r8
+-	jbe	L(UnalignedLeaveCase2OrCase3)
+-#endif
+-	test	%rdx, %rdx
+-	jz	L(Unaligned64Loop_start)
+-
+-L(Unaligned64Leave):
+-	pxor	%xmm1, %xmm1
+-
+-	pcmpeqb	%xmm4, %xmm0
+-	pcmpeqb	%xmm5, %xmm1
+-	pmovmskb %xmm0, %rdx
+-	pmovmskb %xmm1, %rcx
+-	test	%rdx, %rdx
+-	jnz	L(CopyFrom1To16BytesUnaligned_0)
+-	test	%rcx, %rcx
+-	jnz	L(CopyFrom1To16BytesUnaligned_16)
+-
+-	pcmpeqb	%xmm6, %xmm0
+-	pcmpeqb	%xmm7, %xmm1
+-	pmovmskb %xmm0, %rdx
+-	pmovmskb %xmm1, %rcx
+-	test	%rdx, %rdx
+-	jnz	L(CopyFrom1To16BytesUnaligned_32)
+-
+-	bsf	%rcx, %rdx
+-	movdqu	%xmm4, (%rdi)
+-	movdqu	%xmm5, 16(%rdi)
+-	movdqu	%xmm6, 32(%rdi)
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-# ifdef USE_AS_STPCPY
+-	lea	48(%rdi, %rdx), %rax
+-# endif
+-	movdqu	%xmm7, 48(%rdi)
+-	add	$15, %r8
+-	sub	%rdx, %r8
+-	lea	49(%rdi, %rdx), %rdi
+-	jmp	L(StrncpyFillTailWithZero)
+-#else
+-	add	$48, %rsi
+-	add	$48, %rdi
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
+-#endif
+-
+-/* If source adress alignment == destination adress alignment */
+-
+-L(SourceStringAlignmentLess32):
+-	pxor	%xmm0, %xmm0
+-	movdqu	(%rsi), %xmm1
+-	movdqu	16(%rsi), %xmm2
+-	pcmpeqb	%xmm1, %xmm0
+-	pmovmskb %xmm0, %rdx
+-
+-#ifdef USE_AS_STRNCPY
+-# if defined USE_AS_STPCPY || defined USE_AS_STRCAT
+-	cmp	$16, %r8
+-# else
+-	cmp	$17, %r8
+-# endif
+-	jbe	L(CopyFrom1To16BytesTail1Case2OrCase3)
+-#endif
+-	test	%rdx, %rdx
+-	jnz	L(CopyFrom1To16BytesTail1)
+-
+-	pcmpeqb	%xmm2, %xmm0
+-	movdqu	%xmm1, (%rdi)
+-	pmovmskb %xmm0, %rdx
+-
+-#ifdef USE_AS_STRNCPY
+-# if defined USE_AS_STPCPY || defined USE_AS_STRCAT
+-	cmp	$32, %r8
+-# else
+-	cmp	$33, %r8
+-# endif
+-	jbe	L(CopyFrom1To32Bytes1Case2OrCase3)
+-#endif
+-	test	%rdx, %rdx
+-	jnz	L(CopyFrom1To32Bytes1)
+-
+-	and	$15, %rcx
+-	and	$-16, %rsi
+-
+-	jmp	L(Unalign16Both)
+-
+-/*------End of main part with loops---------------------*/
+-
+-/* Case1 */
+-
+-#if (!defined USE_AS_STRNCPY) || (defined USE_AS_STRCAT)
+-	.p2align 4
+-L(CopyFrom1To16Bytes):
+-	add	%rcx, %rdi
+-	add	%rcx, %rsi
+-	bsf	%rdx, %rdx
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
+-#endif
+-	.p2align 4
+-L(CopyFrom1To16BytesTail):
+-	add	%rcx, %rsi
+-	bsf	%rdx, %rdx
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
+-
+-	.p2align 4
+-L(CopyFrom1To32Bytes1):
+-	add	$16, %rsi
+-	add	$16, %rdi
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$16, %r8
+-#endif
+-L(CopyFrom1To16BytesTail1):
+-	bsf	%rdx, %rdx
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
+-
+-	.p2align 4
+-L(CopyFrom1To32Bytes):
+-	bsf	%rdx, %rdx
+-	add	%rcx, %rsi
+-	add	$16, %rdx
+-	sub	%rcx, %rdx
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
+-
+-	.p2align 4
+-L(CopyFrom1To16BytesUnaligned_0):
+-	bsf	%rdx, %rdx
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-# ifdef USE_AS_STPCPY
+-	lea	(%rdi, %rdx), %rax
+-# endif
+-	movdqu	%xmm4, (%rdi)
+-	add	$63, %r8
+-	sub	%rdx, %r8
+-	lea	1(%rdi, %rdx), %rdi
+-	jmp	L(StrncpyFillTailWithZero)
+-#else
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
+-#endif
+-
+-	.p2align 4
+-L(CopyFrom1To16BytesUnaligned_16):
+-	bsf	%rcx, %rdx
+-	movdqu	%xmm4, (%rdi)
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-# ifdef USE_AS_STPCPY
+-	lea	16(%rdi, %rdx), %rax
+-# endif
+-	movdqu	%xmm5, 16(%rdi)
+-	add	$47, %r8
+-	sub	%rdx, %r8
+-	lea	17(%rdi, %rdx), %rdi
+-	jmp	L(StrncpyFillTailWithZero)
+-#else
+-	add	$16, %rsi
+-	add	$16, %rdi
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
+-#endif
+-
+-	.p2align 4
+-L(CopyFrom1To16BytesUnaligned_32):
+-	bsf	%rdx, %rdx
+-	movdqu	%xmm4, (%rdi)
+-	movdqu	%xmm5, 16(%rdi)
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-# ifdef USE_AS_STPCPY
+-	lea	32(%rdi, %rdx), %rax
+-# endif
+-	movdqu	%xmm6, 32(%rdi)
+-	add	$31, %r8
+-	sub	%rdx, %r8
+-	lea	33(%rdi, %rdx), %rdi
+-	jmp	L(StrncpyFillTailWithZero)
+-#else
+-	add	$32, %rsi
+-	add	$32, %rdi
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
+-#endif
+-
+-#ifdef USE_AS_STRNCPY
+-# ifndef USE_AS_STRCAT 
+-	.p2align 4
+-L(CopyFrom1To16BytesUnalignedXmm6):
+-	movdqu	%xmm6, (%rdi, %rcx)
+-	jmp	L(CopyFrom1To16BytesXmmExit)
+-
+-	.p2align 4
+-L(CopyFrom1To16BytesUnalignedXmm5):
+-	movdqu	%xmm5, (%rdi, %rcx)
+-	jmp	L(CopyFrom1To16BytesXmmExit)
+-
+-	.p2align 4
+-L(CopyFrom1To16BytesUnalignedXmm4):
+-	movdqu	%xmm4, (%rdi, %rcx)
+-	jmp	L(CopyFrom1To16BytesXmmExit)
+-
+-	.p2align 4
+-L(CopyFrom1To16BytesUnalignedXmm3):
+-	movdqu	%xmm3, (%rdi, %rcx)
+-	jmp	L(CopyFrom1To16BytesXmmExit)
+-
+-	.p2align 4
+-L(CopyFrom1To16BytesUnalignedXmm1):
+-	movdqu	%xmm1, (%rdi, %rcx)
+-	jmp	L(CopyFrom1To16BytesXmmExit)
+-# endif
+-
+-	.p2align 4
+-L(CopyFrom1To16BytesExit):
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitTable), %rdx, 4)
+-
+-/* Case2 */
+-
+-	.p2align 4
+-L(CopyFrom1To16BytesCase2):
+-	add	$16, %r8
+-	add	%rcx, %rdi
+-	add	%rcx, %rsi
+-	bsf	%rdx, %rdx
+-	cmp	%r8, %rdx
+-	jb	L(CopyFrom1To16BytesExit)
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
+-
+-	.p2align 4
+-L(CopyFrom1To32BytesCase2):
+-	add	%rcx, %rsi
+-	bsf	%rdx, %rdx
+-	add	$16, %rdx
+-	sub	%rcx, %rdx
+-	cmp	%r8, %rdx
+-	jb	L(CopyFrom1To16BytesExit)
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
+-
+-L(CopyFrom1To16BytesTailCase2):
+-	add	%rcx, %rsi
+-	bsf	%rdx, %rdx
+-	cmp	%r8, %rdx
+-	jb	L(CopyFrom1To16BytesExit)
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
+-
+-L(CopyFrom1To16BytesTail1Case2):
+-	bsf	%rdx, %rdx
+-	cmp	%r8, %rdx
+-	jb	L(CopyFrom1To16BytesExit)
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
+-
+-/* Case2 or Case3,  Case3 */
+-
+-	.p2align 4
+-L(CopyFrom1To16BytesCase2OrCase3):
+-	test	%rdx, %rdx
+-	jnz	L(CopyFrom1To16BytesCase2)
+-L(CopyFrom1To16BytesCase3):
+-	add	$16, %r8
+-	add	%rcx, %rdi
+-	add	%rcx, %rsi
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
+-
+-	.p2align 4
+-L(CopyFrom1To32BytesCase2OrCase3):
+-	test	%rdx, %rdx
+-	jnz	L(CopyFrom1To32BytesCase2)
+-	add	%rcx, %rsi
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
+-
+-	.p2align 4
+-L(CopyFrom1To16BytesTailCase2OrCase3):
+-	test	%rdx, %rdx
+-	jnz	L(CopyFrom1To16BytesTailCase2)
+-	add	%rcx, %rsi
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
+-
+-	.p2align 4
+-L(CopyFrom1To32Bytes1Case2OrCase3):
+-	add	$16, %rdi
+-	add	$16, %rsi
+-	sub	$16, %r8
+-L(CopyFrom1To16BytesTail1Case2OrCase3):
+-	test	%rdx, %rdx
+-	jnz	L(CopyFrom1To16BytesTail1Case2)
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
+-
+-#endif
+-
+-/*------------End labels regarding with copying 1-16 bytes--and 1-32 bytes----*/
+-
+-	.p2align 4
+-L(Exit1):
+-	mov	%dh, (%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$1, %r8
+-	lea	1(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit2):
+-	mov	(%rsi), %dx
+-	mov	%dx, (%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	1(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$2, %r8
+-	lea	2(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit3):
+-	mov	(%rsi), %cx
+-	mov	%cx, (%rdi)
+-	mov	%dh, 2(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	2(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$3, %r8
+-	lea	3(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit4):
+-	mov	(%rsi), %edx
+-	mov	%edx, (%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	3(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$4, %r8
+-	lea	4(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit5):
+-	mov	(%rsi), %ecx
+-	mov	%dh, 4(%rdi)
+-	mov	%ecx, (%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	4(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$5, %r8
+-	lea	5(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit6):
+-	mov	(%rsi), %ecx
+-	mov	4(%rsi), %dx
+-	mov	%ecx, (%rdi)
+-	mov	%dx, 4(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	5(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$6, %r8
+-	lea	6(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit7):
+-	mov	(%rsi), %ecx
+-	mov	3(%rsi), %edx
+-	mov	%ecx, (%rdi)
+-	mov	%edx, 3(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	6(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$7, %r8
+-	lea	7(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit8):
+-	mov	(%rsi), %rdx
+-	mov	%rdx, (%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	7(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$8, %r8
+-	lea	8(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit9):
+-	mov	(%rsi), %rcx
+-	mov	%dh, 8(%rdi)
+-	mov	%rcx, (%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	8(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$9, %r8
+-	lea	9(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit10):
+-	mov	(%rsi), %rcx
+-	mov	8(%rsi), %dx
+-	mov	%rcx, (%rdi)
+-	mov	%dx, 8(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	9(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$10, %r8
+-	lea	10(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit11):
+-	mov	(%rsi), %rcx
+-	mov	7(%rsi), %edx
+-	mov	%rcx, (%rdi)
+-	mov	%edx, 7(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	10(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$11, %r8
+-	lea	11(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit12):
+-	mov	(%rsi), %rcx
+-	mov	8(%rsi), %edx
+-	mov	%rcx, (%rdi)
+-	mov	%edx, 8(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	11(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$12, %r8
+-	lea	12(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit13):
+-	mov	(%rsi), %rcx
+-	mov	5(%rsi), %rdx
+-	mov	%rcx, (%rdi)
+-	mov	%rdx, 5(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	12(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$13, %r8
+-	lea	13(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit14):
+-	mov	(%rsi), %rcx
+-	mov	6(%rsi), %rdx
+-	mov	%rcx, (%rdi)
+-	mov	%rdx, 6(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	13(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$14, %r8
+-	lea	14(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit15):
+-	mov	(%rsi), %rcx
+-	mov	7(%rsi), %rdx
+-	mov	%rcx, (%rdi)
+-	mov	%rdx, 7(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	14(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$15, %r8
+-	lea	15(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit16):
+-	movdqu	(%rsi), %xmm0
+-	movdqu	%xmm0, (%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	15(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$16, %r8
+-	lea	16(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit17):
+-	movdqu	(%rsi), %xmm0
+-	movdqu	%xmm0, (%rdi)
+-	mov	%dh, 16(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	16(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$17, %r8
+-	lea	17(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit18):
+-	movdqu	(%rsi), %xmm0
+-	mov	16(%rsi), %cx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%cx, 16(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	17(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$18, %r8
+-	lea	18(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit19):
+-	movdqu	(%rsi), %xmm0
+-	mov	15(%rsi), %ecx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%ecx, 15(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	18(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$19, %r8
+-	lea	19(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit20):
+-	movdqu	(%rsi), %xmm0
+-	mov	16(%rsi), %ecx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%ecx, 16(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	19(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$20, %r8
+-	lea	20(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit21):
+-	movdqu	(%rsi), %xmm0
+-	mov	16(%rsi), %ecx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%ecx, 16(%rdi)
+-	mov	%dh, 20(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	20(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$21, %r8
+-	lea	21(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit22):
+-	movdqu	(%rsi), %xmm0
+-	mov	14(%rsi), %rcx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%rcx, 14(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	21(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$22, %r8
+-	lea	22(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit23):
+-	movdqu	(%rsi), %xmm0
+-	mov	15(%rsi), %rcx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%rcx, 15(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	22(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$23, %r8
+-	lea	23(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit24):
+-	movdqu	(%rsi), %xmm0
+-	mov	16(%rsi), %rcx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%rcx, 16(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	23(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$24, %r8
+-	lea	24(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit25):
+-	movdqu	(%rsi), %xmm0
+-	mov	16(%rsi), %rcx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%rcx, 16(%rdi)
+-	mov	%dh, 24(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	24(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$25, %r8
+-	lea	25(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit26):
+-	movdqu	(%rsi), %xmm0
+-	mov	16(%rsi), %rdx
+-	mov	24(%rsi), %cx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%rdx, 16(%rdi)
+-	mov	%cx, 24(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	25(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$26, %r8
+-	lea	26(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit27):
+-	movdqu	(%rsi), %xmm0
+-	mov	16(%rsi), %rdx
+-	mov	23(%rsi), %ecx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%rdx, 16(%rdi)
+-	mov	%ecx, 23(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	26(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$27, %r8
+-	lea	27(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit28):
+-	movdqu	(%rsi), %xmm0
+-	mov	16(%rsi), %rdx
+-	mov	24(%rsi), %ecx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%rdx, 16(%rdi)
+-	mov	%ecx, 24(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	27(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$28, %r8
+-	lea	28(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit29):
+-	movdqu	(%rsi), %xmm0
+-	movdqu	13(%rsi), %xmm2
+-	movdqu	%xmm0, (%rdi)
+-	movdqu	%xmm2, 13(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	28(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$29, %r8
+-	lea	29(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit30):
+-	movdqu	(%rsi), %xmm0
+-	movdqu	14(%rsi), %xmm2
+-	movdqu	%xmm0, (%rdi)
+-	movdqu	%xmm2, 14(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	29(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$30, %r8
+-	lea	30(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit31):
+-	movdqu	(%rsi), %xmm0
+-	movdqu	15(%rsi), %xmm2
+-	movdqu	%xmm0, (%rdi)
+-	movdqu	%xmm2, 15(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	30(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$31, %r8
+-	lea	31(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Exit32):
+-	movdqu	(%rsi), %xmm0
+-	movdqu	16(%rsi), %xmm2
+-	movdqu	%xmm0, (%rdi)
+-	movdqu	%xmm2, 16(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	31(%rdi), %rax
+-#endif
+-#if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
+-	sub	$32, %r8
+-	lea	32(%rdi), %rdi
+-	jnz	L(StrncpyFillTailWithZero)
+-#endif
+-	RETURN
+-
+-#ifdef USE_AS_STRNCPY
+-
+-	.p2align 4
+-L(StrncpyExit0):
+-#ifdef USE_AS_STPCPY
+-	mov	%rdi, %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, (%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit1):
+-	mov	(%rsi), %dl
+-	mov	%dl, (%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	1(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 1(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit2):
+-	mov	(%rsi), %dx
+-	mov	%dx, (%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	2(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 2(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit3):
+-	mov	(%rsi), %cx
+-	mov	2(%rsi), %dl
+-	mov	%cx, (%rdi)
+-	mov	%dl, 2(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	3(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 3(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit4):
+-	mov	(%rsi), %edx
+-	mov	%edx, (%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	4(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 4(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit5):
+-	mov	(%rsi), %ecx
+-	mov	4(%rsi), %dl
+-	mov	%ecx, (%rdi)
+-	mov	%dl, 4(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	5(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 5(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit6):
+-	mov	(%rsi), %ecx
+-	mov	4(%rsi), %dx
+-	mov	%ecx, (%rdi)
+-	mov	%dx, 4(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	6(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 6(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit7):
+-	mov	(%rsi), %ecx
+-	mov	3(%rsi), %edx
+-	mov	%ecx, (%rdi)
+-	mov	%edx, 3(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	7(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 7(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit8):
+-	mov	(%rsi), %rdx
+-	mov	%rdx, (%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	8(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 8(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit9):
+-	mov	(%rsi), %rcx
+-	mov	8(%rsi), %dl
+-	mov	%rcx, (%rdi)
+-	mov	%dl, 8(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	9(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 9(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit10):
+-	mov	(%rsi), %rcx
+-	mov	8(%rsi), %dx
+-	mov	%rcx, (%rdi)
+-	mov	%dx, 8(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	10(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 10(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit11):
+-	mov	(%rsi), %rcx
+-	mov	7(%rsi), %edx
+-	mov	%rcx, (%rdi)
+-	mov	%edx, 7(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	11(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 11(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit12):
+-	mov	(%rsi), %rcx
+-	mov	8(%rsi), %edx
+-	mov	%rcx, (%rdi)
+-	mov	%edx, 8(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	12(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 12(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit13):
+-	mov	(%rsi), %rcx
+-	mov	5(%rsi), %rdx
+-	mov	%rcx, (%rdi)
+-	mov	%rdx, 5(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	13(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 13(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit14):
+-	mov	(%rsi), %rcx
+-	mov	6(%rsi), %rdx
+-	mov	%rcx, (%rdi)
+-	mov	%rdx, 6(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	14(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 14(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit15):
+-	mov	(%rsi), %rcx
+-	mov	7(%rsi), %rdx
+-	mov	%rcx, (%rdi)
+-	mov	%rdx, 7(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	15(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 15(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit16):
+-	movdqu	(%rsi), %xmm0
+-	movdqu	%xmm0, (%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	16(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 16(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit17):
+-	movdqu	(%rsi), %xmm0
+-	mov	16(%rsi), %cl
+-	movdqu	%xmm0, (%rdi)
+-	mov	%cl, 16(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	17(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 17(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit18):
+-	movdqu	(%rsi), %xmm0
+-	mov	16(%rsi), %cx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%cx, 16(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	18(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 18(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit19):
+-	movdqu	(%rsi), %xmm0
+-	mov	15(%rsi), %ecx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%ecx, 15(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	19(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 19(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit20):
+-	movdqu	(%rsi), %xmm0
+-	mov	16(%rsi), %ecx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%ecx, 16(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	20(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 20(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit21):
+-	movdqu	(%rsi), %xmm0
+-	mov	16(%rsi), %ecx
+-	mov	20(%rsi), %dl
+-	movdqu	%xmm0, (%rdi)
+-	mov	%ecx, 16(%rdi)
+-	mov	%dl, 20(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	21(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 21(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit22):
+-	movdqu	(%rsi), %xmm0
+-	mov	14(%rsi), %rcx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%rcx, 14(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	22(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 22(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit23):
+-	movdqu	(%rsi), %xmm0
+-	mov	15(%rsi), %rcx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%rcx, 15(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	23(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 23(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit24):
+-	movdqu	(%rsi), %xmm0
+-	mov	16(%rsi), %rcx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%rcx, 16(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	24(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 24(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit25):
+-	movdqu	(%rsi), %xmm0
+-	mov	16(%rsi), %rdx
+-	mov	24(%rsi), %cl
+-	movdqu	%xmm0, (%rdi)
+-	mov	%rdx, 16(%rdi)
+-	mov	%cl, 24(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	25(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 25(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit26):
+-	movdqu	(%rsi), %xmm0
+-	mov	16(%rsi), %rdx
+-	mov	24(%rsi), %cx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%rdx, 16(%rdi)
+-	mov	%cx, 24(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	26(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 26(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit27):
+-	movdqu	(%rsi), %xmm0
+-	mov	16(%rsi), %rdx
+-	mov	23(%rsi), %ecx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%rdx, 16(%rdi)
+-	mov	%ecx, 23(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	27(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 27(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit28):
+-	movdqu	(%rsi), %xmm0
+-	mov	16(%rsi), %rdx
+-	mov	24(%rsi), %ecx
+-	movdqu	%xmm0, (%rdi)
+-	mov	%rdx, 16(%rdi)
+-	mov	%ecx, 24(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	28(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 28(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit29):
+-	movdqu	(%rsi), %xmm0
+-	movdqu	13(%rsi), %xmm2
+-	movdqu	%xmm0, (%rdi)
+-	movdqu	%xmm2, 13(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	29(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 29(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit30):
+-	movdqu	(%rsi), %xmm0
+-	movdqu	14(%rsi), %xmm2
+-	movdqu	%xmm0, (%rdi)
+-	movdqu	%xmm2, 14(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	30(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 30(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit31):
+-	movdqu	(%rsi), %xmm0
+-	movdqu	15(%rsi), %xmm2
+-	movdqu	%xmm0, (%rdi)
+-	movdqu	%xmm2, 15(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	31(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 31(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit32):
+-	movdqu	(%rsi), %xmm0
+-	movdqu	16(%rsi), %xmm2
+-	movdqu	%xmm0, (%rdi)
+-	movdqu	%xmm2, 16(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	32(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 32(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(StrncpyExit33):
+-	movdqu	(%rsi), %xmm0
+-	movdqu	16(%rsi), %xmm2
+-	mov	32(%rsi), %cl
+-	movdqu	%xmm0, (%rdi)
+-	movdqu	%xmm2, 16(%rdi)
+-	mov	%cl, 32(%rdi)
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 33(%rdi)
+-#endif
+-	RETURN
+-
+-#ifndef USE_AS_STRCAT
+-
+-	.p2align 4
+-L(Fill0):
+-	RETURN
+-
+-	.p2align 4
+-L(Fill1):
+-	mov	%dl, (%rdi)
+-	RETURN
+-
+-	.p2align 4
+-L(Fill2):
+-	mov	%dx, (%rdi)
+-	RETURN
+-
+-	.p2align 4
+-L(Fill3):
+-	mov	%edx, -1(%rdi)
+-	RETURN
+-
+-	.p2align 4
+-L(Fill4):
+-	mov	%edx, (%rdi)
+-	RETURN
+-
+-	.p2align 4
+-L(Fill5):
+-	mov	%edx, (%rdi)
+-	mov	%dl, 4(%rdi)
+-	RETURN
+-
+-	.p2align 4
+-L(Fill6):
+-	mov	%edx, (%rdi)
+-	mov	%dx, 4(%rdi)
+-	RETURN
+-
+-	.p2align 4
+-L(Fill7):
+-	mov	%rdx, -1(%rdi)
+-	RETURN
+-
+-	.p2align 4
+-L(Fill8):
+-	mov	%rdx, (%rdi)
+-	RETURN
+-
+-	.p2align 4
+-L(Fill9):
+-	mov	%rdx, (%rdi)
+-	mov	%dl, 8(%rdi)
+-	RETURN
+-
+-	.p2align 4
+-L(Fill10):
+-	mov	%rdx, (%rdi)
+-	mov	%dx, 8(%rdi)
+-	RETURN
+-
+-	.p2align 4
+-L(Fill11):
+-	mov	%rdx, (%rdi)
+-	mov	%edx, 7(%rdi)
+-	RETURN
+-
+-	.p2align 4
+-L(Fill12):
+-	mov	%rdx, (%rdi)
+-	mov	%edx, 8(%rdi)
+-	RETURN
+-
+-	.p2align 4
+-L(Fill13):
+-	mov	%rdx, (%rdi)
+-	mov	%rdx, 5(%rdi)
+-	RETURN
+-
+-	.p2align 4
+-L(Fill14):
+-	mov	%rdx, (%rdi)
+-	mov	%rdx, 6(%rdi)
+-	RETURN
+-
+-	.p2align 4
+-L(Fill15):
+-	movdqu	%xmm0, -1(%rdi)
+-	RETURN
+-
+-	.p2align 4
+-L(Fill16):
+-	movdqu	%xmm0, (%rdi)
+-	RETURN
+-
+-	.p2align 4
+-L(CopyFrom1To16BytesUnalignedXmm2):
+-	movdqu	%xmm2, (%rdi, %rcx)
+-
+-	.p2align 4
+-L(CopyFrom1To16BytesXmmExit):
+-	bsf	%rdx, %rdx
+-	add	$15, %r8
+-	add	%rcx, %rdi
+-#ifdef USE_AS_STPCPY
+-	lea	(%rdi, %rdx), %rax
+-#endif
+-	sub	%rdx, %r8
+-	lea	1(%rdi, %rdx), %rdi
+-
+-	.p2align 4
+-L(StrncpyFillTailWithZero):
+-	pxor	%xmm0, %xmm0
+-	xor	%rdx, %rdx
+-	sub	$16, %r8
+-	jbe	L(StrncpyFillExit)
+-
+-	movdqu	%xmm0, (%rdi)
+-	add	$16, %rdi
+-
+-	mov	%rdi, %rsi
+-	and	$0xf, %rsi
+-	sub	%rsi, %rdi
+-	add	%rsi, %r8
+-	sub	$64, %r8
+-	jb	L(StrncpyFillLess64)
+-
+-L(StrncpyFillLoopMovdqa):
+-	movdqa	%xmm0, (%rdi)
+-	movdqa	%xmm0, 16(%rdi)
+-	movdqa	%xmm0, 32(%rdi)
+-	movdqa	%xmm0, 48(%rdi)
+-	add	$64, %rdi
+-	sub	$64, %r8
+-	jae	L(StrncpyFillLoopMovdqa)
+-
+-L(StrncpyFillLess64):
+-	add	$32, %r8
+-	jl	L(StrncpyFillLess32)
+-	movdqa	%xmm0, (%rdi)
+-	movdqa	%xmm0, 16(%rdi)
+-	add	$32, %rdi
+-	sub	$16, %r8
+-	jl	L(StrncpyFillExit)
+-	movdqa	%xmm0, (%rdi)
+-	add	$16, %rdi
+-	BRANCH_TO_JMPTBL_ENTRY (L(FillTable), %r8, 4)
+-
+-L(StrncpyFillLess32):
+-	add	$16, %r8
+-	jl	L(StrncpyFillExit)
+-	movdqa	%xmm0, (%rdi)
+-	add	$16, %rdi
+-	BRANCH_TO_JMPTBL_ENTRY (L(FillTable), %r8, 4)
+-
+-L(StrncpyFillExit):
+-	add	$16, %r8
+-	BRANCH_TO_JMPTBL_ENTRY (L(FillTable), %r8, 4)
+-
+-/* end of ifndef USE_AS_STRCAT */
+-#endif
+-
+-	.p2align 4
+-L(UnalignedLeaveCase2OrCase3):
+-	test	%rdx, %rdx
+-	jnz	L(Unaligned64LeaveCase2)
+-L(Unaligned64LeaveCase3):
+-	lea	64(%r8), %rcx
+-	and	$-16, %rcx
+-	add	$48, %r8
+-	jl	L(CopyFrom1To16BytesCase3)
+-	movdqu	%xmm4, (%rdi)
+-	sub	$16, %r8
+-	jb	L(CopyFrom1To16BytesCase3)
+-	movdqu	%xmm5, 16(%rdi)
+-	sub	$16, %r8
+-	jb	L(CopyFrom1To16BytesCase3)
+-	movdqu	%xmm6, 32(%rdi)
+-	sub	$16, %r8
+-	jb	L(CopyFrom1To16BytesCase3)
+-	movdqu	%xmm7, 48(%rdi)
+-#ifdef USE_AS_STPCPY
+-	lea	64(%rdi), %rax
+-#endif
+-#ifdef USE_AS_STRCAT
+-	xor	%ch, %ch
+-	movb	%ch, 64(%rdi)
+-#endif
+-	RETURN
+-
+-	.p2align 4
+-L(Unaligned64LeaveCase2):
+-	xor	%rcx, %rcx
+-	pcmpeqb	%xmm4, %xmm0
+-	pmovmskb %xmm0, %rdx
+-	add	$48, %r8
+-	jle	L(CopyFrom1To16BytesCase2OrCase3)
+-	test	%rdx, %rdx
+-#ifndef USE_AS_STRCAT
+-	jnz	L(CopyFrom1To16BytesUnalignedXmm4)
+-#else
+-	jnz	L(CopyFrom1To16Bytes)
+-#endif
+-	pcmpeqb	%xmm5, %xmm0
+-	pmovmskb %xmm0, %rdx
+-	movdqu	%xmm4, (%rdi)
+-	add	$16, %rcx
+-	sub	$16, %r8
+-	jbe	L(CopyFrom1To16BytesCase2OrCase3)
+-	test	%rdx, %rdx
+-#ifndef USE_AS_STRCAT
+-	jnz	L(CopyFrom1To16BytesUnalignedXmm5)
+-#else
+-	jnz	L(CopyFrom1To16Bytes)
+-#endif
+-
+-	pcmpeqb	%xmm6, %xmm0
+-	pmovmskb %xmm0, %rdx
+-	movdqu	%xmm5, 16(%rdi)
+-	add	$16, %rcx
+-	sub	$16, %r8
+-	jbe	L(CopyFrom1To16BytesCase2OrCase3)
+-	test	%rdx, %rdx
+-#ifndef USE_AS_STRCAT
+-	jnz	L(CopyFrom1To16BytesUnalignedXmm6)
+-#else
+-	jnz	L(CopyFrom1To16Bytes)
+-#endif
+-
+-	pcmpeqb	%xmm7, %xmm0
+-	pmovmskb %xmm0, %rdx
+-	movdqu	%xmm6, 32(%rdi)
+-	lea	16(%rdi, %rcx), %rdi
+-	lea	16(%rsi, %rcx), %rsi
+-	bsf	%rdx, %rdx
+-	cmp	%r8, %rdx
+-	jb	L(CopyFrom1To16BytesExit)
+-	BRANCH_TO_JMPTBL_ENTRY (L(ExitStrncpyTable), %r8, 4)
+-
+-	.p2align 4
+-L(ExitZero):
+-#ifndef USE_AS_STRCAT
+-	mov	%rdi, %rax
+-#endif
+-	RETURN
+-
+-#endif
+-
+-#ifndef USE_AS_STRCAT
+-END (STRCPY)
+-#else
+-END (STRCAT)
+-#endif
+-	.p2align 4
+-	.section .rodata
+-L(ExitTable):
+-	.int	JMPTBL(L(Exit1), L(ExitTable))
+-	.int	JMPTBL(L(Exit2), L(ExitTable))
+-	.int	JMPTBL(L(Exit3), L(ExitTable))
+-	.int	JMPTBL(L(Exit4), L(ExitTable))
+-	.int	JMPTBL(L(Exit5), L(ExitTable))
+-	.int	JMPTBL(L(Exit6), L(ExitTable))
+-	.int	JMPTBL(L(Exit7), L(ExitTable))
+-	.int	JMPTBL(L(Exit8), L(ExitTable))
+-	.int	JMPTBL(L(Exit9), L(ExitTable))
+-	.int	JMPTBL(L(Exit10), L(ExitTable))
+-	.int	JMPTBL(L(Exit11), L(ExitTable))
+-	.int	JMPTBL(L(Exit12), L(ExitTable))
+-	.int	JMPTBL(L(Exit13), L(ExitTable))
+-	.int	JMPTBL(L(Exit14), L(ExitTable))
+-	.int	JMPTBL(L(Exit15), L(ExitTable))
+-	.int	JMPTBL(L(Exit16), L(ExitTable))
+-	.int	JMPTBL(L(Exit17), L(ExitTable))
+-	.int	JMPTBL(L(Exit18), L(ExitTable))
+-	.int	JMPTBL(L(Exit19), L(ExitTable))
+-	.int	JMPTBL(L(Exit20), L(ExitTable))
+-	.int	JMPTBL(L(Exit21), L(ExitTable))
+-	.int	JMPTBL(L(Exit22), L(ExitTable))
+-	.int	JMPTBL(L(Exit23), L(ExitTable))
+-	.int	JMPTBL(L(Exit24), L(ExitTable))
+-	.int	JMPTBL(L(Exit25), L(ExitTable))
+-	.int	JMPTBL(L(Exit26), L(ExitTable))
+-	.int	JMPTBL(L(Exit27), L(ExitTable))
+-	.int	JMPTBL(L(Exit28), L(ExitTable))
+-	.int	JMPTBL(L(Exit29), L(ExitTable))
+-	.int	JMPTBL(L(Exit30), L(ExitTable))
+-	.int	JMPTBL(L(Exit31), L(ExitTable))
+-	.int	JMPTBL(L(Exit32), L(ExitTable))
+-#ifdef USE_AS_STRNCPY
+-L(ExitStrncpyTable):
+-	.int	JMPTBL(L(StrncpyExit0), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit1), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit2), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit3), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit4), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit5), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit6), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit7), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit8), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit9), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit10), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit11), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit12), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit13), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit14), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit15), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit16), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit17), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit18), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit19), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit20), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit21), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit22), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit23), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit24), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit25), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit26), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit27), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit28), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit29), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit30), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit31), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit32), L(ExitStrncpyTable))
+-	.int	JMPTBL(L(StrncpyExit33), L(ExitStrncpyTable))
+-# ifndef USE_AS_STRCAT
+-	.p2align 4
+-L(FillTable):
+-	.int	JMPTBL(L(Fill0), L(FillTable))
+-	.int	JMPTBL(L(Fill1), L(FillTable))
+-	.int	JMPTBL(L(Fill2), L(FillTable))
+-	.int	JMPTBL(L(Fill3), L(FillTable))
+-	.int	JMPTBL(L(Fill4), L(FillTable))
+-	.int	JMPTBL(L(Fill5), L(FillTable))
+-	.int	JMPTBL(L(Fill6), L(FillTable))
+-	.int	JMPTBL(L(Fill7), L(FillTable))
+-	.int	JMPTBL(L(Fill8), L(FillTable))
+-	.int	JMPTBL(L(Fill9), L(FillTable))
+-	.int	JMPTBL(L(Fill10), L(FillTable))
+-	.int	JMPTBL(L(Fill11), L(FillTable))
+-	.int	JMPTBL(L(Fill12), L(FillTable))
+-	.int	JMPTBL(L(Fill13), L(FillTable))
+-	.int	JMPTBL(L(Fill14), L(FillTable))
+-	.int	JMPTBL(L(Fill15), L(FillTable))
+-	.int	JMPTBL(L(Fill16), L(FillTable))
+-# endif
+-#endif
+diff --git a/libc/arch-x86_64/string/sse2-strlen-slm.S b/libc/arch-x86_64/string/sse2-strlen-slm.S
+deleted file mode 100644
+index 3772fe7..0000000
+--- a/libc/arch-x86_64/string/sse2-strlen-slm.S
++++ /dev/null
+@@ -1,294 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-#ifndef USE_AS_STRCAT
+-
+-#ifndef STRLEN
+-# define STRLEN		strlen
+-#endif
+-
+-#ifndef L
+-# define L(label)	.L##label
+-#endif
+-
+-#ifndef cfi_startproc
+-# define cfi_startproc			.cfi_startproc
+-#endif
+-
+-#ifndef cfi_endproc
+-# define cfi_endproc			.cfi_endproc
+-#endif
+-
+-#ifndef ENTRY
+-# define ENTRY(name)			\
+-	.type name,  @function; 	\
+-	.globl name;			\
+-	.p2align 4;			\
+-name:					\
+-	cfi_startproc
+-#endif
+-
+-#ifndef END
+-# define END(name)			\
+-	cfi_endproc;			\
+-	.size name, .-name
+-#endif
+-#define RETURN ret
+-	.section .text.sse2,"ax",@progbits
+-ENTRY (STRLEN)
+-/* end ifndef USE_AS_STRCAT */
+-#endif
+-	xor	%rax, %rax
+-	mov	%edi, %ecx
+-	and	$0x3f, %ecx
+-	pxor	%xmm0, %xmm0
+-	cmp	$0x30, %ecx
+-	ja	L(next)
+-	movdqu	(%rdi), %xmm1
+-	pcmpeqb	%xmm1, %xmm0
+-	pmovmskb %xmm0, %edx
+-	test	%edx, %edx
+-	jnz	L(exit_less16)
+-	mov	%rdi, %rax
+-	and	$-16, %rax
+-	jmp	L(align16_start)
+-L(next):
+-	mov	%rdi, %rax
+-	and	$-16, %rax
+-	pcmpeqb	(%rax), %xmm0
+-	mov	$-1, %r10d
+-	sub	%rax, %rcx
+-	shl	%cl, %r10d
+-	pmovmskb %xmm0, %edx
+-	and	%r10d, %edx
+-	jnz	L(exit)
+-L(align16_start):
+-	pxor	%xmm0, %xmm0
+-	pxor	%xmm1, %xmm1
+-	pxor	%xmm2, %xmm2
+-	pxor	%xmm3, %xmm3
+-	pcmpeqb	16(%rax), %xmm0
+-	pmovmskb %xmm0, %edx
+-	test	%edx, %edx
+-	jnz	L(exit16)
+-
+-	pcmpeqb	32(%rax), %xmm1
+-	pmovmskb %xmm1, %edx
+-	test	%edx, %edx
+-	jnz	L(exit32)
+-
+-	pcmpeqb	48(%rax), %xmm2
+-	pmovmskb %xmm2, %edx
+-	test	%edx, %edx
+-	jnz	L(exit48)
+-
+-	pcmpeqb	64(%rax), %xmm3
+-	pmovmskb %xmm3, %edx
+-	test	%edx, %edx
+-	jnz	L(exit64)
+-
+-	pcmpeqb	80(%rax), %xmm0
+-	add	$64, %rax
+-	pmovmskb %xmm0, %edx
+-	test	%edx, %edx
+-	jnz	L(exit16)
+-
+-	pcmpeqb	32(%rax), %xmm1
+-	pmovmskb %xmm1, %edx
+-	test	%edx, %edx
+-	jnz	L(exit32)
+-
+-	pcmpeqb	48(%rax), %xmm2
+-	pmovmskb %xmm2, %edx
+-	test	%edx, %edx
+-	jnz	L(exit48)
+-
+-	pcmpeqb	64(%rax), %xmm3
+-	pmovmskb %xmm3, %edx
+-	test	%edx, %edx
+-	jnz	L(exit64)
+-
+-	pcmpeqb	80(%rax), %xmm0
+-	add	$64, %rax
+-	pmovmskb %xmm0, %edx
+-	test	%edx, %edx
+-	jnz	L(exit16)
+-
+-	pcmpeqb	32(%rax), %xmm1
+-	pmovmskb %xmm1, %edx
+-	test	%edx, %edx
+-	jnz	L(exit32)
+-
+-	pcmpeqb	48(%rax), %xmm2
+-	pmovmskb %xmm2, %edx
+-	test	%edx, %edx
+-	jnz	L(exit48)
+-
+-	pcmpeqb	64(%rax), %xmm3
+-	pmovmskb %xmm3, %edx
+-	test	%edx, %edx
+-	jnz	L(exit64)
+-	
+-	pcmpeqb	80(%rax), %xmm0
+-	add	$64, %rax
+-	pmovmskb %xmm0, %edx
+-	test	%edx, %edx
+-	jnz	L(exit16)
+-
+-	pcmpeqb	32(%rax), %xmm1
+-	pmovmskb %xmm1, %edx
+-	test	%edx, %edx
+-	jnz	L(exit32)
+-
+-	pcmpeqb	48(%rax), %xmm2
+-	pmovmskb %xmm2, %edx
+-	test	%edx, %edx
+-	jnz	L(exit48)
+-
+-	pcmpeqb	64(%rax), %xmm3
+-	pmovmskb %xmm3, %edx
+-	test	%edx, %edx
+-	jnz	L(exit64)
+-	
+-
+-	test	$0x3f, %rax
+-	jz	L(align64_loop)
+-
+-	pcmpeqb	80(%rax), %xmm0
+-	add	$80, %rax
+-	pmovmskb %xmm0, %edx
+-	test	%edx, %edx
+-	jnz	L(exit)
+-
+-	test	$0x3f, %rax
+-	jz	L(align64_loop)
+-
+-	pcmpeqb	16(%rax), %xmm1
+-	add	$16, %rax
+-	pmovmskb %xmm1, %edx
+-	test	%edx, %edx
+-	jnz	L(exit)
+-
+-	test	$0x3f, %rax
+-	jz	L(align64_loop)
+-
+-	pcmpeqb	16(%rax), %xmm2
+-	add	$16, %rax
+-	pmovmskb %xmm2, %edx
+-	test	%edx, %edx
+-	jnz	L(exit)
+-
+-	test	$0x3f, %rax
+-	jz	L(align64_loop)
+-
+-	pcmpeqb	16(%rax), %xmm3
+-	add	$16, %rax
+-	pmovmskb %xmm3, %edx
+-	test	%edx, %edx
+-	jnz	L(exit)
+-
+-	add	$16, %rax
+-	.p2align 4
+-	L(align64_loop):
+-	movaps	(%rax),	%xmm4
+-	pminub	16(%rax), 	%xmm4
+-	movaps	32(%rax), 	%xmm5
+-	pminub	48(%rax), 	%xmm5
+-	add	$64, 	%rax
+-	pminub	%xmm4,	%xmm5
+-	pcmpeqb	%xmm0,	%xmm5
+-	pmovmskb %xmm5,	%edx
+-	test	%edx,	%edx
+-	jz	L(align64_loop)
+-
+-
+-	pcmpeqb	-64(%rax), %xmm0
+-	sub	$80, 	%rax
+-	pmovmskb %xmm0, %edx
+-	test	%edx, %edx
+-	jnz	L(exit16)
+-
+-	pcmpeqb	32(%rax), %xmm1
+-	pmovmskb %xmm1, %edx
+-	test	%edx, %edx
+-	jnz	L(exit32)
+-
+-	pcmpeqb	48(%rax), %xmm2
+-	pmovmskb %xmm2, %edx
+-	test	%edx, %edx
+-	jnz	L(exit48)
+-
+-	pcmpeqb	64(%rax), %xmm3
+-	pmovmskb %xmm3, %edx
+-	sub	%rdi, %rax
+-	bsf	%rdx, %rdx
+-	add	%rdx, %rax
+-	add	$64, %rax
+-	RETURN
+-
+-	.p2align 4
+-L(exit):
+-	sub	%rdi, %rax
+-L(exit_less16):
+-	bsf	%rdx, %rdx
+-	add	%rdx, %rax
+-	RETURN
+-	.p2align 4
+-L(exit16):
+-	sub	%rdi, %rax
+-	bsf	%rdx, %rdx
+-	add	%rdx, %rax
+-	add	$16, %rax
+-	RETURN
+-	.p2align 4
+-L(exit32):
+-	sub	%rdi, %rax
+-	bsf	%rdx, %rdx
+-	add	%rdx, %rax
+-	add	$32, %rax
+-	RETURN
+-	.p2align 4
+-L(exit48):
+-	sub	%rdi, %rax
+-	bsf	%rdx, %rdx
+-	add	%rdx, %rax
+-	add	$48, %rax
+-	RETURN
+-	.p2align 4
+-L(exit64):
+-	sub	%rdi, %rax
+-	bsf	%rdx, %rdx
+-	add	%rdx, %rax
+-	add	$64, %rax
+-#ifndef USE_AS_STRCAT
+-	RETURN
+-
+-END (STRLEN)
+-#endif
+diff --git a/libc/arch-x86_64/string/sse2-strncat-slm.S b/libc/arch-x86_64/string/sse2-strncat-slm.S
+deleted file mode 100644
+index 6b4a430..0000000
+--- a/libc/arch-x86_64/string/sse2-strncat-slm.S
++++ /dev/null
+@@ -1,33 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-#define USE_AS_STRNCAT
+-#define STRCAT		strncat
+-#include "sse2-strcat-slm.S"
+diff --git a/libc/arch-x86_64/string/sse2-strncpy-slm.S b/libc/arch-x86_64/string/sse2-strncpy-slm.S
+deleted file mode 100644
+index 594e78f..0000000
+--- a/libc/arch-x86_64/string/sse2-strncpy-slm.S
++++ /dev/null
+@@ -1,33 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-#define USE_AS_STRNCPY
+-#define STRCPY		strncpy
+-#include "sse2-strcpy-slm.S"
+diff --git a/libc/arch-x86_64/string/sse4-memcmp-slm.S b/libc/arch-x86_64/string/sse4-memcmp-slm.S
+deleted file mode 100644
+index 8a8b180..0000000
+--- a/libc/arch-x86_64/string/sse4-memcmp-slm.S
++++ /dev/null
+@@ -1,1799 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-#include "cache.h"
+-
+-#ifndef MEMCMP
+-# define MEMCMP		memcmp
+-#endif
+-
+-#ifndef L
+-# define L(label)	.L##label
+-#endif
+-
+-#ifndef ALIGN
+-# define ALIGN(n)	.p2align n
+-#endif
+-
+-#ifndef cfi_startproc
+-# define cfi_startproc			.cfi_startproc
+-#endif
+-
+-#ifndef cfi_endproc
+-# define cfi_endproc			.cfi_endproc
+-#endif
+-
+-#ifndef ENTRY
+-# define ENTRY(name)			\
+-	.type name,  @function; 	\
+-	.globl name;			\
+-	.p2align 4;			\
+-name:					\
+-	cfi_startproc
+-#endif
+-
+-#ifndef END
+-# define END(name)			\
+-	cfi_endproc;			\
+-	.size name, .-name
+-#endif
+-
+-#ifndef ALIGN
+-# define ALIGN(n)	.p2align n
+-#endif
+-
+-#define JMPTBL(I, B)	(I - B)
+-
+-#define BRANCH_TO_JMPTBL_ENTRY(TABLE, INDEX, SCALE)		\
+-  lea		TABLE(%rip), %r11;				\
+-  movslq	(%r11, INDEX, SCALE), %rcx;			\
+-  add		%r11, %rcx;					\
+-  jmp		*%rcx;						\
+-  ud2
+-
+-	.section .text.sse4.1,"ax",@progbits
+-ENTRY (MEMCMP)
+-#ifdef USE_AS_WMEMCMP
+-	shl	$2, %rdx
+-#endif
+-	pxor	%xmm0, %xmm0
+-	cmp	$79, %rdx
+-	ja	L(79bytesormore)
+-#ifndef USE_AS_WMEMCMP
+-	cmp	$1, %rdx
+-	je	L(firstbyte)
+-#endif
+-	add	%rdx, %rsi
+-	add	%rdx, %rdi
+-	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
+-
+-#ifndef USE_AS_WMEMCMP
+-	ALIGN (4)
+-L(firstbyte):
+-	movzbl	(%rdi), %eax
+-	movzbl	(%rsi), %ecx
+-	sub	%ecx, %eax
+-	ret
+-#endif
+-
+-	ALIGN (4)
+-L(79bytesormore):
+-	movdqu	(%rsi), %xmm1
+-	movdqu	(%rdi), %xmm2
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(16bytesin256)
+-	mov	%rsi, %rcx
+-	and	$-16, %rsi
+-	add	$16, %rsi
+-	sub	%rsi, %rcx
+-
+-	sub	%rcx, %rdi
+-	add	%rcx, %rdx
+-	test	$0xf, %rdi
+-	jz	L(2aligned)
+-
+-	cmp	$128, %rdx
+-	ja	L(128bytesormore)
+-L(less128bytes):
+-	sub	$64, %rdx
+-
+-	movdqu	(%rdi), %xmm2
+-	pxor	(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(16bytesin256)
+-
+-	movdqu	16(%rdi), %xmm2
+-	pxor	16(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(32bytesin256)
+-
+-	movdqu	32(%rdi), %xmm2
+-	pxor	32(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(48bytesin256)
+-
+-	movdqu	48(%rdi), %xmm2
+-	pxor	48(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(64bytesin256)
+-	cmp	$32, %rdx
+-	jb	L(less32bytesin64)
+-
+-	movdqu	64(%rdi), %xmm2
+-	pxor	64(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(80bytesin256)
+-
+-	movdqu	80(%rdi), %xmm2
+-	pxor	80(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(96bytesin256)
+-	sub	$32, %rdx
+-	add	$32, %rdi
+-	add	$32, %rsi
+-L(less32bytesin64):
+-	add	$64, %rdi
+-	add	$64, %rsi
+-	add	%rdx, %rsi
+-	add	%rdx, %rdi
+-	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
+-
+-L(128bytesormore):
+-	cmp	$512, %rdx
+-	ja	L(512bytesormore)
+-	cmp	$256, %rdx
+-	ja	L(less512bytes)
+-L(less256bytes):
+-	sub	$128, %rdx
+-
+-	movdqu	(%rdi), %xmm2
+-	pxor	(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(16bytesin256)
+-
+-	movdqu	16(%rdi), %xmm2
+-	pxor	16(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(32bytesin256)
+-
+-	movdqu	32(%rdi), %xmm2
+-	pxor	32(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(48bytesin256)
+-
+-	movdqu	48(%rdi), %xmm2
+-	pxor	48(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(64bytesin256)
+-
+-	movdqu	64(%rdi), %xmm2
+-	pxor	64(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(80bytesin256)
+-
+-	movdqu	80(%rdi), %xmm2
+-	pxor	80(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(96bytesin256)
+-
+-	movdqu	96(%rdi), %xmm2
+-	pxor	96(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(112bytesin256)
+-
+-	movdqu	112(%rdi), %xmm2
+-	pxor	112(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(128bytesin256)
+-
+-	add	$128, %rsi
+-	add	$128, %rdi
+-
+-	cmp	$64, %rdx
+-	jae	L(less128bytes)
+-
+-	cmp	$32, %rdx
+-	jb	L(less32bytesin128)
+-
+-	movdqu	(%rdi), %xmm2
+-	pxor	(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(16bytesin256)
+-
+-	movdqu	16(%rdi), %xmm2
+-	pxor	16(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(32bytesin256)
+-	sub	$32, %rdx
+-	add	$32, %rdi
+-	add	$32, %rsi
+-L(less32bytesin128):
+-	add	%rdx, %rsi
+-	add	%rdx, %rdi
+-	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
+-
+-L(less512bytes):
+-	sub	$256, %rdx
+-	movdqu	(%rdi), %xmm2
+-	pxor	(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(16bytesin256)
+-
+-	movdqu	16(%rdi), %xmm2
+-	pxor	16(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(32bytesin256)
+-
+-	movdqu	32(%rdi), %xmm2
+-	pxor	32(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(48bytesin256)
+-
+-	movdqu	48(%rdi), %xmm2
+-	pxor	48(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(64bytesin256)
+-
+-	movdqu	64(%rdi), %xmm2
+-	pxor	64(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(80bytesin256)
+-
+-	movdqu	80(%rdi), %xmm2
+-	pxor	80(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(96bytesin256)
+-
+-	movdqu	96(%rdi), %xmm2
+-	pxor	96(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(112bytesin256)
+-
+-	movdqu	112(%rdi), %xmm2
+-	pxor	112(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(128bytesin256)
+-
+-	movdqu	128(%rdi), %xmm2
+-	pxor	128(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(144bytesin256)
+-
+-	movdqu	144(%rdi), %xmm2
+-	pxor	144(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(160bytesin256)
+-
+-	movdqu	160(%rdi), %xmm2
+-	pxor	160(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(176bytesin256)
+-
+-	movdqu	176(%rdi), %xmm2
+-	pxor	176(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(192bytesin256)
+-
+-	movdqu	192(%rdi), %xmm2
+-	pxor	192(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(208bytesin256)
+-
+-	movdqu	208(%rdi), %xmm2
+-	pxor	208(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(224bytesin256)
+-
+-	movdqu	224(%rdi), %xmm2
+-	pxor	224(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(240bytesin256)
+-
+-	movdqu	240(%rdi), %xmm2
+-	pxor	240(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(256bytesin256)
+-
+-	add	$256, %rsi
+-	add	$256, %rdi
+-
+-	cmp	$128, %rdx
+-	jae	L(less256bytes)
+-
+-	cmp	$64, %rdx
+-	jae	L(less128bytes)
+-
+-	cmp	$32, %rdx
+-	jb	L(less32bytesin256)
+-
+-	movdqu	(%rdi), %xmm2
+-	pxor	(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(16bytesin256)
+-
+-	movdqu	16(%rdi), %xmm2
+-	pxor	16(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(32bytesin256)
+-	sub	$32, %rdx
+-	add	$32, %rdi
+-	add	$32, %rsi
+-L(less32bytesin256):
+-	add	%rdx, %rsi
+-	add	%rdx, %rdi
+-	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
+-
+-	ALIGN (4)
+-L(512bytesormore):
+-#ifdef DATA_CACHE_SIZE_HALF
+-	mov	$DATA_CACHE_SIZE_HALF, %r8
+-#else
+-	mov	__x86_64_data_cache_size_half(%rip), %r8
+-#endif
+-	mov	%r8, %r9
+-	shr	$1, %r8
+-	add	%r9, %r8
+-	cmp	%r8, %rdx
+-	ja	L(L2_L3_cache_unaglined)
+-	sub	$64, %rdx
+-	ALIGN (4)
+-L(64bytesormore_loop):
+-	movdqu	(%rdi), %xmm2
+-	pxor	(%rsi), %xmm2
+-	movdqa	%xmm2, %xmm1
+-
+-	movdqu	16(%rdi), %xmm3
+-	pxor	16(%rsi), %xmm3
+-	por	%xmm3, %xmm1
+-
+-	movdqu	32(%rdi), %xmm4
+-	pxor	32(%rsi), %xmm4
+-	por	%xmm4, %xmm1
+-
+-	movdqu	48(%rdi), %xmm5
+-	pxor	48(%rsi), %xmm5
+-	por	%xmm5, %xmm1
+-
+-	ptest	%xmm1, %xmm0
+-	jnc	L(64bytesormore_loop_end)
+-	add	$64, %rsi
+-	add	$64, %rdi
+-	sub	$64, %rdx
+-	jae	L(64bytesormore_loop)
+-
+-	add	$64, %rdx
+-	add	%rdx, %rsi
+-	add	%rdx, %rdi
+-	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
+-
+-L(L2_L3_cache_unaglined):
+-	sub	$64, %rdx
+-	ALIGN (4)
+-L(L2_L3_unaligned_128bytes_loop):
+-	prefetchnta 0x1c0(%rdi)
+-	prefetchnta 0x1c0(%rsi)
+-	movdqu	(%rdi), %xmm2
+-	pxor	(%rsi), %xmm2
+-	movdqa	%xmm2, %xmm1
+-
+-	movdqu	16(%rdi), %xmm3
+-	pxor	16(%rsi), %xmm3
+-	por	%xmm3, %xmm1
+-
+-	movdqu	32(%rdi), %xmm4
+-	pxor	32(%rsi), %xmm4
+-	por	%xmm4, %xmm1
+-
+-	movdqu	48(%rdi), %xmm5
+-	pxor	48(%rsi), %xmm5
+-	por	%xmm5, %xmm1
+-
+-	ptest	%xmm1, %xmm0
+-	jnc	L(64bytesormore_loop_end)
+-	add	$64, %rsi
+-	add	$64, %rdi
+-	sub	$64, %rdx
+-	jae	L(L2_L3_unaligned_128bytes_loop)
+-
+-	add	$64, %rdx
+-	add	%rdx, %rsi
+-	add	%rdx, %rdi
+-	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
+-
+-/*
+- * This case is for machines which are sensitive for unaligned instructions.
+- */
+-	ALIGN (4)
+-L(2aligned):
+-	cmp	$128, %rdx
+-	ja	L(128bytesormorein2aligned)
+-L(less128bytesin2aligned):
+-	sub	$64, %rdx
+-
+-	movdqa	(%rdi), %xmm2
+-	pxor	(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(16bytesin256)
+-
+-	movdqa	16(%rdi), %xmm2
+-	pxor	16(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(32bytesin256)
+-
+-	movdqa	32(%rdi), %xmm2
+-	pxor	32(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(48bytesin256)
+-
+-	movdqa	48(%rdi), %xmm2
+-	pxor	48(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(64bytesin256)
+-	cmp	$32, %rdx
+-	jb	L(less32bytesin64in2alinged)
+-
+-	movdqa	64(%rdi), %xmm2
+-	pxor	64(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(80bytesin256)
+-
+-	movdqa	80(%rdi), %xmm2
+-	pxor	80(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(96bytesin256)
+-	sub	$32, %rdx
+-	add	$32, %rdi
+-	add	$32, %rsi
+-L(less32bytesin64in2alinged):
+-	add	$64, %rdi
+-	add	$64, %rsi
+-	add	%rdx, %rsi
+-	add	%rdx, %rdi
+-	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
+-
+-	ALIGN (4)
+-L(128bytesormorein2aligned):
+-	cmp	$512, %rdx
+-	ja	L(512bytesormorein2aligned)
+-	cmp	$256, %rdx
+-	ja	L(256bytesormorein2aligned)
+-L(less256bytesin2alinged):
+-	sub	$128, %rdx
+-
+-	movdqa	(%rdi), %xmm2
+-	pxor	(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(16bytesin256)
+-
+-	movdqa	16(%rdi), %xmm2
+-	pxor	16(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(32bytesin256)
+-
+-	movdqa	32(%rdi), %xmm2
+-	pxor	32(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(48bytesin256)
+-
+-	movdqa	48(%rdi), %xmm2
+-	pxor	48(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(64bytesin256)
+-
+-	movdqa	64(%rdi), %xmm2
+-	pxor	64(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(80bytesin256)
+-
+-	movdqa	80(%rdi), %xmm2
+-	pxor	80(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(96bytesin256)
+-
+-	movdqa	96(%rdi), %xmm2
+-	pxor	96(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(112bytesin256)
+-
+-	movdqa	112(%rdi), %xmm2
+-	pxor	112(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(128bytesin256)
+-
+-	add	$128, %rsi
+-	add	$128, %rdi
+-
+-	cmp	$64, %rdx
+-	jae	L(less128bytesin2aligned)
+-
+-	cmp	$32, %rdx
+-	jb	L(less32bytesin128in2aligned)
+-
+-	movdqu	(%rdi), %xmm2
+-	pxor	(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(16bytesin256)
+-
+-	movdqu	16(%rdi), %xmm2
+-	pxor	16(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(32bytesin256)
+-	sub	$32, %rdx
+-	add	$32, %rdi
+-	add	$32, %rsi
+-L(less32bytesin128in2aligned):
+-	add	%rdx, %rsi
+-	add	%rdx, %rdi
+-	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
+-
+-	ALIGN (4)
+-L(256bytesormorein2aligned):
+-
+-	sub	$256, %rdx
+-	movdqa	(%rdi), %xmm2
+-	pxor	(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(16bytesin256)
+-
+-	movdqa	16(%rdi), %xmm2
+-	pxor	16(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(32bytesin256)
+-
+-	movdqa	32(%rdi), %xmm2
+-	pxor	32(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(48bytesin256)
+-
+-	movdqa	48(%rdi), %xmm2
+-	pxor	48(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(64bytesin256)
+-
+-	movdqa	64(%rdi), %xmm2
+-	pxor	64(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(80bytesin256)
+-
+-	movdqa	80(%rdi), %xmm2
+-	pxor	80(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(96bytesin256)
+-
+-	movdqa	96(%rdi), %xmm2
+-	pxor	96(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(112bytesin256)
+-
+-	movdqa	112(%rdi), %xmm2
+-	pxor	112(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(128bytesin256)
+-
+-	movdqa	128(%rdi), %xmm2
+-	pxor	128(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(144bytesin256)
+-
+-	movdqa	144(%rdi), %xmm2
+-	pxor	144(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(160bytesin256)
+-
+-	movdqa	160(%rdi), %xmm2
+-	pxor	160(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(176bytesin256)
+-
+-	movdqa	176(%rdi), %xmm2
+-	pxor	176(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(192bytesin256)
+-
+-	movdqa	192(%rdi), %xmm2
+-	pxor	192(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(208bytesin256)
+-
+-	movdqa	208(%rdi), %xmm2
+-	pxor	208(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(224bytesin256)
+-
+-	movdqa	224(%rdi), %xmm2
+-	pxor	224(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(240bytesin256)
+-
+-	movdqa	240(%rdi), %xmm2
+-	pxor	240(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(256bytesin256)
+-
+-	add	$256, %rsi
+-	add	$256, %rdi
+-
+-	cmp	$128, %rdx
+-	jae	L(less256bytesin2alinged)
+-
+-	cmp	$64, %rdx
+-	jae	L(less128bytesin2aligned)
+-
+-	cmp	$32, %rdx
+-	jb	L(less32bytesin256in2alinged)
+-
+-	movdqa	(%rdi), %xmm2
+-	pxor	(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(16bytesin256)
+-
+-	movdqa	16(%rdi), %xmm2
+-	pxor	16(%rsi), %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(32bytesin256)
+-	sub	$32, %rdx
+-	add	$32, %rdi
+-	add	$32, %rsi
+-L(less32bytesin256in2alinged):
+-	add	%rdx, %rsi
+-	add	%rdx, %rdi
+-	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
+-
+-	ALIGN (4)
+-L(512bytesormorein2aligned):
+-#ifdef DATA_CACHE_SIZE_HALF
+-	mov	$DATA_CACHE_SIZE_HALF, %r8
+-#else
+-	mov	__x86_64_data_cache_size_half(%rip), %r8
+-#endif
+-	mov	%r8, %r9
+-	shr	$1, %r8
+-	add	%r9, %r8
+-	cmp	%r8, %rdx
+-	ja	L(L2_L3_cache_aglined)
+-
+-	sub	$64, %rdx
+-	ALIGN (4)
+-L(64bytesormore_loopin2aligned):
+-	movdqa	(%rdi), %xmm2
+-	pxor	(%rsi), %xmm2
+-	movdqa	%xmm2, %xmm1
+-
+-	movdqa	16(%rdi), %xmm3
+-	pxor	16(%rsi), %xmm3
+-	por	%xmm3, %xmm1
+-
+-	movdqa	32(%rdi), %xmm4
+-	pxor	32(%rsi), %xmm4
+-	por	%xmm4, %xmm1
+-
+-	movdqa	48(%rdi), %xmm5
+-	pxor	48(%rsi), %xmm5
+-	por	%xmm5, %xmm1
+-
+-	ptest	%xmm1, %xmm0
+-	jnc	L(64bytesormore_loop_end)
+-	add	$64, %rsi
+-	add	$64, %rdi
+-	sub	$64, %rdx
+-	jae	L(64bytesormore_loopin2aligned)
+-
+-	add	$64, %rdx
+-	add	%rdx, %rsi
+-	add	%rdx, %rdi
+-	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
+-L(L2_L3_cache_aglined):
+-	sub	$64, %rdx
+-	ALIGN (4)
+-L(L2_L3_aligned_128bytes_loop):
+-	prefetchnta 0x1c0(%rdi)
+-	prefetchnta 0x1c0(%rsi)
+-	movdqa	(%rdi), %xmm2
+-	pxor	(%rsi), %xmm2
+-	movdqa	%xmm2, %xmm1
+-
+-	movdqa	16(%rdi), %xmm3
+-	pxor	16(%rsi), %xmm3
+-	por	%xmm3, %xmm1
+-
+-	movdqa	32(%rdi), %xmm4
+-	pxor	32(%rsi), %xmm4
+-	por	%xmm4, %xmm1
+-
+-	movdqa	48(%rdi), %xmm5
+-	pxor	48(%rsi), %xmm5
+-	por	%xmm5, %xmm1
+-
+-	ptest	%xmm1, %xmm0
+-	jnc	L(64bytesormore_loop_end)
+-	add	$64, %rsi
+-	add	$64, %rdi
+-	sub	$64, %rdx
+-	jae	L(L2_L3_aligned_128bytes_loop)
+-
+-	add	$64, %rdx
+-	add	%rdx, %rsi
+-	add	%rdx, %rdi
+-	BRANCH_TO_JMPTBL_ENTRY(L(table_64bytes), %rdx, 4)
+-
+-
+-	ALIGN (4)
+-L(64bytesormore_loop_end):
+-	add	$16, %rdi
+-	add	$16, %rsi
+-	ptest	%xmm2, %xmm0
+-	jnc	L(16bytes)
+-
+-	add	$16, %rdi
+-	add	$16, %rsi
+-	ptest	%xmm3, %xmm0
+-	jnc	L(16bytes)
+-
+-	add	$16, %rdi
+-	add	$16, %rsi
+-	ptest	%xmm4, %xmm0
+-	jnc	L(16bytes)
+-
+-	add	$16, %rdi
+-	add	$16, %rsi
+-	jmp	L(16bytes)
+-
+-L(256bytesin256):
+-	add	$256, %rdi
+-	add	$256, %rsi
+-	jmp	L(16bytes)
+-L(240bytesin256):
+-	add	$240, %rdi
+-	add	$240, %rsi
+-	jmp	L(16bytes)
+-L(224bytesin256):
+-	add	$224, %rdi
+-	add	$224, %rsi
+-	jmp	L(16bytes)
+-L(208bytesin256):
+-	add	$208, %rdi
+-	add	$208, %rsi
+-	jmp	L(16bytes)
+-L(192bytesin256):
+-	add	$192, %rdi
+-	add	$192, %rsi
+-	jmp	L(16bytes)
+-L(176bytesin256):
+-	add	$176, %rdi
+-	add	$176, %rsi
+-	jmp	L(16bytes)
+-L(160bytesin256):
+-	add	$160, %rdi
+-	add	$160, %rsi
+-	jmp	L(16bytes)
+-L(144bytesin256):
+-	add	$144, %rdi
+-	add	$144, %rsi
+-	jmp	L(16bytes)
+-L(128bytesin256):
+-	add	$128, %rdi
+-	add	$128, %rsi
+-	jmp	L(16bytes)
+-L(112bytesin256):
+-	add	$112, %rdi
+-	add	$112, %rsi
+-	jmp	L(16bytes)
+-L(96bytesin256):
+-	add	$96, %rdi
+-	add	$96, %rsi
+-	jmp	L(16bytes)
+-L(80bytesin256):
+-	add	$80, %rdi
+-	add	$80, %rsi
+-	jmp	L(16bytes)
+-L(64bytesin256):
+-	add	$64, %rdi
+-	add	$64, %rsi
+-	jmp	L(16bytes)
+-L(48bytesin256):
+-	add	$16, %rdi
+-	add	$16, %rsi
+-L(32bytesin256):
+-	add	$16, %rdi
+-	add	$16, %rsi
+-L(16bytesin256):
+-	add	$16, %rdi
+-	add	$16, %rsi
+-L(16bytes):
+-	mov	-16(%rdi), %rax
+-	mov	-16(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-L(8bytes):
+-	mov	-8(%rdi), %rax
+-	mov	-8(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	xor	%eax, %eax
+-	ret
+-
+-	ALIGN (4)
+-L(12bytes):
+-	mov	-12(%rdi), %rax
+-	mov	-12(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-L(4bytes):
+-	mov	-4(%rsi), %ecx
+-	mov	-4(%rdi), %eax
+-	cmp	%eax, %ecx
+-	jne	L(diffin4bytes)
+-L(0bytes):
+-	xor	%eax, %eax
+-	ret
+-
+-#ifndef USE_AS_WMEMCMP
+-/* unreal case for wmemcmp */
+-	ALIGN (4)
+-L(65bytes):
+-	movdqu	-65(%rdi), %xmm1
+-	movdqu	-65(%rsi), %xmm2
+-	mov	$-65, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(49bytes):
+-	movdqu	-49(%rdi), %xmm1
+-	movdqu	-49(%rsi), %xmm2
+-	mov	$-49, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(33bytes):
+-	movdqu	-33(%rdi), %xmm1
+-	movdqu	-33(%rsi), %xmm2
+-	mov	$-33, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(17bytes):
+-	mov	-17(%rdi), %rax
+-	mov	-17(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-L(9bytes):
+-	mov	-9(%rdi), %rax
+-	mov	-9(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	movzbl	-1(%rdi), %eax
+-	movzbl	-1(%rsi), %edx
+-	sub	%edx, %eax
+-	ret
+-
+-	ALIGN (4)
+-L(13bytes):
+-	mov	-13(%rdi), %rax
+-	mov	-13(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	mov	-8(%rdi), %rax
+-	mov	-8(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	xor	%eax, %eax
+-	ret
+-
+-	ALIGN (4)
+-L(5bytes):
+-	mov	-5(%rdi), %eax
+-	mov	-5(%rsi), %ecx
+-	cmp	%eax, %ecx
+-	jne	L(diffin4bytes)
+-	movzbl	-1(%rdi), %eax
+-	movzbl	-1(%rsi), %edx
+-	sub	%edx, %eax
+-	ret
+-
+-	ALIGN (4)
+-L(66bytes):
+-	movdqu	-66(%rdi), %xmm1
+-	movdqu	-66(%rsi), %xmm2
+-	mov	$-66, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(50bytes):
+-	movdqu	-50(%rdi), %xmm1
+-	movdqu	-50(%rsi), %xmm2
+-	mov	$-50, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(34bytes):
+-	movdqu	-34(%rdi), %xmm1
+-	movdqu	-34(%rsi), %xmm2
+-	mov	$-34, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(18bytes):
+-	mov	-18(%rdi), %rax
+-	mov	-18(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-L(10bytes):
+-	mov	-10(%rdi), %rax
+-	mov	-10(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	movzwl	-2(%rdi), %eax
+-	movzwl	-2(%rsi), %ecx
+-	cmp	%cl, %al
+-	jne	L(end)
+-	and	$0xffff, %eax
+-	and	$0xffff, %ecx
+-	sub	%ecx, %eax
+-	ret
+-
+-	ALIGN (4)
+-L(14bytes):
+-	mov	-14(%rdi), %rax
+-	mov	-14(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	mov	-8(%rdi), %rax
+-	mov	-8(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	xor	%eax, %eax
+-	ret
+-
+-	ALIGN (4)
+-L(6bytes):
+-	mov	-6(%rdi), %eax
+-	mov	-6(%rsi), %ecx
+-	cmp	%eax, %ecx
+-	jne	L(diffin4bytes)
+-L(2bytes):
+-	movzwl	-2(%rsi), %ecx
+-	movzwl	-2(%rdi), %eax
+-	cmp	%cl, %al
+-	jne	L(end)
+-	and	$0xffff, %eax
+-	and	$0xffff, %ecx
+-	sub	%ecx, %eax
+-	ret
+-
+-	ALIGN (4)
+-L(67bytes):
+-	movdqu	-67(%rdi), %xmm2
+-	movdqu	-67(%rsi), %xmm1
+-	mov	$-67, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(51bytes):
+-	movdqu	-51(%rdi), %xmm2
+-	movdqu	-51(%rsi), %xmm1
+-	mov	$-51, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(35bytes):
+-	movdqu	-35(%rsi), %xmm1
+-	movdqu	-35(%rdi), %xmm2
+-	mov	$-35, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(19bytes):
+-	mov	-19(%rdi), %rax
+-	mov	-19(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-L(11bytes):
+-	mov	-11(%rdi), %rax
+-	mov	-11(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	mov	-4(%rdi), %eax
+-	mov	-4(%rsi), %ecx
+-	cmp	%eax, %ecx
+-	jne	L(diffin4bytes)
+-	xor	%eax, %eax
+-	ret
+-
+-	ALIGN (4)
+-L(15bytes):
+-	mov	-15(%rdi), %rax
+-	mov	-15(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	mov	-8(%rdi), %rax
+-	mov	-8(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	xor	%eax, %eax
+-	ret
+-
+-	ALIGN (4)
+-L(7bytes):
+-	mov	-7(%rdi), %eax
+-	mov	-7(%rsi), %ecx
+-	cmp	%eax, %ecx
+-	jne	L(diffin4bytes)
+-	mov	-4(%rdi), %eax
+-	mov	-4(%rsi), %ecx
+-	cmp	%eax, %ecx
+-	jne	L(diffin4bytes)
+-	xor	%eax, %eax
+-	ret
+-
+-	ALIGN (4)
+-L(3bytes):
+-	movzwl	-3(%rdi), %eax
+-	movzwl	-3(%rsi), %ecx
+-	cmp	%eax, %ecx
+-	jne	L(diffin2bytes)
+-L(1bytes):
+-	movzbl	-1(%rdi), %eax
+-	movzbl	-1(%rsi), %ecx
+-	sub	%ecx, %eax
+-	ret
+-#endif
+-
+-	ALIGN (4)
+-L(68bytes):
+-	movdqu	-68(%rdi), %xmm2
+-	movdqu	-68(%rsi), %xmm1
+-	mov	$-68, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(52bytes):
+-	movdqu	-52(%rdi), %xmm2
+-	movdqu	-52(%rsi), %xmm1
+-	mov	$-52, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(36bytes):
+-	movdqu	-36(%rdi), %xmm2
+-	movdqu	-36(%rsi), %xmm1
+-	mov	$-36, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(20bytes):
+-	movdqu	-20(%rdi), %xmm2
+-	movdqu	-20(%rsi), %xmm1
+-	mov	$-20, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-	mov	-4(%rdi), %eax
+-	mov	-4(%rsi), %ecx
+-	cmp	%eax, %ecx
+-	jne	L(diffin4bytes)
+-	xor	%eax, %eax
+-	ret
+-
+-#ifndef USE_AS_WMEMCMP
+-/* unreal cases for wmemcmp */
+-	ALIGN (4)
+-L(69bytes):
+-	movdqu	-69(%rsi), %xmm1
+-	movdqu	-69(%rdi), %xmm2
+-	mov	$-69, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(53bytes):
+-	movdqu	-53(%rsi), %xmm1
+-	movdqu	-53(%rdi), %xmm2
+-	mov	$-53, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(37bytes):
+-	movdqu	-37(%rsi), %xmm1
+-	movdqu	-37(%rdi), %xmm2
+-	mov	$-37, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(21bytes):
+-	movdqu	-21(%rsi), %xmm1
+-	movdqu	-21(%rdi), %xmm2
+-	mov	$-21, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-	mov	-8(%rdi), %rax
+-	mov	-8(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	xor	%eax, %eax
+-	ret
+-
+-	ALIGN (4)
+-L(70bytes):
+-	movdqu	-70(%rsi), %xmm1
+-	movdqu	-70(%rdi), %xmm2
+-	mov	$-70, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(54bytes):
+-	movdqu	-54(%rsi), %xmm1
+-	movdqu	-54(%rdi), %xmm2
+-	mov	$-54, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(38bytes):
+-	movdqu	-38(%rsi), %xmm1
+-	movdqu	-38(%rdi), %xmm2
+-	mov	$-38, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(22bytes):
+-	movdqu	-22(%rsi), %xmm1
+-	movdqu	-22(%rdi), %xmm2
+-	mov	$-22, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-	mov	-8(%rdi), %rax
+-	mov	-8(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	xor	%eax, %eax
+-	ret
+-
+-	ALIGN (4)
+-L(71bytes):
+-	movdqu	-71(%rsi), %xmm1
+-	movdqu	-71(%rdi), %xmm2
+-	mov	$-71, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(55bytes):
+-	movdqu	-55(%rdi), %xmm2
+-	movdqu	-55(%rsi), %xmm1
+-	mov	$-55, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(39bytes):
+-	movdqu	-39(%rdi), %xmm2
+-	movdqu	-39(%rsi), %xmm1
+-	mov	$-39, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(23bytes):
+-	movdqu	-23(%rdi), %xmm2
+-	movdqu	-23(%rsi), %xmm1
+-	mov	$-23, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-	mov	-8(%rdi), %rax
+-	mov	-8(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	xor	%eax, %eax
+-	ret
+-#endif
+-
+-	ALIGN (4)
+-L(72bytes):
+-	movdqu	-72(%rsi), %xmm1
+-	movdqu	-72(%rdi), %xmm2
+-	mov	$-72, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(56bytes):
+-	movdqu	-56(%rdi), %xmm2
+-	movdqu	-56(%rsi), %xmm1
+-	mov	$-56, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(40bytes):
+-	movdqu	-40(%rdi), %xmm2
+-	movdqu	-40(%rsi), %xmm1
+-	mov	$-40, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(24bytes):
+-	movdqu	-24(%rdi), %xmm2
+-	movdqu	-24(%rsi), %xmm1
+-	mov	$-24, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-	mov	-8(%rdi), %rax
+-	mov	-8(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	xor	%eax, %eax
+-	ret
+-
+-#ifndef USE_AS_WMEMCMP
+-/* unreal cases for wmemcmp */
+-	ALIGN (4)
+-L(73bytes):
+-	movdqu	-73(%rsi), %xmm1
+-	movdqu	-73(%rdi), %xmm2
+-	mov	$-73, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(57bytes):
+-	movdqu	-57(%rdi), %xmm2
+-	movdqu	-57(%rsi), %xmm1
+-	mov	$-57, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(41bytes):
+-	movdqu	-41(%rdi), %xmm2
+-	movdqu	-41(%rsi), %xmm1
+-	mov	$-41, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(25bytes):
+-	movdqu	-25(%rdi), %xmm2
+-	movdqu	-25(%rsi), %xmm1
+-	mov	$-25, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-	mov	-9(%rdi), %rax
+-	mov	-9(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	movzbl	-1(%rdi), %eax
+-	movzbl	-1(%rsi), %ecx
+-	sub	%ecx, %eax
+-	ret
+-
+-	ALIGN (4)
+-L(74bytes):
+-	movdqu	-74(%rsi), %xmm1
+-	movdqu	-74(%rdi), %xmm2
+-	mov	$-74, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(58bytes):
+-	movdqu	-58(%rdi), %xmm2
+-	movdqu	-58(%rsi), %xmm1
+-	mov	$-58, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(42bytes):
+-	movdqu	-42(%rdi), %xmm2
+-	movdqu	-42(%rsi), %xmm1
+-	mov	$-42, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(26bytes):
+-	movdqu	-26(%rdi), %xmm2
+-	movdqu	-26(%rsi), %xmm1
+-	mov	$-26, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-	mov	-10(%rdi), %rax
+-	mov	-10(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	movzwl	-2(%rdi), %eax
+-	movzwl	-2(%rsi), %ecx
+-	jmp	L(diffin2bytes)
+-
+-	ALIGN (4)
+-L(75bytes):
+-	movdqu	-75(%rsi), %xmm1
+-	movdqu	-75(%rdi), %xmm2
+-	mov	$-75, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(59bytes):
+-	movdqu	-59(%rdi), %xmm2
+-	movdqu	-59(%rsi), %xmm1
+-	mov	$-59, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(43bytes):
+-	movdqu	-43(%rdi), %xmm2
+-	movdqu	-43(%rsi), %xmm1
+-	mov	$-43, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(27bytes):
+-	movdqu	-27(%rdi), %xmm2
+-	movdqu	-27(%rsi), %xmm1
+-	mov	$-27, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-	mov	-11(%rdi), %rax
+-	mov	-11(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	mov	-4(%rdi), %eax
+-	mov	-4(%rsi), %ecx
+-	cmp	%eax, %ecx
+-	jne	L(diffin4bytes)
+-	xor	%eax, %eax
+-	ret
+-#endif
+-	ALIGN (4)
+-L(76bytes):
+-	movdqu	-76(%rsi), %xmm1
+-	movdqu	-76(%rdi), %xmm2
+-	mov	$-76, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(60bytes):
+-	movdqu	-60(%rdi), %xmm2
+-	movdqu	-60(%rsi), %xmm1
+-	mov	$-60, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(44bytes):
+-	movdqu	-44(%rdi), %xmm2
+-	movdqu	-44(%rsi), %xmm1
+-	mov	$-44, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(28bytes):
+-	movdqu	-28(%rdi), %xmm2
+-	movdqu	-28(%rsi), %xmm1
+-	mov	$-28, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-	mov	-12(%rdi), %rax
+-	mov	-12(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	mov	-4(%rdi), %eax
+-	mov	-4(%rsi), %ecx
+-	cmp	%eax, %ecx
+-	jne	L(diffin4bytes)
+-	xor	%eax, %eax
+-	ret
+-
+-#ifndef USE_AS_WMEMCMP
+-/* unreal cases for wmemcmp */
+-	ALIGN (4)
+-L(77bytes):
+-	movdqu	-77(%rsi), %xmm1
+-	movdqu	-77(%rdi), %xmm2
+-	mov	$-77, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(61bytes):
+-	movdqu	-61(%rdi), %xmm2
+-	movdqu	-61(%rsi), %xmm1
+-	mov	$-61, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(45bytes):
+-	movdqu	-45(%rdi), %xmm2
+-	movdqu	-45(%rsi), %xmm1
+-	mov	$-45, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(29bytes):
+-	movdqu	-29(%rdi), %xmm2
+-	movdqu	-29(%rsi), %xmm1
+-	mov	$-29, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-
+-	mov	-13(%rdi), %rax
+-	mov	-13(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-
+-	mov	-8(%rdi), %rax
+-	mov	-8(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	xor	%eax, %eax
+-	ret
+-
+-	ALIGN (4)
+-L(78bytes):
+-	movdqu	-78(%rsi), %xmm1
+-	movdqu	-78(%rdi), %xmm2
+-	mov	$-78, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(62bytes):
+-	movdqu	-62(%rdi), %xmm2
+-	movdqu	-62(%rsi), %xmm1
+-	mov	$-62, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(46bytes):
+-	movdqu	-46(%rdi), %xmm2
+-	movdqu	-46(%rsi), %xmm1
+-	mov	$-46, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(30bytes):
+-	movdqu	-30(%rdi), %xmm2
+-	movdqu	-30(%rsi), %xmm1
+-	mov	$-30, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-	mov	-14(%rdi), %rax
+-	mov	-14(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	mov	-8(%rdi), %rax
+-	mov	-8(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	xor	%eax, %eax
+-	ret
+-
+-	ALIGN (4)
+-L(79bytes):
+-	movdqu	-79(%rsi), %xmm1
+-	movdqu	-79(%rdi), %xmm2
+-	mov	$-79, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(63bytes):
+-	movdqu	-63(%rdi), %xmm2
+-	movdqu	-63(%rsi), %xmm1
+-	mov	$-63, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(47bytes):
+-	movdqu	-47(%rdi), %xmm2
+-	movdqu	-47(%rsi), %xmm1
+-	mov	$-47, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(31bytes):
+-	movdqu	-31(%rdi), %xmm2
+-	movdqu	-31(%rsi), %xmm1
+-	mov	$-31, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-	mov	-15(%rdi), %rax
+-	mov	-15(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	mov	-8(%rdi), %rax
+-	mov	-8(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	xor	%eax, %eax
+-	ret
+-#endif
+-	ALIGN (4)
+-L(64bytes):
+-	movdqu	-64(%rdi), %xmm2
+-	movdqu	-64(%rsi), %xmm1
+-	mov	$-64, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(48bytes):
+-	movdqu	-48(%rdi), %xmm2
+-	movdqu	-48(%rsi), %xmm1
+-	mov	$-48, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-L(32bytes):
+-	movdqu	-32(%rdi), %xmm2
+-	movdqu	-32(%rsi), %xmm1
+-	mov	$-32, %dl
+-	pxor	%xmm1, %xmm2
+-	ptest	%xmm2, %xmm0
+-	jnc	L(less16bytes)
+-
+-	mov	-16(%rdi), %rax
+-	mov	-16(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-
+-	mov	-8(%rdi), %rax
+-	mov	-8(%rsi), %rcx
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	xor	%eax, %eax
+-	ret
+-
+-/*
+- * Aligned 8 bytes to avoid 2 branch "taken" in one 16 alinged code block.
+- */
+-	ALIGN (3)
+-L(less16bytes):
+-	movsbq	%dl, %rdx
+-	mov	(%rsi, %rdx), %rcx
+-	mov	(%rdi, %rdx), %rax
+-	cmp	%rax, %rcx
+-	jne	L(diffin8bytes)
+-	mov	8(%rsi, %rdx), %rcx
+-	mov	8(%rdi, %rdx), %rax
+-L(diffin8bytes):
+-	cmp	%eax, %ecx
+-	jne	L(diffin4bytes)
+-	shr	$32, %rcx
+-	shr	$32, %rax
+-
+-#ifdef USE_AS_WMEMCMP
+-/* for wmemcmp */
+-	cmp	%eax, %ecx
+-	jne	L(diffin4bytes)
+-	xor	%eax, %eax
+-	ret
+-#endif
+-
+-L(diffin4bytes):
+-#ifndef USE_AS_WMEMCMP
+-	cmp	%cx, %ax
+-	jne	L(diffin2bytes)
+-	shr	$16, %ecx
+-	shr	$16, %eax
+-L(diffin2bytes):
+-	cmp	%cl, %al
+-	jne	L(end)
+-	and	$0xffff, %eax
+-	and	$0xffff, %ecx
+-	sub	%ecx, %eax
+-	ret
+-#else
+-
+-/* for wmemcmp */
+-	mov	$1, %eax
+-	jl	L(nequal_bigger)
+-	neg	%eax
+-	ret
+-
+-	ALIGN (4)
+-L(nequal_bigger):
+-	ret
+-
+-L(unreal_case):
+-	xor	%eax, %eax
+-	ret
+-#endif
+-
+-	ALIGN (4)
+-L(end):
+-	and	$0xff, %eax
+-	and	$0xff, %ecx
+-	sub	%ecx, %eax
+-	ret
+-
+-END (MEMCMP)
+-
+-	.section .rodata.sse4.1,"a",@progbits
+-	ALIGN (3)
+-#ifndef USE_AS_WMEMCMP
+-L(table_64bytes):
+-	.int	JMPTBL (L(0bytes), L(table_64bytes))
+-	.int	JMPTBL (L(1bytes), L(table_64bytes))
+-	.int	JMPTBL (L(2bytes), L(table_64bytes))
+-	.int	JMPTBL (L(3bytes), L(table_64bytes))
+-	.int	JMPTBL (L(4bytes), L(table_64bytes))
+-	.int	JMPTBL (L(5bytes), L(table_64bytes))
+-	.int	JMPTBL (L(6bytes), L(table_64bytes))
+-	.int	JMPTBL (L(7bytes), L(table_64bytes))
+-	.int	JMPTBL (L(8bytes), L(table_64bytes))
+-	.int	JMPTBL (L(9bytes), L(table_64bytes))
+-	.int	JMPTBL (L(10bytes), L(table_64bytes))
+-	.int	JMPTBL (L(11bytes), L(table_64bytes))
+-	.int	JMPTBL (L(12bytes), L(table_64bytes))
+-	.int	JMPTBL (L(13bytes), L(table_64bytes))
+-	.int	JMPTBL (L(14bytes), L(table_64bytes))
+-	.int	JMPTBL (L(15bytes), L(table_64bytes))
+-	.int	JMPTBL (L(16bytes), L(table_64bytes))
+-	.int	JMPTBL (L(17bytes), L(table_64bytes))
+-	.int	JMPTBL (L(18bytes), L(table_64bytes))
+-	.int	JMPTBL (L(19bytes), L(table_64bytes))
+-	.int	JMPTBL (L(20bytes), L(table_64bytes))
+-	.int	JMPTBL (L(21bytes), L(table_64bytes))
+-	.int	JMPTBL (L(22bytes), L(table_64bytes))
+-	.int	JMPTBL (L(23bytes), L(table_64bytes))
+-	.int	JMPTBL (L(24bytes), L(table_64bytes))
+-	.int	JMPTBL (L(25bytes), L(table_64bytes))
+-	.int	JMPTBL (L(26bytes), L(table_64bytes))
+-	.int	JMPTBL (L(27bytes), L(table_64bytes))
+-	.int	JMPTBL (L(28bytes), L(table_64bytes))
+-	.int	JMPTBL (L(29bytes), L(table_64bytes))
+-	.int	JMPTBL (L(30bytes), L(table_64bytes))
+-	.int	JMPTBL (L(31bytes), L(table_64bytes))
+-	.int	JMPTBL (L(32bytes), L(table_64bytes))
+-	.int	JMPTBL (L(33bytes), L(table_64bytes))
+-	.int	JMPTBL (L(34bytes), L(table_64bytes))
+-	.int	JMPTBL (L(35bytes), L(table_64bytes))
+-	.int	JMPTBL (L(36bytes), L(table_64bytes))
+-	.int	JMPTBL (L(37bytes), L(table_64bytes))
+-	.int	JMPTBL (L(38bytes), L(table_64bytes))
+-	.int	JMPTBL (L(39bytes), L(table_64bytes))
+-	.int	JMPTBL (L(40bytes), L(table_64bytes))
+-	.int	JMPTBL (L(41bytes), L(table_64bytes))
+-	.int	JMPTBL (L(42bytes), L(table_64bytes))
+-	.int	JMPTBL (L(43bytes), L(table_64bytes))
+-	.int	JMPTBL (L(44bytes), L(table_64bytes))
+-	.int	JMPTBL (L(45bytes), L(table_64bytes))
+-	.int	JMPTBL (L(46bytes), L(table_64bytes))
+-	.int	JMPTBL (L(47bytes), L(table_64bytes))
+-	.int	JMPTBL (L(48bytes), L(table_64bytes))
+-	.int	JMPTBL (L(49bytes), L(table_64bytes))
+-	.int	JMPTBL (L(50bytes), L(table_64bytes))
+-	.int	JMPTBL (L(51bytes), L(table_64bytes))
+-	.int	JMPTBL (L(52bytes), L(table_64bytes))
+-	.int	JMPTBL (L(53bytes), L(table_64bytes))
+-	.int	JMPTBL (L(54bytes), L(table_64bytes))
+-	.int	JMPTBL (L(55bytes), L(table_64bytes))
+-	.int	JMPTBL (L(56bytes), L(table_64bytes))
+-	.int	JMPTBL (L(57bytes), L(table_64bytes))
+-	.int	JMPTBL (L(58bytes), L(table_64bytes))
+-	.int	JMPTBL (L(59bytes), L(table_64bytes))
+-	.int	JMPTBL (L(60bytes), L(table_64bytes))
+-	.int	JMPTBL (L(61bytes), L(table_64bytes))
+-	.int	JMPTBL (L(62bytes), L(table_64bytes))
+-	.int	JMPTBL (L(63bytes), L(table_64bytes))
+-	.int	JMPTBL (L(64bytes), L(table_64bytes))
+-	.int	JMPTBL (L(65bytes), L(table_64bytes))
+-	.int	JMPTBL (L(66bytes), L(table_64bytes))
+-	.int	JMPTBL (L(67bytes), L(table_64bytes))
+-	.int	JMPTBL (L(68bytes), L(table_64bytes))
+-	.int	JMPTBL (L(69bytes), L(table_64bytes))
+-	.int	JMPTBL (L(70bytes), L(table_64bytes))
+-	.int	JMPTBL (L(71bytes), L(table_64bytes))
+-	.int	JMPTBL (L(72bytes), L(table_64bytes))
+-	.int	JMPTBL (L(73bytes), L(table_64bytes))
+-	.int	JMPTBL (L(74bytes), L(table_64bytes))
+-	.int	JMPTBL (L(75bytes), L(table_64bytes))
+-	.int	JMPTBL (L(76bytes), L(table_64bytes))
+-	.int	JMPTBL (L(77bytes), L(table_64bytes))
+-	.int	JMPTBL (L(78bytes), L(table_64bytes))
+-	.int	JMPTBL (L(79bytes), L(table_64bytes))
+-#else
+-L(table_64bytes):
+-	.int	JMPTBL (L(0bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(4bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(8bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(12bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(16bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(20bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(24bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(28bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(32bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(36bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(40bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(44bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(48bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(52bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(56bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(60bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(64bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(68bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(72bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(76bytes), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-	.int	JMPTBL (L(unreal_case), L(table_64bytes))
+-#endif
+diff --git a/libc/arch-x86_64/string/ssse3-strcmp-slm.S b/libc/arch-x86_64/string/ssse3-strcmp-slm.S
+deleted file mode 100644
+index e8acd5b..0000000
+--- a/libc/arch-x86_64/string/ssse3-strcmp-slm.S
++++ /dev/null
+@@ -1,1925 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-#ifdef USE_AS_STRNCMP
+-/* Since the counter, %r11, is unsigned, we branch to strcmp_exitz
+-   if the new counter > the old one or is 0.  */
+-#define UPDATE_STRNCMP_COUNTER				\
+-	/* calculate left number to compare */		\
+-	lea	-16(%rcx, %r11), %r9;			\
+-	cmp	%r9, %r11;				\
+-	jb	L(strcmp_exitz);			\
+-	test	%r9, %r9;				\
+-	je	L(strcmp_exitz);			\
+-	mov	%r9, %r11
+-
+-#else
+-#define UPDATE_STRNCMP_COUNTER
+-#ifndef STRCMP
+-#define STRCMP		strcmp
+-#endif
+-#endif
+-
+-#ifndef L
+-# define L(label)	.L##label
+-#endif
+-
+-#ifndef cfi_startproc
+-# define cfi_startproc			.cfi_startproc
+-#endif
+-
+-#ifndef cfi_endproc
+-# define cfi_endproc			.cfi_endproc
+-#endif
+-
+-#ifndef ENTRY
+-# define ENTRY(name)			\
+-	.type name,  @function; 	\
+-	.globl name;			\
+-	.p2align 4;			\
+-name:					\
+-	cfi_startproc
+-#endif
+-
+-#ifndef END
+-# define END(name)			\
+-	cfi_endproc;			\
+-	.size name, .-name
+-#endif
+-#define RETURN ret
+-	.section .text.ssse3,"ax",@progbits
+-ENTRY (STRCMP)
+-/*
+- * This implementation uses SSE to compare up to 16 bytes at a time.
+- */
+-#ifdef USE_AS_STRNCMP
+-	test	%rdx, %rdx
+-	je	L(strcmp_exitz)
+-	cmp	$1, %rdx
+-	je	L(Byte0)
+-	mov	%rdx, %r11
+-#endif
+-	mov	%esi, %ecx
+-	mov	%edi, %eax
+-/* Use 64bit AND here to avoid long NOP padding.  */
+-	and	$0x3f, %rcx		/* rsi alignment in cache line */
+-	and	$0x3f, %rax		/* rdi alignment in cache line */
+-	cmp	$0x30, %ecx
+-	ja	L(crosscache)	/* rsi: 16-byte load will cross cache line */
+-	cmp	$0x30, %eax
+-	ja	L(crosscache)	/* rdi: 16-byte load will cross cache line */
+-	movlpd	(%rdi), %xmm1
+-	movlpd	(%rsi), %xmm2
+-	movhpd	8(%rdi), %xmm1
+-	movhpd	8(%rsi), %xmm2
+-	pxor	%xmm0, %xmm0		/* clear %xmm0 for null char checks */
+-	pcmpeqb	%xmm1, %xmm0		/* Any null chars? */
+-	pcmpeqb	%xmm2, %xmm1		/* compare first 16 bytes for equality */
+-	psubb	%xmm0, %xmm1		/* packed sub of comparison results*/
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx		/* if first 16 bytes are same, edx == 0xffff */
+-	jnz	L(less16bytes)	/* If not, find different value or null char */
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)	/* finish comparision */
+-#endif
+-	add	$16, %rsi		/* prepare to search next 16 bytes */
+-	add	$16, %rdi		/* prepare to search next 16 bytes */
+-
+-	/*
+-	 * Determine source and destination string offsets from 16-byte alignment.
+-	 * Use relative offset difference between the two to determine which case
+-	 * below to use.
+-	 */
+-	.p2align 4
+-L(crosscache):
+-	and	$0xfffffffffffffff0, %rsi	/* force %rsi is 16 byte aligned */
+-	and	$0xfffffffffffffff0, %rdi	/* force %rdi is 16 byte aligned */
+-	mov	$0xffff, %edx			/* for equivalent offset */
+-	xor	%r8d, %r8d
+-	and	$0xf, %ecx			/* offset of rsi */
+-	and	$0xf, %eax			/* offset of rdi */
+-	cmp	%eax, %ecx
+-	je	L(ashr_0)			/* rsi and rdi relative offset same */
+-	ja	L(bigger)
+-	mov	%edx, %r8d			/* r8d is offset flag for exit tail */
+-	xchg	%ecx, %eax
+-	xchg	%rsi, %rdi
+-L(bigger):
+-	lea	15(%rax), %r9
+-	sub	%rcx, %r9
+-	lea	L(unaligned_table)(%rip), %r10
+-	movslq	(%r10, %r9,4), %r9
+-	lea	(%r10, %r9), %r10
+-	jmp	*%r10				/* jump to corresponding case */
+-
+-/*
+- * The following cases will be handled by ashr_0
+- *  rcx(offset of rsi)  rax(offset of rdi)  relative offset  corresponding case
+- *        n(0~15)            n(0~15)           15(15+ n-n)         ashr_0
+- */
+-	.p2align 4
+-L(ashr_0):
+-
+-	movdqa	(%rsi), %xmm1
+-	pxor	%xmm0, %xmm0			/* clear %xmm0 for null char check */
+-	pcmpeqb	%xmm1, %xmm0			/* Any null chars? */
+-	pcmpeqb	(%rdi), %xmm1			/* compare 16 bytes for equality */
+-	psubb	%xmm0, %xmm1			/* packed sub of comparison results*/
+-	pmovmskb %xmm1, %r9d
+-	shr	%cl, %edx			/* adjust 0xffff for offset */
+-	shr	%cl, %r9d			/* adjust for 16-byte offset */
+-	sub	%r9d, %edx
+-	/*
+-	 * edx must be the same with r9d if in left byte (16-rcx) is equal to
+-	 * the start from (16-rax) and no null char was seen.
+-	 */
+-	jne	L(less32bytes)		/* mismatch or null char */
+-	UPDATE_STRNCMP_COUNTER
+-	mov	$16, %rcx
+-	mov	$16, %r9
+-	pxor	%xmm0, %xmm0			/* clear xmm0, may have changed above */
+-
+-	/*
+-	 * Now both strings are aligned at 16-byte boundary. Loop over strings
+-	 * checking 32-bytes per iteration.
+-	 */
+-	.p2align 4
+-L(loop_ashr_0):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)		/* mismatch or null char seen */
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-	add	$16, %rcx
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-	add	$16, %rcx
+-	jmp	L(loop_ashr_0)
+-
+-/*
+- * The following cases will be handled by ashr_1
+- * rcx(offset of rsi)  rax(offset of rdi)   relative offset   	corresponding case
+- *        n(15)            n -15            0(15 +(n-15) - n)         ashr_1
+- */
+-	.p2align 4
+-L(ashr_1):
+-	pxor	%xmm0, %xmm0
+-	movdqa	(%rdi), %xmm2
+-	movdqa	(%rsi), %xmm1
+-	pcmpeqb	%xmm1, %xmm0		/* Any null chars? */
+-	pslldq	$15, %xmm2		/* shift first string to align with second */
+-	pcmpeqb	%xmm1, %xmm2		/* compare 16 bytes for equality */
+-	psubb	%xmm0, %xmm2		/* packed sub of comparison results*/
+-	pmovmskb %xmm2, %r9d
+-	shr	%cl, %edx		/* adjust 0xffff for offset */
+-	shr	%cl, %r9d		/* adjust for 16-byte offset */
+-	sub	%r9d, %edx
+-	jnz	L(less32bytes)	/* mismatch or null char seen */
+-	movdqa	(%rdi), %xmm3
+-	UPDATE_STRNCMP_COUNTER
+-
+-	pxor	%xmm0, %xmm0
+-	mov	$16, %rcx		/* index for loads*/
+-	mov	$1, %r9d		/* byte position left over from less32bytes case */
+-	/*
+-	 * Setup %r10 value allows us to detect crossing a page boundary.
+-	 * When %r10 goes positive we have crossed a page boundary and
+-	 * need to do a nibble.
+-	 */
+-	lea	1(%rdi), %r10
+-	and	$0xfff, %r10		/* offset into 4K page */
+-	sub	$0x1000, %r10		/* subtract 4K pagesize */
+-
+-	.p2align 4
+-L(loop_ashr_1):
+-	add	$16, %r10
+-	jg	L(nibble_ashr_1)	/* cross page boundary */
+-
+-L(gobble_ashr_1):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4		 /* store for next cycle */
+-
+-	palignr $1, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-
+-	add	$16, %r10
+-	jg	L(nibble_ashr_1)	/* cross page boundary */
+-
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4		/* store for next cycle */
+-
+-	palignr $1, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-	jmp	L(loop_ashr_1)
+-
+-	/*
+-	 * Nibble avoids loads across page boundary. This is to avoid a potential
+-	 * access into unmapped memory.
+-	 */
+-	.p2align 4
+-L(nibble_ashr_1):
+-	pcmpeqb	%xmm3, %xmm0		 /* check nibble for null char*/
+-	pmovmskb %xmm0, %edx
+-	test	$0xfffe, %edx
+-	jnz	L(ashr_1_exittail)	/* find null char*/
+-
+-#ifdef USE_AS_STRNCMP
+-	cmp	$14, %r11
+-	jbe	L(ashr_1_exittail)
+-#endif
+-
+-	pxor	%xmm0, %xmm0
+-	sub	$0x1000, %r10		/* substract 4K from %r10 */
+-	jmp	L(gobble_ashr_1)
+-
+-	/*
+-	 * Once find null char, determine if there is a string mismatch
+-	 * before the null char.
+-	 */
+-	.p2align 4
+-L(ashr_1_exittail):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	psrldq	$1, %xmm0
+-	psrldq	$1, %xmm3
+-	jmp	L(aftertail)
+-
+-/*
+- * The following cases will be handled by ashr_2
+- * rcx(offset of rsi)  rax(offset of rdi)   relative offset   	corresponding case
+- *        n(14~15)            n -14         1(15 +(n-14) - n)         ashr_2
+- */
+-	.p2align 4
+-L(ashr_2):
+-	pxor	%xmm0, %xmm0
+-	movdqa	(%rdi), %xmm2
+-	movdqa	(%rsi), %xmm1
+-	pcmpeqb	%xmm1, %xmm0
+-	pslldq	$14, %xmm2
+-	pcmpeqb	%xmm1, %xmm2
+-	psubb	%xmm0, %xmm2
+-	pmovmskb %xmm2, %r9d
+-	shr	%cl, %edx
+-	shr	%cl, %r9d
+-	sub	%r9d, %edx
+-	jnz	L(less32bytes)
+-	movdqa	(%rdi), %xmm3
+-	UPDATE_STRNCMP_COUNTER
+-
+-	pxor	%xmm0, %xmm0
+-	mov	$16, %rcx	/* index for loads */
+-	mov	$2, %r9d	/* byte position left over from less32bytes case */
+-	/*
+-	 * Setup %r10 value allows us to detect crossing a page boundary.
+-	 * When %r10 goes positive we have crossed a page boundary and
+-	 * need to do a nibble.
+-	 */
+-	lea	2(%rdi), %r10
+-	and	$0xfff, %r10	/* offset into 4K page */
+-	sub	$0x1000, %r10	/* subtract 4K pagesize */
+-
+-	.p2align 4
+-L(loop_ashr_2):
+-	add	$16, %r10
+-	jg	L(nibble_ashr_2)
+-
+-L(gobble_ashr_2):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $2, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-
+-	add	$16, %r10
+-	jg	L(nibble_ashr_2)	/* cross page boundary */
+-
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $2, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-	jmp	L(loop_ashr_2)
+-
+-	.p2align 4
+-L(nibble_ashr_2):
+-	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
+-	pmovmskb %xmm0, %edx
+-	test	$0xfffc, %edx
+-	jnz	L(ashr_2_exittail)
+-
+-#ifdef USE_AS_STRNCMP
+-	cmp	$13, %r11
+-	jbe	L(ashr_2_exittail)
+-#endif
+-
+-	pxor	%xmm0, %xmm0
+-	sub	$0x1000, %r10
+-	jmp	L(gobble_ashr_2)
+-
+-	.p2align 4
+-L(ashr_2_exittail):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	psrldq	$2, %xmm0
+-	psrldq	$2, %xmm3
+-	jmp	L(aftertail)
+-
+-/*
+- * The following cases will be handled by ashr_3
+- *  rcx(offset of rsi)  rax(offset of rdi)  relative offset	 corresponding case
+- *        n(13~15)            n -13         2(15 +(n-13) - n)         ashr_3
+- */
+-	.p2align 4
+-L(ashr_3):
+-	pxor	%xmm0, %xmm0
+-	movdqa	(%rdi), %xmm2
+-	movdqa	(%rsi), %xmm1
+-	pcmpeqb	%xmm1, %xmm0
+-	pslldq	$13, %xmm2
+-	pcmpeqb	%xmm1, %xmm2
+-	psubb	%xmm0, %xmm2
+-	pmovmskb %xmm2, %r9d
+-	shr	%cl, %edx
+-	shr	%cl, %r9d
+-	sub	%r9d, %edx
+-	jnz	L(less32bytes)
+-	movdqa	(%rdi), %xmm3
+-
+-	UPDATE_STRNCMP_COUNTER
+-
+-	pxor	%xmm0, %xmm0
+-	mov	$16, %rcx	/* index for loads */
+-	mov	$3, %r9d	/* byte position left over from less32bytes case */
+-	/*
+-	 * Setup %r10 value allows us to detect crossing a page boundary.
+-	 * When %r10 goes positive we have crossed a page boundary and
+-	 * need to do a nibble.
+-	 */
+-	lea	3(%rdi), %r10
+-	and	$0xfff, %r10	/* offset into 4K page */
+-	sub	$0x1000, %r10	/* subtract 4K pagesize */
+-
+-	.p2align 4
+-L(loop_ashr_3):
+-	add	$16, %r10
+-	jg	L(nibble_ashr_3)
+-
+-L(gobble_ashr_3):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $3, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-
+-	add	$16, %r10
+-	jg	L(nibble_ashr_3)	/* cross page boundary */
+-
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $3, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-	jmp	L(loop_ashr_3)
+-
+-	.p2align 4
+-L(nibble_ashr_3):
+-	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
+-	pmovmskb %xmm0, %edx
+-	test	$0xfff8, %edx
+-	jnz	L(ashr_3_exittail)
+-
+-#ifdef USE_AS_STRNCMP
+-	cmp	$12, %r11
+-	jbe	L(ashr_3_exittail)
+-#endif
+-
+-	pxor	%xmm0, %xmm0
+-	sub	$0x1000, %r10
+-	jmp	L(gobble_ashr_3)
+-
+-	.p2align 4
+-L(ashr_3_exittail):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	psrldq	$3, %xmm0
+-	psrldq	$3, %xmm3
+-	jmp	L(aftertail)
+-
+-/*
+- * The following cases will be handled by ashr_4
+- *  rcx(offset of rsi)  rax(offset of rdi)  relative offset	 corresponding case
+- *        n(12~15)            n -12         3(15 +(n-12) - n)         ashr_4
+- */
+-	.p2align 4
+-L(ashr_4):
+-	pxor	%xmm0, %xmm0
+-	movdqa	(%rdi), %xmm2
+-	movdqa	(%rsi), %xmm1
+-	pcmpeqb	%xmm1, %xmm0
+-	pslldq	$12, %xmm2
+-	pcmpeqb	%xmm1, %xmm2
+-	psubb	%xmm0, %xmm2
+-	pmovmskb %xmm2, %r9d
+-	shr	%cl, %edx
+-	shr	%cl, %r9d
+-	sub	%r9d, %edx
+-	jnz	L(less32bytes)
+-	movdqa	(%rdi), %xmm3
+-
+-	UPDATE_STRNCMP_COUNTER
+-
+-	pxor	%xmm0, %xmm0
+-	mov	$16, %rcx	/* index for loads */
+-	mov	$4, %r9d	/* byte position left over from less32bytes case */
+-	/*
+-	 * Setup %r10 value allows us to detect crossing a page boundary.
+-	 * When %r10 goes positive we have crossed a page boundary and
+-	 * need to do a nibble.
+-	 */
+-	lea	4(%rdi), %r10
+-	and	$0xfff, %r10	/* offset into 4K page */
+-	sub	$0x1000, %r10	/* subtract 4K pagesize */
+-
+-	.p2align 4
+-L(loop_ashr_4):
+-	add	$16, %r10
+-	jg	L(nibble_ashr_4)
+-
+-L(gobble_ashr_4):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $4, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-
+-	add	$16, %r10
+-	jg	L(nibble_ashr_4)	/* cross page boundary */
+-
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $4, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-	jmp	L(loop_ashr_4)
+-
+-	.p2align 4
+-L(nibble_ashr_4):
+-	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
+-	pmovmskb %xmm0, %edx
+-	test	$0xfff0, %edx
+-	jnz	L(ashr_4_exittail)
+-
+-#ifdef USE_AS_STRNCMP
+-	cmp	$11, %r11
+-	jbe	L(ashr_4_exittail)
+-#endif
+-
+-	pxor	%xmm0, %xmm0
+-	sub	$0x1000, %r10
+-	jmp	L(gobble_ashr_4)
+-
+-	.p2align 4
+-L(ashr_4_exittail):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	psrldq	$4, %xmm0
+-	psrldq	$4, %xmm3
+-	jmp	L(aftertail)
+-
+-/*
+- * The following cases will be handled by ashr_5
+- *  rcx(offset of rsi)  rax(offset of rdi)        relative offset      corresponding case
+- *        n(11~15)          n - 11      	  4(15 +(n-11) - n)         ashr_5
+- */
+-	.p2align 4
+-L(ashr_5):
+-	pxor	%xmm0, %xmm0
+-	movdqa	(%rdi), %xmm2
+-	movdqa	(%rsi), %xmm1
+-	pcmpeqb	%xmm1, %xmm0
+-	pslldq	$11, %xmm2
+-	pcmpeqb	%xmm1, %xmm2
+-	psubb	%xmm0, %xmm2
+-	pmovmskb %xmm2, %r9d
+-	shr	%cl, %edx
+-	shr	%cl, %r9d
+-	sub	%r9d, %edx
+-	jnz	L(less32bytes)
+-	movdqa	(%rdi), %xmm3
+-
+-	UPDATE_STRNCMP_COUNTER
+-
+-	pxor	%xmm0, %xmm0
+-	mov	$16, %rcx	/* index for loads */
+-	mov	$5, %r9d	/* byte position left over from less32bytes case */
+-	/*
+-	 * Setup %r10 value allows us to detect crossing a page boundary.
+-	 * When %r10 goes positive we have crossed a page boundary and
+-	 * need to do a nibble.
+-	 */
+-	lea	5(%rdi), %r10
+-	and	$0xfff, %r10	/* offset into 4K page */
+-	sub	$0x1000, %r10	/* subtract 4K pagesize */
+-
+-	.p2align 4
+-L(loop_ashr_5):
+-	add	$16, %r10
+-	jg	L(nibble_ashr_5)
+-
+-L(gobble_ashr_5):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $5, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-
+-	add	$16, %r10
+-	jg	L(nibble_ashr_5)	/* cross page boundary */
+-
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $5, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-	jmp	L(loop_ashr_5)
+-
+-	.p2align 4
+-L(nibble_ashr_5):
+-	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
+-	pmovmskb %xmm0, %edx
+-	test	$0xffe0, %edx
+-	jnz	L(ashr_5_exittail)
+-
+-#ifdef USE_AS_STRNCMP
+-	cmp	$10, %r11
+-	jbe	L(ashr_5_exittail)
+-#endif
+-
+-	pxor	%xmm0, %xmm0
+-	sub	$0x1000, %r10
+-	jmp	L(gobble_ashr_5)
+-
+-	.p2align 4
+-L(ashr_5_exittail):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	psrldq	$5, %xmm0
+-	psrldq	$5, %xmm3
+-	jmp	L(aftertail)
+-
+-/*
+- * The following cases will be handled by ashr_6
+- *  rcx(offset of rsi)  rax(offset of rdi)        relative offset      corresponding case
+- *        n(10~15)          n - 10      	  5(15 +(n-10) - n)         ashr_6
+- */
+-	.p2align 4
+-L(ashr_6):
+-	pxor	%xmm0, %xmm0
+-	movdqa	(%rdi), %xmm2
+-	movdqa	(%rsi), %xmm1
+-	pcmpeqb	%xmm1, %xmm0
+-	pslldq	$10, %xmm2
+-	pcmpeqb	%xmm1, %xmm2
+-	psubb	%xmm0, %xmm2
+-	pmovmskb %xmm2, %r9d
+-	shr	%cl, %edx
+-	shr	%cl, %r9d
+-	sub	%r9d, %edx
+-	jnz	L(less32bytes)
+-	movdqa	(%rdi), %xmm3
+-
+-	UPDATE_STRNCMP_COUNTER
+-
+-	pxor	%xmm0, %xmm0
+-	mov	$16, %rcx	/* index for loads */
+-	mov	$6, %r9d	/* byte position left over from less32bytes case */
+-	/*
+-	 * Setup %r10 value allows us to detect crossing a page boundary.
+-	 * When %r10 goes positive we have crossed a page boundary and
+-	 * need to do a nibble.
+-	 */
+-	lea	6(%rdi), %r10
+-	and	$0xfff, %r10	/* offset into 4K page */
+-	sub	$0x1000, %r10	/* subtract 4K pagesize */
+-
+-	.p2align 4
+-L(loop_ashr_6):
+-	add	$16, %r10
+-	jg	L(nibble_ashr_6)
+-
+-L(gobble_ashr_6):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $6, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-
+-	add	$16, %r10
+-	jg	L(nibble_ashr_6)	/* cross page boundary */
+-
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $6, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-	jmp	L(loop_ashr_6)
+-
+-	.p2align 4
+-L(nibble_ashr_6):
+-	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
+-	pmovmskb %xmm0, %edx
+-	test	$0xffc0, %edx
+-	jnz	L(ashr_6_exittail)
+-
+-#ifdef USE_AS_STRNCMP
+-	cmp	$9, %r11
+-	jbe	L(ashr_6_exittail)
+-#endif
+-
+-	pxor	%xmm0, %xmm0
+-	sub	$0x1000, %r10
+-	jmp	L(gobble_ashr_6)
+-
+-	.p2align 4
+-L(ashr_6_exittail):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	psrldq	$6, %xmm0
+-	psrldq	$6, %xmm3
+-	jmp	L(aftertail)
+-
+-/*
+- * The following cases will be handled by ashr_7
+- *  rcx(offset of rsi)  rax(offset of rdi)        relative offset      corresponding case
+- *        n(9~15)          n - 9      	        6(15 +(n - 9) - n)         ashr_7
+- */
+-	.p2align 4
+-L(ashr_7):
+-	pxor	%xmm0, %xmm0
+-	movdqa	(%rdi), %xmm2
+-	movdqa	(%rsi), %xmm1
+-	pcmpeqb	%xmm1, %xmm0
+-	pslldq	$9, %xmm2
+-	pcmpeqb	%xmm1, %xmm2
+-	psubb	%xmm0, %xmm2
+-	pmovmskb %xmm2, %r9d
+-	shr	%cl, %edx
+-	shr	%cl, %r9d
+-	sub	%r9d, %edx
+-	jnz	L(less32bytes)
+-	movdqa	(%rdi), %xmm3
+-
+-	UPDATE_STRNCMP_COUNTER
+-
+-	pxor	%xmm0, %xmm0
+-	mov	$16, %rcx	/* index for loads */
+-	mov	$7, %r9d	/* byte position left over from less32bytes case */
+-	/*
+-	 * Setup %r10 value allows us to detect crossing a page boundary.
+-	 * When %r10 goes positive we have crossed a page boundary and
+-	 * need to do a nibble.
+-	 */
+-	lea	7(%rdi), %r10
+-	and	$0xfff, %r10	/* offset into 4K page */
+-	sub	$0x1000, %r10	/* subtract 4K pagesize */
+-
+-	.p2align 4
+-L(loop_ashr_7):
+-	add	$16, %r10
+-	jg	L(nibble_ashr_7)
+-
+-L(gobble_ashr_7):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $7, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-
+-	add	$16, %r10
+-	jg	L(nibble_ashr_7)	/* cross page boundary */
+-
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $7, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-	jmp	L(loop_ashr_7)
+-
+-	.p2align 4
+-L(nibble_ashr_7):
+-	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
+-	pmovmskb %xmm0, %edx
+-	test	$0xff80, %edx
+-	jnz	L(ashr_7_exittail)
+-
+-#ifdef USE_AS_STRNCMP
+-	cmp	$8, %r11
+-	jbe	L(ashr_7_exittail)
+-#endif
+-
+-	pxor	%xmm0, %xmm0
+-	sub	$0x1000, %r10
+-	jmp	L(gobble_ashr_7)
+-
+-	.p2align 4
+-L(ashr_7_exittail):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	psrldq	$7, %xmm0
+-	psrldq	$7, %xmm3
+-	jmp	L(aftertail)
+-
+-/*
+- *  The following cases will be handled by ashr_8
+- *  rcx(offset of rsi)  rax(offset of rdi)        relative offset	 corresponding case
+- *        n(8~15)          n - 8      	        7(15 +(n - 8) - n)         ashr_8
+- */
+-	.p2align 4
+-L(ashr_8):
+-	pxor	%xmm0, %xmm0
+-	movdqa	(%rdi), %xmm2
+-	movdqa	(%rsi), %xmm1
+-	pcmpeqb	%xmm1, %xmm0
+-	pslldq	$8, %xmm2
+-	pcmpeqb	%xmm1, %xmm2
+-	psubb	%xmm0, %xmm2
+-	pmovmskb %xmm2, %r9d
+-	shr	%cl, %edx
+-	shr	%cl, %r9d
+-	sub	%r9d, %edx
+-	jnz	L(less32bytes)
+-	movdqa	(%rdi), %xmm3
+-
+-	UPDATE_STRNCMP_COUNTER
+-
+-	pxor	%xmm0, %xmm0
+-	mov	$16, %rcx	/* index for loads */
+-	mov	$8, %r9d	/* byte position left over from less32bytes case */
+-	/*
+-	 * Setup %r10 value allows us to detect crossing a page boundary.
+-	 * When %r10 goes positive we have crossed a page boundary and
+-	 * need to do a nibble.
+-	 */
+-	lea	8(%rdi), %r10
+-	and	$0xfff, %r10	/* offset into 4K page */
+-	sub	$0x1000, %r10	/* subtract 4K pagesize */
+-
+-	.p2align 4
+-L(loop_ashr_8):
+-	add	$16, %r10
+-	jg	L(nibble_ashr_8)
+-
+-L(gobble_ashr_8):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $8, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-
+-	add	$16, %r10
+-	jg	L(nibble_ashr_8)	/* cross page boundary */
+-
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $8, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-	jmp	L(loop_ashr_8)
+-
+-	.p2align 4
+-L(nibble_ashr_8):
+-	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
+-	pmovmskb %xmm0, %edx
+-	test	$0xff00, %edx
+-	jnz	L(ashr_8_exittail)
+-
+-#ifdef USE_AS_STRNCMP
+-	cmp	$7, %r11
+-	jbe	L(ashr_8_exittail)
+-#endif
+-
+-	pxor	%xmm0, %xmm0
+-	sub	$0x1000, %r10
+-	jmp	L(gobble_ashr_8)
+-
+-	.p2align 4
+-L(ashr_8_exittail):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	psrldq	$8, %xmm0
+-	psrldq	$8, %xmm3
+-	jmp	L(aftertail)
+-
+-/*
+- *  The following cases will be handled by ashr_9
+- *  rcx(offset of rsi)  rax(offset of rdi)        relative offset	 corresponding case
+- *        n(7~15)          n - 7      	        8(15 +(n - 7) - n)         ashr_9
+- */
+-	.p2align 4
+-L(ashr_9):
+-	pxor	%xmm0, %xmm0
+-	movdqa	(%rdi), %xmm2
+-	movdqa	(%rsi), %xmm1
+-	pcmpeqb	%xmm1, %xmm0
+-	pslldq	$7, %xmm2
+-	pcmpeqb	%xmm1, %xmm2
+-	psubb	%xmm0, %xmm2
+-	pmovmskb %xmm2, %r9d
+-	shr	%cl, %edx
+-	shr	%cl, %r9d
+-	sub	%r9d, %edx
+-	jnz	L(less32bytes)
+-	movdqa	(%rdi), %xmm3
+-
+-	UPDATE_STRNCMP_COUNTER
+-
+-	pxor	%xmm0, %xmm0
+-	mov	$16, %rcx	/* index for loads */
+-	mov	$9, %r9d	/* byte position left over from less32bytes case */
+-	/*
+-	 * Setup %r10 value allows us to detect crossing a page boundary.
+-	 * When %r10 goes positive we have crossed a page boundary and
+-	 * need to do a nibble.
+-	 */
+-	lea	9(%rdi), %r10
+-	and	$0xfff, %r10	/* offset into 4K page */
+-	sub	$0x1000, %r10	/* subtract 4K pagesize */
+-
+-	.p2align 4
+-L(loop_ashr_9):
+-	add	$16, %r10
+-	jg	L(nibble_ashr_9)
+-
+-L(gobble_ashr_9):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $9, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-
+-	add	$16, %r10
+-	jg	L(nibble_ashr_9)	/* cross page boundary */
+-
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $9, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3		/* store for next cycle */
+-	jmp	L(loop_ashr_9)
+-
+-	.p2align 4
+-L(nibble_ashr_9):
+-	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
+-	pmovmskb %xmm0, %edx
+-	test	$0xfe00, %edx
+-	jnz	L(ashr_9_exittail)
+-
+-#ifdef USE_AS_STRNCMP
+-	cmp	$6, %r11
+-	jbe	L(ashr_9_exittail)
+-#endif
+-
+-	pxor	%xmm0, %xmm0
+-	sub	$0x1000, %r10
+-	jmp	L(gobble_ashr_9)
+-
+-	.p2align 4
+-L(ashr_9_exittail):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	psrldq	$9, %xmm0
+-	psrldq	$9, %xmm3
+-	jmp	L(aftertail)
+-
+-/*
+- *  The following cases will be handled by ashr_10
+- *  rcx(offset of rsi)  rax(offset of rdi)        relative offset	 corresponding case
+- *        n(6~15)          n - 6      	        9(15 +(n - 6) - n)         ashr_10
+- */
+-	.p2align 4
+-L(ashr_10):
+-	pxor	%xmm0, %xmm0
+-	movdqa	(%rdi), %xmm2
+-	movdqa	(%rsi), %xmm1
+-	pcmpeqb	%xmm1, %xmm0
+-	pslldq	$6, %xmm2
+-	pcmpeqb	%xmm1, %xmm2
+-	psubb	%xmm0, %xmm2
+-	pmovmskb %xmm2, %r9d
+-	shr	%cl, %edx
+-	shr	%cl, %r9d
+-	sub	%r9d, %edx
+-	jnz	L(less32bytes)
+-	movdqa	(%rdi), %xmm3
+-
+-	UPDATE_STRNCMP_COUNTER
+-
+-	pxor	%xmm0, %xmm0
+-	mov	$16, %rcx	/* index for loads */
+-	mov	$10, %r9d	/* byte position left over from less32bytes case */
+-	/*
+-	 * Setup %r10 value allows us to detect crossing a page boundary.
+-	 * When %r10 goes positive we have crossed a page boundary and
+-	 * need to do a nibble.
+-	 */
+-	lea	10(%rdi), %r10
+-	and	$0xfff, %r10	/* offset into 4K page */
+-	sub	$0x1000, %r10	/* subtract 4K pagesize */
+-
+-	.p2align 4
+-L(loop_ashr_10):
+-	add	$16, %r10
+-	jg	L(nibble_ashr_10)
+-
+-L(gobble_ashr_10):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $10, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-
+-	add	$16, %r10
+-	jg	L(nibble_ashr_10)	/* cross page boundary */
+-
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $10, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-	jmp	L(loop_ashr_10)
+-
+-	.p2align 4
+-L(nibble_ashr_10):
+-	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
+-	pmovmskb %xmm0, %edx
+-	test	$0xfc00, %edx
+-	jnz	L(ashr_10_exittail)
+-
+-#ifdef USE_AS_STRNCMP
+-	cmp	$5, %r11
+-	jbe	L(ashr_10_exittail)
+-#endif
+-
+-	pxor	%xmm0, %xmm0
+-	sub	$0x1000, %r10
+-	jmp	L(gobble_ashr_10)
+-
+-	.p2align 4
+-L(ashr_10_exittail):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	psrldq	$10, %xmm0
+-	psrldq	$10, %xmm3
+-	jmp	L(aftertail)
+-
+-/*
+- *  The following cases will be handled by ashr_11
+- *  rcx(offset of rsi)  rax(offset of rdi)        relative offset	 corresponding case
+- *        n(5~15)          n - 5      	        10(15 +(n - 5) - n)         ashr_11
+- */
+-	.p2align 4
+-L(ashr_11):
+-	pxor	%xmm0, %xmm0
+-	movdqa	(%rdi), %xmm2
+-	movdqa	(%rsi), %xmm1
+-	pcmpeqb	%xmm1, %xmm0
+-	pslldq	$5, %xmm2
+-	pcmpeqb	%xmm1, %xmm2
+-	psubb	%xmm0, %xmm2
+-	pmovmskb %xmm2, %r9d
+-	shr	%cl, %edx
+-	shr	%cl, %r9d
+-	sub	%r9d, %edx
+-	jnz	L(less32bytes)
+-	movdqa	(%rdi), %xmm3
+-
+-	UPDATE_STRNCMP_COUNTER
+-
+-	pxor	%xmm0, %xmm0
+-	mov	$16, %rcx	/* index for loads */
+-	mov	$11, %r9d	/* byte position left over from less32bytes case */
+-	/*
+-	 * Setup %r10 value allows us to detect crossing a page boundary.
+-	 * When %r10 goes positive we have crossed a page boundary and
+-	 * need to do a nibble.
+-	 */
+-	lea	11(%rdi), %r10
+-	and	$0xfff, %r10	/* offset into 4K page */
+-	sub	$0x1000, %r10	/* subtract 4K pagesize */
+-
+-	.p2align 4
+-L(loop_ashr_11):
+-	add	$16, %r10
+-	jg	L(nibble_ashr_11)
+-
+-L(gobble_ashr_11):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $11, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-
+-	add	$16, %r10
+-	jg	L(nibble_ashr_11)	/* cross page boundary */
+-
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $11, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-	jmp	L(loop_ashr_11)
+-
+-	.p2align 4
+-L(nibble_ashr_11):
+-	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
+-	pmovmskb %xmm0, %edx
+-	test	$0xf800, %edx
+-	jnz	L(ashr_11_exittail)
+-
+-#ifdef USE_AS_STRNCMP
+-	cmp	$4, %r11
+-	jbe	L(ashr_11_exittail)
+-#endif
+-
+-	pxor	%xmm0, %xmm0
+-	sub	$0x1000, %r10
+-	jmp	L(gobble_ashr_11)
+-
+-	.p2align 4
+-L(ashr_11_exittail):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	psrldq	$11, %xmm0
+-	psrldq	$11, %xmm3
+-	jmp	L(aftertail)
+-
+-/*
+- *  The following cases will be handled by ashr_12
+- *  rcx(offset of rsi)  rax(offset of rdi)        relative offset	 corresponding case
+- *        n(4~15)          n - 4      	        11(15 +(n - 4) - n)         ashr_12
+- */
+-	.p2align 4
+-L(ashr_12):
+-	pxor	%xmm0, %xmm0
+-	movdqa	(%rdi), %xmm2
+-	movdqa	(%rsi), %xmm1
+-	pcmpeqb	%xmm1, %xmm0
+-	pslldq	$4, %xmm2
+-	pcmpeqb	%xmm1, %xmm2
+-	psubb	%xmm0, %xmm2
+-	pmovmskb %xmm2, %r9d
+-	shr	%cl, %edx
+-	shr	%cl, %r9d
+-	sub	%r9d, %edx
+-	jnz	L(less32bytes)
+-	movdqa	(%rdi), %xmm3
+-
+-	UPDATE_STRNCMP_COUNTER
+-
+-	pxor	%xmm0, %xmm0
+-	mov	$16, %rcx	/* index for loads */
+-	mov	$12, %r9d	/* byte position left over from less32bytes case */
+-	/*
+-	 * Setup %r10 value allows us to detect crossing a page boundary.
+-	 * When %r10 goes positive we have crossed a page boundary and
+-	 * need to do a nibble.
+-	 */
+-	lea	12(%rdi), %r10
+-	and	$0xfff, %r10	/* offset into 4K page */
+-	sub	$0x1000, %r10	/* subtract 4K pagesize */
+-
+-	.p2align 4
+-L(loop_ashr_12):
+-	add	$16, %r10
+-	jg	L(nibble_ashr_12)
+-
+-L(gobble_ashr_12):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $12, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-
+-	add	$16, %r10
+-	jg	L(nibble_ashr_12)	/* cross page boundary */
+-
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $12, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-	jmp	L(loop_ashr_12)
+-
+-	.p2align 4
+-L(nibble_ashr_12):
+-	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
+-	pmovmskb %xmm0, %edx
+-	test	$0xf000, %edx
+-	jnz	L(ashr_12_exittail)
+-
+-#ifdef USE_AS_STRNCMP
+-	cmp	$3, %r11
+-	jbe	L(ashr_12_exittail)
+-#endif
+-
+-	pxor	%xmm0, %xmm0
+-	sub	$0x1000, %r10
+-	jmp	L(gobble_ashr_12)
+-
+-	.p2align 4
+-L(ashr_12_exittail):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	psrldq	$12, %xmm0
+-	psrldq	$12, %xmm3
+-	jmp	L(aftertail)
+-
+-/*
+- *  The following cases will be handled by ashr_13
+- *  rcx(offset of rsi)  rax(offset of rdi)        relative offset	 corresponding case
+- *        n(3~15)          n - 3      	        12(15 +(n - 3) - n)         ashr_13
+- */
+-	.p2align 4
+-L(ashr_13):
+-	pxor	%xmm0, %xmm0
+-	movdqa	(%rdi), %xmm2
+-	movdqa	(%rsi), %xmm1
+-	pcmpeqb	%xmm1, %xmm0
+-	pslldq	$3, %xmm2
+-	pcmpeqb	%xmm1, %xmm2
+-	psubb	%xmm0, %xmm2
+-	pmovmskb %xmm2, %r9d
+-	shr	%cl, %edx
+-	shr	%cl, %r9d
+-	sub	%r9d, %edx
+-	jnz	L(less32bytes)
+-	movdqa	(%rdi), %xmm3
+-
+-	UPDATE_STRNCMP_COUNTER
+-
+-	pxor	%xmm0, %xmm0
+-	mov	$16, %rcx	/* index for loads */
+-	mov	$13, %r9d	/* byte position left over from less32bytes case */
+-	/*
+-	 * Setup %r10 value allows us to detect crossing a page boundary.
+-	 * When %r10 goes positive we have crossed a page boundary and
+-	 * need to do a nibble.
+-	 */
+-	lea	13(%rdi), %r10
+-	and	$0xfff, %r10	/* offset into 4K page */
+-	sub	$0x1000, %r10	/* subtract 4K pagesize */
+-
+-	.p2align 4
+-L(loop_ashr_13):
+-	add	$16, %r10
+-	jg	L(nibble_ashr_13)
+-
+-L(gobble_ashr_13):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $13, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-
+-	add	$16, %r10
+-	jg	L(nibble_ashr_13)	/* cross page boundary */
+-
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $13, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-	jmp	L(loop_ashr_13)
+-
+-	.p2align 4
+-L(nibble_ashr_13):
+-	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
+-	pmovmskb %xmm0, %edx
+-	test	$0xe000, %edx
+-	jnz	L(ashr_13_exittail)
+-
+-#ifdef USE_AS_STRNCMP
+-	cmp	$2, %r11
+-	jbe	L(ashr_13_exittail)
+-#endif
+-
+-	pxor	%xmm0, %xmm0
+-	sub	$0x1000, %r10
+-	jmp	L(gobble_ashr_13)
+-
+-	.p2align 4
+-L(ashr_13_exittail):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	psrldq  $13, %xmm0
+-	psrldq  $13, %xmm3
+-	jmp	L(aftertail)
+-
+-/*
+- *  The following cases will be handled by ashr_14
+- *  rcx(offset of rsi)  rax(offset of rdi)        relative offset	 corresponding case
+- *        n(2~15)          n - 2      	        13(15 +(n - 2) - n)         ashr_14
+- */
+-	.p2align 4
+-L(ashr_14):
+-	pxor	%xmm0, %xmm0
+-	movdqa	(%rdi), %xmm2
+-	movdqa	(%rsi), %xmm1
+-	pcmpeqb	%xmm1, %xmm0
+-	pslldq  $2, %xmm2
+-	pcmpeqb	%xmm1, %xmm2
+-	psubb	%xmm0, %xmm2
+-	pmovmskb %xmm2, %r9d
+-	shr	%cl, %edx
+-	shr	%cl, %r9d
+-	sub	%r9d, %edx
+-	jnz	L(less32bytes)
+-	movdqa	(%rdi), %xmm3
+-
+-	UPDATE_STRNCMP_COUNTER
+-
+-	pxor	%xmm0, %xmm0
+-	mov	$16, %rcx	/* index for loads */
+-	mov	$14, %r9d	/* byte position left over from less32bytes case */
+-	/*
+-	 * Setup %r10 value allows us to detect crossing a page boundary.
+-	 * When %r10 goes positive we have crossed a page boundary and
+-	 * need to do a nibble.
+-	 */
+-	lea	14(%rdi), %r10
+-	and	$0xfff, %r10	/* offset into 4K page */
+-	sub	$0x1000, %r10	/* subtract 4K pagesize */
+-
+-	.p2align 4
+-L(loop_ashr_14):
+-	add	$16, %r10
+-	jg	L(nibble_ashr_14)
+-
+-L(gobble_ashr_14):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $14, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-
+-	add	$16, %r10
+-	jg	L(nibble_ashr_14)	/* cross page boundary */
+-
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $14, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-	jmp	L(loop_ashr_14)
+-
+-	.p2align 4
+-L(nibble_ashr_14):
+-	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
+-	pmovmskb %xmm0, %edx
+-	test	$0xc000, %edx
+-	jnz	L(ashr_14_exittail)
+-
+-#ifdef USE_AS_STRNCMP
+-	cmp	$1, %r11
+-	jbe	L(ashr_14_exittail)
+-#endif
+-
+-	pxor	%xmm0, %xmm0
+-	sub	$0x1000, %r10
+-	jmp	L(gobble_ashr_14)
+-
+-	.p2align 4
+-L(ashr_14_exittail):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	psrldq	$14, %xmm0
+-	psrldq	$14, %xmm3
+-	jmp	L(aftertail)
+-
+-/*
+- *  The following cases will be handled by ashr_15
+- *  rcx(offset of rsi)  rax(offset of rdi)        relative offset	 corresponding case
+- *        n(1~15)          n - 1      	        14(15 +(n - 1) - n)         ashr_15
+- */
+-	.p2align 4
+-L(ashr_15):
+-	pxor	%xmm0, %xmm0
+-	movdqa	(%rdi), %xmm2
+-	movdqa	(%rsi), %xmm1
+-	pcmpeqb	%xmm1, %xmm0
+-	pslldq	$1, %xmm2
+-	pcmpeqb	%xmm1, %xmm2
+-	psubb	%xmm0, %xmm2
+-	pmovmskb %xmm2, %r9d
+-	shr	%cl, %edx
+-	shr	%cl, %r9d
+-	sub	%r9d, %edx
+-	jnz	L(less32bytes)
+-
+-	movdqa	(%rdi), %xmm3
+-
+-	UPDATE_STRNCMP_COUNTER
+-
+-	pxor	%xmm0, %xmm0
+-	mov	$16, %rcx	/* index for loads */
+-	mov	$15, %r9d	/* byte position left over from less32bytes case */
+-	/*
+-	 * Setup %r10 value allows us to detect crossing a page boundary.
+-	 * When %r10 goes positive we have crossed a page boundary and
+-	 * need to do a nibble.
+-	 */
+-	lea	15(%rdi), %r10
+-	and	$0xfff, %r10	/* offset into 4K page */
+-
+-	sub	$0x1000, %r10	/* subtract 4K pagesize */
+-
+-	.p2align 4
+-L(loop_ashr_15):
+-	add	$16, %r10
+-	jg	L(nibble_ashr_15)
+-
+-L(gobble_ashr_15):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $15, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-
+-	add	$16, %r10
+-	jg	L(nibble_ashr_15)	/* cross page boundary */
+-
+-	movdqa	(%rsi, %rcx), %xmm1
+-	movdqa	(%rdi, %rcx), %xmm2
+-	movdqa	%xmm2, %xmm4
+-
+-	palignr $15, %xmm3, %xmm2        /* merge into one 16byte value */
+-
+-	pcmpeqb	%xmm1, %xmm0
+-	pcmpeqb	%xmm2, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	sub	$0xffff, %edx
+-	jnz	L(exit)
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	$16, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-
+-	add	$16, %rcx
+-	movdqa	%xmm4, %xmm3
+-	jmp	L(loop_ashr_15)
+-
+-	.p2align 4
+-L(nibble_ashr_15):
+-	pcmpeqb	%xmm3, %xmm0		/* check nibble for null char */
+-	pmovmskb %xmm0, %edx
+-	test	$0x8000, %edx
+-	jnz	L(ashr_15_exittail)
+-
+-#ifdef USE_AS_STRNCMP
+-	test	%r11, %r11
+-	je	L(ashr_15_exittail)
+-#endif
+-
+-	pxor	%xmm0, %xmm0
+-	sub	$0x1000, %r10
+-	jmp	L(gobble_ashr_15)
+-
+-	.p2align 4
+-L(ashr_15_exittail):
+-	movdqa	(%rsi, %rcx), %xmm1
+-	psrldq	$15, %xmm3
+-	psrldq	$15, %xmm0
+-
+-	.p2align 4
+-L(aftertail):
+-	pcmpeqb	%xmm3, %xmm1
+-	psubb	%xmm0, %xmm1
+-	pmovmskb %xmm1, %edx
+-	not	%edx
+-
+-	.p2align 4
+-L(exit):
+-	lea	-16(%r9, %rcx), %rax	/* locate the exact offset for rdi */
+-L(less32bytes):
+-	lea	(%rdi, %rax), %rdi	/* locate the exact address for first operand(rdi) */
+-	lea	(%rsi, %rcx), %rsi	/* locate the exact address for second operand(rsi) */
+-	test	%r8d, %r8d
+-	jz	L(ret)
+-	xchg	%rsi, %rdi		/* recover original order according to flag(%r8d) */
+-
+-	.p2align 4
+-L(ret):
+-L(less16bytes):
+-	bsf	%rdx, %rdx		/* find and store bit index in %rdx */
+-
+-#ifdef USE_AS_STRNCMP
+-	sub	%rdx, %r11
+-	jbe	L(strcmp_exitz)
+-#endif
+-	movzbl	(%rsi, %rdx), %ecx
+-	movzbl	(%rdi, %rdx), %eax
+-
+-	sub	%ecx, %eax
+-	ret
+-
+-L(strcmp_exitz):
+-	xor	%eax, %eax
+-	ret
+-
+-	.p2align 4
+-L(Byte0):
+-	movzbl	(%rsi), %ecx
+-	movzbl	(%rdi), %eax
+-
+-	sub	%ecx, %eax
+-	ret
+-END (STRCMP)
+-
+-	.section .rodata,"a",@progbits
+-	.p2align 3
+-L(unaligned_table):
+-	.int	L(ashr_1) - L(unaligned_table)
+-	.int	L(ashr_2) - L(unaligned_table)
+-	.int	L(ashr_3) - L(unaligned_table)
+-	.int	L(ashr_4) - L(unaligned_table)
+-	.int	L(ashr_5) - L(unaligned_table)
+-	.int	L(ashr_6) - L(unaligned_table)
+-	.int	L(ashr_7) - L(unaligned_table)
+-	.int	L(ashr_8) - L(unaligned_table)
+-	.int	L(ashr_9) - L(unaligned_table)
+-	.int	L(ashr_10) - L(unaligned_table)
+-	.int	L(ashr_11) - L(unaligned_table)
+-	.int	L(ashr_12) - L(unaligned_table)
+-	.int	L(ashr_13) - L(unaligned_table)
+-	.int	L(ashr_14) - L(unaligned_table)
+-	.int	L(ashr_15) - L(unaligned_table)
+-	.int	L(ashr_0) - L(unaligned_table)
+diff --git a/libc/arch-x86_64/string/ssse3-strncmp-slm.S b/libc/arch-x86_64/string/ssse3-strncmp-slm.S
+deleted file mode 100644
+index 0e40775..0000000
+--- a/libc/arch-x86_64/string/ssse3-strncmp-slm.S
++++ /dev/null
+@@ -1,33 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-#define USE_AS_STRNCMP
+-#define STRCMP		strncmp
+-#include "ssse3-strcmp-slm.S"
+-- 
+2.7.4
+

--- a/aosp_diff/preliminary/bionic/05_0005-Optimize-bionic-string-functions-with-avx-implementa.patch
+++ b/aosp_diff/preliminary/bionic/05_0005-Optimize-bionic-string-functions-with-avx-implementa.patch
@@ -1,0 +1,4268 @@
+From 3e05d36d7fc7af99a7b1ea0943642a20b3a64998 Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Sun, 27 Sep 2020 14:22:37 +0530
+Subject: [PATCH] Optimize bionic string functions with avx implementation
+
+Following are the string functions that has been
+optimized with avx2 implementation from glibc 2.32 version.
+  - strcmp, strncmp
+  - strlen, strnlen
+  - strchr, strrchr
+  - strcpy, strncpy
+  - stpcpy, stpncpy
+  - strcat, strncat
+  - wcscmp, wcsncmp
+  - wcslen, wcsnlen
+  - wcschr, wcsrchr
+
+Tracked-On:
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ libc/Android.bp                                    |   42 +-
+ libc/arch-x86_64/dynamic_function_dispatch.cpp     |  136 ++-
+ libc/arch-x86_64/generic/string/memchr.c           |    2 +-
+ libc/arch-x86_64/generic/string/memrchr.c          |    2 +-
+ libc/arch-x86_64/generic/string/strchr.cpp         |   19 +
+ libc/arch-x86_64/generic/string/strnlen.c          |   19 +
+ libc/arch-x86_64/generic/string/strrchr.cpp        |   19 +
+ libc/arch-x86_64/generic/string/wcschr.c           |   19 +
+ libc/arch-x86_64/generic/string/wcscmp.c           |   19 +
+ libc/arch-x86_64/generic/string/wcslen.c           |   19 +
+ libc/arch-x86_64/generic/string/wcsncmp.c          |   19 +
+ libc/arch-x86_64/generic/string/wcsnlen.c          |   19 +
+ libc/arch-x86_64/generic/string/wcsrchr.c          |   19 +
+ libc/arch-x86_64/generic/string/wmemset.c          |    2 +-
+ libc/arch-x86_64/include/cache.h                   |   36 -
+ libc/arch-x86_64/kabylake/string/avx2-stpcpy-kbl.S |    3 +
+ .../arch-x86_64/kabylake/string/avx2-stpncpy-kbl.S |    5 +
+ libc/arch-x86_64/kabylake/string/avx2-strcat-kbl.S |  299 ++++++
+ libc/arch-x86_64/kabylake/string/avx2-strchr-kbl.S |  277 ++++++
+ libc/arch-x86_64/kabylake/string/avx2-strcmp-kbl.S |  885 +++++++++++++++++
+ libc/arch-x86_64/kabylake/string/avx2-strcpy-kbl.S | 1046 ++++++++++++++++++++
+ libc/arch-x86_64/kabylake/string/avx2-strlen-kbl.S |  418 ++++++++
+ .../arch-x86_64/kabylake/string/avx2-strncat-kbl.S |    3 +
+ .../arch-x86_64/kabylake/string/avx2-strncmp-kbl.S |    4 +
+ .../arch-x86_64/kabylake/string/avx2-strncpy-kbl.S |    4 +
+ .../arch-x86_64/kabylake/string/avx2-strnlen-kbl.S |    4 +
+ .../arch-x86_64/kabylake/string/avx2-strrchr-kbl.S |  258 +++++
+ libc/arch-x86_64/kabylake/string/avx2-wcschr-kbl.S |    3 +
+ libc/arch-x86_64/kabylake/string/avx2-wcscmp-kbl.S |    4 +
+ libc/arch-x86_64/kabylake/string/avx2-wcslen-kbl.S |    4 +
+ .../arch-x86_64/kabylake/string/avx2-wcsncmp-kbl.S |    6 +
+ .../arch-x86_64/kabylake/string/avx2-wcsnlen-kbl.S |    6 +
+ .../arch-x86_64/kabylake/string/avx2-wcsrchr-kbl.S |    3 +
+ libc/arch-x86_64/kabylake/string/avx_regs.h        |   26 +
+ libc/arch-x86_64/kabylake/string/cache.h           |   36 +
+ libc/arch-x86_64/silvermont/string/cache.h         |   36 +
+ .../silvermont/string/sse2-memcpy-slm.s            |    6 +-
+ .../silvermont/string/sse2-stpcpy-slm.S            |    2 +-
+ .../silvermont/string/sse2-stpncpy-slm.S           |    2 +-
+ .../silvermont/string/sse2-strcat-slm.S            |    2 +-
+ .../silvermont/string/sse2-strcpy-slm.S            |    2 +-
+ .../silvermont/string/sse2-strlen-slm.S            |    2 +-
+ .../silvermont/string/sse2-strncat-slm.S           |    2 +-
+ .../silvermont/string/sse2-strncpy-slm.S           |    2 +-
+ .../silvermont/string/ssse3-strcmp-slm.S           |    2 +-
+ .../silvermont/string/ssse3-strncmp-slm.S          |    2 +-
+ libc/arch-x86_64/static_function_dispatch.S        |   24 +-
+ 47 files changed, 3707 insertions(+), 62 deletions(-)
+ create mode 100644 libc/arch-x86_64/generic/string/strchr.cpp
+ create mode 100644 libc/arch-x86_64/generic/string/strnlen.c
+ create mode 100644 libc/arch-x86_64/generic/string/strrchr.cpp
+ create mode 100644 libc/arch-x86_64/generic/string/wcschr.c
+ create mode 100644 libc/arch-x86_64/generic/string/wcscmp.c
+ create mode 100644 libc/arch-x86_64/generic/string/wcslen.c
+ create mode 100644 libc/arch-x86_64/generic/string/wcsncmp.c
+ create mode 100644 libc/arch-x86_64/generic/string/wcsnlen.c
+ create mode 100644 libc/arch-x86_64/generic/string/wcsrchr.c
+ delete mode 100644 libc/arch-x86_64/include/cache.h
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-stpcpy-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-stpncpy-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-strcat-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-strchr-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-strcmp-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-strcpy-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-strlen-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-strncat-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-strncmp-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-strncpy-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-strnlen-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-strrchr-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-wcschr-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-wcscmp-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-wcslen-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-wcsncmp-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-wcsnlen-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx2-wcsrchr-kbl.S
+ create mode 100644 libc/arch-x86_64/kabylake/string/avx_regs.h
+ create mode 100644 libc/arch-x86_64/kabylake/string/cache.h
+ create mode 100644 libc/arch-x86_64/silvermont/string/cache.h
+
+diff --git a/libc/Android.bp b/libc/Android.bp
+index 58586a5..4c05eca 100644
+--- a/libc/Android.bp
++++ b/libc/Android.bp
+@@ -331,6 +331,12 @@ cc_library_static {
+         x86_64: {
+             exclude_srcs: [
+                 "upstream-freebsd/lib/libc/string/wmemset.c",
++                "upstream-freebsd/lib/libc/string/wcscmp.c",
++                "upstream-freebsd/lib/libc/string/wcsncmp.c",
++                "upstream-freebsd/lib/libc/string/wcslen.c",
++                "upstream-freebsd/lib/libc/string/wcsnlen.c",
++                "upstream-freebsd/lib/libc/string/wcschr.c",
++                "upstream-freebsd/lib/libc/string/wcsrchr.c",
+             ],
+         },
+     },
+@@ -955,15 +961,22 @@ cc_library_static {
+         },
+         x86_64: {
+             cflags: ["-include openbsd-compat.h"],
+-            include_dirs: ["bionic/libc/arch-x86_64/include"],
+             local_include_dirs: [
+-                // "private",
+                  "upstream-openbsd/android/include",
+             ],
+             srcs: [
+                 "arch-x86_64/generic/string/wmemset.c",
+                 "arch-x86_64/generic/string/memchr.c",
+                 "arch-x86_64/generic/string/memrchr.c",
++                "arch-x86_64/generic/string/strchr.cpp",
++                "arch-x86_64/generic/string/strrchr.cpp",
++                "arch-x86_64/generic/string/strnlen.c",
++                "arch-x86_64/generic/string/wcscmp.c",
++                "arch-x86_64/generic/string/wcsncmp.c",
++                "arch-x86_64/generic/string/wcslen.c",
++                "arch-x86_64/generic/string/wcsnlen.c",
++                "arch-x86_64/generic/string/wcschr.c",
++                "arch-x86_64/generic/string/wcsrchr.c",
+ 
+                 "arch-x86_64/silvermont/string/sse2-memmove-slm.S",
+                 "arch-x86_64/silvermont/string/sse2-memcpy-slm.s",
+@@ -985,7 +998,25 @@ cc_library_static {
+                 "arch-x86_64/kabylake/string/avx2-memmove-kbl.S",
+                 "arch-x86_64/kabylake/string/avx2-memchr-kbl.S",
+                 "arch-x86_64/kabylake/string/avx2-memrchr-kbl.S",
+-
++                "arch-x86_64/kabylake/string/avx2-strcmp-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-strncmp-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-strlen-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-strnlen-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-strchr-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-strrchr-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-strcpy-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-strncpy-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-stpcpy-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-stpncpy-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-strcat-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-strncat-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-wcscmp-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-wcsncmp-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-wcslen-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-wcsnlen-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-wcschr-kbl.S",
++                "arch-x86_64/kabylake/string/avx2-wcsrchr-kbl.S",
++            
+                 "arch-x86_64/bionic/__bionic_clone.S",
+                 "arch-x86_64/bionic/_exit_with_stack_teardown.S",
+                 "arch-x86_64/bionic/__restore_rt.S",
+@@ -993,6 +1024,11 @@ cc_library_static {
+                 "arch-x86_64/bionic/syscall.S",
+                 "arch-x86_64/bionic/vfork.S",
+             ],
++            exclude_srcs: [
++                "bionic/strchr.cpp",
++                "bionic/strnlen.c",
++                "bionic/strrchr.cpp",
++            ],
+         },
+     },
+ 
+diff --git a/libc/arch-x86_64/dynamic_function_dispatch.cpp b/libc/arch-x86_64/dynamic_function_dispatch.cpp
+index 3e8c0fe..352635c 100644
+--- a/libc/arch-x86_64/dynamic_function_dispatch.cpp
++++ b/libc/arch-x86_64/dynamic_function_dispatch.cpp
+@@ -49,30 +49,156 @@ DEFINE_IFUNC_FOR(memmove) {
+ typedef void* memcpy_func(void* __dst, const void* __src, size_t __n);
+ DEFINE_IFUNC_FOR(memcpy) {
+     __builtin_cpu_init();
+-    if (__builtin_cpu_supports("sse2")) RETURN_FUNC(memcpy_func, memcpy_sse2);
+     if (__builtin_cpu_supports("avx2")) RETURN_FUNC(memcpy_func, memcpy_avx2);
+-    RETURN_FUNC(memcpy_func, memmove_generic);
++    RETURN_FUNC(memcpy_func, memcpy_generic);
+ }
+ 
+ typedef void* memchr_func(const void* __s, int __ch, size_t __n);
+ DEFINE_IFUNC_FOR(memchr) {
+     __builtin_cpu_init();
+     if (__builtin_cpu_supports("avx2")) RETURN_FUNC(memchr_func, memchr_avx2);
+-    RETURN_FUNC(memchr_func, memchr_openbsd);
++    RETURN_FUNC(memchr_func, memchr_generic);
+ }
+ 
+ typedef void* memrchr_func(const void* __s, int __ch, size_t __n);
+ DEFINE_IFUNC_FOR(memrchr) {
+     __builtin_cpu_init();
+     if (__builtin_cpu_supports("avx2")) RETURN_FUNC(memrchr_func, memrchr_avx2);
+-    RETURN_FUNC(memrchr_func, memrchr_openbsd);
++    RETURN_FUNC(memrchr_func, memrchr_generic);
+ }
+ 
+ typedef int wmemset_func(const wchar_t* __lhs, const wchar_t* __rhs, size_t __n);
+ DEFINE_IFUNC_FOR(wmemset) {
+     __builtin_cpu_init();
+     if (__builtin_cpu_supports("avx2")) RETURN_FUNC(wmemset_func, wmemset_avx2);
+-    RETURN_FUNC(wmemset_func, wmemset_freebsd);
++    RETURN_FUNC(wmemset_func, wmemset_generic);
++}
++
++typedef int strcmp_func(const char* __lhs, const char* __rhs);
++DEFINE_IFUNC_FOR(strcmp) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(strcmp_func, strcmp_avx2);
++    RETURN_FUNC(strcmp_func, strcmp_generic);
++}
++
++typedef int strncmp_func(const char* __lhs, const char* __rhs, size_t __n);
++DEFINE_IFUNC_FOR(strncmp) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(strncmp_func, strncmp_avx2);
++    RETURN_FUNC(strncmp_func, strncmp_generic);
++}
++
++typedef char* strcpy_func(char* __dst, const char* __src);
++DEFINE_IFUNC_FOR(strcpy) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(strcpy_func, strcpy_avx2);
++    RETURN_FUNC(strcpy_func, strcpy_generic);
++}
++
++typedef char* strncpy_func(char* __dst, const char* __src, size_t __n);
++DEFINE_IFUNC_FOR(strncpy) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(strncpy_func, strncpy_avx2);
++    RETURN_FUNC(strncpy_func, strncpy_generic);
++}
++
++typedef char* stpcpy_func(char* __dst, const char* __src);
++DEFINE_IFUNC_FOR(stpcpy) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(stpcpy_func, stpcpy_avx2);
++    RETURN_FUNC(stpcpy_func, stpcpy_generic);
++}
++
++typedef char* stpncpy_func(char* __dst, const char* __src, size_t __n);
++DEFINE_IFUNC_FOR(stpncpy) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(stpncpy_func, stpncpy_avx2);
++    RETURN_FUNC(strncpy_func, strncpy_generic);
++}
++
++typedef size_t strlen_func(const char* __s);
++DEFINE_IFUNC_FOR(strlen) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(strlen_func, strlen_avx2);
++    RETURN_FUNC(strlen_func, strlen_generic);
++}
++
++
++typedef size_t strnlen_func(const char* __s, size_t __n);
++DEFINE_IFUNC_FOR(strnlen) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(strnlen_func, strnlen_avx2);
++    RETURN_FUNC(strnlen_func, strnlen_generic);
++}
++
++typedef char* strchr_func(const char* __s, int __ch);
++DEFINE_IFUNC_FOR(strchr) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(strchr_func, strchr_avx2);
++    RETURN_FUNC(strchr_func, strchr_generic);
++}
++
++typedef char* strrchr_func(const char* __s, int __ch);
++DEFINE_IFUNC_FOR(strrchr) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(strrchr_func, strrchr_avx2);
++    RETURN_FUNC(strrchr_func, strrchr_generic);
++}
++
++typedef char* strcat_func(char* __dst, const char* __src);
++DEFINE_IFUNC_FOR(strcat) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(strcat_func, strcat_avx2);
++    RETURN_FUNC(strcat_func, strcat_generic);
++}
++
++typedef char* strncat_func(char* __dst, const char* __src, size_t __n);
++DEFINE_IFUNC_FOR(strncat) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(strncat_func, strncat_avx2);
++    RETURN_FUNC(strncat_func, strncat_generic);
++}
++
++typedef int wcscmp_func(const wchar_t* __lhs, const wchar_t* __rhs);
++DEFINE_IFUNC_FOR(wcscmp) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(wcscmp_func, wcscmp_avx2);
++    RETURN_FUNC(wcscmp_func, wcscmp_generic);
++}
++
++typedef int wcsncmp_func(const wchar_t* __lhs, const wchar_t* __rhs, size_t __n);
++DEFINE_IFUNC_FOR(wcsncmp) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(wcsncmp_func, wcsncmp_avx2);
++    RETURN_FUNC(wcsncmp_func, wcsncmp_generic);
++}
++
++typedef size_t wcslen_func(const wchar_t* __s);
++DEFINE_IFUNC_FOR(wcslen) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(wcslen_func, wcslen_avx2);
++    RETURN_FUNC(wcslen_func, wcslen_generic);
++}
++
++typedef size_t wcsnlen_func(const wchar_t* __s, size_t __n);
++DEFINE_IFUNC_FOR(wcsnlen) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(wcsnlen_func, wcsnlen_avx2);
++    RETURN_FUNC(wcsnlen_func, wcsnlen_generic);
++}
++
++typedef wchar_t* wcschr_func(const wchar_t* __s, wchar_t __wc);
++DEFINE_IFUNC_FOR(wcschr) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(wcschr_func, wcschr_avx2);
++    RETURN_FUNC(wcschr_func, wcschr_generic);
++}
++
++typedef wchar_t* wcsrchr_func(const wchar_t* __s, wchar_t __wc);
++DEFINE_IFUNC_FOR(wcsrchr) {
++    __builtin_cpu_init();
++    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(wcsrchr_func, wcsrchr_avx2);
++    RETURN_FUNC(wcsrchr_func, wcsrchr_generic);
+ }
+ 
+ }  // extern "C"
+diff --git a/libc/arch-x86_64/generic/string/memchr.c b/libc/arch-x86_64/generic/string/memchr.c
+index f530eac..fccf029 100644
+--- a/libc/arch-x86_64/generic/string/memchr.c
++++ b/libc/arch-x86_64/generic/string/memchr.c
+@@ -14,6 +14,6 @@
+  * limitations under the License.
+ */
+ 
+-#define memchr memchr_openbsd
++#define memchr memchr_generic
+ 
+ #include <upstream-openbsd/lib/libc/string/memchr.c>
+diff --git a/libc/arch-x86_64/generic/string/memrchr.c b/libc/arch-x86_64/generic/string/memrchr.c
+index 44262f2..7525474 100644
+--- a/libc/arch-x86_64/generic/string/memrchr.c
++++ b/libc/arch-x86_64/generic/string/memrchr.c
+@@ -14,6 +14,6 @@
+  * limitations under the License.
+ */
+ 
+-#define memrchr memrchr_openbsd
++#define memrchr memrchr_generic
+ 
+ #include <upstream-openbsd/lib/libc/string/memrchr.c>
+diff --git a/libc/arch-x86_64/generic/string/strchr.cpp b/libc/arch-x86_64/generic/string/strchr.cpp
+new file mode 100644
+index 0000000..8a3d6d6
+--- /dev/null
++++ b/libc/arch-x86_64/generic/string/strchr.cpp
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define strchr strchr_generic
++
++#include <bionic/strchr.cpp>
+diff --git a/libc/arch-x86_64/generic/string/strnlen.c b/libc/arch-x86_64/generic/string/strnlen.c
+new file mode 100644
+index 0000000..f47adbd
+--- /dev/null
++++ b/libc/arch-x86_64/generic/string/strnlen.c
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define strnlen strnlen_generic
++
++#include <bionic/strnlen.c>
+diff --git a/libc/arch-x86_64/generic/string/strrchr.cpp b/libc/arch-x86_64/generic/string/strrchr.cpp
+new file mode 100644
+index 0000000..9f0f33f
+--- /dev/null
++++ b/libc/arch-x86_64/generic/string/strrchr.cpp
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define strrchr strrchr_generic
++
++#include <bionic/strrchr.cpp>
+diff --git a/libc/arch-x86_64/generic/string/wcschr.c b/libc/arch-x86_64/generic/string/wcschr.c
+new file mode 100644
+index 0000000..d45e45d
+--- /dev/null
++++ b/libc/arch-x86_64/generic/string/wcschr.c
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define wcschr wcschr_generic
++
++#include <upstream-freebsd/lib/libc/string/wcschr.c>
+diff --git a/libc/arch-x86_64/generic/string/wcscmp.c b/libc/arch-x86_64/generic/string/wcscmp.c
+new file mode 100644
+index 0000000..e55bab5
+--- /dev/null
++++ b/libc/arch-x86_64/generic/string/wcscmp.c
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define wcscmp wcscmp_generic
++
++#include <upstream-freebsd/lib/libc/string/wcscmp.c>
+diff --git a/libc/arch-x86_64/generic/string/wcslen.c b/libc/arch-x86_64/generic/string/wcslen.c
+new file mode 100644
+index 0000000..5b873fc
+--- /dev/null
++++ b/libc/arch-x86_64/generic/string/wcslen.c
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define wcslen wcslen_generic
++
++#include <upstream-freebsd/lib/libc/string/wcslen.c>
+diff --git a/libc/arch-x86_64/generic/string/wcsncmp.c b/libc/arch-x86_64/generic/string/wcsncmp.c
+new file mode 100644
+index 0000000..40b2ca2
+--- /dev/null
++++ b/libc/arch-x86_64/generic/string/wcsncmp.c
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define wcsncmp wcsncmp_generic
++
++#include <upstream-freebsd/lib/libc/string/wcsncmp.c>
+diff --git a/libc/arch-x86_64/generic/string/wcsnlen.c b/libc/arch-x86_64/generic/string/wcsnlen.c
+new file mode 100644
+index 0000000..91051ce
+--- /dev/null
++++ b/libc/arch-x86_64/generic/string/wcsnlen.c
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define wcsnlen wcsnlen_generic
++
++#include <upstream-freebsd/lib/libc/string/wcsnlen.c>
+diff --git a/libc/arch-x86_64/generic/string/wcsrchr.c b/libc/arch-x86_64/generic/string/wcsrchr.c
+new file mode 100644
+index 0000000..73e8c25
+--- /dev/null
++++ b/libc/arch-x86_64/generic/string/wcsrchr.c
+@@ -0,0 +1,19 @@
++/*
++ * Copyright (C) 2019 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++*/
++
++#define wcsrchr wcsrchr_generic
++
++#include <upstream-freebsd/lib/libc/string/wcsrchr.c>
+diff --git a/libc/arch-x86_64/generic/string/wmemset.c b/libc/arch-x86_64/generic/string/wmemset.c
+index 35d489f..42de09a 100644
+--- a/libc/arch-x86_64/generic/string/wmemset.c
++++ b/libc/arch-x86_64/generic/string/wmemset.c
+@@ -14,6 +14,6 @@
+  * limitations under the License.
+ */
+ 
+-#define wmemset wmemset_freebsd
++#define wmemset wmemset_generic
+ 
+ #include <upstream-freebsd/lib/libc/string/wmemset.c>
+diff --git a/libc/arch-x86_64/include/cache.h b/libc/arch-x86_64/include/cache.h
+deleted file mode 100644
+index 4131509..0000000
+--- a/libc/arch-x86_64/include/cache.h
++++ /dev/null
+@@ -1,36 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-/* Values are optimized for Core Architecture */
+-#define SHARED_CACHE_SIZE (4096*1024)  /* Core Architecture L2 Cache */
+-#define DATA_CACHE_SIZE   (24*1024)    /* Core Architecture L1 Data Cache */
+-
+-#define SHARED_CACHE_SIZE_HALF (SHARED_CACHE_SIZE / 2)
+-#define DATA_CACHE_SIZE_HALF   (DATA_CACHE_SIZE / 2)
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-stpcpy-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-stpcpy-kbl.S
+new file mode 100644
+index 0000000..63f9ba2
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-stpcpy-kbl.S
+@@ -0,0 +1,3 @@
++#define USE_AS_STPCPY
++#define STRCPY stpcpy_avx2
++#include "avx2-strcpy-kbl.S"
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-stpncpy-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-stpncpy-kbl.S
+new file mode 100644
+index 0000000..c1bbdb2
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-stpncpy-kbl.S
+@@ -0,0 +1,5 @@
++#define USE_AS_STPCPY
++#define USE_AS_STRNCPY
++#define STRCPY stpncpy_avx2
++#include "avx_regs.h"
++#include "avx2-strcpy-kbl.S"
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-strcat-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-strcat-kbl.S
+new file mode 100644
+index 0000000..d1e9b4b
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-strcat-kbl.S
+@@ -0,0 +1,299 @@
++/* strcat with AVX2
++   Copyright (C) 2011-2020 Free Software Foundation, Inc.
++   Contributed by Intel Corporation.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++
++
++# ifndef STRCAT
++#  define STRCAT  strcat_avx2
++# endif
++
++# ifndef L
++#  define L(label)      .L##label
++# endif
++
++# ifndef cfi_startproc
++#  define cfi_startproc .cfi_startproc
++# endif
++
++# ifndef cfi_endproc
++#  define cfi_endproc   .cfi_endproc
++# endif
++
++# ifndef ENTRY
++#  define ENTRY(name)   \
++        .type name, @function;  \
++        .globl name;    \
++        .p2align 4;     \
++name:   \
++        cfi_startproc
++# endif
++
++# ifndef END
++#  define END(name)     \
++        cfi_endproc;    \
++        .size name, .-name
++# endif
++
++# define USE_AS_STRCAT
++
++/* Number of bytes in a vector register */
++# define VEC_SIZE	32
++
++	.section .text.avx,"ax",@progbits
++ENTRY (STRCAT)
++	mov	%rdi, %r9
++# ifdef USE_AS_STRNCAT
++	mov	%rdx, %r8
++# endif
++
++	xor	%eax, %eax
++	mov	%edi, %ecx
++	and	$((VEC_SIZE * 4) - 1), %ecx
++	vpxor	%xmm6, %xmm6, %xmm6
++	cmp	$(VEC_SIZE * 3), %ecx
++	ja	L(fourth_vector_boundary)
++	vpcmpeqb (%rdi), %ymm6, %ymm0
++	vpmovmskb %ymm0, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_first_vector)
++	mov	%rdi, %rax
++	and	$-VEC_SIZE, %rax
++	jmp	L(align_vec_size_start)
++L(fourth_vector_boundary):
++	mov	%rdi, %rax
++	and	$-VEC_SIZE, %rax
++	vpcmpeqb	(%rax), %ymm6, %ymm0
++	mov	$-1, %r10d
++	sub	%rax, %rcx
++	shl	%cl, %r10d
++	vpmovmskb %ymm0, %edx
++	and	%r10d, %edx
++	jnz	L(exit)
++
++L(align_vec_size_start):
++	vpcmpeqb VEC_SIZE(%rax), %ymm6, %ymm0
++	vpmovmskb %ymm0, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_second_vector)
++
++	vpcmpeqb (VEC_SIZE * 2)(%rax), %ymm6, %ymm1
++	vpmovmskb %ymm1, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_third_vector)
++
++	vpcmpeqb (VEC_SIZE * 3)(%rax), %ymm6, %ymm2
++	vpmovmskb %ymm2, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_fourth_vector)
++
++	vpcmpeqb (VEC_SIZE * 4)(%rax), %ymm6, %ymm3
++	vpmovmskb %ymm3, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_fifth_vector)
++
++	vpcmpeqb (VEC_SIZE * 5)(%rax), %ymm6, %ymm0
++	add	$(VEC_SIZE * 4), %rax
++	vpmovmskb %ymm0, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_second_vector)
++
++	vpcmpeqb (VEC_SIZE * 2)(%rax), %ymm6, %ymm1
++	vpmovmskb %ymm1, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_third_vector)
++
++	vpcmpeqb (VEC_SIZE * 3)(%rax), %ymm6, %ymm2
++	vpmovmskb %ymm2, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_fourth_vector)
++
++	vpcmpeqb (VEC_SIZE * 4)(%rax), %ymm6, %ymm3
++	vpmovmskb %ymm3, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_fifth_vector)
++
++	vpcmpeqb (VEC_SIZE * 5)(%rax), %ymm6, %ymm0
++	add	$(VEC_SIZE * 4), %rax
++	vpmovmskb %ymm0, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_second_vector)
++
++	vpcmpeqb (VEC_SIZE * 2)(%rax), %ymm6, %ymm1
++	vpmovmskb %ymm1, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_third_vector)
++
++	vpcmpeqb (VEC_SIZE * 3)(%rax), %ymm6, %ymm2
++	vpmovmskb %ymm2, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_fourth_vector)
++
++	vpcmpeqb (VEC_SIZE * 4)(%rax), %ymm6, %ymm3
++	vpmovmskb %ymm3, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_fifth_vector)
++
++	vpcmpeqb (VEC_SIZE * 5)(%rax), %ymm6, %ymm0
++	add	$(VEC_SIZE * 4), %rax
++	vpmovmskb %ymm0, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_second_vector)
++
++	vpcmpeqb (VEC_SIZE * 2)(%rax), %ymm6, %ymm1
++	vpmovmskb %ymm1, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_third_vector)
++
++	vpcmpeqb (VEC_SIZE * 3)(%rax), %ymm6, %ymm2
++	vpmovmskb %ymm2, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_fourth_vector)
++
++	vpcmpeqb (VEC_SIZE * 4)(%rax), %ymm6, %ymm3
++	vpmovmskb %ymm3, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_fifth_vector)
++
++	test	$((VEC_SIZE * 4) - 1), %rax
++	jz	L(align_four_vec_loop)
++
++	vpcmpeqb (VEC_SIZE * 5)(%rax), %ymm6, %ymm0
++	add	$(VEC_SIZE * 5), %rax
++	vpmovmskb %ymm0, %edx
++	test	%edx, %edx
++	jnz	L(exit)
++
++	test	$((VEC_SIZE * 4) - 1), %rax
++	jz	L(align_four_vec_loop)
++
++	vpcmpeqb VEC_SIZE(%rax), %ymm6, %ymm1
++	add	$VEC_SIZE, %rax
++	vpmovmskb %ymm1, %edx
++	test	%edx, %edx
++	jnz	L(exit)
++
++	test	$((VEC_SIZE * 4) - 1), %rax
++	jz	L(align_four_vec_loop)
++
++	vpcmpeqb VEC_SIZE(%rax), %ymm6, %ymm2
++	add	$VEC_SIZE, %rax
++	vpmovmskb %ymm2, %edx
++	test	%edx, %edx
++	jnz	L(exit)
++
++	test	$((VEC_SIZE * 4) - 1), %rax
++	jz	L(align_four_vec_loop)
++
++	vpcmpeqb VEC_SIZE(%rax), %ymm6, %ymm3
++	add	$VEC_SIZE, %rax
++	vpmovmskb %ymm3, %edx
++	test	%edx, %edx
++	jnz	L(exit)
++
++	add	$VEC_SIZE, %rax
++
++	.p2align 4
++L(align_four_vec_loop):
++	vmovaps	(%rax),	%ymm4
++	vpminub	VEC_SIZE(%rax),	%ymm4, %ymm4
++	vmovaps	(VEC_SIZE * 2)(%rax),	%ymm5
++	vpminub	(VEC_SIZE * 3)(%rax),	%ymm5, %ymm5
++	add	$(VEC_SIZE * 4),	%rax
++	vpminub	%ymm4,	%ymm5, %ymm5
++	vpcmpeqb %ymm5,	%ymm6, %ymm5
++	vpmovmskb %ymm5,	%edx
++	test	%edx,	%edx
++	jz	L(align_four_vec_loop)
++
++	vpcmpeqb -(VEC_SIZE * 4)(%rax), %ymm6, %ymm0
++	sub	$(VEC_SIZE * 5),	%rax
++	vpmovmskb %ymm0, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_second_vector)
++
++	vpcmpeqb (VEC_SIZE * 2)(%rax), %ymm6, %ymm1
++	vpmovmskb %ymm1, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_third_vector)
++
++	vpcmpeqb (VEC_SIZE * 3)(%rax), %ymm6, %ymm2
++	vpmovmskb %ymm2, %edx
++	test	%edx, %edx
++	jnz	L(exit_null_on_fourth_vector)
++
++	vpcmpeqb (VEC_SIZE * 4)(%rax), %ymm6, %ymm3
++	vpmovmskb %ymm3, %edx
++	sub	%rdi, %rax
++	bsf	%rdx, %rdx
++	add	%rdx, %rax
++	add	$(VEC_SIZE * 4), %rax
++	jmp	L(StartStrcpyPart)
++
++	.p2align 4
++L(exit):
++	sub	%rdi, %rax
++L(exit_null_on_first_vector):
++	bsf	%rdx, %rdx
++	add	%rdx, %rax
++	jmp	L(StartStrcpyPart)
++
++	.p2align 4
++L(exit_null_on_second_vector):
++	sub	%rdi, %rax
++	bsf	%rdx, %rdx
++	add	%rdx, %rax
++	add	$VEC_SIZE, %rax
++	jmp	L(StartStrcpyPart)
++
++	.p2align 4
++L(exit_null_on_third_vector):
++	sub	%rdi, %rax
++	bsf	%rdx, %rdx
++	add	%rdx, %rax
++	add	$(VEC_SIZE * 2), %rax
++	jmp	L(StartStrcpyPart)
++
++	.p2align 4
++L(exit_null_on_fourth_vector):
++	sub	%rdi, %rax
++	bsf	%rdx, %rdx
++	add	%rdx, %rax
++	add	$(VEC_SIZE * 3), %rax
++	jmp	L(StartStrcpyPart)
++
++	.p2align 4
++L(exit_null_on_fifth_vector):
++	sub	%rdi, %rax
++	bsf	%rdx, %rdx
++	add	%rdx, %rax
++	add	$(VEC_SIZE * 4), %rax
++
++	.p2align 4
++L(StartStrcpyPart):
++	lea	(%r9, %rax), %rdi
++	mov	%rsi, %rcx
++	mov	%r9, %rax      /* save result */
++
++# ifdef USE_AS_STRNCAT
++	test	%r8, %r8
++	jz	L(ExitZero)
++#  define USE_AS_STRNCPY
++# endif
++
++# include "avx2-strcpy-kbl.S"
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-strchr-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-strchr-kbl.S
+new file mode 100644
+index 0000000..7d8a44c
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-strchr-kbl.S
+@@ -0,0 +1,277 @@
++/* strchr/strchrnul optimized with AVX2.
++   Copyright (C) 2017-2020 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++
++# ifndef STRCHR
++#  define STRCHR	strchr_avx2
++# endif
++
++# ifndef L
++#  define L(label)      .L##label
++# endif
++
++# ifndef cfi_startproc
++#  define cfi_startproc .cfi_startproc
++# endif
++
++# ifndef cfi_endproc
++#  define cfi_endproc   .cfi_endproc
++# endif
++
++# ifndef ENTRY
++#  define ENTRY(name)   \
++        .type name, @function;  \
++        .globl name;    \
++        .p2align 4;     \
++name:   \
++        cfi_startproc
++# endif
++
++# ifndef END
++#  define END(name)     \
++        cfi_endproc;    \
++        .size name, .-name
++# endif
++
++# ifdef USE_AS_WCSCHR
++#  define VPBROADCAST	vpbroadcastd
++#  define VPCMPEQ	vpcmpeqd
++#  define CHAR_REG	esi
++# else
++#  define VPBROADCAST	vpbroadcastb
++#  define VPCMPEQ	vpcmpeqb
++#  define CHAR_REG	sil
++# endif
++
++# ifndef VZEROUPPER
++#  define VZEROUPPER	vzeroupper
++# endif
++
++# define VEC_SIZE 32
++
++	.section .text.avx,"ax",@progbits
++ENTRY (STRCHR)
++	movl	%edi, %ecx
++	/* Broadcast CHAR to YMM0.  */
++	vmovd	%esi, %xmm0
++	vpxor	%xmm9, %xmm9, %xmm9
++	VPBROADCAST %xmm0, %ymm0
++	/* Check if we may cross page boundary with one vector load.  */
++	andl	$(2 * VEC_SIZE - 1), %ecx
++	cmpl	$VEC_SIZE, %ecx
++	ja	L(cros_page_boundary)
++
++	/* Check the first VEC_SIZE bytes.  Search for both CHAR and the
++	   null byte.  */
++	vmovdqu	(%rdi), %ymm8
++	VPCMPEQ %ymm8, %ymm0, %ymm1
++	VPCMPEQ %ymm8, %ymm9, %ymm2
++	vpor	%ymm1, %ymm2, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x0)
++
++	/* Align data for aligned loads in the loop.  */
++	addq	$VEC_SIZE, %rdi
++	andl	$(VEC_SIZE - 1), %ecx
++	andq	$-VEC_SIZE, %rdi
++
++	jmp	L(more_4x_vec)
++
++	.p2align 4
++L(cros_page_boundary):
++	andl	$(VEC_SIZE - 1), %ecx
++	andq	$-VEC_SIZE, %rdi
++	vmovdqu	(%rdi), %ymm8
++	VPCMPEQ %ymm8, %ymm0, %ymm1
++	VPCMPEQ %ymm8, %ymm9, %ymm2
++	vpor	%ymm1, %ymm2, %ymm1
++	vpmovmskb %ymm1, %eax
++	/* Remove the leading bytes.  */
++	sarl	%cl, %eax
++	testl	%eax, %eax
++	jz	L(aligned_more)
++	/* Found CHAR or the null byte.  */
++	tzcntl	%eax, %eax
++	addq	%rcx, %rax
++# ifdef USE_AS_STRCHRNUL
++	addq	%rdi, %rax
++# else
++	xorl	%edx, %edx
++	leaq	(%rdi, %rax), %rax
++	cmp	(%rax), %CHAR_REG
++	cmovne	%rdx, %rax
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(aligned_more):
++	addq	$VEC_SIZE, %rdi
++
++L(more_4x_vec):
++	/* Check the first 4 * VEC_SIZE.  Only one VEC_SIZE at a time
++	   since data is only aligned to VEC_SIZE.  */
++	vmovdqa	(%rdi), %ymm8
++	VPCMPEQ %ymm8, %ymm0, %ymm1
++	VPCMPEQ %ymm8, %ymm9, %ymm2
++	vpor	%ymm1, %ymm2, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x0)
++
++	vmovdqa	VEC_SIZE(%rdi), %ymm8
++	VPCMPEQ %ymm8, %ymm0, %ymm1
++	VPCMPEQ %ymm8, %ymm9, %ymm2
++	vpor	%ymm1, %ymm2, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x1)
++
++	vmovdqa	(VEC_SIZE * 2)(%rdi), %ymm8
++	VPCMPEQ %ymm8, %ymm0, %ymm1
++	VPCMPEQ %ymm8, %ymm9, %ymm2
++	vpor	%ymm1, %ymm2, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x2)
++
++	vmovdqa	(VEC_SIZE * 3)(%rdi), %ymm8
++	VPCMPEQ %ymm8, %ymm0, %ymm1
++	VPCMPEQ %ymm8, %ymm9, %ymm2
++	vpor	%ymm1, %ymm2, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x3)
++
++	addq	$(VEC_SIZE * 4), %rdi
++
++	/* Align data to 4 * VEC_SIZE.  */
++	movq	%rdi, %rcx
++	andl	$(4 * VEC_SIZE - 1), %ecx
++	andq	$-(4 * VEC_SIZE), %rdi
++
++	.p2align 4
++L(loop_4x_vec):
++	/* Compare 4 * VEC at a time forward.  */
++	vmovdqa	(%rdi), %ymm5
++	vmovdqa	VEC_SIZE(%rdi), %ymm6
++	vmovdqa	(VEC_SIZE * 2)(%rdi), %ymm7
++	vmovdqa	(VEC_SIZE * 3)(%rdi), %ymm8
++
++	VPCMPEQ %ymm5, %ymm0, %ymm1
++	VPCMPEQ %ymm6, %ymm0, %ymm2
++	VPCMPEQ %ymm7, %ymm0, %ymm3
++	VPCMPEQ %ymm8, %ymm0, %ymm4
++
++	VPCMPEQ %ymm5, %ymm9, %ymm5
++	VPCMPEQ %ymm6, %ymm9, %ymm6
++	VPCMPEQ %ymm7, %ymm9, %ymm7
++	VPCMPEQ %ymm8, %ymm9, %ymm8
++
++	vpor	%ymm1, %ymm5, %ymm1
++	vpor	%ymm2, %ymm6, %ymm2
++	vpor	%ymm3, %ymm7, %ymm3
++	vpor	%ymm4, %ymm8, %ymm4
++
++	vpor	%ymm1, %ymm2, %ymm5
++	vpor	%ymm3, %ymm4, %ymm6
++
++	vpor	%ymm5, %ymm6, %ymm5
++
++	vpmovmskb %ymm5, %eax
++	testl	%eax, %eax
++	jnz	L(4x_vec_end)
++
++	addq	$(VEC_SIZE * 4), %rdi
++
++	jmp	L(loop_4x_vec)
++
++	.p2align 4
++L(first_vec_x0):
++	/* Found CHAR or the null byte.  */
++	tzcntl	%eax, %eax
++# ifdef USE_AS_STRCHRNUL
++	addq	%rdi, %rax
++# else
++	xorl	%edx, %edx
++	leaq	(%rdi, %rax), %rax
++	cmp	(%rax), %CHAR_REG
++	cmovne	%rdx, %rax
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(first_vec_x1):
++	tzcntl	%eax, %eax
++# ifdef USE_AS_STRCHRNUL
++	addq	$VEC_SIZE, %rax
++	addq	%rdi, %rax
++# else
++	xorl	%edx, %edx
++	leaq	VEC_SIZE(%rdi, %rax), %rax
++	cmp	(%rax), %CHAR_REG
++	cmovne	%rdx, %rax
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(first_vec_x2):
++	tzcntl	%eax, %eax
++# ifdef USE_AS_STRCHRNUL
++	addq	$(VEC_SIZE * 2), %rax
++	addq	%rdi, %rax
++# else
++	xorl	%edx, %edx
++	leaq	(VEC_SIZE * 2)(%rdi, %rax), %rax
++	cmp	(%rax), %CHAR_REG
++	cmovne	%rdx, %rax
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(4x_vec_end):
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x0)
++	vpmovmskb %ymm2, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x1)
++	vpmovmskb %ymm3, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x2)
++	vpmovmskb %ymm4, %eax
++	testl	%eax, %eax
++L(first_vec_x3):
++	tzcntl	%eax, %eax
++# ifdef USE_AS_STRCHRNUL
++	addq	$(VEC_SIZE * 3), %rax
++	addq	%rdi, %rax
++# else
++	xorl	%edx, %edx
++	leaq	(VEC_SIZE * 3)(%rdi, %rax), %rax
++	cmp	(%rax), %CHAR_REG
++	cmovne	%rdx, %rax
++# endif
++	VZEROUPPER
++	ret
++
++END (STRCHR)
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-strcmp-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-strcmp-kbl.S
+new file mode 100644
+index 0000000..b241812
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-strcmp-kbl.S
+@@ -0,0 +1,885 @@
++/* strcmp/wcscmp/strncmp/wcsncmp optimized with AVX2.
++   Copyright (C) 2018-2020 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++
++# ifndef STRCMP
++#  define STRCMP	strcmp_avx2
++# endif
++
++# ifndef L
++#  define L(label)      .L##label
++# endif
++
++# ifndef cfi_startproc
++#  define cfi_startproc .cfi_startproc
++# endif
++
++# ifndef cfi_endproc
++#  define cfi_endproc   .cfi_endproc
++# endif
++
++# ifndef ENTRY
++#  define ENTRY(name)   \
++        .type name, @function;  \
++        .globl name;    \
++        .p2align 4;     \
++name:   \
++        cfi_startproc
++# endif
++
++# ifndef END
++#  define END(name)     \
++        cfi_endproc;    \
++        .size name, .-name
++# endif
++
++# define PAGE_SIZE	4096
++
++/* VEC_SIZE = Number of bytes in a ymm register */
++# define VEC_SIZE	32
++
++/* Shift for dividing by (VEC_SIZE * 4).  */
++# define DIVIDE_BY_VEC_4_SHIFT	7
++# if (VEC_SIZE * 4) != (1 << DIVIDE_BY_VEC_4_SHIFT)
++#  error (VEC_SIZE * 4) != (1 << DIVIDE_BY_VEC_4_SHIFT)
++# endif
++
++# ifdef USE_AS_WCSCMP
++/* Compare packed dwords.  */
++#  define VPCMPEQ	vpcmpeqd
++/* Compare packed dwords and store minimum.  */
++#  define VPMINU	vpminud
++/* 1 dword char == 4 bytes.  */
++#  define SIZE_OF_CHAR	4
++# else
++/* Compare packed bytes.  */
++#  define VPCMPEQ	vpcmpeqb
++/* Compare packed bytes and store minimum.  */
++#  define VPMINU	vpminub
++/* 1 byte char == 1 byte.  */
++#  define SIZE_OF_CHAR	1
++# endif
++
++# ifndef VZEROUPPER
++#  define VZEROUPPER	vzeroupper
++# endif
++
++/* Warning!
++           wcscmp/wcsncmp have to use SIGNED comparison for elements.
++           strcmp/strncmp have to use UNSIGNED comparison for elements.
++*/
++
++/* The main idea of the string comparison (byte or dword) using AVX2
++   consists of comparing (VPCMPEQ) two ymm vectors. The latter can be on
++   either packed bytes or dwords depending on USE_AS_WCSCMP. In order
++   to check the null char, algorithm keeps the matched bytes/dwords,
++   requiring two more AVX2 instructions (VPMINU and VPCMPEQ). In general,
++   the costs of comparing VEC_SIZE bytes (32-bytes) are two VPCMPEQ and
++   one VPMINU instructions, together with movdqu and testl instructions.
++   Main loop (away from from page boundary) compares 4 vectors are a time,
++   effectively comparing 4 x VEC_SIZE bytes (128 bytes) on each loop.
++
++   The routine strncmp/wcsncmp (enabled by defining USE_AS_STRNCMP) logic
++   is the same as strcmp, except that an a maximum offset is tracked.  If
++   the maximum offset is reached before a difference is found, zero is
++   returned.  */
++
++	.section .text.avx,"ax",@progbits
++ENTRY (STRCMP)
++# ifdef USE_AS_STRNCMP
++	/* Check for simple cases (0 or 1) in offset.  */
++	cmp	$1, %RDX_LP
++	je	L(char0)
++	jb	L(zero)
++#  ifdef USE_AS_WCSCMP
++	/* Convert units: from wide to byte char.  */
++	shl	$2, %RDX_LP
++#  endif
++	/* Register %r11 tracks the maximum offset.  */
++	mov	%RDX_LP, %R11_LP
++# endif
++	movl	%edi, %eax
++	xorl	%edx, %edx
++	/* Make %xmm7 (%ymm7) all zeros in this function.  */
++	vpxor	%xmm7, %xmm7, %xmm7
++	orl	%esi, %eax
++	andl	$(PAGE_SIZE - 1), %eax
++	cmpl	$(PAGE_SIZE - (VEC_SIZE * 4)), %eax
++	jg	L(cross_page)
++	/* Start comparing 4 vectors.  */
++	vmovdqu	(%rdi), %ymm1
++	VPCMPEQ	(%rsi), %ymm1, %ymm0
++	VPMINU	%ymm1, %ymm0, %ymm0
++	VPCMPEQ	%ymm7, %ymm0, %ymm0
++	vpmovmskb %ymm0, %ecx
++	testl	%ecx, %ecx
++	je	L(next_3_vectors)
++	tzcntl	%ecx, %edx
++# ifdef USE_AS_STRNCMP
++	/* Return 0 if the mismatched index (%rdx) is after the maximum
++	   offset (%r11).   */
++	cmpq	%r11, %rdx
++	jae	L(zero)
++# endif
++# ifdef USE_AS_WCSCMP
++	xorl	%eax, %eax
++	movl	(%rdi, %rdx), %ecx
++	cmpl	(%rsi, %rdx), %ecx
++	je	L(return)
++L(wcscmp_return):
++	setl	%al
++	negl	%eax
++	orl	$1, %eax
++L(return):
++# else
++	movzbl	(%rdi, %rdx), %eax
++	movzbl	(%rsi, %rdx), %edx
++	subl	%edx, %eax
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(return_vec_size):
++	tzcntl	%ecx, %edx
++# ifdef USE_AS_STRNCMP
++	/* Return 0 if the mismatched index (%rdx + VEC_SIZE) is after
++	   the maximum offset (%r11).  */
++	addq	$VEC_SIZE, %rdx
++	cmpq	%r11, %rdx
++	jae	L(zero)
++#  ifdef USE_AS_WCSCMP
++	xorl	%eax, %eax
++	movl	(%rdi, %rdx), %ecx
++	cmpl	(%rsi, %rdx), %ecx
++	jne	L(wcscmp_return)
++#  else
++	movzbl	(%rdi, %rdx), %eax
++	movzbl	(%rsi, %rdx), %edx
++	subl	%edx, %eax
++#  endif
++# else
++#  ifdef USE_AS_WCSCMP
++	xorl	%eax, %eax
++	movl	VEC_SIZE(%rdi, %rdx), %ecx
++	cmpl	VEC_SIZE(%rsi, %rdx), %ecx
++	jne	L(wcscmp_return)
++#  else
++	movzbl	VEC_SIZE(%rdi, %rdx), %eax
++	movzbl	VEC_SIZE(%rsi, %rdx), %edx
++	subl	%edx, %eax
++#  endif
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(return_2_vec_size):
++	tzcntl	%ecx, %edx
++# ifdef USE_AS_STRNCMP
++	/* Return 0 if the mismatched index (%rdx + 2 * VEC_SIZE) is
++	   after the maximum offset (%r11).  */
++	addq	$(VEC_SIZE * 2), %rdx
++	cmpq	%r11, %rdx
++	jae	L(zero)
++#  ifdef USE_AS_WCSCMP
++	xorl	%eax, %eax
++	movl	(%rdi, %rdx), %ecx
++	cmpl	(%rsi, %rdx), %ecx
++	jne	L(wcscmp_return)
++#  else
++	movzbl	(%rdi, %rdx), %eax
++	movzbl	(%rsi, %rdx), %edx
++	subl	%edx, %eax
++#  endif
++# else
++#  ifdef USE_AS_WCSCMP
++	xorl	%eax, %eax
++	movl	(VEC_SIZE * 2)(%rdi, %rdx), %ecx
++	cmpl	(VEC_SIZE * 2)(%rsi, %rdx), %ecx
++	jne	L(wcscmp_return)
++#  else
++	movzbl	(VEC_SIZE * 2)(%rdi, %rdx), %eax
++	movzbl	(VEC_SIZE * 2)(%rsi, %rdx), %edx
++	subl	%edx, %eax
++#  endif
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(return_3_vec_size):
++	tzcntl	%ecx, %edx
++# ifdef USE_AS_STRNCMP
++	/* Return 0 if the mismatched index (%rdx + 3 * VEC_SIZE) is
++	   after the maximum offset (%r11).  */
++	addq	$(VEC_SIZE * 3), %rdx
++	cmpq	%r11, %rdx
++	jae	L(zero)
++#  ifdef USE_AS_WCSCMP
++	xorl	%eax, %eax
++	movl	(%rdi, %rdx), %ecx
++	cmpl	(%rsi, %rdx), %ecx
++	jne	L(wcscmp_return)
++#  else
++	movzbl	(%rdi, %rdx), %eax
++	movzbl	(%rsi, %rdx), %edx
++	subl	%edx, %eax
++#  endif
++# else
++#  ifdef USE_AS_WCSCMP
++	xorl	%eax, %eax
++	movl	(VEC_SIZE * 3)(%rdi, %rdx), %ecx
++	cmpl	(VEC_SIZE * 3)(%rsi, %rdx), %ecx
++	jne	L(wcscmp_return)
++#  else
++	movzbl	(VEC_SIZE * 3)(%rdi, %rdx), %eax
++	movzbl	(VEC_SIZE * 3)(%rsi, %rdx), %edx
++	subl	%edx, %eax
++#  endif
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(next_3_vectors):
++	vmovdqu	VEC_SIZE(%rdi), %ymm6
++	VPCMPEQ	VEC_SIZE(%rsi), %ymm6, %ymm3
++	VPMINU	%ymm6, %ymm3, %ymm3
++	VPCMPEQ	%ymm7, %ymm3, %ymm3
++	vpmovmskb %ymm3, %ecx
++	testl	%ecx, %ecx
++	jne	L(return_vec_size)
++	vmovdqu	(VEC_SIZE * 2)(%rdi), %ymm5
++	vmovdqu	(VEC_SIZE * 3)(%rdi), %ymm4
++	vmovdqu	(VEC_SIZE * 3)(%rsi), %ymm0
++	VPCMPEQ	(VEC_SIZE * 2)(%rsi), %ymm5, %ymm2
++	VPMINU	%ymm5, %ymm2, %ymm2
++	VPCMPEQ	%ymm4, %ymm0, %ymm0
++	VPCMPEQ	%ymm7, %ymm2, %ymm2
++	vpmovmskb %ymm2, %ecx
++	testl	%ecx, %ecx
++	jne	L(return_2_vec_size)
++	VPMINU	%ymm4, %ymm0, %ymm0
++	VPCMPEQ	%ymm7, %ymm0, %ymm0
++	vpmovmskb %ymm0, %ecx
++	testl	%ecx, %ecx
++	jne	L(return_3_vec_size)
++L(main_loop_header):
++	leaq	(VEC_SIZE * 4)(%rdi), %rdx
++	movl	$PAGE_SIZE, %ecx
++	/* Align load via RAX.  */
++	andq	$-(VEC_SIZE * 4), %rdx
++	subq	%rdi, %rdx
++	leaq	(%rdi, %rdx), %rax
++# ifdef USE_AS_STRNCMP
++	/* Starting from this point, the maximum offset, or simply the
++	   'offset', DECREASES by the same amount when base pointers are
++	   moved forward.  Return 0 when:
++	     1) On match: offset <= the matched vector index.
++	     2) On mistmach, offset is before the mistmatched index.
++	 */
++	subq	%rdx, %r11
++	jbe	L(zero)
++# endif
++	addq	%rsi, %rdx
++	movq	%rdx, %rsi
++	andl	$(PAGE_SIZE - 1), %esi
++	/* Number of bytes before page crossing.  */
++	subq	%rsi, %rcx
++	/* Number of VEC_SIZE * 4 blocks before page crossing.  */
++	shrq	$DIVIDE_BY_VEC_4_SHIFT, %rcx
++	/* ESI: Number of VEC_SIZE * 4 blocks before page crossing.   */
++	movl	%ecx, %esi
++	jmp	L(loop_start)
++
++	.p2align 4
++L(loop):
++# ifdef USE_AS_STRNCMP
++	/* Base pointers are moved forward by 4 * VEC_SIZE.  Decrease
++	   the maximum offset (%r11) by the same amount.  */
++	subq	$(VEC_SIZE * 4), %r11
++	jbe	L(zero)
++# endif
++	addq	$(VEC_SIZE * 4), %rax
++	addq	$(VEC_SIZE * 4), %rdx
++L(loop_start):
++	testl	%esi, %esi
++	leal	-1(%esi), %esi
++	je	L(loop_cross_page)
++L(back_to_loop):
++	/* Main loop, comparing 4 vectors are a time.  */
++	vmovdqa	(%rax), %ymm0
++	vmovdqa	VEC_SIZE(%rax), %ymm3
++	VPCMPEQ	(%rdx), %ymm0, %ymm4
++	VPCMPEQ	VEC_SIZE(%rdx), %ymm3, %ymm1
++	VPMINU	%ymm0, %ymm4, %ymm4
++	VPMINU	%ymm3, %ymm1, %ymm1
++	vmovdqa	(VEC_SIZE * 2)(%rax), %ymm2
++	VPMINU	%ymm1, %ymm4, %ymm0
++	vmovdqa	(VEC_SIZE * 3)(%rax), %ymm3
++	VPCMPEQ	(VEC_SIZE * 2)(%rdx), %ymm2, %ymm5
++	VPCMPEQ	(VEC_SIZE * 3)(%rdx), %ymm3, %ymm6
++	VPMINU	%ymm2, %ymm5, %ymm5
++	VPMINU	%ymm3, %ymm6, %ymm6
++	VPMINU	%ymm5, %ymm0, %ymm0
++	VPMINU	%ymm6, %ymm0, %ymm0
++	VPCMPEQ	%ymm7, %ymm0, %ymm0
++
++	/* Test each mask (32 bits) individually because for VEC_SIZE
++	   == 32 is not possible to OR the four masks and keep all bits
++	   in a 64-bit integer register, differing from SSE2 strcmp
++	   where ORing is possible.  */
++	vpmovmskb %ymm0, %ecx
++	testl	%ecx, %ecx
++	je	L(loop)
++	VPCMPEQ	%ymm7, %ymm4, %ymm0
++	vpmovmskb %ymm0, %edi
++	testl	%edi, %edi
++	je	L(test_vec)
++	tzcntl	%edi, %ecx
++# ifdef USE_AS_STRNCMP
++	cmpq	%rcx, %r11
++	jbe	L(zero)
++#  ifdef USE_AS_WCSCMP
++	movq	%rax, %rsi
++	xorl	%eax, %eax
++	movl	(%rsi, %rcx), %edi
++	cmpl	(%rdx, %rcx), %edi
++	jne	L(wcscmp_return)
++#  else
++	movzbl	(%rax, %rcx), %eax
++	movzbl	(%rdx, %rcx), %edx
++	subl	%edx, %eax
++#  endif
++# else
++#  ifdef USE_AS_WCSCMP
++	movq	%rax, %rsi
++	xorl	%eax, %eax
++	movl	(%rsi, %rcx), %edi
++	cmpl	(%rdx, %rcx), %edi
++	jne	L(wcscmp_return)
++#  else
++	movzbl	(%rax, %rcx), %eax
++	movzbl	(%rdx, %rcx), %edx
++	subl	%edx, %eax
++#  endif
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(test_vec):
++# ifdef USE_AS_STRNCMP
++	/* The first vector matched.  Return 0 if the maximum offset
++	   (%r11) <= VEC_SIZE.  */
++	cmpq	$VEC_SIZE, %r11
++	jbe	L(zero)
++# endif
++	VPCMPEQ	%ymm7, %ymm1, %ymm1
++	vpmovmskb %ymm1, %ecx
++	testl	%ecx, %ecx
++	je	L(test_2_vec)
++	tzcntl	%ecx, %edi
++# ifdef USE_AS_STRNCMP
++	addq	$VEC_SIZE, %rdi
++	cmpq	%rdi, %r11
++	jbe	L(zero)
++#  ifdef USE_AS_WCSCMP
++	movq	%rax, %rsi
++	xorl	%eax, %eax
++	movl	(%rsi, %rdi), %ecx
++	cmpl	(%rdx, %rdi), %ecx
++	jne	L(wcscmp_return)
++#  else
++	movzbl	(%rax, %rdi), %eax
++	movzbl	(%rdx, %rdi), %edx
++	subl	%edx, %eax
++#  endif
++# else
++#  ifdef USE_AS_WCSCMP
++	movq	%rax, %rsi
++	xorl	%eax, %eax
++	movl	VEC_SIZE(%rsi, %rdi), %ecx
++	cmpl	VEC_SIZE(%rdx, %rdi), %ecx
++	jne	L(wcscmp_return)
++#  else
++	movzbl	VEC_SIZE(%rax, %rdi), %eax
++	movzbl	VEC_SIZE(%rdx, %rdi), %edx
++	subl	%edx, %eax
++#  endif
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(test_2_vec):
++# ifdef USE_AS_STRNCMP
++	/* The first 2 vectors matched.  Return 0 if the maximum offset
++	   (%r11) <= 2 * VEC_SIZE.  */
++	cmpq	$(VEC_SIZE * 2), %r11
++	jbe	L(zero)
++# endif
++	VPCMPEQ	%ymm7, %ymm5, %ymm5
++	vpmovmskb %ymm5, %ecx
++	testl	%ecx, %ecx
++	je	L(test_3_vec)
++	tzcntl	%ecx, %edi
++# ifdef USE_AS_STRNCMP
++	addq	$(VEC_SIZE * 2), %rdi
++	cmpq	%rdi, %r11
++	jbe	L(zero)
++#  ifdef USE_AS_WCSCMP
++	movq	%rax, %rsi
++	xorl	%eax, %eax
++	movl	(%rsi, %rdi), %ecx
++	cmpl	(%rdx, %rdi), %ecx
++	jne	L(wcscmp_return)
++#  else
++	movzbl	(%rax, %rdi), %eax
++	movzbl	(%rdx, %rdi), %edx
++	subl	%edx, %eax
++#  endif
++# else
++#  ifdef USE_AS_WCSCMP
++	movq	%rax, %rsi
++	xorl	%eax, %eax
++	movl	(VEC_SIZE * 2)(%rsi, %rdi), %ecx
++	cmpl	(VEC_SIZE * 2)(%rdx, %rdi), %ecx
++	jne	L(wcscmp_return)
++#  else
++	movzbl	(VEC_SIZE * 2)(%rax, %rdi), %eax
++	movzbl	(VEC_SIZE * 2)(%rdx, %rdi), %edx
++	subl	%edx, %eax
++#  endif
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(test_3_vec):
++# ifdef USE_AS_STRNCMP
++	/* The first 3 vectors matched.  Return 0 if the maximum offset
++	   (%r11) <= 3 * VEC_SIZE.  */
++	cmpq	$(VEC_SIZE * 3), %r11
++	jbe	L(zero)
++# endif
++	VPCMPEQ	%ymm7, %ymm6, %ymm6
++	vpmovmskb %ymm6, %esi
++	tzcntl	%esi, %ecx
++# ifdef USE_AS_STRNCMP
++	addq	$(VEC_SIZE * 3), %rcx
++	cmpq	%rcx, %r11
++	jbe	L(zero)
++#  ifdef USE_AS_WCSCMP
++	movq	%rax, %rsi
++	xorl	%eax, %eax
++	movl	(%rsi, %rcx), %esi
++	cmpl	(%rdx, %rcx), %esi
++	jne	L(wcscmp_return)
++#  else
++	movzbl	(%rax, %rcx), %eax
++	movzbl	(%rdx, %rcx), %edx
++	subl	%edx, %eax
++#  endif
++# else
++#  ifdef USE_AS_WCSCMP
++	movq	%rax, %rsi
++	xorl	%eax, %eax
++	movl	(VEC_SIZE * 3)(%rsi, %rcx), %esi
++	cmpl	(VEC_SIZE * 3)(%rdx, %rcx), %esi
++	jne	L(wcscmp_return)
++#  else
++	movzbl	(VEC_SIZE * 3)(%rax, %rcx), %eax
++	movzbl	(VEC_SIZE * 3)(%rdx, %rcx), %edx
++	subl	%edx, %eax
++#  endif
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(loop_cross_page):
++	xorl	%r10d, %r10d
++	movq	%rdx, %rcx
++	/* Align load via RDX.  We load the extra ECX bytes which should
++	   be ignored.  */
++	andl	$((VEC_SIZE * 4) - 1), %ecx
++	/* R10 is -RCX.  */
++	subq	%rcx, %r10
++
++	/* This works only if VEC_SIZE * 2 == 64. */
++# if (VEC_SIZE * 2) != 64
++#  error (VEC_SIZE * 2) != 64
++# endif
++
++	/* Check if the first VEC_SIZE * 2 bytes should be ignored.  */
++	cmpl	$(VEC_SIZE * 2), %ecx
++	jge	L(loop_cross_page_2_vec)
++
++	vmovdqu	(%rax, %r10), %ymm2
++	vmovdqu	VEC_SIZE(%rax, %r10), %ymm3
++	VPCMPEQ	(%rdx, %r10), %ymm2, %ymm0
++	VPCMPEQ	VEC_SIZE(%rdx, %r10), %ymm3, %ymm1
++	VPMINU	%ymm2, %ymm0, %ymm0
++	VPMINU	%ymm3, %ymm1, %ymm1
++	VPCMPEQ	%ymm7, %ymm0, %ymm0
++	VPCMPEQ	%ymm7, %ymm1, %ymm1
++
++	vpmovmskb %ymm0, %edi
++	vpmovmskb %ymm1, %esi
++
++	salq	$32, %rsi
++	xorq	%rsi, %rdi
++
++	/* Since ECX < VEC_SIZE * 2, simply skip the first ECX bytes.  */
++	shrq	%cl, %rdi
++
++	testq	%rdi, %rdi
++	je	L(loop_cross_page_2_vec)
++	tzcntq	%rdi, %rcx
++# ifdef USE_AS_STRNCMP
++	cmpq	%rcx, %r11
++	jbe	L(zero)
++#  ifdef USE_AS_WCSCMP
++	movq	%rax, %rsi
++	xorl	%eax, %eax
++	movl	(%rsi, %rcx), %edi
++	cmpl	(%rdx, %rcx), %edi
++	jne	L(wcscmp_return)
++#  else
++	movzbl	(%rax, %rcx), %eax
++	movzbl	(%rdx, %rcx), %edx
++	subl	%edx, %eax
++#  endif
++# else
++#  ifdef USE_AS_WCSCMP
++	movq	%rax, %rsi
++	xorl	%eax, %eax
++	movl	(%rsi, %rcx), %edi
++	cmpl	(%rdx, %rcx), %edi
++	jne	L(wcscmp_return)
++#  else
++	movzbl	(%rax, %rcx), %eax
++	movzbl	(%rdx, %rcx), %edx
++	subl	%edx, %eax
++#  endif
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(loop_cross_page_2_vec):
++	/* The first VEC_SIZE * 2 bytes match or are ignored.  */
++	vmovdqu	(VEC_SIZE * 2)(%rax, %r10), %ymm2
++	vmovdqu	(VEC_SIZE * 3)(%rax, %r10), %ymm3
++	VPCMPEQ	(VEC_SIZE * 2)(%rdx, %r10), %ymm2, %ymm5
++	VPMINU	%ymm2, %ymm5, %ymm5
++	VPCMPEQ	(VEC_SIZE * 3)(%rdx, %r10), %ymm3, %ymm6
++	VPCMPEQ	%ymm7, %ymm5, %ymm5
++	VPMINU	%ymm3, %ymm6, %ymm6
++	VPCMPEQ	%ymm7, %ymm6, %ymm6
++
++	vpmovmskb %ymm5, %edi
++	vpmovmskb %ymm6, %esi
++
++	salq	$32, %rsi
++	xorq	%rsi, %rdi
++
++	xorl	%r8d, %r8d
++	/* If ECX > VEC_SIZE * 2, skip ECX - (VEC_SIZE * 2) bytes.  */
++	subl	$(VEC_SIZE * 2), %ecx
++	jle	1f
++	/* Skip ECX bytes.  */
++	shrq	%cl, %rdi
++	/* R8 has number of bytes skipped.  */
++	movl	%ecx, %r8d
++1:
++	/* Before jumping back to the loop, set ESI to the number of
++	   VEC_SIZE * 4 blocks before page crossing.  */
++	movl	$(PAGE_SIZE / (VEC_SIZE * 4) - 1), %esi
++
++	testq	%rdi, %rdi
++# ifdef USE_AS_STRNCMP
++	/* At this point, if %rdi value is 0, it already tested
++	   VEC_SIZE*4+%r10 byte starting from %rax. This label
++	   checks whether strncmp maximum offset reached or not.  */
++	je	L(string_nbyte_offset_check)
++# else
++	je	L(back_to_loop)
++# endif
++	tzcntq	%rdi, %rcx
++	addq	%r10, %rcx
++	/* Adjust for number of bytes skipped.  */
++	addq	%r8, %rcx
++# ifdef USE_AS_STRNCMP
++	addq	$(VEC_SIZE * 2), %rcx
++	subq	%rcx, %r11
++	jbe	L(zero)
++#  ifdef USE_AS_WCSCMP
++	movq	%rax, %rsi
++	xorl	%eax, %eax
++	movl	(%rsi, %rcx), %edi
++	cmpl	(%rdx, %rcx), %edi
++	jne	L(wcscmp_return)
++#  else
++	movzbl	(%rax, %rcx), %eax
++	movzbl	(%rdx, %rcx), %edx
++	subl	%edx, %eax
++#  endif
++# else
++#  ifdef USE_AS_WCSCMP
++	movq	%rax, %rsi
++	xorl	%eax, %eax
++	movl	(VEC_SIZE * 2)(%rsi, %rcx), %edi
++	cmpl	(VEC_SIZE * 2)(%rdx, %rcx), %edi
++	jne	L(wcscmp_return)
++#  else
++	movzbl	(VEC_SIZE * 2)(%rax, %rcx), %eax
++	movzbl	(VEC_SIZE * 2)(%rdx, %rcx), %edx
++	subl	%edx, %eax
++#  endif
++# endif
++	VZEROUPPER
++	ret
++
++# ifdef USE_AS_STRNCMP
++L(string_nbyte_offset_check):
++	leaq	(VEC_SIZE * 4)(%r10), %r10
++	cmpq	%r10, %r11
++	jbe	L(zero)
++	jmp	L(back_to_loop)
++# endif
++
++	.p2align 4
++L(cross_page_loop):
++	/* Check one byte/dword at a time.  */
++# ifdef USE_AS_WCSCMP
++	cmpl	%ecx, %eax
++# else
++	subl	%ecx, %eax
++# endif
++	jne	L(different)
++	addl	$SIZE_OF_CHAR, %edx
++	cmpl	$(VEC_SIZE * 4), %edx
++	je	L(main_loop_header)
++# ifdef USE_AS_STRNCMP
++	cmpq	%r11, %rdx
++	jae	L(zero)
++# endif
++# ifdef USE_AS_WCSCMP
++	movl	(%rdi, %rdx), %eax
++	movl	(%rsi, %rdx), %ecx
++# else
++	movzbl	(%rdi, %rdx), %eax
++	movzbl	(%rsi, %rdx), %ecx
++# endif
++	/* Check null char.  */
++	testl	%eax, %eax
++	jne	L(cross_page_loop)
++	/* Since %eax == 0, subtract is OK for both SIGNED and UNSIGNED
++	   comparisons.  */
++	subl	%ecx, %eax
++# ifndef USE_AS_WCSCMP
++L(different):
++# endif
++	VZEROUPPER
++	ret
++
++# ifdef USE_AS_WCSCMP
++	.p2align 4
++L(different):
++	/* Use movl to avoid modifying EFLAGS.  */
++	movl	$0, %eax
++	setl	%al
++	negl	%eax
++	orl	$1, %eax
++	VZEROUPPER
++	ret
++# endif
++
++# ifdef USE_AS_STRNCMP
++	.p2align 4
++L(zero):
++	xorl	%eax, %eax
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(char0):
++#  ifdef USE_AS_WCSCMP
++	xorl	%eax, %eax
++	movl	(%rdi), %ecx
++	cmpl	(%rsi), %ecx
++	jne	L(wcscmp_return)
++#  else
++	movzbl	(%rsi), %ecx
++	movzbl	(%rdi), %eax
++	subl	%ecx, %eax
++#  endif
++	VZEROUPPER
++	ret
++# endif
++
++	.p2align 4
++L(last_vector):
++	addq	%rdx, %rdi
++	addq	%rdx, %rsi
++# ifdef USE_AS_STRNCMP
++	subq	%rdx, %r11
++# endif
++	tzcntl	%ecx, %edx
++# ifdef USE_AS_STRNCMP
++	cmpq	%r11, %rdx
++	jae	L(zero)
++# endif
++# ifdef USE_AS_WCSCMP
++	xorl	%eax, %eax
++	movl	(%rdi, %rdx), %ecx
++	cmpl	(%rsi, %rdx), %ecx
++	jne	L(wcscmp_return)
++# else
++	movzbl	(%rdi, %rdx), %eax
++	movzbl	(%rsi, %rdx), %edx
++	subl	%edx, %eax
++# endif
++	VZEROUPPER
++	ret
++
++	/* Comparing on page boundary region requires special treatment:
++	   It must done one vector at the time, starting with the wider
++	   ymm vector if possible, if not, with xmm. If fetching 16 bytes
++	   (xmm) still passes the boundary, byte comparison must be done.
++	 */
++	.p2align 4
++L(cross_page):
++	/* Try one ymm vector at a time.  */
++	cmpl	$(PAGE_SIZE - VEC_SIZE), %eax
++	jg	L(cross_page_1_vector)
++L(loop_1_vector):
++	vmovdqu	(%rdi, %rdx), %ymm1
++	VPCMPEQ	(%rsi, %rdx), %ymm1, %ymm0
++	VPMINU	%ymm1, %ymm0, %ymm0
++	VPCMPEQ	%ymm7, %ymm0, %ymm0
++	vpmovmskb %ymm0, %ecx
++	testl	%ecx, %ecx
++	jne	L(last_vector)
++
++	addl	$VEC_SIZE, %edx
++
++	addl	$VEC_SIZE, %eax
++# ifdef USE_AS_STRNCMP
++	/* Return 0 if the current offset (%rdx) >= the maximum offset
++	   (%r11).  */
++	cmpq	%r11, %rdx
++	jae	L(zero)
++# endif
++	cmpl	$(PAGE_SIZE - VEC_SIZE), %eax
++	jle	L(loop_1_vector)
++L(cross_page_1_vector):
++	/* Less than 32 bytes to check, try one xmm vector.  */
++	cmpl	$(PAGE_SIZE - 16), %eax
++	jg	L(cross_page_1_xmm)
++	vmovdqu	(%rdi, %rdx), %xmm1
++	VPCMPEQ	(%rsi, %rdx), %xmm1, %xmm0
++	VPMINU	%xmm1, %xmm0, %xmm0
++	VPCMPEQ	%xmm7, %xmm0, %xmm0
++	vpmovmskb %xmm0, %ecx
++	testl	%ecx, %ecx
++	jne	L(last_vector)
++
++	addl	$16, %edx
++# ifndef USE_AS_WCSCMP
++	addl	$16, %eax
++# endif
++# ifdef USE_AS_STRNCMP
++	/* Return 0 if the current offset (%rdx) >= the maximum offset
++	   (%r11).  */
++	cmpq	%r11, %rdx
++	jae	L(zero)
++# endif
++
++L(cross_page_1_xmm):
++# ifndef USE_AS_WCSCMP
++	/* Less than 16 bytes to check, try 8 byte vector.  NB: No need
++	   for wcscmp nor wcsncmp since wide char is 4 bytes.   */
++	cmpl	$(PAGE_SIZE - 8), %eax
++	jg	L(cross_page_8bytes)
++	vmovq	(%rdi, %rdx), %xmm1
++	vmovq	(%rsi, %rdx), %xmm0
++	VPCMPEQ	%xmm0, %xmm1, %xmm0
++	VPMINU	%xmm1, %xmm0, %xmm0
++	VPCMPEQ	%xmm7, %xmm0, %xmm0
++	vpmovmskb %xmm0, %ecx
++	/* Only last 8 bits are valid.  */
++	andl	$0xff, %ecx
++	testl	%ecx, %ecx
++	jne	L(last_vector)
++
++	addl	$8, %edx
++	addl	$8, %eax
++#  ifdef USE_AS_STRNCMP
++	/* Return 0 if the current offset (%rdx) >= the maximum offset
++	   (%r11).  */
++	cmpq	%r11, %rdx
++	jae	L(zero)
++#  endif
++
++L(cross_page_8bytes):
++	/* Less than 8 bytes to check, try 4 byte vector.  */
++	cmpl	$(PAGE_SIZE - 4), %eax
++	jg	L(cross_page_4bytes)
++	vmovd	(%rdi, %rdx), %xmm1
++	vmovd	(%rsi, %rdx), %xmm0
++	VPCMPEQ	%xmm0, %xmm1, %xmm0
++	VPMINU	%xmm1, %xmm0, %xmm0
++	VPCMPEQ	%xmm7, %xmm0, %xmm0
++	vpmovmskb %xmm0, %ecx
++	/* Only last 4 bits are valid.  */
++	andl	$0xf, %ecx
++	testl	%ecx, %ecx
++	jne	L(last_vector)
++
++	addl	$4, %edx
++#  ifdef USE_AS_STRNCMP
++	/* Return 0 if the current offset (%rdx) >= the maximum offset
++	   (%r11).  */
++	cmpq	%r11, %rdx
++	jae	L(zero)
++#  endif
++
++L(cross_page_4bytes):
++# endif
++	/* Less than 4 bytes to check, try one byte/dword at a time.  */
++# ifdef USE_AS_STRNCMP
++	cmpq	%r11, %rdx
++	jae	L(zero)
++# endif
++# ifdef USE_AS_WCSCMP
++	movl	(%rdi, %rdx), %eax
++	movl	(%rsi, %rdx), %ecx
++# else
++	movzbl	(%rdi, %rdx), %eax
++	movzbl	(%rsi, %rdx), %ecx
++# endif
++	testl	%eax, %eax
++	jne	L(cross_page_loop)
++	subl	%ecx, %eax
++	VZEROUPPER
++	ret
++END (STRCMP)
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-strcpy-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-strcpy-kbl.S
+new file mode 100644
+index 0000000..809a9ac
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-strcpy-kbl.S
+@@ -0,0 +1,1046 @@
++/* strcpy with AVX2
++   Copyright (C) 2011-2020 Free Software Foundation, Inc.
++   Contributed by Intel Corporation.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++
++# ifndef USE_AS_STRCAT
++
++#  ifndef STRCPY
++#   define STRCPY  strcpy_avx2
++#  endif
++
++# endif
++
++# ifndef L
++#  define L(label)      .L##label
++# endif
++
++# ifndef cfi_startproc
++#  define cfi_startproc .cfi_startproc
++# endif
++
++# ifndef cfi_endproc
++#  define cfi_endproc   .cfi_endproc
++# endif
++
++# ifndef ENTRY
++#  define ENTRY(name)   \
++        .type name, @function;  \
++        .globl name;    \
++        .p2align 4;     \
++name:   \
++        cfi_startproc
++# endif
++
++# ifndef END
++#  define END(name)     \
++        cfi_endproc;    \
++        .size name, .-name
++# endif
++
++/* Number of bytes in a vector register */
++# ifndef VEC_SIZE
++#  define VEC_SIZE	32
++# endif
++
++# ifndef VZEROUPPER
++#  define VZEROUPPER	vzeroupper
++# endif
++
++/* zero register */
++#define xmmZ	xmm0
++#define ymmZ	ymm0
++
++/* mask register */
++#define ymmM	ymm1
++
++# ifndef USE_AS_STRCAT
++
++	.section .text.avx,"ax",@progbits
++ENTRY (STRCPY)
++#  ifdef USE_AS_STRNCPY
++	mov	%RDX_LP, %R8_LP
++	test	%R8_LP, %R8_LP
++	jz	L(ExitZero)
++#  endif
++	mov	%rsi, %rcx
++#  ifndef USE_AS_STPCPY
++	mov	%rdi, %rax      /* save result */
++#  endif
++
++# endif
++
++	vpxor	%xmmZ, %xmmZ, %xmmZ
++
++	and	$((VEC_SIZE * 4) - 1), %ecx
++	cmp	$(VEC_SIZE * 2), %ecx
++	jbe	L(SourceStringAlignmentLessTwoVecSize)
++
++	and	$-VEC_SIZE, %rsi
++	and	$(VEC_SIZE - 1), %ecx
++
++	vpcmpeqb (%rsi), %ymmZ, %ymmM
++	vpmovmskb %ymmM, %edx
++	shr	%cl, %rdx
++
++# ifdef USE_AS_STRNCPY
++#  if defined USE_AS_STPCPY || defined USE_AS_STRCAT
++	mov	$VEC_SIZE, %r10
++	sub	%rcx, %r10
++	cmp	%r10, %r8
++#  else
++	mov	$(VEC_SIZE + 1), %r10
++	sub	%rcx, %r10
++	cmp	%r10, %r8
++#  endif
++	jbe	L(CopyVecSizeTailCase2OrCase3)
++# endif
++	test	%edx, %edx
++	jnz	L(CopyVecSizeTail)
++
++	vpcmpeqb VEC_SIZE(%rsi), %ymmZ, %ymm2
++	vpmovmskb %ymm2, %edx
++
++# ifdef USE_AS_STRNCPY
++	add	$VEC_SIZE, %r10
++	cmp	%r10, %r8
++	jbe	L(CopyTwoVecSizeCase2OrCase3)
++# endif
++	test	%edx, %edx
++	jnz	L(CopyTwoVecSize)
++
++	vmovdqu (%rsi, %rcx), %ymm2   /* copy VEC_SIZE bytes */
++	vmovdqu %ymm2, (%rdi)
++
++/* If source address alignment != destination address alignment */
++	.p2align 4
++L(UnalignVecSizeBoth):
++	sub	%rcx, %rdi
++# ifdef USE_AS_STRNCPY
++	add	%rcx, %r8
++	sbb	%rcx, %rcx
++	or	%rcx, %r8
++# endif
++	mov	$VEC_SIZE, %rcx
++	vmovdqa (%rsi, %rcx), %ymm2
++	vmovdqu %ymm2, (%rdi, %rcx)
++	vmovdqa VEC_SIZE(%rsi, %rcx), %ymm2
++	vpcmpeqb %ymm2, %ymmZ, %ymmM
++	vpmovmskb %ymmM, %edx
++	add	$VEC_SIZE, %rcx
++# ifdef USE_AS_STRNCPY
++	sub	$(VEC_SIZE * 3), %r8
++	jbe	L(CopyVecSizeCase2OrCase3)
++# endif
++	test	%edx, %edx
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	jnz	L(CopyVecSizeUnalignedVec2)
++# else
++	jnz	L(CopyVecSize)
++# endif
++
++	vmovdqu %ymm2, (%rdi, %rcx)
++	vmovdqa VEC_SIZE(%rsi, %rcx), %ymm3
++	vpcmpeqb %ymm3, %ymmZ, %ymmM
++	vpmovmskb %ymmM, %edx
++	add	$VEC_SIZE, %rcx
++# ifdef USE_AS_STRNCPY
++	sub	$VEC_SIZE, %r8
++	jbe	L(CopyVecSizeCase2OrCase3)
++# endif
++	test	%edx, %edx
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	jnz	L(CopyVecSizeUnalignedVec3)
++# else
++	jnz	L(CopyVecSize)
++# endif
++
++	vmovdqu %ymm3, (%rdi, %rcx)
++	vmovdqa VEC_SIZE(%rsi, %rcx), %ymm4
++	vpcmpeqb %ymm4, %ymmZ, %ymmM
++	vpmovmskb %ymmM, %edx
++	add	$VEC_SIZE, %rcx
++# ifdef USE_AS_STRNCPY
++	sub	$VEC_SIZE, %r8
++	jbe	L(CopyVecSizeCase2OrCase3)
++# endif
++	test	%edx, %edx
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	jnz	L(CopyVecSizeUnalignedVec4)
++# else
++	jnz	L(CopyVecSize)
++# endif
++
++	vmovdqu %ymm4, (%rdi, %rcx)
++	vmovdqa VEC_SIZE(%rsi, %rcx), %ymm2
++	vpcmpeqb %ymm2, %ymmZ, %ymmM
++	vpmovmskb %ymmM, %edx
++	add	$VEC_SIZE, %rcx
++# ifdef USE_AS_STRNCPY
++	sub	$VEC_SIZE, %r8
++	jbe	L(CopyVecSizeCase2OrCase3)
++# endif
++	test	%edx, %edx
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	jnz	L(CopyVecSizeUnalignedVec2)
++# else
++	jnz	L(CopyVecSize)
++# endif
++
++	vmovdqu %ymm2, (%rdi, %rcx)
++	vmovdqa VEC_SIZE(%rsi, %rcx), %ymm2
++	vpcmpeqb %ymm2, %ymmZ, %ymmM
++	vpmovmskb %ymmM, %edx
++	add	$VEC_SIZE, %rcx
++# ifdef USE_AS_STRNCPY
++	sub	$VEC_SIZE, %r8
++	jbe	L(CopyVecSizeCase2OrCase3)
++# endif
++	test	%edx, %edx
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	jnz	L(CopyVecSizeUnalignedVec2)
++# else
++	jnz	L(CopyVecSize)
++# endif
++
++	vmovdqa VEC_SIZE(%rsi, %rcx), %ymm3
++	vmovdqu %ymm2, (%rdi, %rcx)
++	vpcmpeqb %ymm3, %ymmZ, %ymmM
++	vpmovmskb %ymmM, %edx
++	add	$VEC_SIZE, %rcx
++# ifdef USE_AS_STRNCPY
++	sub	$VEC_SIZE, %r8
++	jbe	L(CopyVecSizeCase2OrCase3)
++# endif
++	test	%edx, %edx
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	jnz	L(CopyVecSizeUnalignedVec3)
++# else
++	jnz	L(CopyVecSize)
++# endif
++
++	vmovdqu %ymm3, (%rdi, %rcx)
++	mov	%rsi, %rdx
++	lea	VEC_SIZE(%rsi, %rcx), %rsi
++	and	$-(VEC_SIZE * 4), %rsi
++	sub	%rsi, %rdx
++	sub	%rdx, %rdi
++# ifdef USE_AS_STRNCPY
++	lea	(VEC_SIZE * 8)(%r8, %rdx), %r8
++# endif
++L(UnalignedFourVecSizeLoop):
++	vmovdqa (%rsi), %ymm4
++	vmovdqa VEC_SIZE(%rsi), %ymm5
++	vmovdqa (VEC_SIZE * 2)(%rsi), %ymm6
++	vmovdqa (VEC_SIZE * 3)(%rsi), %ymm7
++	vpminub %ymm5, %ymm4, %ymm2
++	vpminub %ymm7, %ymm6, %ymm3
++	vpminub %ymm2, %ymm3, %ymm3
++	vpcmpeqb %ymmM, %ymm3, %ymm3
++	vpmovmskb %ymm3, %edx
++# ifdef USE_AS_STRNCPY
++	sub	$(VEC_SIZE * 4), %r8
++	jbe	L(UnalignedLeaveCase2OrCase3)
++# endif
++	test	%edx, %edx
++	jnz	L(UnalignedFourVecSizeLeave)
++
++L(UnalignedFourVecSizeLoop_start):
++	add	$(VEC_SIZE * 4), %rdi
++	add	$(VEC_SIZE * 4), %rsi
++	vmovdqu %ymm4, -(VEC_SIZE * 4)(%rdi)
++	vmovdqa (%rsi), %ymm4
++	vmovdqu %ymm5, -(VEC_SIZE * 3)(%rdi)
++	vmovdqa VEC_SIZE(%rsi), %ymm5
++	vpminub %ymm5, %ymm4, %ymm2
++	vmovdqu %ymm6, -(VEC_SIZE * 2)(%rdi)
++	vmovdqa (VEC_SIZE * 2)(%rsi), %ymm6
++	vmovdqu %ymm7, -VEC_SIZE(%rdi)
++	vmovdqa (VEC_SIZE * 3)(%rsi), %ymm7
++	vpminub %ymm7, %ymm6, %ymm3
++	vpminub %ymm2, %ymm3, %ymm3
++	vpcmpeqb %ymmM, %ymm3, %ymm3
++	vpmovmskb %ymm3, %edx
++# ifdef USE_AS_STRNCPY
++	sub	$(VEC_SIZE * 4), %r8
++	jbe	L(UnalignedLeaveCase2OrCase3)
++# endif
++	test	%edx, %edx
++	jz	L(UnalignedFourVecSizeLoop_start)
++
++L(UnalignedFourVecSizeLeave):
++	vpcmpeqb %ymm4, %ymmZ, %ymmM
++	vpmovmskb %ymmM, %edx
++	test	%edx, %edx
++	jnz	L(CopyVecSizeUnaligned_0)
++
++	vpcmpeqb %ymm5, %ymmZ, %ymmM
++	vpmovmskb %ymmM, %ecx
++	test	%ecx, %ecx
++	jnz	L(CopyVecSizeUnaligned_16)
++
++	vpcmpeqb %ymm6, %ymmZ, %ymmM
++	vpmovmskb %ymmM, %edx
++	test	%edx, %edx
++	jnz	L(CopyVecSizeUnaligned_32)
++
++	vpcmpeqb %ymm7, %ymmZ, %ymmM
++	vpmovmskb %ymmM, %ecx
++	bsf	%ecx, %edx
++	vmovdqu %ymm4, (%rdi)
++	vmovdqu %ymm5, VEC_SIZE(%rdi)
++	vmovdqu %ymm6, (VEC_SIZE * 2)(%rdi)
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++# ifdef USE_AS_STPCPY
++	lea	(VEC_SIZE * 3)(%rdi, %rdx), %rax
++# endif
++	vmovdqu %ymm7, (VEC_SIZE * 3)(%rdi)
++	add	$(VEC_SIZE - 1), %r8
++	sub	%rdx, %r8
++	lea	((VEC_SIZE * 3) + 1)(%rdi, %rdx), %rdi
++	jmp	L(StrncpyFillTailWithZero)
++# else
++	add	$(VEC_SIZE * 3), %rsi
++	add	$(VEC_SIZE * 3), %rdi
++	jmp	L(CopyVecSizeExit)
++# endif
++
++/* If source address alignment == destination address alignment */
++
++L(SourceStringAlignmentLessTwoVecSize):
++	vmovdqu (%rsi), %ymm3
++	vmovdqu VEC_SIZE(%rsi), %ymm2
++	vpcmpeqb %ymm3, %ymmZ, %ymmM
++	vpmovmskb %ymmM, %edx
++
++# ifdef USE_AS_STRNCPY
++#  if defined USE_AS_STPCPY || defined USE_AS_STRCAT
++	cmp	$VEC_SIZE, %r8
++#  else
++	cmp	$(VEC_SIZE + 1), %r8
++#  endif
++	jbe	L(CopyVecSizeTail1Case2OrCase3)
++# endif
++	test	%edx, %edx
++	jnz	L(CopyVecSizeTail1)
++
++	vmovdqu %ymm3, (%rdi)
++	vpcmpeqb %ymm2, %ymmZ, %ymmM
++	vpmovmskb %ymmM, %edx
++
++# ifdef USE_AS_STRNCPY
++#  if defined USE_AS_STPCPY || defined USE_AS_STRCAT
++	cmp	$(VEC_SIZE * 2), %r8
++#  else
++	cmp	$((VEC_SIZE * 2) + 1), %r8
++#  endif
++	jbe	L(CopyTwoVecSize1Case2OrCase3)
++# endif
++	test	%edx, %edx
++	jnz	L(CopyTwoVecSize1)
++
++	and	$-VEC_SIZE, %rsi
++	and	$(VEC_SIZE - 1), %ecx
++	jmp	L(UnalignVecSizeBoth)
++
++/*------End of main part with loops---------------------*/
++
++/* Case1 */
++
++# if (!defined USE_AS_STRNCPY) || (defined USE_AS_STRCAT)
++	.p2align 4
++L(CopyVecSize):
++	add	%rcx, %rdi
++# endif
++L(CopyVecSizeTail):
++	add	%rcx, %rsi
++L(CopyVecSizeTail1):
++	bsf	%edx, %edx
++L(CopyVecSizeExit):
++	cmp	$32, %edx
++	jae	L(Exit32_63)
++	cmp	$16, %edx
++	jae	L(Exit16_31)
++	cmp	$8, %edx
++	jae	L(Exit8_15)
++	cmp	$4, %edx
++	jae	L(Exit4_7)
++	cmp	$3, %edx
++	je	L(Exit3)
++	cmp	$1, %edx
++	ja	L(Exit2)
++	je	L(Exit1)
++	movb	$0, (%rdi)
++# ifdef USE_AS_STPCPY
++	lea	(%rdi), %rax
++# endif
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$1, %r8
++	lea	1(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(CopyTwoVecSize1):
++	add	$VEC_SIZE, %rsi
++	add	$VEC_SIZE, %rdi
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$VEC_SIZE, %r8
++# endif
++	jmp	L(CopyVecSizeTail1)
++
++	.p2align 4
++L(CopyTwoVecSize):
++	bsf	%edx, %edx
++	add	%rcx, %rsi
++	add	$VEC_SIZE, %edx
++	sub	%ecx, %edx
++	jmp	L(CopyVecSizeExit)
++
++	.p2align 4
++L(CopyVecSizeUnaligned_0):
++	bsf	%edx, %edx
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++# ifdef USE_AS_STPCPY
++	lea	(%rdi, %rdx), %rax
++# endif
++	vmovdqu %ymm4, (%rdi)
++	add	$((VEC_SIZE * 4) - 1), %r8
++	sub	%rdx, %r8
++	lea	1(%rdi, %rdx), %rdi
++	jmp	L(StrncpyFillTailWithZero)
++# else
++	jmp	L(CopyVecSizeExit)
++# endif
++
++	.p2align 4
++L(CopyVecSizeUnaligned_16):
++	bsf	%ecx, %edx
++	vmovdqu %ymm4, (%rdi)
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++# ifdef USE_AS_STPCPY
++	lea	VEC_SIZE(%rdi, %rdx), %rax
++# endif
++	vmovdqu %ymm5, VEC_SIZE(%rdi)
++	add	$((VEC_SIZE * 3) - 1), %r8
++	sub	%rdx, %r8
++	lea	(VEC_SIZE + 1)(%rdi, %rdx), %rdi
++	jmp	L(StrncpyFillTailWithZero)
++# else
++	add	$VEC_SIZE, %rsi
++	add	$VEC_SIZE, %rdi
++	jmp	L(CopyVecSizeExit)
++# endif
++
++	.p2align 4
++L(CopyVecSizeUnaligned_32):
++	bsf	%edx, %edx
++	vmovdqu %ymm4, (%rdi)
++	vmovdqu %ymm5, VEC_SIZE(%rdi)
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++# ifdef USE_AS_STPCPY
++	lea	(VEC_SIZE * 2)(%rdi, %rdx), %rax
++# endif
++	vmovdqu %ymm6, (VEC_SIZE * 2)(%rdi)
++	add	$((VEC_SIZE * 2) - 1), %r8
++	sub	%rdx, %r8
++	lea	((VEC_SIZE * 2) + 1)(%rdi, %rdx), %rdi
++	jmp	L(StrncpyFillTailWithZero)
++# else
++	add	$(VEC_SIZE * 2), %rsi
++	add	$(VEC_SIZE * 2), %rdi
++	jmp	L(CopyVecSizeExit)
++# endif
++
++# ifdef USE_AS_STRNCPY
++#  ifndef USE_AS_STRCAT
++	.p2align 4
++L(CopyVecSizeUnalignedVec6):
++	vmovdqu %ymm6, (%rdi, %rcx)
++	jmp	L(CopyVecSizeVecExit)
++
++	.p2align 4
++L(CopyVecSizeUnalignedVec5):
++	vmovdqu %ymm5, (%rdi, %rcx)
++	jmp	L(CopyVecSizeVecExit)
++
++	.p2align 4
++L(CopyVecSizeUnalignedVec4):
++	vmovdqu %ymm4, (%rdi, %rcx)
++	jmp	L(CopyVecSizeVecExit)
++
++	.p2align 4
++L(CopyVecSizeUnalignedVec3):
++	vmovdqu %ymm3, (%rdi, %rcx)
++	jmp	L(CopyVecSizeVecExit)
++#  endif
++
++/* Case2 */
++
++	.p2align 4
++L(CopyVecSizeCase2):
++	add	$VEC_SIZE, %r8
++	add	%rcx, %rdi
++	add	%rcx, %rsi
++	bsf	%edx, %edx
++	cmp	%r8d, %edx
++	jb	L(CopyVecSizeExit)
++	jmp	L(StrncpyExit)
++
++	.p2align 4
++L(CopyTwoVecSizeCase2):
++	add	%rcx, %rsi
++	bsf	%edx, %edx
++	add	$VEC_SIZE, %edx
++	sub	%ecx, %edx
++	cmp	%r8d, %edx
++	jb	L(CopyVecSizeExit)
++	jmp	L(StrncpyExit)
++
++L(CopyVecSizeTailCase2):
++	add	%rcx, %rsi
++	bsf	%edx, %edx
++	cmp	%r8d, %edx
++	jb	L(CopyVecSizeExit)
++	jmp	L(StrncpyExit)
++
++L(CopyVecSizeTail1Case2):
++	bsf	%edx, %edx
++	cmp	%r8d, %edx
++	jb	L(CopyVecSizeExit)
++	jmp	L(StrncpyExit)
++
++/* Case2 or Case3,  Case3 */
++
++	.p2align 4
++L(CopyVecSizeCase2OrCase3):
++	test	%rdx, %rdx
++	jnz	L(CopyVecSizeCase2)
++L(CopyVecSizeCase3):
++	add	$VEC_SIZE, %r8
++	add	%rcx, %rdi
++	add	%rcx, %rsi
++	jmp	L(StrncpyExit)
++
++	.p2align 4
++L(CopyTwoVecSizeCase2OrCase3):
++	test	%rdx, %rdx
++	jnz	L(CopyTwoVecSizeCase2)
++	add	%rcx, %rsi
++	jmp	L(StrncpyExit)
++
++	.p2align 4
++L(CopyVecSizeTailCase2OrCase3):
++	test	%rdx, %rdx
++	jnz	L(CopyVecSizeTailCase2)
++	add	%rcx, %rsi
++	jmp	L(StrncpyExit)
++
++	.p2align 4
++L(CopyTwoVecSize1Case2OrCase3):
++	add	$VEC_SIZE, %rdi
++	add	$VEC_SIZE, %rsi
++	sub	$VEC_SIZE, %r8
++L(CopyVecSizeTail1Case2OrCase3):
++	test	%rdx, %rdx
++	jnz	L(CopyVecSizeTail1Case2)
++	jmp	L(StrncpyExit)
++# endif
++
++/*------------End labels regarding with copying 1-VEC_SIZE bytes--and 1-(VEC_SIZE*2) bytes----*/
++
++	.p2align 4
++L(Exit1):
++	movzwl	(%rsi), %edx
++	mov	%dx, (%rdi)
++# ifdef USE_AS_STPCPY
++	lea	1(%rdi), %rax
++# endif
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$2, %r8
++	lea	2(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(Exit2):
++	movzwl	(%rsi), %ecx
++	mov	%cx, (%rdi)
++	movb	$0, 2(%rdi)
++# ifdef USE_AS_STPCPY
++	lea	2(%rdi), %rax
++# endif
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$3, %r8
++	lea	3(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(Exit3):
++	mov	(%rsi), %edx
++	mov	%edx, (%rdi)
++# ifdef USE_AS_STPCPY
++	lea	3(%rdi), %rax
++# endif
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	$4, %r8
++	lea	4(%rdi), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(Exit4_7):
++	mov	(%rsi), %ecx
++	mov	%ecx, (%rdi)
++	mov	-3(%rsi, %rdx), %ecx
++	mov	%ecx, -3(%rdi, %rdx)
++# ifdef USE_AS_STPCPY
++	lea	(%rdi, %rdx), %rax
++# endif
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	%rdx, %r8
++	sub	$1, %r8
++	lea	1(%rdi, %rdx), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(Exit8_15):
++	mov	(%rsi), %rcx
++	mov	-7(%rsi, %rdx), %r9
++	mov	%rcx, (%rdi)
++	mov	%r9, -7(%rdi, %rdx)
++# ifdef USE_AS_STPCPY
++	lea	(%rdi, %rdx), %rax
++# endif
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	%rdx, %r8
++	sub	$1, %r8
++	lea	1(%rdi, %rdx), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(Exit16_31):
++	vmovdqu (%rsi), %xmm2
++	vmovdqu -15(%rsi, %rdx), %xmm3
++	vmovdqu %xmm2, (%rdi)
++	vmovdqu %xmm3, -15(%rdi, %rdx)
++# ifdef USE_AS_STPCPY
++	lea	(%rdi, %rdx), %rax
++# endif
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub %rdx, %r8
++	sub $1, %r8
++	lea 1(%rdi, %rdx), %rdi
++	jnz L(StrncpyFillTailWithZero)
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(Exit32_63):
++	vmovdqu (%rsi), %ymm2
++	vmovdqu -31(%rsi, %rdx), %ymm3
++	vmovdqu %ymm2, (%rdi)
++	vmovdqu %ymm3, -31(%rdi, %rdx)
++# ifdef USE_AS_STPCPY
++	lea	(%rdi, %rdx), %rax
++# endif
++# if defined USE_AS_STRNCPY && !defined USE_AS_STRCAT
++	sub	%rdx, %r8
++	sub	$1, %r8
++	lea	1(%rdi, %rdx), %rdi
++	jnz	L(StrncpyFillTailWithZero)
++# endif
++	VZEROUPPER
++	ret
++
++# ifdef USE_AS_STRNCPY
++
++	.p2align 4
++L(StrncpyExit1):
++	movzbl	(%rsi), %edx
++	mov	%dl, (%rdi)
++#  ifdef USE_AS_STPCPY
++	lea	1(%rdi), %rax
++#  endif
++#  ifdef USE_AS_STRCAT
++	movb	$0, 1(%rdi)
++#  endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(StrncpyExit2):
++	movzwl	(%rsi), %edx
++	mov	%dx, (%rdi)
++#  ifdef USE_AS_STPCPY
++	lea	2(%rdi), %rax
++#  endif
++#  ifdef USE_AS_STRCAT
++	movb	$0, 2(%rdi)
++#  endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(StrncpyExit3_4):
++	movzwl	(%rsi), %ecx
++	movzwl	-2(%rsi, %r8), %edx
++	mov	%cx, (%rdi)
++	mov	%dx, -2(%rdi, %r8)
++#  ifdef USE_AS_STPCPY
++	lea	(%rdi, %r8), %rax
++#  endif
++#  ifdef USE_AS_STRCAT
++	movb	$0, (%rdi, %r8)
++#  endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(StrncpyExit5_8):
++	mov	(%rsi), %ecx
++	mov	-4(%rsi, %r8), %edx
++	mov	%ecx, (%rdi)
++	mov	%edx, -4(%rdi, %r8)
++#  ifdef USE_AS_STPCPY
++	lea	(%rdi, %r8), %rax
++#  endif
++#  ifdef USE_AS_STRCAT
++	movb	$0, (%rdi, %r8)
++#  endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(StrncpyExit9_16):
++	mov	(%rsi), %rcx
++	mov	-8(%rsi, %r8), %rdx
++	mov	%rcx, (%rdi)
++	mov	%rdx, -8(%rdi, %r8)
++#  ifdef USE_AS_STPCPY
++	lea	(%rdi, %r8), %rax
++#  endif
++#  ifdef USE_AS_STRCAT
++	movb	$0, (%rdi, %r8)
++#  endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(StrncpyExit17_32):
++	vmovdqu (%rsi), %xmm2
++	vmovdqu -16(%rsi, %r8), %xmm3
++	vmovdqu %xmm2, (%rdi)
++	vmovdqu %xmm3, -16(%rdi, %r8)
++#  ifdef USE_AS_STPCPY
++	lea	(%rdi, %r8), %rax
++#  endif
++#  ifdef USE_AS_STRCAT
++	movb	$0, (%rdi, %r8)
++#  endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(StrncpyExit33_64):
++	/*  0/32, 31/16 */
++	vmovdqu (%rsi), %ymm2
++	vmovdqu -VEC_SIZE(%rsi, %r8), %ymm3
++	vmovdqu %ymm2, (%rdi)
++	vmovdqu %ymm3, -VEC_SIZE(%rdi, %r8)
++#  ifdef USE_AS_STPCPY
++	lea	(%rdi, %r8), %rax
++#  endif
++#  ifdef USE_AS_STRCAT
++	movb	$0, (%rdi, %r8)
++#  endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(StrncpyExit65):
++	/* 0/32, 32/32, 64/1 */
++	vmovdqu (%rsi), %ymm2
++	vmovdqu 32(%rsi), %ymm3
++	mov	64(%rsi), %cl
++	vmovdqu %ymm2, (%rdi)
++	vmovdqu %ymm3, 32(%rdi)
++	mov	%cl, 64(%rdi)
++#  ifdef USE_AS_STPCPY
++	lea	65(%rdi), %rax
++#  endif
++#  ifdef USE_AS_STRCAT
++	movb	$0, 65(%rdi)
++#  endif
++	VZEROUPPER
++	ret
++
++#  ifndef USE_AS_STRCAT
++
++	.p2align 4
++L(Fill1):
++	mov	%dl, (%rdi)
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(Fill2):
++	mov	%dx, (%rdi)
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(Fill3_4):
++	mov	%dx, (%rdi)
++	mov     %dx, -2(%rdi, %r8)
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(Fill5_8):
++	mov	%edx, (%rdi)
++	mov     %edx, -4(%rdi, %r8)
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(Fill9_16):
++	mov	%rdx, (%rdi)
++	mov	%rdx, -8(%rdi, %r8)
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(Fill17_32):
++	vmovdqu %xmmZ, (%rdi)
++	vmovdqu %xmmZ, -16(%rdi, %r8)
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(CopyVecSizeUnalignedVec2):
++	vmovdqu %ymm2, (%rdi, %rcx)
++
++	.p2align 4
++L(CopyVecSizeVecExit):
++	bsf	%edx, %edx
++	add	$(VEC_SIZE - 1), %r8
++	add	%rcx, %rdi
++#   ifdef USE_AS_STPCPY
++	lea	(%rdi, %rdx), %rax
++#   endif
++	sub	%rdx, %r8
++	lea	1(%rdi, %rdx), %rdi
++
++	.p2align 4
++L(StrncpyFillTailWithZero):
++	xor	%edx, %edx
++	sub	$VEC_SIZE, %r8
++	jbe	L(StrncpyFillExit)
++
++	vmovdqu %ymmZ, (%rdi)
++	add	$VEC_SIZE, %rdi
++
++	mov	%rdi, %rsi
++	and	$(VEC_SIZE - 1), %esi
++	sub	%rsi, %rdi
++	add	%rsi, %r8
++	sub	$(VEC_SIZE * 4), %r8
++	jb	L(StrncpyFillLessFourVecSize)
++
++L(StrncpyFillLoopVmovdqa):
++	vmovdqa %ymmZ, (%rdi)
++	vmovdqa %ymmZ, VEC_SIZE(%rdi)
++	vmovdqa %ymmZ, (VEC_SIZE * 2)(%rdi)
++	vmovdqa %ymmZ, (VEC_SIZE * 3)(%rdi)
++	add	$(VEC_SIZE * 4), %rdi
++	sub	$(VEC_SIZE * 4), %r8
++	jae	L(StrncpyFillLoopVmovdqa)
++
++L(StrncpyFillLessFourVecSize):
++	add	$(VEC_SIZE * 2), %r8
++	jl	L(StrncpyFillLessTwoVecSize)
++	vmovdqa %ymmZ, (%rdi)
++	vmovdqa %ymmZ, VEC_SIZE(%rdi)
++	add	$(VEC_SIZE * 2), %rdi
++	sub	$VEC_SIZE, %r8
++	jl	L(StrncpyFillExit)
++	vmovdqa %ymmZ, (%rdi)
++	add	$VEC_SIZE, %rdi
++	jmp	L(Fill)
++
++	.p2align 4
++L(StrncpyFillLessTwoVecSize):
++	add	$VEC_SIZE, %r8
++	jl	L(StrncpyFillExit)
++	vmovdqa %ymmZ, (%rdi)
++	add	$VEC_SIZE, %rdi
++	jmp	L(Fill)
++
++	.p2align 4
++L(StrncpyFillExit):
++	add	$VEC_SIZE, %r8
++L(Fill):
++	cmp	$17, %r8d
++	jae	L(Fill17_32)
++	cmp	$9, %r8d
++	jae	L(Fill9_16)
++	cmp	$5, %r8d
++	jae	L(Fill5_8)
++	cmp	$3, %r8d
++	jae	L(Fill3_4)
++	cmp	$1, %r8d
++	ja	L(Fill2)
++	je	L(Fill1)
++	VZEROUPPER
++	ret
++
++/* end of ifndef USE_AS_STRCAT */
++#  endif
++
++	.p2align 4
++L(UnalignedLeaveCase2OrCase3):
++	test	%rdx, %rdx
++	jnz	L(UnalignedFourVecSizeLeaveCase2)
++L(UnalignedFourVecSizeLeaveCase3):
++	lea	(VEC_SIZE * 4)(%r8), %rcx
++	and	$-VEC_SIZE, %rcx
++	add	$(VEC_SIZE * 3), %r8
++	jl	L(CopyVecSizeCase3)
++	vmovdqu %ymm4, (%rdi)
++	sub	$VEC_SIZE, %r8
++	jb	L(CopyVecSizeCase3)
++	vmovdqu %ymm5, VEC_SIZE(%rdi)
++	sub	$VEC_SIZE, %r8
++	jb	L(CopyVecSizeCase3)
++	vmovdqu %ymm6, (VEC_SIZE * 2)(%rdi)
++	sub	$VEC_SIZE, %r8
++	jb	L(CopyVecSizeCase3)
++	vmovdqu %ymm7, (VEC_SIZE * 3)(%rdi)
++#  ifdef USE_AS_STPCPY
++	lea	(VEC_SIZE * 4)(%rdi), %rax
++#  endif
++#  ifdef USE_AS_STRCAT
++	movb	$0, (VEC_SIZE * 4)(%rdi)
++#  endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(UnalignedFourVecSizeLeaveCase2):
++	xor	%ecx, %ecx
++	vpcmpeqb %ymm4, %ymmZ, %ymmM
++	vpmovmskb %ymmM, %edx
++	add	$(VEC_SIZE * 3), %r8
++	jle	L(CopyVecSizeCase2OrCase3)
++	test	%edx, %edx
++#  ifndef USE_AS_STRCAT
++	jnz	L(CopyVecSizeUnalignedVec4)
++#  else
++	jnz	L(CopyVecSize)
++#  endif
++	vpcmpeqb %ymm5, %ymmZ, %ymmM
++	vpmovmskb %ymmM, %edx
++	vmovdqu %ymm4, (%rdi)
++	add	$VEC_SIZE, %rcx
++	sub	$VEC_SIZE, %r8
++	jbe	L(CopyVecSizeCase2OrCase3)
++	test	%edx, %edx
++#  ifndef USE_AS_STRCAT
++	jnz	L(CopyVecSizeUnalignedVec5)
++#  else
++	jnz	L(CopyVecSize)
++#  endif
++
++	vpcmpeqb %ymm6, %ymmZ, %ymmM
++	vpmovmskb %ymmM, %edx
++	vmovdqu %ymm5, VEC_SIZE(%rdi)
++	add	$VEC_SIZE, %rcx
++	sub	$VEC_SIZE, %r8
++	jbe	L(CopyVecSizeCase2OrCase3)
++	test	%edx, %edx
++#  ifndef USE_AS_STRCAT
++	jnz	L(CopyVecSizeUnalignedVec6)
++#  else
++	jnz	L(CopyVecSize)
++#  endif
++
++	vpcmpeqb %ymm7, %ymmZ, %ymmM
++	vpmovmskb %ymmM, %edx
++	vmovdqu %ymm6, (VEC_SIZE * 2)(%rdi)
++	lea	VEC_SIZE(%rdi, %rcx), %rdi
++	lea	VEC_SIZE(%rsi, %rcx), %rsi
++	bsf	%edx, %edx
++	cmp	%r8d, %edx
++	jb	L(CopyVecSizeExit)
++L(StrncpyExit):
++	cmp	$65, %r8d
++	je	L(StrncpyExit65)
++	cmp	$33, %r8d
++	jae	L(StrncpyExit33_64)
++	cmp	$17, %r8d
++	jae	L(StrncpyExit17_32)
++	cmp	$9, %r8d
++	jae	L(StrncpyExit9_16)
++	cmp	$5, %r8d
++	jae	L(StrncpyExit5_8)
++	cmp	$3, %r8d
++	jae	L(StrncpyExit3_4)
++	cmp	$1, %r8d
++	ja	L(StrncpyExit2)
++	je	L(StrncpyExit1)
++#  ifdef USE_AS_STPCPY
++	mov	%rdi, %rax
++#  endif
++#  ifdef USE_AS_STRCAT
++	movb	$0, (%rdi)
++#  endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(ExitZero):
++#  ifndef USE_AS_STRCAT
++	mov	%rdi, %rax
++#  endif
++	VZEROUPPER
++	ret
++
++# endif
++
++# ifndef USE_AS_STRCAT
++END (STRCPY)
++# else
++END (STRCAT)
++# endif
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-strlen-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-strlen-kbl.S
+new file mode 100644
+index 0000000..912d771
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-strlen-kbl.S
+@@ -0,0 +1,418 @@
++/* strlen/strnlen/wcslen/wcsnlen optimized with AVX2.
++   Copyright (C) 2017-2020 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++# ifndef STRLEN
++#  define STRLEN	strlen_avx2
++# endif
++
++# ifndef L
++#  define L(label)      .L##label
++# endif
++
++# ifndef cfi_startproc
++#  define cfi_startproc .cfi_startproc
++# endif
++
++# ifndef cfi_endproc
++#  define cfi_endproc   .cfi_endproc
++# endif
++
++# ifndef ENTRY
++#  define ENTRY(name)   \
++        .type name, @function;  \
++        .globl name;    \
++        .p2align 4;     \
++name:   \
++        cfi_startproc
++# endif
++
++# ifndef END
++#  define END(name)     \
++        cfi_endproc;    \
++        .size name, .-name
++# endif
++
++# ifdef USE_AS_WCSLEN
++#  define VPCMPEQ	vpcmpeqd
++#  define VPMINU	vpminud
++# else
++#  define VPCMPEQ	vpcmpeqb
++#  define VPMINU	vpminub
++# endif
++
++# ifndef VZEROUPPER
++#  define VZEROUPPER	vzeroupper
++# endif
++
++# define VEC_SIZE 32
++
++	.section .text.avx,"ax",@progbits
++ENTRY (STRLEN)
++# ifdef USE_AS_STRNLEN
++	/* Check for zero length.  */
++	test	%RSI_LP, %RSI_LP
++	jz	L(zero)
++#  ifdef USE_AS_WCSLEN
++	shl	$2, %RSI_LP
++#  elif defined __ILP32__
++	/* Clear the upper 32 bits.  */
++	movl	%esi, %esi
++#  endif
++	mov	%RSI_LP, %R8_LP
++# endif
++	movl	%edi, %ecx
++	movq	%rdi, %rdx
++	vpxor	%xmm0, %xmm0, %xmm0
++
++	/* Check if we may cross page boundary with one vector load.  */
++	andl	$(2 * VEC_SIZE - 1), %ecx
++	cmpl	$VEC_SIZE, %ecx
++	ja	L(cros_page_boundary)
++
++	/* Check the first VEC_SIZE bytes.  */
++	VPCMPEQ (%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++
++# ifdef USE_AS_STRNLEN
++	jnz	L(first_vec_x0_check)
++	/* Adjust length and check the end of data.  */
++	subq	$VEC_SIZE, %rsi
++	jbe	L(max)
++# else
++	jnz	L(first_vec_x0)
++# endif
++
++	/* Align data for aligned loads in the loop.  */
++	addq	$VEC_SIZE, %rdi
++	andl	$(VEC_SIZE - 1), %ecx
++	andq	$-VEC_SIZE, %rdi
++
++# ifdef USE_AS_STRNLEN
++	/* Adjust length.  */
++	addq	%rcx, %rsi
++
++	subq	$(VEC_SIZE * 4), %rsi
++	jbe	L(last_4x_vec_or_less)
++# endif
++	jmp	L(more_4x_vec)
++
++	.p2align 4
++L(cros_page_boundary):
++	andl	$(VEC_SIZE - 1), %ecx
++	andq	$-VEC_SIZE, %rdi
++	VPCMPEQ (%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	/* Remove the leading bytes.  */
++	sarl	%cl, %eax
++	testl	%eax, %eax
++	jz	L(aligned_more)
++	tzcntl	%eax, %eax
++# ifdef USE_AS_STRNLEN
++	/* Check the end of data.  */
++	cmpq	%rax, %rsi
++	jbe	L(max)
++# endif
++	addq	%rdi, %rax
++	addq	%rcx, %rax
++	subq	%rdx, %rax
++# ifdef USE_AS_WCSLEN
++	shrq	$2, %rax
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(aligned_more):
++# ifdef USE_AS_STRNLEN
++        /* "rcx" is less than VEC_SIZE.  Calculate "rdx + rcx - VEC_SIZE"
++	    with "rdx - (VEC_SIZE - rcx)" instead of "(rdx + rcx) - VEC_SIZE"
++	    to void possible addition overflow.  */
++	negq	%rcx
++	addq	$VEC_SIZE, %rcx
++
++	/* Check the end of data.  */
++	subq	%rcx, %rsi
++	jbe	L(max)
++# endif
++
++	addq	$VEC_SIZE, %rdi
++
++# ifdef USE_AS_STRNLEN
++	subq	$(VEC_SIZE * 4), %rsi
++	jbe	L(last_4x_vec_or_less)
++# endif
++
++L(more_4x_vec):
++	/* Check the first 4 * VEC_SIZE.  Only one VEC_SIZE at a time
++	   since data is only aligned to VEC_SIZE.  */
++	VPCMPEQ (%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x0)
++
++	VPCMPEQ VEC_SIZE(%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x1)
++
++	VPCMPEQ (VEC_SIZE * 2)(%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x2)
++
++	VPCMPEQ (VEC_SIZE * 3)(%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x3)
++
++	addq	$(VEC_SIZE * 4), %rdi
++
++# ifdef USE_AS_STRNLEN
++	subq	$(VEC_SIZE * 4), %rsi
++	jbe	L(last_4x_vec_or_less)
++# endif
++
++	/* Align data to 4 * VEC_SIZE.  */
++	movq	%rdi, %rcx
++	andl	$(4 * VEC_SIZE - 1), %ecx
++	andq	$-(4 * VEC_SIZE), %rdi
++
++# ifdef USE_AS_STRNLEN
++	/* Adjust length.  */
++	addq	%rcx, %rsi
++# endif
++
++	.p2align 4
++L(loop_4x_vec):
++	/* Compare 4 * VEC at a time forward.  */
++	vmovdqa (%rdi), %ymm1
++	vmovdqa	VEC_SIZE(%rdi), %ymm2
++	vmovdqa	(VEC_SIZE * 2)(%rdi), %ymm3
++	vmovdqa	(VEC_SIZE * 3)(%rdi), %ymm4
++	VPMINU	%ymm1, %ymm2, %ymm5
++	VPMINU	%ymm3, %ymm4, %ymm6
++	VPMINU	%ymm5, %ymm6, %ymm5
++
++	VPCMPEQ	%ymm5, %ymm0, %ymm5
++	vpmovmskb %ymm5, %eax
++	testl	%eax, %eax
++	jnz	L(4x_vec_end)
++
++	addq	$(VEC_SIZE * 4), %rdi
++
++# ifndef USE_AS_STRNLEN
++	jmp	L(loop_4x_vec)
++# else
++	subq	$(VEC_SIZE * 4), %rsi
++	ja	L(loop_4x_vec)
++
++L(last_4x_vec_or_less):
++	/* Less than 4 * VEC and aligned to VEC_SIZE.  */
++	addl	$(VEC_SIZE * 2), %esi
++	jle	L(last_2x_vec)
++
++	VPCMPEQ (%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x0)
++
++	VPCMPEQ VEC_SIZE(%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x1)
++
++	VPCMPEQ (VEC_SIZE * 2)(%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++
++	jnz	L(first_vec_x2_check)
++	subl	$VEC_SIZE, %esi
++	jle	L(max)
++
++	VPCMPEQ (VEC_SIZE * 3)(%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++
++	jnz	L(first_vec_x3_check)
++	movq	%r8, %rax
++#  ifdef USE_AS_WCSLEN
++	shrq	$2, %rax
++#  endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(last_2x_vec):
++	addl	$(VEC_SIZE * 2), %esi
++	VPCMPEQ (%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++
++	jnz	L(first_vec_x0_check)
++	subl	$VEC_SIZE, %esi
++	jle	L(max)
++
++	VPCMPEQ VEC_SIZE(%rdi), %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x1_check)
++	movq	%r8, %rax
++#  ifdef USE_AS_WCSLEN
++	shrq	$2, %rax
++#  endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(first_vec_x0_check):
++	tzcntl	%eax, %eax
++	/* Check the end of data.  */
++	cmpq	%rax, %rsi
++	jbe	L(max)
++	addq	%rdi, %rax
++	subq	%rdx, %rax
++#  ifdef USE_AS_WCSLEN
++	shrq	$2, %rax
++#  endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(first_vec_x1_check):
++	tzcntl	%eax, %eax
++	/* Check the end of data.  */
++	cmpq	%rax, %rsi
++	jbe	L(max)
++	addq	$VEC_SIZE, %rax
++	addq	%rdi, %rax
++	subq	%rdx, %rax
++#  ifdef USE_AS_WCSLEN
++	shrq	$2, %rax
++#  endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(first_vec_x2_check):
++	tzcntl	%eax, %eax
++	/* Check the end of data.  */
++	cmpq	%rax, %rsi
++	jbe	L(max)
++	addq	$(VEC_SIZE * 2), %rax
++	addq	%rdi, %rax
++	subq	%rdx, %rax
++#  ifdef USE_AS_WCSLEN
++	shrq	$2, %rax
++#  endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(first_vec_x3_check):
++	tzcntl	%eax, %eax
++	/* Check the end of data.  */
++	cmpq	%rax, %rsi
++	jbe	L(max)
++	addq	$(VEC_SIZE * 3), %rax
++	addq	%rdi, %rax
++	subq	%rdx, %rax
++#  ifdef USE_AS_WCSLEN
++	shrq	$2, %rax
++#  endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(max):
++	movq	%r8, %rax
++#  ifdef USE_AS_WCSLEN
++	shrq	$2, %rax
++#  endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(zero):
++	xorl	%eax, %eax
++	ret
++# endif
++
++	.p2align 4
++L(first_vec_x0):
++	tzcntl	%eax, %eax
++	addq	%rdi, %rax
++	subq	%rdx, %rax
++# ifdef USE_AS_WCSLEN
++	shrq	$2, %rax
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(first_vec_x1):
++	tzcntl	%eax, %eax
++	addq	$VEC_SIZE, %rax
++	addq	%rdi, %rax
++	subq	%rdx, %rax
++# ifdef USE_AS_WCSLEN
++	shrq	$2, %rax
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(first_vec_x2):
++	tzcntl	%eax, %eax
++	addq	$(VEC_SIZE * 2), %rax
++	addq	%rdi, %rax
++	subq	%rdx, %rax
++# ifdef USE_AS_WCSLEN
++	shrq	$2, %rax
++# endif
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(4x_vec_end):
++	VPCMPEQ	%ymm1, %ymm0, %ymm1
++	vpmovmskb %ymm1, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x0)
++	VPCMPEQ %ymm2, %ymm0, %ymm2
++	vpmovmskb %ymm2, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x1)
++	VPCMPEQ %ymm3, %ymm0, %ymm3
++	vpmovmskb %ymm3, %eax
++	testl	%eax, %eax
++	jnz	L(first_vec_x2)
++	VPCMPEQ %ymm4, %ymm0, %ymm4
++	vpmovmskb %ymm4, %eax
++L(first_vec_x3):
++	tzcntl	%eax, %eax
++	addq	$(VEC_SIZE * 3), %rax
++	addq	%rdi, %rax
++	subq	%rdx, %rax
++# ifdef USE_AS_WCSLEN
++	shrq	$2, %rax
++# endif
++	VZEROUPPER
++	ret
++
++END (STRLEN)
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-strncat-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-strncat-kbl.S
+new file mode 100644
+index 0000000..71e1a46
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-strncat-kbl.S
+@@ -0,0 +1,3 @@
++#define USE_AS_STRNCAT
++#define STRCAT strncat_avx2
++#include "avx2-strcat-kbl.S"
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-strncmp-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-strncmp-kbl.S
+new file mode 100644
+index 0000000..b21a191
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-strncmp-kbl.S
+@@ -0,0 +1,4 @@
++#define STRCMP	strncmp_avx2
++#define USE_AS_STRNCMP 1
++#include "avx_regs.h"
++#include "avx2-strcmp-kbl.S"
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-strncpy-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-strncpy-kbl.S
+new file mode 100644
+index 0000000..7ad8406
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-strncpy-kbl.S
+@@ -0,0 +1,4 @@
++#define USE_AS_STRNCPY
++#define STRCPY strncpy_avx2
++#include "avx_regs.h"
++#include "avx2-strcpy-kbl.S"
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-strnlen-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-strnlen-kbl.S
+new file mode 100644
+index 0000000..22cc5c5
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-strnlen-kbl.S
+@@ -0,0 +1,4 @@
++#define STRLEN strnlen_avx2
++#define USE_AS_STRNLEN 1
++#include "avx_regs.h"
++#include "avx2-strlen-kbl.S"
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-strrchr-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-strrchr-kbl.S
+new file mode 100644
+index 0000000..b3a65fb
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-strrchr-kbl.S
+@@ -0,0 +1,258 @@
++/* strrchr/wcsrchr optimized with AVX2.
++   Copyright (C) 2017-2020 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++
++# ifndef STRRCHR
++#  define STRRCHR	strrchr_avx2
++# endif
++
++# ifndef L
++#  define L(label)      .L##label
++# endif
++
++# ifndef cfi_startproc
++#  define cfi_startproc .cfi_startproc
++# endif
++
++# ifndef cfi_endproc
++#  define cfi_endproc   .cfi_endproc
++# endif
++
++# ifndef ENTRY
++#  define ENTRY(name)   \
++        .type name, @function;  \
++        .globl name;    \
++        .p2align 4;     \
++name:   \
++        cfi_startproc
++# endif
++
++# ifndef END
++#  define END(name)     \
++        cfi_endproc;    \
++        .size name, .-name
++# endif
++
++# ifdef USE_AS_WCSRCHR
++#  define VPBROADCAST	vpbroadcastd
++#  define VPCMPEQ	vpcmpeqd
++# else
++#  define VPBROADCAST	vpbroadcastb
++#  define VPCMPEQ	vpcmpeqb
++# endif
++
++# ifndef VZEROUPPER
++#  define VZEROUPPER	vzeroupper
++# endif
++
++# define VEC_SIZE	32
++
++	.section .text.avx,"ax",@progbits
++ENTRY (STRRCHR)
++	movd	%esi, %xmm4
++	movl	%edi, %ecx
++	/* Broadcast CHAR to YMM4.  */
++	VPBROADCAST %xmm4, %ymm4
++	vpxor	%xmm0, %xmm0, %xmm0
++
++	/* Check if we may cross page boundary with one vector load.  */
++	andl	$(2 * VEC_SIZE - 1), %ecx
++	cmpl	$VEC_SIZE, %ecx
++	ja	L(cros_page_boundary)
++
++	vmovdqu	(%rdi), %ymm1
++	VPCMPEQ	%ymm1, %ymm0, %ymm2
++	VPCMPEQ	%ymm1, %ymm4, %ymm3
++	vpmovmskb %ymm2, %ecx
++	vpmovmskb %ymm3, %eax
++	addq	$VEC_SIZE, %rdi
++
++	testl	%eax, %eax
++	jnz	L(first_vec)
++
++	testl	%ecx, %ecx
++	jnz	L(return_null)
++
++	andq	$-VEC_SIZE, %rdi
++	xorl	%edx, %edx
++	jmp	L(aligned_loop)
++
++	.p2align 4
++L(first_vec):
++	/* Check if there is a nul CHAR.  */
++	testl	%ecx, %ecx
++	jnz	L(char_and_nul_in_first_vec)
++
++	/* Remember the match and keep searching.  */
++	movl	%eax, %edx
++	movq	%rdi, %rsi
++	andq	$-VEC_SIZE, %rdi
++	jmp	L(aligned_loop)
++
++	.p2align 4
++L(cros_page_boundary):
++	andl	$(VEC_SIZE - 1), %ecx
++	andq	$-VEC_SIZE, %rdi
++	vmovdqa	(%rdi), %ymm1
++	VPCMPEQ	%ymm1, %ymm0, %ymm2
++	VPCMPEQ	%ymm1, %ymm4, %ymm3
++	vpmovmskb %ymm2, %edx
++	vpmovmskb %ymm3, %eax
++	shrl	%cl, %edx
++	shrl	%cl, %eax
++	addq	$VEC_SIZE, %rdi
++
++	/* Check if there is a CHAR.  */
++	testl	%eax, %eax
++	jnz	L(found_char)
++
++	testl	%edx, %edx
++	jnz	L(return_null)
++
++	jmp	L(aligned_loop)
++
++	.p2align 4
++L(found_char):
++	testl	%edx, %edx
++	jnz	L(char_and_nul)
++
++	/* Remember the match and keep searching.  */
++	movl	%eax, %edx
++	leaq	(%rdi, %rcx), %rsi
++
++	.p2align 4
++L(aligned_loop):
++	vmovdqa	(%rdi), %ymm1
++	VPCMPEQ	%ymm1, %ymm0, %ymm2
++	addq	$VEC_SIZE, %rdi
++	VPCMPEQ	%ymm1, %ymm4, %ymm3
++	vpmovmskb %ymm2, %ecx
++	vpmovmskb %ymm3, %eax
++	orl	%eax, %ecx
++	jnz	L(char_nor_null)
++
++	vmovdqa	(%rdi), %ymm1
++	VPCMPEQ	%ymm1, %ymm0, %ymm2
++	add	$VEC_SIZE, %rdi
++	VPCMPEQ	%ymm1, %ymm4, %ymm3
++	vpmovmskb %ymm2, %ecx
++	vpmovmskb %ymm3, %eax
++	orl	%eax, %ecx
++	jnz	L(char_nor_null)
++
++	vmovdqa	(%rdi), %ymm1
++	VPCMPEQ	%ymm1, %ymm0, %ymm2
++	addq	$VEC_SIZE, %rdi
++	VPCMPEQ	%ymm1, %ymm4, %ymm3
++	vpmovmskb %ymm2, %ecx
++	vpmovmskb %ymm3, %eax
++	orl	%eax, %ecx
++	jnz	L(char_nor_null)
++
++	vmovdqa	(%rdi), %ymm1
++	VPCMPEQ	%ymm1, %ymm0, %ymm2
++	addq	$VEC_SIZE, %rdi
++	VPCMPEQ	%ymm1, %ymm4, %ymm3
++	vpmovmskb %ymm2, %ecx
++	vpmovmskb %ymm3, %eax
++	orl	%eax, %ecx
++	jz	L(aligned_loop)
++
++	.p2align 4
++L(char_nor_null):
++	/* Find a CHAR or a nul CHAR in a loop.  */
++	testl	%eax, %eax
++	jnz	L(match)
++L(return_value):
++	testl	%edx, %edx
++	jz	L(return_null)
++	movl	%edx, %eax
++	movq	%rsi, %rdi
++
++# ifdef USE_AS_WCSRCHR
++	/* Keep the first bit for each matching CHAR for bsr.  */
++	andl	$0x11111111, %eax
++# endif
++	bsrl	%eax, %eax
++	leaq	-VEC_SIZE(%rdi, %rax), %rax
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(match):
++	/* Find a CHAR.  Check if there is a nul CHAR.  */
++	vpmovmskb %ymm2, %ecx
++	testl	%ecx, %ecx
++	jnz	L(find_nul)
++
++	/* Remember the match and keep searching.  */
++	movl	%eax, %edx
++	movq	%rdi, %rsi
++	jmp	L(aligned_loop)
++
++	.p2align 4
++L(find_nul):
++# ifdef USE_AS_WCSRCHR
++	/* Keep the first bit for each matching CHAR for bsr.  */
++	andl	$0x11111111, %ecx
++	andl	$0x11111111, %eax
++# endif
++	/* Mask out any matching bits after the nul CHAR.  */
++	movl	%ecx, %r8d
++	subl	$1, %r8d
++	xorl	%ecx, %r8d
++	andl	%r8d, %eax
++	testl	%eax, %eax
++	/* If there is no CHAR here, return the remembered one.  */
++	jz	L(return_value)
++	bsrl	%eax, %eax
++	leaq	-VEC_SIZE(%rdi, %rax), %rax
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(char_and_nul):
++	/* Find both a CHAR and a nul CHAR.  */
++	addq	%rcx, %rdi
++	movl	%edx, %ecx
++L(char_and_nul_in_first_vec):
++# ifdef USE_AS_WCSRCHR
++	/* Keep the first bit for each matching CHAR for bsr.  */
++	andl	$0x11111111, %ecx
++	andl	$0x11111111, %eax
++# endif
++	/* Mask out any matching bits after the nul CHAR.  */
++	movl	%ecx, %r8d
++	subl	$1, %r8d
++	xorl	%ecx, %r8d
++	andl	%r8d, %eax
++	testl	%eax, %eax
++	/* Return null pointer if the nul CHAR comes first.  */
++	jz	L(return_null)
++	bsrl	%eax, %eax
++	leaq	-VEC_SIZE(%rdi, %rax), %rax
++	VZEROUPPER
++	ret
++
++	.p2align 4
++L(return_null):
++	xorl	%eax, %eax
++	VZEROUPPER
++	ret
++
++END (STRRCHR)
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-wcschr-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-wcschr-kbl.S
+new file mode 100644
+index 0000000..b031247
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-wcschr-kbl.S
+@@ -0,0 +1,3 @@
++#define STRCHR wcschr_avx2
++#define USE_AS_WCSCHR 1
++#include "avx2-strchr-kbl.S"
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-wcscmp-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-wcscmp-kbl.S
+new file mode 100644
+index 0000000..bcbcd4c
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-wcscmp-kbl.S
+@@ -0,0 +1,4 @@
++#define STRCMP wcscmp_avx2
++#define USE_AS_WCSCMP 1
++
++#include "avx2-strcmp-kbl.S"
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-wcslen-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-wcslen-kbl.S
+new file mode 100644
+index 0000000..f1b9735
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-wcslen-kbl.S
+@@ -0,0 +1,4 @@
++#define STRLEN wcslen_avx2
++#define USE_AS_WCSLEN 1
++
++#include "avx2-strlen-kbl.S"
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-wcsncmp-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-wcsncmp-kbl.S
+new file mode 100644
+index 0000000..7603169
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-wcsncmp-kbl.S
+@@ -0,0 +1,6 @@
++#define STRCMP wcsncmp_avx2
++#define USE_AS_STRNCMP 1
++#define USE_AS_WCSCMP 1
++
++#include "avx_regs.h"
++#include "avx2-strcmp-kbl.S"
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-wcsnlen-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-wcsnlen-kbl.S
+new file mode 100644
+index 0000000..2095cd8
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-wcsnlen-kbl.S
+@@ -0,0 +1,6 @@
++#define STRLEN wcsnlen_avx2
++#define USE_AS_WCSLEN 1
++#define USE_AS_STRNLEN 1
++
++#include "avx_regs.h"
++#include "avx2-strlen-kbl.S"
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-wcsrchr-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-wcsrchr-kbl.S
+new file mode 100644
+index 0000000..fbec128
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx2-wcsrchr-kbl.S
+@@ -0,0 +1,3 @@
++#define STRRCHR wcsrchr_avx2
++#define USE_AS_WCSRCHR 1
++#include "avx2-strrchr-kbl.S"
+diff --git a/libc/arch-x86_64/kabylake/string/avx_regs.h b/libc/arch-x86_64/kabylake/string/avx_regs.h
+new file mode 100644
+index 0000000..223d97e
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/avx_regs.h
+@@ -0,0 +1,26 @@
++/* Long and pointer size in bytes.  */
++#define LP_SIZE 8
++
++/* Instruction to operate on long and pointer.  */
++#define LP_OP(insn) insn##q
++
++/* Assembler address directive. */
++#define ASM_ADDR .quad
++
++/* Registers to hold long and pointer.  */
++#define RAX_LP  rax
++#define RBP_LP  rbp
++#define RBX_LP  rbx
++#define RCX_LP  rcx
++#define RDI_LP  rdi
++#define RDX_LP  rdx
++#define RSI_LP  rsi
++#define RSP_LP  rsp
++#define R8_LP   r8
++#define R9_LP   r9
++#define R10_LP  r10
++#define R11_LP  r11
++#define R12_LP  r12
++#define R13_LP  r13
++#define R14_LP  r14
++#define R15_LP  r15
+diff --git a/libc/arch-x86_64/kabylake/string/cache.h b/libc/arch-x86_64/kabylake/string/cache.h
+new file mode 100644
+index 0000000..4131509
+--- /dev/null
++++ b/libc/arch-x86_64/kabylake/string/cache.h
+@@ -0,0 +1,36 @@
++/*
++Copyright (c) 2014, Intel Corporation
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++    * Redistributions of source code must retain the above copyright notice,
++    * this list of conditions and the following disclaimer.
++
++    * Redistributions in binary form must reproduce the above copyright notice,
++    * this list of conditions and the following disclaimer in the documentation
++    * and/or other materials provided with the distribution.
++
++    * Neither the name of Intel Corporation nor the names of its contributors
++    * may be used to endorse or promote products derived from this software
++    * without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
++ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
++WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
++ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
++ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++/* Values are optimized for Core Architecture */
++#define SHARED_CACHE_SIZE (4096*1024)  /* Core Architecture L2 Cache */
++#define DATA_CACHE_SIZE   (24*1024)    /* Core Architecture L1 Data Cache */
++
++#define SHARED_CACHE_SIZE_HALF (SHARED_CACHE_SIZE / 2)
++#define DATA_CACHE_SIZE_HALF   (DATA_CACHE_SIZE / 2)
+diff --git a/libc/arch-x86_64/silvermont/string/cache.h b/libc/arch-x86_64/silvermont/string/cache.h
+new file mode 100644
+index 0000000..3606d2a
+--- /dev/null
++++ b/libc/arch-x86_64/silvermont/string/cache.h
+@@ -0,0 +1,36 @@
++/*
++Copyright (c) 2014, Intel Corporation
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++    * Redistributions of source code must retain the above copyright notice,
++    * this list of conditions and the following disclaimer.
++
++    * Redistributions in binary form must reproduce the above copyright notice,
++    * this list of conditions and the following disclaimer in the documentation
++    * and/or other materials provided with the distribution.
++
++    * Neither the name of Intel Corporation nor the names of its contributors
++    * may be used to endorse or promote products derived from this software
++    * without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
++ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
++WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
++ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
++(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
++LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
++ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
++(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
++SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++*/
++
++/* Values are optimized for Silvermont */
++#define SHARED_CACHE_SIZE (1024*1024)  /* Silvermont L2 Cache */
++#define DATA_CACHE_SIZE   (24*1024)    /* Silvermont L1 Data Cache */
++
++#define SHARED_CACHE_SIZE_HALF (SHARED_CACHE_SIZE / 2)
++#define DATA_CACHE_SIZE_HALF   (DATA_CACHE_SIZE / 2)
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-memcpy-slm.s b/libc/arch-x86_64/silvermont/string/sse2-memcpy-slm.s
+index 2965b23..2f0638e 100644
+--- a/libc/arch-x86_64/silvermont/string/sse2-memcpy-slm.s
++++ b/libc/arch-x86_64/silvermont/string/sse2-memcpy-slm.s
+@@ -1,12 +1,12 @@
+ 	.text
+ 	.file	"FastMemcpy_avx_sse2.c"
+-	.globl	memcpy_sse2                  # -- Begin function memcpy
++	.globl	memcpy_generic                  # -- Begin function memcpy
+ 	.p2align	4, 0x90
+-	.type	memcpy_sse2,@function
++	.type	memcpy_generic,@function
+ 
+ 
+ 
+-memcpy_sse2:                                 # @memcpy
++memcpy_generic:                                 # @memcpy
+ 	.cfi_startproc
+ 
+ # %bb.0:
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-stpcpy-slm.S b/libc/arch-x86_64/silvermont/string/sse2-stpcpy-slm.S
+index 0ad2d44..ce15cdf 100644
+--- a/libc/arch-x86_64/silvermont/string/sse2-stpcpy-slm.S
++++ b/libc/arch-x86_64/silvermont/string/sse2-stpcpy-slm.S
+@@ -29,5 +29,5 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+ #define USE_AS_STPCPY
+-#define STRCPY		stpcpy
++#define STRCPY		stpcpy_generic
+ #include "sse2-strcpy-slm.S"
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-stpncpy-slm.S b/libc/arch-x86_64/silvermont/string/sse2-stpncpy-slm.S
+index 3066685..02b4df0 100644
+--- a/libc/arch-x86_64/silvermont/string/sse2-stpncpy-slm.S
++++ b/libc/arch-x86_64/silvermont/string/sse2-stpncpy-slm.S
+@@ -30,5 +30,5 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #define USE_AS_STRNCPY
+ #define USE_AS_STPCPY
+-#define STRCPY		stpncpy
++#define STRCPY		stpncpy_generic
+ #include "sse2-strcpy-slm.S"
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-strcat-slm.S b/libc/arch-x86_64/silvermont/string/sse2-strcat-slm.S
+index dd8207f..007adfe 100644
+--- a/libc/arch-x86_64/silvermont/string/sse2-strcat-slm.S
++++ b/libc/arch-x86_64/silvermont/string/sse2-strcat-slm.S
+@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+ #ifndef STRCAT
+-# define STRCAT		strcat
++# define STRCAT		strcat_generic
+ #endif
+ 
+ #ifndef L
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-strcpy-slm.S b/libc/arch-x86_64/silvermont/string/sse2-strcpy-slm.S
+index 3e146bf..ade9eac 100644
+--- a/libc/arch-x86_64/silvermont/string/sse2-strcpy-slm.S
++++ b/libc/arch-x86_64/silvermont/string/sse2-strcpy-slm.S
+@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #ifndef USE_AS_STRCAT
+ 
+ # ifndef STRCPY
+-#  define STRCPY	strcpy
++#  define STRCPY	strcpy_generic
+ # endif
+ 
+ # ifndef L
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-strlen-slm.S b/libc/arch-x86_64/silvermont/string/sse2-strlen-slm.S
+index 3772fe7..df24f9d 100644
+--- a/libc/arch-x86_64/silvermont/string/sse2-strlen-slm.S
++++ b/libc/arch-x86_64/silvermont/string/sse2-strlen-slm.S
+@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #ifndef USE_AS_STRCAT
+ 
+ #ifndef STRLEN
+-# define STRLEN		strlen
++# define STRLEN		strlen_generic
+ #endif
+ 
+ #ifndef L
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-strncat-slm.S b/libc/arch-x86_64/silvermont/string/sse2-strncat-slm.S
+index 6b4a430..c5394f9 100644
+--- a/libc/arch-x86_64/silvermont/string/sse2-strncat-slm.S
++++ b/libc/arch-x86_64/silvermont/string/sse2-strncat-slm.S
+@@ -29,5 +29,5 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+ #define USE_AS_STRNCAT
+-#define STRCAT		strncat
++#define STRCAT		strncat_generic
+ #include "sse2-strcat-slm.S"
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-strncpy-slm.S b/libc/arch-x86_64/silvermont/string/sse2-strncpy-slm.S
+index 594e78f..2e8d68d 100644
+--- a/libc/arch-x86_64/silvermont/string/sse2-strncpy-slm.S
++++ b/libc/arch-x86_64/silvermont/string/sse2-strncpy-slm.S
+@@ -29,5 +29,5 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+ #define USE_AS_STRNCPY
+-#define STRCPY		strncpy
++#define STRCPY		strncpy_generic
+ #include "sse2-strcpy-slm.S"
+diff --git a/libc/arch-x86_64/silvermont/string/ssse3-strcmp-slm.S b/libc/arch-x86_64/silvermont/string/ssse3-strcmp-slm.S
+index e8acd5b..fa2542f 100644
+--- a/libc/arch-x86_64/silvermont/string/ssse3-strcmp-slm.S
++++ b/libc/arch-x86_64/silvermont/string/ssse3-strcmp-slm.S
+@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #else
+ #define UPDATE_STRNCMP_COUNTER
+ #ifndef STRCMP
+-#define STRCMP		strcmp
++#define STRCMP		strcmp_generic
+ #endif
+ #endif
+ 
+diff --git a/libc/arch-x86_64/silvermont/string/ssse3-strncmp-slm.S b/libc/arch-x86_64/silvermont/string/ssse3-strncmp-slm.S
+index 0e40775..5d20a48 100644
+--- a/libc/arch-x86_64/silvermont/string/ssse3-strncmp-slm.S
++++ b/libc/arch-x86_64/silvermont/string/ssse3-strncmp-slm.S
+@@ -29,5 +29,5 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+ #define USE_AS_STRNCMP
+-#define STRCMP		strncmp
++#define STRCMP		strncmp_generic
+ #include "ssse3-strcmp-slm.S"
+diff --git a/libc/arch-x86_64/static_function_dispatch.S b/libc/arch-x86_64/static_function_dispatch.S
+index a30bb36..b8a8eb7 100644
+--- a/libc/arch-x86_64/static_function_dispatch.S
++++ b/libc/arch-x86_64/static_function_dispatch.S
+@@ -36,6 +36,24 @@ END(name)
+ FUNCTION_DELEGATE(memcmp, memcmp_generic)
+ FUNCTION_DELEGATE(memcpy, memmove_generic)
+ FUNCTION_DELEGATE(memmove, memmove_generic)
+-FUNCTION_DELEGATE(memchr, memchr_openbsd)
+-FUNCTION_DELEGATE(memrchr, memrchr_openbsd)
+-FUNCTION_DELEGATE(wmemset, wmemset_freebsd)
++FUNCTION_DELEGATE(memchr, memchr_generic)
++FUNCTION_DELEGATE(memrchr, memrchr_generic)
++FUNCTION_DELEGATE(wmemset, wmemset_generic)
++FUNCTION_DELEGATE(strcmp, strcmp_generic)
++FUNCTION_DELEGATE(strncmp, strncmp_generic)
++FUNCTION_DELEGATE(strcpy, strcpy_generic)
++FUNCTION_DELEGATE(strncpy, strncpy_generic)
++FUNCTION_DELEGATE(stpcpy, stpcpy_generic)
++FUNCTION_DELEGATE(stpncpy, stpncpy_generic)
++FUNCTION_DELEGATE(strlen, strlen_generic)
++FUNCTION_DELEGATE(strnlen, strnlen_generic)
++FUNCTION_DELEGATE(strchr, strchr_generic)
++FUNCTION_DELEGATE(strrchr, strrchr_generic)
++FUNCTION_DELEGATE(strcat, strcat_generic)
++FUNCTION_DELEGATE(strncat, strncat_generic)
++FUNCTION_DELEGATE(wcscmp, wcscmp_generic)
++FUNCTION_DELEGATE(wcsncmp, wcsncmp_generic)
++FUNCTION_DELEGATE(wcslen, wcslen_generic)
++FUNCTION_DELEGATE(wcsnlen, wcsnlen_generic)
++FUNCTION_DELEGATE(wcschr, wcschr_generic)
++FUNCTION_DELEGATE(wcsrchr, wcsrchr_generic)
+-- 
+2.7.4
+

--- a/aosp_diff/preliminary/external/arm-optimized-routines/02_0002-Make-avx-enablement-of-sinf-cosf-expf-march-independ.patch
+++ b/aosp_diff/preliminary/external/arm-optimized-routines/02_0002-Make-avx-enablement-of-sinf-cosf-expf-march-independ.patch
@@ -1,0 +1,70 @@
+From 317e89664f48da982a71404369b717686ea90baf Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Thu, 24 Sep 2020 12:25:06 +0530
+Subject: [PATCH] Make avx enablement of sinf,cosf,expf march independent
+
+Tracked-On:
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ Android.bp  | 21 ++++++++++-----------
+ math/expf.c |  5 +++++
+ 2 files changed, 15 insertions(+), 11 deletions(-)
+
+diff --git a/Android.bp b/Android.bp
+index 541ab38..c8559df 100755
+--- a/Android.bp
++++ b/Android.bp
+@@ -35,7 +35,6 @@ cc_library {
+     srcs: [
+         "math/*.c",
+     ],
+-
+     // arch-specific settings
+     arch: {
+         arm64: {
+@@ -43,16 +42,16 @@ cc_library {
+                 "-DHAVE_FAST_FMA=1",
+             ],
+         },
+-    x86_64: {
+-            avx2: {
+-               cflags: ["-march=skylake",],
+-	       exclude_srcs: [
+-                  "math/cosf.c", // x86_64 has an optimized avx2 implementation
+-                  "math/sinf.c", // x86_64 has an optimized avx2 implementation
+-                  "math/expf.c", // x86_64 has an optimized avx2 implementation
+-	       ],
+-	    },
+-	},
++        x86_64: {
++           // This flag is required to enable __math_may_uflowf
++           // when compiling expf from libm for x86_64 target 
++           cflags: ["-DWANT_ERRNO_UFLOW"],
++           exclude_srcs: [
++               "math/sinf.c",
++               "math/cosf.c",
++               "math/expf.c",
++           ],
++        },
+     },
+     target: {
+         darwin: {
+diff --git a/math/expf.c b/math/expf.c
+index 0fe1f7d..78d9952 100644
+--- a/math/expf.c
++++ b/math/expf.c
+@@ -86,6 +86,11 @@ expf (float x)
+   return eval_as_float (y);
+ }
+ #if USE_GLIBC_ABI
++#ifdef FROM_LIBM 
++strong_alias (expf_generic, __expf_finite)
++hidden_alias (expf_generic, __ieee754_expf)
++#else
+ strong_alias (expf, __expf_finite)
+ hidden_alias (expf, __ieee754_expf)
+ #endif
++#endif
+-- 
+2.17.1
+


### PR DESCRIPTION
Following memory related functions are optimized with
avx2 implementation:

memcpy (for both 32-bit and 64-bit)
below functions ported from glibc 2.20 only for 64-bit
 - memchr
 - memcmp
 - memmove
 - memrchr
 
Following are the string functions that has been
optimized with avx2 implementation from glibc 2.32 version.
 - strcmp, strncmp
 - strlen, strnlen
 - strchr, strrchr
 - strcpy, strncpy
 - stpcpy, stpncpy
 - strcat, strncat
 - wcscmp, wcsncmp
 - wcslen, wcsnlen
 - wcschr, wcsrchr
 
This patch also has necessary changes to pick up the right
version(avx/sse) of the functions at runtime using IFUNC.
This helps in building Unified Image for Android 11.

Tracked-On: OAM-94306
Signed-off-by: ahs <amrita.h.s@intel.com>