### PR TITLE
Changes to allow multiple perf variants of an .so

### DIFF
--- a/aosp_diff/preliminary/bionic/06_0006-Linker-changes-to-allow-perf-variants-of-an-.so.patch
+++ b/aosp_diff/preliminary/bionic/06_0006-Linker-changes-to-allow-perf-variants-of-an-.so.patch
@@ -1,0 +1,228 @@
+From b1457106cfcde3c57167439342eb195374e14b58 Mon Sep 17 00:00:00 2001
+From: Vinay Kompella <vinay.kompella@intel.com>
+Date: Tue, 3 Nov 2020 16:32:04 +0530
+Subject: [PATCH] Linker changes to allow perf variants of an .so
+
+This patch enables the linker to find perf variants of
+an .so if they exist.
+Enables us to have One-image catering to multiple
+IA CPUs which may or may not support all ISA features.
+Example: Pentium SKUs dont support AVX.
+
+Tracked-On: OAM-94488
+Signed-off-by: Vinay Kompella <vinay.kompella@intel.com>
+---
+ linker/linker.cpp                | 69 ++++++++++++++++++++++++++------
+ linker/linker_translate_path.cpp | 30 ++++++++++++++
+ linker/linker_translate_path.h   |  1 +
+ linker/linker_utils.cpp          | 13 ++++++
+ linker/linker_utils.h            |  1 +
+ 5 files changed, 101 insertions(+), 13 deletions(-)
+
+diff --git a/linker/linker.cpp b/linker/linker.cpp
+index f24167722..f8f89acd7 100644
+--- a/linker/linker.cpp
++++ b/linker/linker.cpp
+@@ -98,23 +98,35 @@ static const char* const kLdConfigVndkLiteFilePath = "/system/etc/ld.config.vndk
+ static const char* const kLdGeneratedConfigFilePath = "/linkerconfig/ld.config.txt";
+ 
+ #if defined(__LP64__)
+-static const char* const kSystemLibDir        = "/system/lib64";
+-static const char* const kOdmLibDir           = "/odm/lib64";
+-static const char* const kVendorLibDir        = "/vendor/lib64";
+-static const char* const kAsanSystemLibDir    = "/data/asan/system/lib64";
+-static const char* const kAsanOdmLibDir       = "/data/asan/odm/lib64";
+-static const char* const kAsanVendorLibDir    = "/data/asan/vendor/lib64";
++static const char* const kSystemLibPerfAvx2Dir     = "/system/lib64/IA-Perf/avx2";
++static const char* const kSystemLibDir             = "/system/lib64";
++static const char* const kOdmLibDir                = "/odm/lib64";
++static const char* const kVendorLibDir             = "/vendor/lib64";
++static const char* const kAsanSystemLibPerfAvx2Dir = "/data/asan/system/lib64/IA-Perf/avx2";
++static const char* const kAsanSystemLibDir         = "/data/asan/system/lib64";
++static const char* const kAsanOdmLibDir            = "/data/asan/odm/lib64";
++static const char* const kAsanVendorLibDir         = "/data/asan/vendor/lib64";
+ #else
+-static const char* const kSystemLibDir        = "/system/lib";
+-static const char* const kOdmLibDir           = "/odm/lib";
+-static const char* const kVendorLibDir        = "/vendor/lib";
+-static const char* const kAsanSystemLibDir    = "/data/asan/system/lib";
+-static const char* const kAsanOdmLibDir       = "/data/asan/odm/lib";
+-static const char* const kAsanVendorLibDir    = "/data/asan/vendor/lib";
++static const char* const kSystemLibPerfAvx2Dir     = "/system/lib/IA-Perf/avx2";
++static const char* const kSystemLibDir             = "/system/lib";
++static const char* const kOdmLibDir                = "/odm/lib";
++static const char* const kVendorLibDir             = "/vendor/lib";
++static const char* const kAsanSystemLibPerfAvx2Dir = "/data/asan/system/lib/IA-Perf/avx2";
++static const char* const kAsanSystemLibDir         = "/data/asan/system/lib";
++static const char* const kAsanOdmLibDir            = "/data/asan/odm/lib";
++static const char* const kAsanVendorLibDir         = "/data/asan/vendor/lib";
+ #endif
+ 
+ static const char* const kAsanLibDirPrefix = "/data/asan";
+ 
++static const char* const kDefaultPerfAvx2LdPaths[] = {
++  kSystemLibPerfAvx2Dir,
++  kSystemLibDir,
++  kOdmLibDir,
++  kVendorLibDir,
++  nullptr
++};
++
+ static const char* const kDefaultLdPaths[] = {
+   kSystemLibDir,
+   kOdmLibDir,
+@@ -122,6 +134,18 @@ static const char* const kDefaultLdPaths[] = {
+   nullptr
+ };
+ 
++static const char* const kAsanDefaultPerfAvx2LdPaths[] = {
++  kAsanSystemLibPerfAvx2Dir,
++  kSystemLibPerfAvx2Dir,
++  kAsanSystemLibDir,
++  kSystemLibDir,
++  kAsanOdmLibDir,
++  kOdmLibDir,
++  kAsanVendorLibDir,
++  kVendorLibDir,
++  nullptr
++};
++
+ static const char* const kAsanDefaultLdPaths[] = {
+   kAsanSystemLibDir,
+   kSystemLibDir,
+@@ -2160,6 +2184,24 @@ void* do_dlopen(const char* name, int flags,
+   }
+   // End Workaround for dlopen(/system/lib/<soname>) when .so is in /apex.
+ 
++  // Workaround for dlopen(FullPath/<soname>) when platform supports corresponding feature and
++  // .so may have an avx2 version.
++  std::string name_to_avx2;
++  if (translateSystemPathToPerfFeaturePath("avx2", name, &name_to_avx2)) {
++    const char* new_name = name_to_avx2.c_str();
++    LD_LOG(kLogDlopen, "dlopen considering translation from %s to Avx2 path %s",
++           name,
++           new_name);
++    if (!file_exists(new_name)) {
++      LD_LOG(kLogDlopen, "dlopen %s does not exist, not translating",
++             new_name);
++    } else {
++      LD_LOG(kLogDlopen, "dlopen translation accepted: using %s", new_name);
++      name = new_name;
++    }
++  }
++  // End Workaround for dlopen(FullPath/<soname>) when .so may have avx2 version.
++
+   std::string asan_name_holder;
+ 
+   const char* translated_name = name;
+@@ -3335,7 +3377,8 @@ bool soinfo::protect_relro() {
+ 
+ static std::vector<android_namespace_t*> init_default_namespace_no_config(bool is_asan) {
+   g_default_namespace.set_isolated(false);
+-  auto default_ld_paths = is_asan ? kAsanDefaultLdPaths : kDefaultLdPaths;
++  auto default_ld_paths = is_asan ? (PlatformSupportsISAFeature("avx2") ? kAsanDefaultPerfAvx2LdPaths  : kAsanDefaultLdPaths) :
++                                    (PlatformSupportsISAFeature("avx2") ? kDefaultPerfAvx2LdPaths      : kDefaultLdPaths);
+ 
+   char real_path[PATH_MAX];
+   std::vector<std::string> ld_default_paths;
+diff --git a/linker/linker_translate_path.cpp b/linker/linker_translate_path.cpp
+index df7d0aabe..bc90e77c4 100644
+--- a/linker/linker_translate_path.cpp
++++ b/linker/linker_translate_path.cpp
+@@ -29,6 +29,7 @@
+ #include "linker.h"
+ #include "linker_translate_path.h"
+ #include "linker_utils.h"
++#include "android-base/strings.h"
+ 
+ #if defined(__LP64__)
+ static const char* const kSystemLibDir        = "/system/lib64";
+@@ -38,6 +39,10 @@ static const char* const kSystemLibDir        = "/system/lib";
+ static const char* const kI18nApexLibDir      = "/apex/com.android.i18n/lib";
+ #endif
+ 
++static const char* const kSystemApexDir       = "/system/apex";
++static const char* const kApexDir             = "/apex";
++static const char* const kPerfDir             = "/IA-Perf/";
++
+ // Workaround for dlopen(/system/lib(64)/<soname>) when .so is in /apex. http://b/121248172
+ /**
+  * Translate /system path to /apex path if needed
+@@ -75,3 +80,28 @@ bool translateSystemPathToApexPath(const char* name, std::string* out_name_to_ap
+   return false;
+ }
+ // End Workaround for dlopen(/system/lib/<soname>) when .so is in /apex.
++
++/**
++ * Translate so path to Perf feature so path if needed
++ *
++ * param out_name_to_perf_feature pointing to corresponding perf feature path
++ * return true if translation is needed
++ */
++bool translateSystemPathToPerfFeaturePath(const char* isa_feature, const char* name, std::string* out_name_to_perf_feature) {
++  // If the platform doesn't support avx, there's nothing to do.
++  if (!PlatformSupportsISAFeature(isa_feature) || name == nullptr) {
++    return false;
++  }
++
++  std::string dir_name = dirname(name);
++
++  if (dir_name != kSystemLibDir &&
++      !android::base::StartsWith(dir_name,kApexDir) &&
++      !android::base::StartsWith(dir_name,kSystemApexDir)) {
++    return false;
++  }
++
++  *out_name_to_perf_feature = dir_name + kPerfDir + isa_feature + "/" + basename(name);
++  return true;
++}
++// End Workaround for dlopen(FullPath/<soname>) when .so could have avx version .
+diff --git a/linker/linker_translate_path.h b/linker/linker_translate_path.h
+index 86a3ec1e9..cf6ec5f65 100644
+--- a/linker/linker_translate_path.h
++++ b/linker/linker_translate_path.h
+@@ -31,3 +31,4 @@
+ #include <string>
+ 
+ bool translateSystemPathToApexPath(const char* name, std::string* out_name_to_apex);
++bool translateSystemPathToPerfFeaturePath(const char* isa_feature, const char* name, std::string* out_name_to_perf_feature);
+diff --git a/linker/linker_utils.cpp b/linker/linker_utils.cpp
+index 29110ed56..5e43d1526 100644
+--- a/linker/linker_utils.cpp
++++ b/linker/linker_utils.cpp
+@@ -36,6 +36,8 @@
+ #include <sys/stat.h>
+ #include <unistd.h>
+ 
++static int kPlatformSupportsAvx2 = -1;
++
+ void format_string(std::string* str, const std::vector<std::pair<std::string, std::string>>& params) {
+   size_t pos = 0;
+   while (pos < str->size()) {
+@@ -258,3 +260,14 @@ bool is_first_stage_init() {
+   static bool ret = (getpid() == 1 && access("/proc/self/exe", F_OK) == -1);
+   return ret;
+ }
++
++bool PlatformSupportsISAFeature(const char* isa_feature) {
++  if (strcmp(isa_feature, "avx2") == 0) {
++    if (kPlatformSupportsAvx2 == -1) {
++      __builtin_cpu_init();
++      kPlatformSupportsAvx2 = __builtin_cpu_supports("avx2") ? 1 : 0;
++    }
++    return kPlatformSupportsAvx2;
++  }
++  return false;
++}
+diff --git a/linker/linker_utils.h b/linker/linker_utils.h
+index 5073b1068..c745b6609 100644
+--- a/linker/linker_utils.h
++++ b/linker/linker_utils.h
+@@ -59,3 +59,4 @@ off64_t page_start(off64_t offset);
+ size_t page_offset(off64_t offset);
+ bool safe_add(off64_t* out, off64_t a, size_t b);
+ bool is_first_stage_init();
++bool PlatformSupportsISAFeature(const char* isa_feature);
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/frameworks/av/03_0003-Generate-avx2-version-of-libaudioprocessing-library.patch
+++ b/aosp_diff/preliminary/frameworks/av/03_0003-Generate-avx2-version-of-libaudioprocessing-library.patch
@@ -1,0 +1,101 @@
+From 15a2d3c17a09b92bd42d4355ccd15375a62442f2 Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Tue, 3 Nov 2020 15:23:50 +0530
+Subject: [PATCH] Generate avx2 version of libaudioprocessing library
+
+Tracked-On: OAM-94488
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ media/libaudioprocessing/Android.bp | 54 +++++++++++++++++++----------
+ 1 file changed, 36 insertions(+), 18 deletions(-)
+
+diff --git a/media/libaudioprocessing/Android.bp b/media/libaudioprocessing/Android.bp
+index 39b0ceb1b6..0b01fde868 100644
+--- a/media/libaudioprocessing/Android.bp
++++ b/media/libaudioprocessing/Android.bp
+@@ -19,29 +19,22 @@ cc_defaults {
+         // uncomment to disable NEON on architectures that actually do support NEON, for benchmarking
+         // "-DUSE_NEON=false",
+     ],
++}
+ 
++cc_defaults {
++    name: "libaudioprocessing_defaults_avx2",
+     arch: {
+         x86: {
+-            avx2: {
+-                cflags: [
+-                    "-mavx2",
+-                    "-mfma",
+-                ],
+-            },
++           cflags: [ "-mavx2", "-mfma"],
+         },
+         x86_64: {
+-            avx2: {
+-                cflags: [
+-                    "-mavx2",
+-                    "-mfma",
+-                ],
+-            },
++           cflags: [ "-mavx2", "-mfma"],
+         },
+     },
+ }
+ 
+-cc_library_shared {
+-    name: "libaudioprocessing",
++cc_defaults {
++    name: "libaudioprocessing_generic",
+     defaults: ["libaudioprocessing_defaults"],
+ 
+     srcs: [
+@@ -61,12 +54,10 @@ cc_library_shared {
+         "libsonic",
+         "libvibrator",
+     ],
+-
+-    whole_static_libs: ["libaudioprocessing_base"],
+ }
+ 
+-cc_library_static {
+-    name: "libaudioprocessing_base",
++cc_defaults {
++    name: "libaudioprocessing_base_generic",
+     defaults: ["libaudioprocessing_defaults"],
+     vendor_available: true,
+ 
+@@ -84,3 +75,30 @@ cc_library_static {
+         },
+     },
+ }
++
++cc_library_static {
++   name: "libaudioprocessing_base",
++   defaults: ["libaudioprocessing_base_generic"],
++}
++
++cc_library_static {
++   name: "libaudioprocessing_base_avx2",
++   defaults: ["libaudioprocessing_base_generic", "libaudioprocessing_defaults_avx2"],
++}
++
++cc_library_shared {
++   name: "libaudioprocessing",
++   defaults: ["libaudioprocessing_generic"],
++   whole_static_libs: ["libaudioprocessing_base"],
++}
++
++cc_library_shared {
++   name: "libaudioprocessing_avx2",
++   defaults: ["libaudioprocessing_generic", "libaudioprocessing_defaults_avx2"],
++   target: {
++       android: {
++          relative_install_path: "IA-Perf/avx2",
++       },
++   },
++   whole_static_libs: ["libaudioprocessing_base_avx2"],
++}
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/frameworks/ml/01_0001-Generate-avx2-version-of-libneuralnetworks.patch
+++ b/aosp_diff/preliminary/frameworks/ml/01_0001-Generate-avx2-version-of-libneuralnetworks.patch
@@ -1,0 +1,107 @@
+From 52a7d45b25473ba12f68ac6d9b65cebd2593ad00 Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Tue, 3 Nov 2020 15:32:43 +0530
+Subject: [PATCH] Generate avx2 version of libneuralnetworks
+
+Tracked-On: OAM-94488
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ nn/Android.bp         | 19 +------------------
+ nn/apex/Android.bp    |  2 +-
+ nn/runtime/Android.bp | 27 +++++++++++++++++++++++++--
+ 3 files changed, 27 insertions(+), 21 deletions(-)
+
+diff --git a/nn/Android.bp b/nn/Android.bp
+index 904718a30..ceeee8db6 100644
+--- a/nn/Android.bp
++++ b/nn/Android.bp
+@@ -39,27 +39,10 @@ cc_defaults {
+         "-Werror",
+         "-Wextra",
+     ],
+-    arch: {
+-        x86: {
+-            avx2: {
+-                cflags: [
+-                    "-mavx2",
+-                    "-mfma",
+-                ],
+-            },
+-        },
+-        x86_64: {
+-            avx2: {
+-                cflags: [
+-                    "-mavx2",
+-                    "-mfma",
+-                ],
+-            },
+-        },
+-    },
+     product_variables: {
+         debuggable: { // eng and userdebug builds
+             cflags: ["-DNN_DEBUGGABLE"],
+         },
+     },
+ }
++
+diff --git a/nn/apex/Android.bp b/nn/apex/Android.bp
+index 42391eb08..02527434d 100644
+--- a/nn/apex/Android.bp
++++ b/nn/apex/Android.bp
+@@ -35,7 +35,7 @@ apex_defaults {
+     updatable: true,
+     min_sdk_version: "R",
+     androidManifest: ":com.android.neuralnetworks-androidManifest",
+-    native_shared_libs: ["libneuralnetworks"],
++    native_shared_libs: ["libneuralnetworks", "libneuralnetworks_avx2"],
+     compile_multilib: "both",
+     key: "com.android.neuralnetworks.key",
+     certificate: ":com.android.neuralnetworks.certificate",
+diff --git a/nn/runtime/Android.bp b/nn/runtime/Android.bp
+index d5f7787f3..b33358dea 100644
+--- a/nn/runtime/Android.bp
++++ b/nn/runtime/Android.bp
+@@ -114,8 +114,8 @@ cc_defaults {
+     ],
+ }
+ 
+-cc_library_shared {
+-    name: "libneuralnetworks",
++cc_defaults {
++    name: "libneuralnetworks_generic",
+     defaults: [
+         "libneuralnetworks_defaults",
+         "neuralnetworks_defaults",
+@@ -133,6 +133,29 @@ cc_library_shared {
+     },
+ }
+ 
++cc_library_shared {
++   name: "libneuralnetworks",
++   defaults: ["libneuralnetworks_generic"],
++}
++
++cc_library_shared {
++    name: "libneuralnetworks_avx2",
++    defaults: ["libneuralnetworks_generic"], 
++    arch: {
++        x86: {
++           cflags: [ "-mavx2", "-mfma", ],
++        },
++        x86_64: {
++           cflags: [ "-mavx2", "-mfma", ],
++        },
++    },
++    target: {
++       android: {
++          relative_install_path: "IA-Perf/avx2",
++       },
++    },
++}
++
+ // Required for tests (b/147158681)
+ cc_library_static {
+     name: "libneuralnetworks_static",
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/system/linkerconfig/01_0001-Config-changes-to-prefer-perf-variants-of-an-.so.patch
+++ b/aosp_diff/preliminary/system/linkerconfig/01_0001-Config-changes-to-prefer-perf-variants-of-an-.so.patch
@@ -1,0 +1,218 @@
+From 4b99a8221c69cab24981d49933197168d0ed61b7 Mon Sep 17 00:00:00 2001
+From: Vinay Kompella <vinay.kompella@intel.com>
+Date: Tue, 3 Nov 2020 16:36:42 +0530
+Subject: [PATCH] Config changes to prefer perf variants of an .so
+
+This patch introduces changes in linkerconfig to
+prefer perf variants of an .so in searchpaths.
+Enables us to have One-image catering to multiple
+IA CPUs which may or may not support all ISA features.
+Example: Pentium SKUs dont support AVX.
+
+Tracked-On: OAM-94488
+Signed-off-by: Vinay Kompella <vinay.kompella@intel.com>
+---
+ contents/namespace/art.cc                  |  9 +++++++++
+ contents/namespace/rs.cc                   |  6 ++++++
+ contents/namespace/systemdefault.cc        |  7 +++++++
+ contents/namespace/vendordefault.cc        |  5 +++++
+ contents/namespace/vndk.cc                 |  5 +++++
+ modules/environment.cc                     | 21 +++++++++++++++++++++
+ modules/include/linkerconfig/environment.h |  2 ++
+ modules/namespace.cc                       | 10 ++++++++++
+ 8 files changed, 65 insertions(+)
+
+diff --git a/contents/namespace/art.cc b/contents/namespace/art.cc
+index 0d0b982..323bd51 100644
+--- a/contents/namespace/art.cc
++++ b/contents/namespace/art.cc
+@@ -17,6 +17,7 @@
+ // This namespace exposes externally accessible libraries from the ART APEX.
+ // Keep in sync with the "art" namespace in art/build/apex/ld.config.txt.
+ 
++#include "linkerconfig/environment.h"
+ #include "linkerconfig/namespacebuilder.h"
+ 
+ using android::linkerconfig::modules::ApexInfo;
+@@ -36,7 +37,15 @@ Namespace BuildArtNamespace([[maybe_unused]] const Context& ctx,
+                /*is_isolated=*/true,
+                /*is_visible=*/!ctx.IsVendorSection());
+ 
++  if (modules::PlatformSupportsISAFeature("avx2")) {
++    ns.AddSearchPath(
++        "/apex/com.android.art/${LIB}" + modules::GetSearchPathForISAFeature("avx2"),
++        AsanPath::SAME_PATH);
++  }
+   ns.AddSearchPath("/apex/com.android.art/${LIB}", AsanPath::SAME_PATH);
++  if (modules::PlatformSupportsISAFeature("avx2")) {
++    ns.AddPermittedPath("/system/${LIB}" + modules::GetSearchPathForISAFeature("avx2"));
++  }
+   ns.AddPermittedPath("/system/${LIB}");
+ 
+   if (ctx.IsApexBinaryConfig()) {
+diff --git a/contents/namespace/rs.cc b/contents/namespace/rs.cc
+index 4960547..6cd6b61 100644
+--- a/contents/namespace/rs.cc
++++ b/contents/namespace/rs.cc
+@@ -19,6 +19,7 @@
+ // the genuine characteristics of Renderscript; /data is in the permitted path
+ // to load the compiled *.so file and libmediandk.so can be used here.
+ 
++#include "linkerconfig/environment.h"
+ #include "linkerconfig/namespacebuilder.h"
+ 
+ using android::linkerconfig::modules::AsanPath;
+@@ -33,6 +34,11 @@ Namespace BuildRsNamespace([[maybe_unused]] const Context& ctx) {
+ 
+   ns.AddSearchPath("/odm/${LIB}/vndk-sp", AsanPath::WITH_DATA_ASAN);
+   ns.AddSearchPath("/vendor/${LIB}/vndk-sp", AsanPath::WITH_DATA_ASAN);
++  if (modules::PlatformSupportsISAFeature("avx2")) {
++    ns.AddSearchPath(
++        "/apex/com.android.vndk.v" + Var("VENDOR_VNDK_VERSION") + "/${LIB}" +
++         modules::GetSearchPathForISAFeature("avx2"), AsanPath::SAME_PATH);
++  }
+   ns.AddSearchPath(
+       "/apex/com.android.vndk.v" + Var("VENDOR_VNDK_VERSION") + "/${LIB}",
+       AsanPath::SAME_PATH);
+diff --git a/contents/namespace/systemdefault.cc b/contents/namespace/systemdefault.cc
+index a9bfdb1..cd73836 100644
+--- a/contents/namespace/systemdefault.cc
++++ b/contents/namespace/systemdefault.cc
+@@ -40,6 +40,9 @@ Namespace BuildSystemDefaultNamespace([[maybe_unused]] const Context& ctx) {
+                /*is_isolated=*/is_fully_treblelized,
+                /*is_visible=*/true);
+ 
++  if (modules::PlatformSupportsISAFeature("avx2")) {
++    ns.AddSearchPath("/system/${LIB}" + modules::GetSearchPathForISAFeature("avx2"), AsanPath::WITH_DATA_ASAN);
++  }
+   ns.AddSearchPath("/system/${LIB}", AsanPath::WITH_DATA_ASAN);
+   ns.AddSearchPath(system_ext + "/${LIB}", AsanPath::WITH_DATA_ASAN);
+   if (!IsProductVndkVersionDefined() || !is_fully_treblelized) {
+@@ -93,6 +96,10 @@ Namespace BuildSystemDefaultNamespace([[maybe_unused]] const Context& ctx) {
+         "/apex/com.android.runtime/${LIB}/bionic",
+         "/system/${LIB}/bootstrap"};
+ 
++    if (modules::PlatformSupportsISAFeature("avx2")) {
++      ns.AddPermittedPath("/system/${LIB}" + modules::GetSearchPathForISAFeature("avx2"), AsanPath::SAME_PATH);
++    }
++
+     for (const auto& path : permitted_paths) {
+       ns.AddPermittedPath(path, AsanPath::SAME_PATH);
+     }
+diff --git a/contents/namespace/vendordefault.cc b/contents/namespace/vendordefault.cc
+index 6d56904..96fec36 100644
+--- a/contents/namespace/vendordefault.cc
++++ b/contents/namespace/vendordefault.cc
+@@ -87,6 +87,11 @@ Namespace BuildVendorDefaultNamespace([[maybe_unused]] const Context& ctx) {
+     ns.AddSearchPath(Var("SYSTEM_EXT") + "/${LIB}", AsanPath::WITH_DATA_ASAN);
+     ns.AddSearchPath(Var("PRODUCT") + "/${LIB}", AsanPath::WITH_DATA_ASAN);
+     // Put system vndk at the last search order in vndk_lite for GSI
++    if (modules::PlatformSupportsISAFeature("avx2")) {
++      ns.AddSearchPath(
++          "/apex/com.android.vndk.v" + Var("VENDOR_VNDK_VERSION") + "/${LIB}" +
++           modules::GetSearchPathForISAFeature("avx2"), AsanPath::SAME_PATH);
++    }
+     ns.AddSearchPath(
+         "/apex/com.android.vndk.v" + Var("VENDOR_VNDK_VERSION") + "/${LIB}",
+         AsanPath::SAME_PATH);
+diff --git a/contents/namespace/vndk.cc b/contents/namespace/vndk.cc
+index a95db80..7faccac 100644
+--- a/contents/namespace/vndk.cc
++++ b/contents/namespace/vndk.cc
+@@ -69,6 +69,11 @@ Namespace BuildVndkNamespace([[maybe_unused]] const Context& ctx,
+       ns.AddSearchPath(lib_path + "vndk", AsanPath::WITH_DATA_ASAN);
+     }
+   }
++  if (modules::PlatformSupportsISAFeature("avx2")) {
++    ns.AddSearchPath(
++        "/apex/com.android.vndk.v" + vndk_version + "/${LIB}" +
++         modules::GetSearchPathForISAFeature("avx2"), AsanPath::SAME_PATH);
++  }
+   ns.AddSearchPath("/apex/com.android.vndk.v" + vndk_version + "/${LIB}",
+                    AsanPath::SAME_PATH);
+ 
+diff --git a/modules/environment.cc b/modules/environment.cc
+index e63be71..6fb06e9 100644
+--- a/modules/environment.cc
++++ b/modules/environment.cc
+@@ -23,6 +23,9 @@
+ namespace android {
+ namespace linkerconfig {
+ namespace modules {
++
++static int kPlatformSupportsAvx2 = -1;
++
+ bool IsLegacyDevice() {
+   return (!Variables::GetValue("ro.vndk.version").has_value() &&
+           !Variables::GetValue("ro.vndk.lite").has_value()) ||
+@@ -52,6 +55,24 @@ bool IsProductVndkVersionDefined() {
+ bool IsRecoveryMode() {
+   return access("/system/bin/recovery", F_OK) == 0;
+ }
++
++bool PlatformSupportsISAFeature(const char* isa_feature) {
++  if (strcmp(isa_feature, "avx2") == 0) {
++    if (kPlatformSupportsAvx2 == -1) {
++      __builtin_cpu_init();
++      kPlatformSupportsAvx2 = (__builtin_cpu_supports("avx2")) ? 1 : 0;
++    }
++    return kPlatformSupportsAvx2;
++  }
++  return false;
++}
++
++std::string GetSearchPathForISAFeature(const char* isa_feature) {
++  std::string searchPath = "/IA-Perf/";
++  searchPath += isa_feature;
++  return searchPath;
++}
++
+ }  // namespace modules
+ }  // namespace linkerconfig
+ }  // namespace android
+diff --git a/modules/include/linkerconfig/environment.h b/modules/include/linkerconfig/environment.h
+index 3aa0d32..4a4b324 100644
+--- a/modules/include/linkerconfig/environment.h
++++ b/modules/include/linkerconfig/environment.h
+@@ -26,6 +26,8 @@ std::string GetVendorVndkVersion();
+ std::string GetProductVndkVersion();
+ bool IsProductVndkVersionDefined();
+ bool IsRecoveryMode();
++bool PlatformSupportsISAFeature(const char* isa_feature);
++std::string GetSearchPathForISAFeature(const char* isa_feature);
+ }  // namespace modules
+ }  // namespace linkerconfig
+ }  // namespace android
+diff --git a/modules/namespace.cc b/modules/namespace.cc
+index b553c46..4c63d01 100644
+--- a/modules/namespace.cc
++++ b/modules/namespace.cc
+@@ -20,6 +20,7 @@
+ 
+ #include "linkerconfig/apex.h"
+ #include "linkerconfig/log.h"
++#include "linkerconfig/environment.h"
+ 
+ namespace {
+ 
+@@ -43,8 +44,17 @@ namespace linkerconfig {
+ namespace modules {
+ 
+ void InitializeWithApex(Namespace& ns, const ApexInfo& apex_info) {
++  if (PlatformSupportsISAFeature("avx2")) {
++    ns.AddSearchPath(apex_info.path + "/${LIB}" + GetSearchPathForISAFeature("avx2"));
++  }
+   ns.AddSearchPath(apex_info.path + "/${LIB}");
++  if (PlatformSupportsISAFeature("avx2")) {
++    ns.AddPermittedPath(apex_info.path + "/${LIB}" + GetSearchPathForISAFeature("avx2"));
++  }
+   ns.AddPermittedPath(apex_info.path + "/${LIB}");
++  if (PlatformSupportsISAFeature("avx2")) {
++    ns.AddPermittedPath("/system/${LIB}" + GetSearchPathForISAFeature("avx2"));
++  }
+   ns.AddPermittedPath("/system/${LIB}");
+   ns.AddProvides(apex_info.provide_libs);
+   ns.AddRequires(apex_info.require_libs);
+-- 
+2.17.1
+


### PR DESCRIPTION
Enables us to have One-image catering to multiple
IA CPUs which may or may not support all ISA features.
Example: Pentium SKUs dont support AVX.

Tracked-On: OAM-94488
Signed-off-by: Vinay Kompella <vinay.kompella@intel.com>