### PR TITLE
adb: dbc: tty: add adb over dbc tty support

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/0001-adb-dbc-tty-device-offline-issue.patch
+++ b/aosp_diff/preliminary/frameworks/base/0001-adb-dbc-tty-device-offline-issue.patch
@@ -1,0 +1,99 @@
+From 604140c31469ad8669c0aedf3dbfda5ca3f03a2f Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Sun, 22 Nov 2020 12:52:55 +0530
+Subject: [PATCH] adb: dbc: tty: device offline issue
+
+Restarting the adb daemon when DbC device move to the dbc
+state configured from dbc state enable.
+To do so added DEVPATH variable which match to the DbC TTY
+DEVPATH uevent.
+
+Tracked-On: OAM-94662
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Signed-off-by: Balaji <m.balaji@intel.com>
+
+diff --git a/services/usb/java/com/android/server/usb/UsbDeviceManager.java b/services/usb/java/com/android/server/usb/UsbDeviceManager.java
+index 7595e3f249c..a1fffcd4e5d 100644
+--- a/services/usb/java/com/android/server/usb/UsbDeviceManager.java
++++ b/services/usb/java/com/android/server/usb/UsbDeviceManager.java
+@@ -129,6 +129,8 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
+      */
+     private static final String NORMAL_BOOT = "normal";
+ 
++    private static final String USB_DBC_STATE_MATCH =
++            "DEVPATH=/devices/virtual/tty/ttyDBC0";
+     private static final String USB_STATE_MATCH =
+             "DEVPATH=/devices/virtual/android_usb/android0";
+     private static final String ACCESSORY_START_MATCH =
+@@ -219,6 +221,10 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
+             if (DEBUG) Slog.v(TAG, "USB UEVENT: " + event.toString());
+ 
+             String state = event.get("USB_STATE");
++
++            if (state == null)
++                state = event.get("ACTION");
++
+             String accessory = event.get("ACCESSORY");
+             if (state != null) {
+                 mHandler.updateState(state);
+@@ -357,6 +363,7 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
+         mUEventObserver = new UsbUEventObserver();
+         mUEventObserver.startObserving(USB_STATE_MATCH);
+         mUEventObserver.startObserving(ACCESSORY_START_MATCH);
++        mUEventObserver.startObserving(USB_DBC_STATE_MATCH);
+     }
+ 
+     UsbProfileGroupSettingsManager getCurrentSettings() {
+@@ -446,6 +453,7 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
+     abstract static class UsbHandler extends Handler {
+ 
+         // current USB state
++        private boolean mDbcConnected;
+         private boolean mHostConnected;
+         private boolean mSourcePower;
+         private boolean mSinkPower;
+@@ -573,6 +581,9 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
+             } else if ("CONFIGURED".equals(state)) {
+                 connected = 1;
+                 configured = 1;
++            } else if ("add".equals(state)) {
++                connected = 2;
++                configured = 1;
+             } else {
+                 Slog.e(TAG, "unknown state " + state);
+                 return;
+@@ -800,11 +811,18 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
+ 
+         @Override
+         public void handleMessage(Message msg) {
++            final String ADBD = "adbd";
++            final String CTL_START = "ctl.start";
++            final String CTL_STOP = "ctl.stop";
++
+             switch (msg.what) {
+                 case MSG_UPDATE_STATE:
+                     mConnected = (msg.arg1 == 1);
+                     mConfigured = (msg.arg2 == 1);
+-
++                    if (msg.arg1==2) {
++                        mConnected = (msg.arg1 == 2);
++                        mDbcConnected = (msg.arg1 == 2);
++                    }
+                     updateUsbNotification(false);
+                     updateAdbNotification(false);
+                     if (mBootCompleted) {
+@@ -828,6 +846,11 @@ public class UsbDeviceManager implements ActivityTaskManagerInternal.ScreenObser
+                     } else {
+                         mPendingBootBroadcast = true;
+                     }
++                    if (mDbcConnected) {
++                        setSystemProperty("sys.usb.controller", "none");
++                        setSystemProperty(CTL_STOP, ADBD);
++                        setSystemProperty(CTL_START, ADBD);
++                    }
+                     break;
+                 case MSG_UPDATE_PORT_STATE:
+                     SomeArgs args = (SomeArgs) msg.obj;
+-- 
+2.28.0
+

--- a/aosp_diff/preliminary/system/core/0001-adb-dbc-tty-add-adb-over-dbc-tty-support.patch
+++ b/aosp_diff/preliminary/system/core/0001-adb-dbc-tty-add-adb-over-dbc-tty-support.patch
@@ -1,0 +1,477 @@
+From 2aa1ae010d9690a03572167a71b38b99bfaa311c Mon Sep 17 00:00:00 2001
+From: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+Date: Sun, 22 Nov 2020 12:59:30 +0530
+Subject: [PATCH] adb: dbc: tty: add adb over dbc tty support
+
+Added adb over dbc tty support in adb framework.
+
+This implementation is based on Blocking I/O calls.
+
+Set "persist.vendor.sys.usb.adbover" android property to "dbc"
+to use adb over dbc tty otherwise set thisproperty to "dwc"
+(which is the default valueof this property) to use adb over
+normal USB (which need USB Device Mode IP to be enabled).
+
+Tracked-On: OAM-94662
+Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>
+
+diff --git a/adb/adb.h b/adb/adb.h
+index ce12a55f9..1d8d3d452 100644
+--- a/adb/adb.h
++++ b/adb/adb.h
+@@ -196,6 +196,10 @@ void put_apacket(apacket* p);
+ #define ADB_SUBCLASS 0x42
+ #define ADB_PROTOCOL 0x1
+ 
++#define ADB_DBC_CLASS 0xDC
++#define ADB_DBC_SUBCLASS 0x2
++#define ADB_DBC_PROTOCOL 0x1
++
+ void local_init(const std::string& addr);
+ bool local_connect(int port);
+ int local_connect_arbitrary_ports(int console_port, int adb_port, std::string* error);
+@@ -216,6 +220,8 @@ extern const char* adb_device_banner;
+ #define USB_FFS_ADB_EP0 USB_FFS_ADB_EP(ep0)
+ #define USB_FFS_ADB_OUT USB_FFS_ADB_EP(ep1)
+ #define USB_FFS_ADB_IN USB_FFS_ADB_EP(ep2)
++
++#define USB_DBC_ADB_PATH  "/dev/ttyDBC0"
+ #endif
+ 
+ enum class HostRequestResult {
+diff --git a/adb/client/commandline.cpp b/adb/client/commandline.cpp
+index ad4e21c4d..82562cc0e 100644
+--- a/adb/client/commandline.cpp
++++ b/adb/client/commandline.cpp
+@@ -1118,7 +1118,8 @@ static bool adb_root(const char* command) {
+     }
+ 
+     // Figure out whether we actually did anything.
+-    char buf[256];
++    // adb root blocked here as at time there is no any read happening from target.
++/*    char buf[256];
+     char* cur = buf;
+     ssize_t bytes_left = sizeof(buf);
+     while (bytes_left > 0) {
+@@ -1143,15 +1144,17 @@ static bool adb_root(const char* command) {
+     if (cur != buf && strstr(buf, "restarting") == nullptr) {
+         return true;
+     }
+-
++*/
+     // Wait for the device to go away.
+     TransportType previous_type;
+     const char* previous_serial;
+     TransportId previous_id;
+     adb_get_transport(&previous_type, &previous_serial, &previous_id);
+ 
+-    adb_set_transport(kTransportAny, nullptr, transport_id);
+-    wait_for_device("wait-for-disconnect");
++    // adb_set_transport(kTransportAny, nullptr, transport_id);
++    // wait_for_device("wait-for-disconnect");
++    // Let transport destructor to remove transport at target disconnect
++    std::this_thread::sleep_for(1s);
+ 
+     // Wait for the device to come back.
+     // If we were using a specific transport ID, there's nothing we can wait for.
+@@ -1806,7 +1809,7 @@ int adb_commandline(int argc, const char** argv) {
+         }
+         return adb_connect_command(command);
+     } else if (!strcmp(argv[0], "root") || !strcmp(argv[0], "unroot")) {
+-        return adb_root(argv[0]) ? 0 : 1;
++        return adb_root(argv[0]) ? adb_query_command(format_host_command("reconnect")) : 1;
+     } else if (!strcmp(argv[0], "bugreport")) {
+         Bugreport bugreport;
+         return bugreport.DoIt(argc, argv);
+diff --git a/adb/client/transport_usb.cpp b/adb/client/transport_usb.cpp
+index 777edde0b..e7b0a83f5 100644
+--- a/adb/client/transport_usb.cpp
++++ b/adb/client/transport_usb.cpp
+@@ -199,7 +199,12 @@ void init_usb_transport(atransport* t, usb_handle* h) {
+ }
+ 
+ int is_adb_interface(int usb_class, int usb_subclass, int usb_protocol) {
+-    return (usb_class == ADB_CLASS && usb_subclass == ADB_SUBCLASS && usb_protocol == ADB_PROTOCOL);
++    if ((usb_class == ADB_CLASS && usb_subclass == ADB_SUBCLASS && usb_protocol == ADB_PROTOCOL) ||
++            (usb_class == ADB_DBC_CLASS && usb_subclass == ADB_DBC_SUBCLASS &&
++            usb_protocol == ADB_DBC_PROTOCOL))
++        return true;
++    else
++        return false;
+ }
+ 
+ bool should_use_libusb() {
+diff --git a/adb/client/usb_linux.cpp b/adb/client/usb_linux.cpp
+index 95b1817dc..ec1ad14bc 100644
+--- a/adb/client/usb_linux.cpp
++++ b/adb/client/usb_linux.cpp
+@@ -353,6 +353,9 @@ static int usb_bulk_read(usb_handle* h, void* data, int len) {
+     urb->buffer = data;
+     urb->buffer_length = len;
+ 
++    usbdevfs_ctrltransfer ufs;
++    unsigned short int ufsdata;
++
+     if (h->dead) {
+         errno = EINVAL;
+         return -1;
+@@ -367,6 +370,38 @@ static int usb_bulk_read(usb_handle* h, void* data, int len) {
+         D("[ reap urb - wait ]");
+         h->reaper_thread = pthread_self();
+         int fd = h->fd;
++
++        ufsdata = 0;
++        ufs.bRequestType = 0x82;
++        ufs.bRequest = USB_REQ_GET_STATUS;
++        ufs.wValue = 0x0000;
++        ufs.wIndex = h->ep_in;
++        ufs.wLength = 0x0002;
++        ufs.data = &ufsdata;
++
++        if (TEMP_FAILURE_RETRY(ioctl(h->fd,USBDEVFS_CONTROL,&ufs))== -1) {
++            D("clear_halt read failed");
++        } else {
++            D("clear_halt read successful %d",ufsdata);
++        }
++
++        if (ufsdata) {
++            ufs.bRequestType = 0x02;
++            ufs.bRequest = USB_REQ_CLEAR_FEATURE;
++            ufs.wValue = 0x0000;
++            ufs.wIndex = h->ep_out;
++            ufs.wLength = 0x0000;
++            ufs.data = NULL;
++
++            if (TEMP_FAILURE_RETRY(ioctl(h->fd,USBDEVFS_CONTROL,&ufs))== -1) {
++                D("clear_halt read2 failed");
++            } else {
++                D("clear_halt read2 successful ");
++            }
++            errno = ETIMEDOUT;
++            return -1;
++        }
++
+         lock.unlock();
+ 
+         // This ioctl must not have TEMP_FAILURE_RETRY because we send SIGALRM to break out.
+diff --git a/adb/daemon/main.cpp b/adb/daemon/main.cpp
+index 658e24456..544dcb90b 100644
+--- a/adb/daemon/main.cpp
++++ b/adb/daemon/main.cpp
+@@ -236,7 +236,7 @@ int adbd_main(int server_port) {
+     bool is_usb = false;
+ 
+ #if defined(__ANDROID__)
+-    if (access(USB_FFS_ADB_EP0, F_OK) == 0) {
++    if ((access(USB_FFS_ADB_EP0, F_OK) == 0) || (access(USB_DBC_ADB_PATH,F_OK) == 0)) {
+         // Listen on USB.
+         usb_init();
+         is_usb = true;
+diff --git a/adb/daemon/usb.cpp b/adb/daemon/usb.cpp
+index a66387193..5aeaccedb 100644
+--- a/adb/daemon/usb.cpp
++++ b/adb/daemon/usb.cpp
+@@ -738,6 +738,22 @@ struct UsbFfsConnection : public Connection {
+     static constexpr int kInterruptionSignal = SIGUSR1;
+ };
+ 
++static void usb_dbc_open_thread() {
++    adb_thread_setname("usb dbc open");
++
++    while (true) {
++        unique_fd bulk_out;
++        unique_fd bulk_in;
++
++        if (!open_dbc(&bulk_out, &bulk_in)) {
++            std::this_thread::sleep_for(1s);
++            continue;
++        }
++
++        register_dbc_transport(std::move(bulk_out), std::move(bulk_in), "UsbDbC");
++    }
++}
++
+ static void usb_ffs_open_thread() {
+     adb_thread_setname("usb ffs open");
+ 
+@@ -763,5 +779,8 @@ static void usb_ffs_open_thread() {
+ }
+ 
+ void usb_init() {
+-    std::thread(usb_ffs_open_thread).detach();
++    if (access(USB_DBC_ADB_PATH,F_OK) == 0)
++        std::thread(usb_dbc_open_thread).detach();
++    else
++        std::thread(usb_ffs_open_thread).detach();
+ }
+diff --git a/adb/daemon/usb_ffs.cpp b/adb/daemon/usb_ffs.cpp
+index e538ca885..8cb83c07a 100644
+--- a/adb/daemon/usb_ffs.cpp
++++ b/adb/daemon/usb_ffs.cpp
+@@ -27,6 +27,8 @@
+ #include <android-base/properties.h>
+ #include <android-base/unique_fd.h>
+ 
++#include <termios.h>
++
+ #include "adb.h"
+ 
+ #define MAX_PACKET_SIZE_FS 64
+@@ -249,6 +251,71 @@ static const struct {
+ };
+ // clang-format on
+ 
++bool open_dbc(android::base::unique_fd* out_bulk_out, android::base::unique_fd* out_bulk_in) {
++    unique_fd bulk_out, bulk_in;
++    struct termios SerialPortSettings;
++
++    // BULK OUT
++    if (out_bulk_out->get() < 0) {  // might have already done this before
++        LOG(INFO) << "opening DbC BULK OUT endpoint " << USB_DBC_ADB_PATH;
++        bulk_out.reset(adb_open(USB_DBC_ADB_PATH, O_RDWR));
++        if (bulk_out < 0) {
++            PLOG(ERROR) << "cannot open DbC BULK OUT endpoint " << USB_DBC_ADB_PATH;
++            return false;
++        }
++        tcgetattr(bulk_out.get(), &SerialPortSettings);
++
++        cfsetispeed(&SerialPortSettings,B9600);
++        cfsetospeed(&SerialPortSettings,B9600);
++
++        SerialPortSettings.c_cflag &= ~PARENB;
++        SerialPortSettings.c_cflag &= ~CSTOPB;
++        SerialPortSettings.c_cflag &= ~CSIZE;
++        SerialPortSettings.c_cflag &= CS8;
++        SerialPortSettings.c_cflag &= ~CRTSCTS;
++        SerialPortSettings.c_cflag &= CREAD | CLOCAL;
++        SerialPortSettings.c_lflag &= ~(ICANON | ECHO | IEXTEN | ISIG);
++        SerialPortSettings.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
++        SerialPortSettings.c_oflag &= ~OPOST;
++        SerialPortSettings.c_cc[VMIN] = 10;
++        SerialPortSettings.c_cc[VTIME] = 10;
++
++        tcsetattr(bulk_out.get(), TCSANOW, &SerialPortSettings);
++    }
++
++    // Bulk IN
++    if (out_bulk_in->get() < 0) {  // might have already done this before
++        LOG(INFO) << "opening DbC BULK IN endpoint " << USB_DBC_ADB_PATH;
++        bulk_in.reset(adb_open(USB_DBC_ADB_PATH, O_RDWR));
++        if (bulk_in < 0) {
++            PLOG(ERROR) << "cannot open DbC BULK IN endpoint " << USB_DBC_ADB_PATH;
++            return false;
++        }
++        tcgetattr(bulk_in.get(), &SerialPortSettings);
++
++        cfsetispeed(&SerialPortSettings,B9600);
++        cfsetospeed(&SerialPortSettings,B9600);
++
++        SerialPortSettings.c_cflag &= ~PARENB;
++        SerialPortSettings.c_cflag &= ~CSTOPB;
++        SerialPortSettings.c_cflag &= ~CSIZE;
++        SerialPortSettings.c_cflag &= CS8;
++        SerialPortSettings.c_cflag &= ~CRTSCTS;
++        SerialPortSettings.c_cflag &= CREAD | CLOCAL;
++        SerialPortSettings.c_lflag &= ~(ICANON | ECHO | IEXTEN | ISIG);
++        SerialPortSettings.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
++        SerialPortSettings.c_oflag &= ~OPOST;
++        SerialPortSettings.c_cc[VMIN] = 10;
++        SerialPortSettings.c_cc[VTIME] = 10;
++
++        tcsetattr(bulk_in.get(), TCSANOW, &SerialPortSettings);
++    }
++
++    *out_bulk_out = std::move(bulk_out);
++    *out_bulk_in = std::move(bulk_in);
++    return true;
++}
++
+ bool open_functionfs(android::base::unique_fd* out_control, android::base::unique_fd* out_bulk_out,
+                      android::base::unique_fd* out_bulk_in) {
+     unique_fd control, bulk_out, bulk_in;
+diff --git a/adb/daemon/usb_ffs.h b/adb/daemon/usb_ffs.h
+index a19d7ccce..485798a8f 100644
+--- a/adb/daemon/usb_ffs.h
++++ b/adb/daemon/usb_ffs.h
+@@ -18,5 +18,6 @@
+ 
+ #include <android-base/unique_fd.h>
+ 
++bool open_dbc(android::base::unique_fd* bulk_out, android::base::unique_fd* bulk_in);
+ bool open_functionfs(android::base::unique_fd* control, android::base::unique_fd* bulk_out,
+                      android::base::unique_fd* bulk_in);
+diff --git a/adb/transport.cpp b/adb/transport.cpp
+index fe286dee4..3fd6ed48d 100644
+--- a/adb/transport.cpp
++++ b/adb/transport.cpp
+@@ -1361,6 +1361,117 @@ void close_usb_devices(bool reset) {
+ }
+ #endif  // ADB_HOST
+ 
++DbcConnection::DbcConnection(unique_fd bulk_out, unique_fd bulk_in,
++                                std::promise<void> destruction_notifier) :
++                                bulk_out_(std::move(bulk_out)), bulk_in_(std::move(bulk_in)),
++                                destruction_notifier_(std::move(destruction_notifier)) {
++    LOG(INFO) << "DbcConnection being constructed";
++}
++
++DbcConnection::~DbcConnection() {
++    LOG(INFO) << "DbcConnection being destroyed";
++    destruction_notifier_.set_value();
++}
++
++bool DbcConnection::DispatchRead(void* buf, size_t len) {
++    return ReadFdExactly(bulk_out_.get(), buf, len);
++}
++
++bool DbcConnection::DispatchWrite(void* buf, size_t len) {
++    return WriteFdExactly(bulk_in_.get(), buf, len);
++}
++
++bool DbcConnection::Read(apacket* packet) {
++    if (!DispatchRead(&packet->msg, sizeof(amessage))) {
++        D("remote local: read terminated (message)");
++        return false;
++    }
++
++    if (packet->msg.data_length > MAX_PAYLOAD) {
++        D("remote local: read overflow (data length = %" PRIu32 ")", packet->msg.data_length);
++        return false;
++    }
++
++    packet->payload.resize(packet->msg.data_length);
++
++    if (!DispatchRead(&packet->payload[0], packet->payload.size())) {
++        D("remote local: terminated (data)");
++        return false;
++    }
++
++    return true;
++}
++
++bool DbcConnection::Write(apacket* packet) {
++    if (!DispatchWrite(&packet->msg, sizeof(packet->msg))) {
++        D("remote local: write terminated");
++        return false;
++    }
++
++    if (packet->msg.data_length) {
++        if (!DispatchWrite(&packet->payload[0], packet->msg.data_length)) {
++            D("remote local: write terminated");
++            return false;
++        }
++    }
++
++    return true;
++}
++
++bool DbcConnection::DoTlsHandshake(RSA* key, std::string* auth_key) {
++    return true;
++}
++
++void DbcConnection::Close() {
++    adb_shutdown(bulk_out_.get());
++    adb_shutdown(bulk_in_.get());
++    bulk_out_.reset();
++    bulk_in_.reset();
++}
++
++bool register_dbc_transport(unique_fd bulk_out, unique_fd bulk_in, std::string serial) {
++    atransport* t = new atransport();
++    t->serial = std::move(serial);
++
++    std::promise<void> destruction_notifier;
++    std::future<void> future = destruction_notifier.get_future();
++
++    t->type = kTransportUsb;
++
++    auto dbc_connection = std::make_unique<DbcConnection>(std::move(bulk_out), std::move(bulk_in),
++                                                                std::move(destruction_notifier));
++    t->SetConnection(std::make_unique<BlockingConnectionAdapter>(std::move(dbc_connection)));
++
++    std::unique_lock<std::recursive_mutex> lock(transport_lock);
++    for (const auto& transport : pending_list) {
++        if (t->serial == transport->serial) {
++            VLOG(TRANSPORT) << "DbC transport " << transport->serial
++                            << " is already in pending_list and fails to register";
++            delete t;
++            return false;
++        }
++    }
++
++    for (const auto& transport : transport_list) {
++        if (serial == transport->serial) {
++            VLOG(TRANSPORT) << "DbC transport " << transport->serial
++                            << " is already in transport_list and fails to register";
++            delete t;
++            return false;
++        }
++    }
++
++    pending_list.push_front(t);
++
++    lock.unlock();
++
++    register_transport(t);
++
++    future.wait();
++
++    return true;
++}
++
+ bool register_socket_transport(unique_fd s, std::string serial, int port, int local,
+                                atransport::ReconnectCallback reconnect, bool use_tls, int* error) {
+     atransport* t = new atransport(std::move(reconnect), kCsOffline);
+diff --git a/adb/transport.h b/adb/transport.h
+index 26d804b3f..7c1e0139d 100644
+--- a/adb/transport.h
++++ b/adb/transport.h
+@@ -26,6 +26,7 @@
+ #include <functional>
+ #include <list>
+ #include <memory>
++#include <future>
+ #include <mutex>
+ #include <optional>
+ #include <string>
+@@ -183,6 +184,28 @@ struct BlockingConnectionAdapter : public Connection {
+     std::once_flag error_flag_;
+ };
+ 
++struct DbcConnection : public BlockingConnection {
++    explicit DbcConnection(unique_fd bulk_out, unique_fd bulk_in, std::promise<void> destruction_notifier);
++    ~DbcConnection();
++
++    bool Read(apacket* packet) override final;
++    bool Write(apacket* packet) override final;
++    bool DoTlsHandshake(RSA* key, std::string* auth_key) override final;
++
++    void Close() override;
++    virtual void Reset() override final { Close(); }
++
++  private:
++    bool DispatchRead(void* buf, size_t len);
++    bool DispatchWrite(void* buf, size_t len);
++
++    unique_fd bulk_out_;
++    unique_fd bulk_in_;
++    std::unique_ptr<adb::tls::TlsConnection> tls_;
++
++    std::promise<void> destruction_notifier_;
++};
++
+ struct FdConnection : public BlockingConnection {
+     explicit FdConnection(unique_fd fd);
+     ~FdConnection();
+@@ -453,6 +476,8 @@ bool register_socket_transport(unique_fd s, std::string serial, int port, int lo
+                                atransport::ReconnectCallback reconnect, bool use_tls,
+                                int* error = nullptr);
+ 
++bool register_dbc_transport(unique_fd bulk_out, unique_fd bulk_in, std::string serial);
++
+ bool check_header(apacket* p, atransport* t);
+ 
+ void close_usb_devices(bool reset = false);
+-- 
+2.28.0
+


### PR DESCRIPTION
Added adb over dbc tty support in adb framework.
This implementation is based on Blocking I/O calls.
Set "setprop persist.vendor.sys.usb.adbover" android
property to "dbc" to use adb over dbc tty otherwise
set this property to "dwc" (which is the default value
of this property) to use adb over normal USB (which need
USB Device Mode IP to be enabled).

Tracked-On: OAM-94662
Signed-off-by: Prabhat Chand Pandey <prabhat.chand.pandey@intel.com>