### PR TITLE
Filterout isa perf libraries from vndk list

### DIFF
--- a/aosp_diff/preliminary/build/soong/0005-Filterout-isa-perf-libraries-from-vndk-list.patch
+++ b/aosp_diff/preliminary/build/soong/0005-Filterout-isa-perf-libraries-from-vndk-list.patch
@@ -1,0 +1,43 @@
+From 5d485ddda05191b3b8f9f60a52093f8536dded80 Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Mon, 9 Nov 2020 10:39:09 +0530
+Subject: [PATCH] Filterout isa perf libraries from vndk list
+
+Currently we have added perf libs under vndksp,
+filter them out as they are not new libraries,
+rather avx2 implementations of existing libraries.
+Should have no impact on GSI.
+
+Tracked-On: OAM-94541
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ cc/vndk.go | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/cc/vndk.go b/cc/vndk.go
+index a0608696e..267a2163c 100644
+--- a/cc/vndk.go
++++ b/cc/vndk.go
+@@ -794,8 +794,18 @@ func (c *vndkSnapshotSingleton) buildVndkLibrariesTxtFiles(ctx android.Singleton
+ 		}
+ 		return
+ 	}
++	filterOutAvxLibs := func(libList []string) (filtered []string) {
++		for _, lib := range libList {
++			if !strings.Contains(lib, "_avx2.") {
++				filtered = append(filtered, lib)
++			}
++		}
++		return
++	}
+ 	merged = append(merged, addPrefix(filterOutLibClangRt(llndk), "LLNDK: ")...)
+-	merged = append(merged, addPrefix(vndksp, "VNDK-SP: ")...)
++	// Currently we have added perf libs under vndksp, filter them out as they are not new libraries,
++	// rather avx implementations of existing libraries. Should have no impact on GSI
++	merged = append(merged, addPrefix(filterOutAvxLibs(vndksp), "VNDK-SP: ")...)
+ 	merged = append(merged, addPrefix(filterOutLibClangRt(vndkcore), "VNDK-core: ")...)
+ 	merged = append(merged, addPrefix(vndkprivate, "VNDK-private: ")...)
+ 	c.vndkLibrariesFile = android.PathForOutput(ctx, "vndk", "vndk.libraries.txt")
+-- 
+2.17.1
+


### PR DESCRIPTION
Currently we have added perf libs under vndksp,
filter them out as they are not new libraries,
rather avx2 implementations of existing libraries.
Should have no impact on GSI.

Tracked-On: OAM-94541
Signed-off-by: ahs <amrita.h.s@intel.com>