### PR TITLE
Propagate power button event to user space when device wakes up

### DIFF
--- a/bsp_diff/common/kernel/lts2019-chromium/12_0012-ACPI-PM-Propagate-power-button-event-to-user-space-w.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/12_0012-ACPI-PM-Propagate-power-button-event-to-user-space-w.patch
@@ -1,0 +1,73 @@
+From fe8161af94943fc6c0d82a4e4645cf3c0e450e8d Mon Sep 17 00:00:00 2001
+From: Kaushlendra Kumar <kaushalendra.kumar@intel.com>
+Date: Wed, 28 Oct 2020 12:25:56 +0530
+Subject: [PATCH] ACPI/PM: Propagate power button event to user space when
+ device wakes up
+
+Sometimes power button does not wake up the systemm, we get suspends event
+right after that. here Android needs to see KEY_POWER at resume. Otherwise, its
+opportunistic suspend will kick in shortly.
+
+However, other OS such as Ubuntu doesn't like KEY_POWER at resume. So
+add a knob "/sys/module/button/parameters/key_power_at_resume" for users
+to select.
+
+Tracked-On:
+---
+ drivers/acpi/button.c | 6 +++++-
+ drivers/acpi/sleep.c  | 8 ++++++++
+ 2 files changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/acpi/button.c b/drivers/acpi/button.c
+index 985afc62da82..3f7a6e398816 100644
+--- a/drivers/acpi/button.c
++++ b/drivers/acpi/button.c
+@@ -138,6 +138,10 @@ struct acpi_button {
+ 	bool suspended;
+ };
+ 
++/* does userspace want to see KEY_POWER at resume? */
++static bool __read_mostly key_power_at_resume = true;
++module_param(key_power_at_resume, bool, 0644);
++
+ static BLOCKING_NOTIFIER_HEAD(acpi_lid_notifier);
+ static struct acpi_device *lid_device;
+ static u8 lid_init_state = ACPI_BUTTON_LID_INIT_METHOD;
+@@ -426,7 +430,7 @@ static void acpi_button_notify(struct acpi_device *device, u32 event)
+ 			int keycode;
+ 
+ 			acpi_pm_wakeup_event(&device->dev);
+-			if (button->suspended)
++			if (button->suspended && !key_power_at_resume)
+ 				break;
+ 
+ 			keycode = test_bit(KEY_SLEEP, input->keybit) ?
+diff --git a/drivers/acpi/sleep.c b/drivers/acpi/sleep.c
+index fe2c197d2863..7a25bb156edd 100644
+--- a/drivers/acpi/sleep.c
++++ b/drivers/acpi/sleep.c
+@@ -443,6 +443,13 @@ static int acpi_pm_prepare(void)
+ 	return error;
+ }
+ 
++static void pwr_btn_notify(struct acpi_device *device)
++{
++
++	device->driver->ops.notify(device, ACPI_FIXED_HARDWARE_EVENT);
++}
++
++
+ /**
+  *	acpi_pm_finish - Instruct the platform to leave a sleep state.
+  *
+@@ -486,6 +493,7 @@ static void acpi_pm_finish(void)
+ 						    NULL, -1);
+ 	if (pwr_btn_adev) {
+ 		pm_wakeup_event(&pwr_btn_adev->dev, 0);
++		pwr_btn_notify(pwr_btn_adev);
+ 		acpi_dev_put(pwr_btn_adev);
+ 	}
+ }
+-- 
+2.28.0
+


### PR DESCRIPTION
Sometimes power button does not wake up the systemm, we get suspends event
right after that. here Android needs to see KEY_POWER at resume. Otherwise, its
opportunistic suspend will kick in shortly.

However, other OS such as Ubuntu doesn't like KEY_POWER at resume. So
add a knob "/sys/module/button/parameters/key_power_at_resume" for users
to select.

Tracked-On: OAM-94240
Signed-off-by: Kaushlendra Kumar <kaushlendra.kumar@intel.com>
Signed-off-by: Shwetha B <shwetha.b@intel.com>