### PR TITLE
AOSP R41 Rebase code chages for frameworks-native

### DIFF
--- a/aosp_diff/caas/frameworks/native/03-0001-AOSP-R41-Rebase-code-changes-for-frameworks-native.patch
+++ b/aosp_diff/caas/frameworks/native/03-0001-AOSP-R41-Rebase-code-changes-for-frameworks-native.patch
@@ -1,0 +1,109 @@
+From f95307eff8ed4fead369553512c284a71cecae55 Mon Sep 17 00:00:00 2001
+From: jayanth1 <shankar.srinivas.jayanthi@intel.com>
+Date: Mon, 19 Oct 2020 14:36:39 +0530
+Subject: [PATCH] AOSP R41 Rebase code changes for frameworks/native
+
+This patch is for AOSP R41 rebase code changes and to fix the
+compilation issue
+
+Change-Id: I0ff464e1394fdf06a473ba8aab4ef9008094d677
+Tracked-On: OAM-94365
+Signed-off-by: jayanth1 <shankar.srinivas.jayanthi@intel.com>
+
+diff --git a/cmds/installd/InstalldNativeService.cpp b/cmds/installd/InstalldNativeService.cpp
+index 34727270e..84be6cada 100644
+--- a/cmds/installd/InstalldNativeService.cpp
++++ b/cmds/installd/InstalldNativeService.cpp
+@@ -2136,6 +2136,27 @@ binder::Status InstalldNativeService::compileLayouts(const std::string& apkPath,
+     return *_aidl_return ? ok() : error("viewcompiler failed");
+ }
+ 
++binder::Status InstalldNativeService::markBootComplete(const std::string& instructionSet) {
++    ENFORCE_UID(AID_SYSTEM);
++    std::lock_guard<std::recursive_mutex> lock(mLock);
++
++    const char* instruction_set = instructionSet.c_str();
++
++    char boot_marker_path[PKG_PATH_MAX];
++    sprintf(boot_marker_path,
++          "%s/%s/%s/.booting",
++          android_data_dir.c_str(),
++          DALVIK_CACHE,
++          instruction_set);
++
++    ALOGV("mark_boot_complete : %s", boot_marker_path);
++    if (unlink(boot_marker_path) != 0) {
++        return error(StringPrintf("Failed to unlink %s", boot_marker_path));
++    }
++    return ok();
++}
++
++
+ binder::Status InstalldNativeService::linkNativeLibraryDirectory(
+         const std::unique_ptr<std::string>& uuid, const std::string& packageName,
+         const std::string& nativeLibPath32, int32_t userId) {
+diff --git a/cmds/installd/InstalldNativeService.h b/cmds/installd/InstalldNativeService.h
+index eba966d4a..2b7bf33cb 100644
+--- a/cmds/installd/InstalldNativeService.h
++++ b/cmds/installd/InstalldNativeService.h
+@@ -123,6 +123,7 @@ public:
+             int32_t uid);
+     binder::Status removeIdmap(const std::string& overlayApkPath);
+     binder::Status rmPackageDir(const std::string& packageDir);
++    binder::Status markBootComplete(const std::string& instructionSet);
+     binder::Status freeCache(const std::unique_ptr<std::string>& uuid, int64_t targetFreeBytes,
+             int64_t cacheReservedBytes, int32_t flags);
+     binder::Status linkNativeLibraryDirectory(const std::unique_ptr<std::string>& uuid,
+diff --git a/cmds/installd/binder/android/os/IInstalld.aidl b/cmds/installd/binder/android/os/IInstalld.aidl
+index b795c0264..26e9984f1 100644
+--- a/cmds/installd/binder/android/os/IInstalld.aidl
++++ b/cmds/installd/binder/android/os/IInstalld.aidl
+@@ -75,6 +75,7 @@ interface IInstalld {
+     void idmap(@utf8InCpp String targetApkPath, @utf8InCpp String overlayApkPath, int uid);
+     void removeIdmap(@utf8InCpp String overlayApkPath);
+     void rmPackageDir(@utf8InCpp String packageDir);
++    void markBootComplete(@utf8InCpp String instructionSet);
+     void freeCache(@nullable @utf8InCpp String uuid, long targetFreeBytes,
+             long cacheReservedBytes, int flags);
+     void linkNativeLibraryDirectory(@nullable @utf8InCpp String uuid,
+diff --git a/libs/graphicsenv/GraphicsEnv.cpp b/libs/graphicsenv/GraphicsEnv.cpp
+index 6e59cc504..7d82cfe06 100644
+--- a/libs/graphicsenv/GraphicsEnv.cpp
++++ b/libs/graphicsenv/GraphicsEnv.cpp
+@@ -139,10 +139,20 @@ static const std::string getSystemNativeLibraries(NativeLibrary type) {
+     return env;
+ }
+ 
++
+ bool GraphicsEnv::isDebuggable() {
+     return prctl(PR_GET_DUMPABLE, 0, 0, 0, 0) > 0;
+ }
+ 
++int GraphicsEnv::getCanLoadSystemLibraries() {
++      if (property_get_bool("ro.debuggable", false) && prctl(PR_GET_DUMPABLE, 0, 0, 0, 0)) {
++          // Return an integer value since this crosses library boundaries
++          return 1;
++      }
++      return 0;
++  }
++
++
+ void GraphicsEnv::setDriverPathAndSphalLibraries(const std::string path,
+                                                  const std::string sphalLibraries) {
+     if (!mDriverPath.empty() || !mSphalLibraries.empty()) {
+diff --git a/libs/graphicsenv/include/graphicsenv/GraphicsEnv.h b/libs/graphicsenv/include/graphicsenv/GraphicsEnv.h
+index 227b4587c..bbb7f9230 100644
+--- a/libs/graphicsenv/include/graphicsenv/GraphicsEnv.h
++++ b/libs/graphicsenv/include/graphicsenv/GraphicsEnv.h
+@@ -84,6 +84,8 @@ private:
+ public:
+     static GraphicsEnv& getInstance();
+ 
++    int getCanLoadSystemLibraries();
++
+     // Check if the process is debuggable. It returns false except in any of the
+     // following circumstances:
+     // 1. ro.debuggable=1 (global debuggable enabled).
+-- 
+2.28.0
+


### PR DESCRIPTION
This patch is to align with r41 aosp code changes and resolve the
compilation issue

Tracked-On: OAM-94365
Signed-off-by: jayanth1 <shankar.srinivas.jayanthi@intel.com>