### PR TITLE
Changes to allow multiple perf variants libRSCpuRef.so

### DIFF
--- a/aosp_diff/preliminary/art/03_0003-Generate-avx2-version-of-libart.so-and-libartd.so.patch
+++ b/aosp_diff/preliminary/art/03_0003-Generate-avx2-version-of-libart.so-and-libartd.so.patch
@@ -1,0 +1,198 @@
+From eb8a3a738d0ac9b4be2a216ae13af2ec4d382e7a Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Thu, 5 Nov 2020 17:57:05 +0530
+Subject: [PATCH] Generate avx2 version of libart.so and libartd.so
+
+Tracked-On: OAM-94488
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ build/Android.bp            | 19 -----------
+ build/apex/Android.bp       |  2 ++
+ build/apex/art_apex_test.py |  8 +++++
+ runtime/Android.bp          | 66 +++++++++++++++++++++++++++++--------
+ 4 files changed, 62 insertions(+), 33 deletions(-)
+
+diff --git a/build/Android.bp b/build/Android.bp
+index 946e5a60e9..fca6351581 100644
+--- a/build/Android.bp
++++ b/build/Android.bp
+@@ -115,25 +115,6 @@ art_global_defaults {
+         "-D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS",
+     ],
+ 
+-    arch: {
+-        x86: {
+-            avx2: {
+-                cflags: [
+-                    "-mavx2",
+-                    "-mfma",
+-                ],
+-            },
+-        },
+-        x86_64: {
+-            avx2: {
+-                cflags: [
+-                    "-mavx2",
+-                    "-mfma",
+-                ],
+-            },
+-        },
+-    },
+-
+     target: {
+         android: {
+             cflags: [
+diff --git a/build/apex/Android.bp b/build/apex/Android.bp
+index 22510ef5df..293e69ca1d 100644
+--- a/build/apex/Android.bp
++++ b/build/apex/Android.bp
+@@ -40,6 +40,7 @@ art_runtime_base_native_shared_libs = [
+     // TODO(b/124476339): Clean up the following libraries once "required"
+     // dependencies work with APEX libraries.
+     "libart",
++    "libart_avx2",
+     "libart-compiler",
+     "libdt_fd_forward",
+     "libdt_socket",
+@@ -78,6 +79,7 @@ art_runtime_debug_binaries_both_on_device_first_on_host = [
+ art_runtime_debug_native_shared_libs = [
+     "libadbconnectiond",
+     "libartd",
++    "libartd_avx2",
+     "libartd-compiler",
+     "libdexfiled_external",
+     "libopenjdkjvmd",
+diff --git a/build/apex/art_apex_test.py b/build/apex/art_apex_test.py
+index 6bccdf5926..ee0b5860f2 100755
+--- a/build/apex/art_apex_test.py
++++ b/build/apex/art_apex_test.py
+@@ -491,6 +491,12 @@ class MultilibChecker(Checker):
+     self.check_file('lib/%s.so' % basename)
+     self.check_file('lib64/%s.so' % basename)
+ 
++  def check_native_isa_perf_library(self, basename):
++    # TODO: Use $TARGET_ARCH (e.g. check whether it is "arm" or "arm64") to improve
++    # the precision of this test?
++    self.check_file('lib/IA-Perf/avx2/%s.so' % basename)
++    self.check_file('lib64/IA-Perf/avx2/%s.so' % basename)
++
+   def check_optional_native_library(self, basename_glob):
+     self.ignore_path('lib/%s.so' % basename_glob)
+     self.ignore_path('lib64/%s.so' % basename_glob)
+@@ -527,6 +533,7 @@ class ReleaseChecker:
+     # Check internal libraries for ART.
+     self._checker.check_native_library('libadbconnection')
+     self._checker.check_native_library('libart')
++    self._checker.check_native_isa_perf_library('libart_avx2')
+     self._checker.check_native_library('libart-compiler')
+     self._checker.check_native_library('libart-dexlayout')
+     self._checker.check_native_library('libart-disassembler')
+@@ -684,6 +691,7 @@ class DebugChecker:
+     self._checker.check_native_library('libart-disassembler')
+     self._checker.check_native_library('libartbased')
+     self._checker.check_native_library('libartd')
++    self._checker.check_native_isa_perf_library('libartd_avx2')
+     self._checker.check_native_library('libartd-compiler')
+     self._checker.check_native_library('libartd-dexlayout')
+     self._checker.check_native_library('libartd-disassembler')
+diff --git a/runtime/Android.bp b/runtime/Android.bp
+index 7e750160fb..59976de4f1 100644
+--- a/runtime/Android.bp
++++ b/runtime/Android.bp
+@@ -321,12 +321,6 @@ libart_cc_defaults {
+                 "arch/x86/thread_x86.cc",
+                 "arch/x86/fault_handler_x86.cc",
+             ],
+-            avx: {
+-                asflags: ["-DMTERP_USE_AVX"],
+-            },
+-            avx2: {
+-                asflags: ["-DMTERP_USE_AVX"],
+-            },
+         },
+         x86_64: {
+             srcs: [
+@@ -345,12 +339,6 @@ libart_cc_defaults {
+                 "monitor_pool.cc",
+                 "arch/x86/fault_handler_x86.cc",
+             ],
+-            avx: {
+-                asflags: ["-DMTERP_USE_AVX"],
+-            },
+-            avx2: {
+-                asflags: ["-DMTERP_USE_AVX"],
+-            },
+         },
+     },
+     target: {
+@@ -516,6 +504,56 @@ gensrcs {
+ 
+ art_cc_library {
+     name: "libart",
++    defaults: ["libart_defaults_generic"],
++}
++
++art_cc_library {
++    name: "libartd",
++    defaults: ["libartd_defaults_generic"],
++}
++
++art_cc_library {
++    name: "libart_avx2",
++    target: {
++       android: { 
++          relative_install_path: "IA-Perf/avx2",
++       },
++    },
++    defaults: ["libart_defaults_generic"],
++    arch: {
++        x86: {
++            cflags: ["-mavx2", "-mfma"],
++            asflags: ["-DMTERP_USE_AVX"],
++        },
++        x86_64: {
++            cflags: ["-mavx2", "-mfma"],
++            asflags: ["-DMTERP_USE_AVX"],
++        },
++    },
++}
++
++art_cc_library {
++    name: "libartd_avx2",
++    target: {
++       android: { 
++          relative_install_path: "IA-Perf/avx2",
++       },
++    },
++    defaults: ["libartd_defaults_generic"],
++    arch: {
++        x86: {
++            cflags: ["-mavx2", "-mfma"],
++            asflags: ["-DMTERP_USE_AVX"],
++        },
++        x86_64: {
++            cflags: ["-mavx2", "-mfma"],
++            asflags: ["-DMTERP_USE_AVX"],
++        },
++    },
++}
++
++libart_cc_defaults {
++    name: "libart_defaults_generic",
+     defaults: [
+         "libart_defaults",
+         "libart_nativeunwind_defaults",
+@@ -548,8 +586,8 @@ art_cc_library {
+     ],
+ }
+ 
+-art_cc_library {
+-    name: "libartd",
++libart_cc_defaults {
++    name: "libartd_defaults_generic",
+     defaults: [
+         "art_debug_defaults",
+         "libart_defaults",
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/frameworks/rs/01_0001-Generate-avx2-version-of-libRSCpuRef.so.patch
+++ b/aosp_diff/preliminary/frameworks/rs/01_0001-Generate-avx2-version-of-libRSCpuRef.so.patch
@@ -1,0 +1,60 @@
+From 53f0b37357befbb27224e363de9396ebdacc0951 Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Wed, 4 Nov 2020 14:31:12 +0530
+Subject: [PATCH] Generate avx2 version of libRSCpuRef.so
+
+Tracked-On: OAM-94488
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ cpu_ref/Android.bp | 27 ++++++++++++++++++++++-----
+ 1 file changed, 22 insertions(+), 5 deletions(-)
+
+diff --git a/cpu_ref/Android.bp b/cpu_ref/Android.bp
+index b8da9245..7f733aef 100644
+--- a/cpu_ref/Android.bp
++++ b/cpu_ref/Android.bp
+@@ -1,5 +1,5 @@
+-cc_library_shared {
+-    name: "libRSCpuRef",
++cc_defaults {
++    name: "libRSCpuRef_generic",
+     defaults: ["libbcc-targets"],
+     vendor_available: true,
+     native_bridge_supported: true,
+@@ -80,9 +80,6 @@ cc_library_shared {
+         x86_64: {
+             cflags: ["-DARCH_X86_HAVE_SSSE3"],
+             srcs: ["rsCpuIntrinsics_x86.cpp"],
+-	    avx2: {
+-                cflags: ["-DARCH_X86_HAVE_AVX2", "-mavx2", "-mfma"],
+-            },
+         },
+     },
+ 
+@@ -128,3 +125,23 @@ cc_library_shared {
+         },
+     },
+ }
++
++cc_library_shared {
++   name: "libRSCpuRef",
++   defaults: ["libRSCpuRef_generic"],
++}
++
++cc_library_shared {
++   name: "libRSCpuRef_avx2",
++   defaults: ["libRSCpuRef_generic"],
++   target: {
++       android: {
++          relative_install_path: "IA-Perf/avx2",
++       },
++   },
++   arch: {
++      x86_64: {
++         cflags: ["-DARCH_X86_HAVE_AVX2", "-mavx2", "-mfma"],
++      },
++   }
++}
+-- 
+2.17.1
+


### PR DESCRIPTION
Enables us to have One-image catering to multiple
IA CPUs which may or may not support all ISA features.
Example:  Pentium SKUs dont support AVX.

Tracked-On: OAM-94488
Signed-off-by: ahs <amrita.h.s@intel.com>