### PR TITLE
Fix the mistake of adb in detailing with incremental fs

### DIFF
--- a/aosp_diff/caas/system/core/0002-Fix-the-mistake-of-adb-in-detailing-with-incremental.patch
+++ b/aosp_diff/caas/system/core/0002-Fix-the-mistake-of-adb-in-detailing-with-incremental.patch
@@ -1,0 +1,29 @@
+From 08aaec1d207f58e123f45b73b2f165c6c3e31afa Mon Sep 17 00:00:00 2001
+From: "Chen, Yu" <yu.y.chen@intel.com>
+Date: Wed, 28 Oct 2020 19:25:59 +0800
+Subject: [PATCH] Fix the mistake of adb in detailing with incremental fs
+
+adb should reject installing once it meets "Failed to stat input file"
+
+Tracked-On: OAM-94444
+Signed-off-by: Zhiwei Li <zhiwei.li@intel.com>
+---
+ adb/client/incremental.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/adb/client/incremental.cpp b/adb/client/incremental.cpp
+index c8f69c381..010850779 100644
+--- a/adb/client/incremental.cpp
++++ b/adb/client/incremental.cpp
+@@ -148,7 +148,7 @@ bool can_install(const Files& files) {
+ 
+ std::optional<Process> install(const Files& files, const Args& passthrough_args, bool silent) {
+     auto connection_fd = start_install(files, passthrough_args, silent);
+-    if (connection_fd < 0) {
++    if (connection_fd <= 0) {
+         if (!silent) {
+             fprintf(stderr, "adb: failed to initiate installation on device.\n");
+         }
+-- 
+2.29.0
+


### PR DESCRIPTION
adb should reject installing once it meets "Failed to stat input file"

Tracked-On: OAM-94444
Signed-off-by: Zhiwei Li <zhiwei.li@intel.com>