### PR TITLE
x86/e820: fix the function type for e820__mapped_all

### DIFF
--- a/bsp_diff/common/kernel/lts2019-chromium/27_0027-x86-e820-fix-the-function-type-for-e820__mapped_all.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/27_0027-x86-e820-fix-the-function-type-for-e820__mapped_all.patch
@@ -1,0 +1,51 @@
+From fdb5096dc0623942d01bcf30fb328902f81cff87 Mon Sep 17 00:00:00 2001
+From: Sami Tolvanen <samitolvanen@google.com>
+Date: Mon, 24 Aug 2020 09:30:22 -0700
+Subject: [PATCH] x86/e820: fix the function type for e820__mapped_all
+
+e820__mapped_all is passed as a callback to is_mmconf_reserved, which
+expects a function of type:
+
+  typedef bool (*check_reserved_t)(u64 start, u64 end, unsigned type);
+
+This trips indirect call checking with Clang's Control-Flow Integrity
+(CFI). Change the last argument from enum e820_type to unsigned to fix
+the type mismatch.
+
+Tracked-On: OAM-94510
+Reported-by: Sedat Dilek <sedat.dilek@gmail.com>
+Signed-off-by: Sami Tolvanen <samitolvanen@google.com>
+---
+ arch/x86/include/asm/e820/api.h | 2 +-
+ arch/x86/kernel/e820.c          | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/x86/include/asm/e820/api.h b/arch/x86/include/asm/e820/api.h
+index e8f58ddd06d9..e872a796619d 100644
+--- a/arch/x86/include/asm/e820/api.h
++++ b/arch/x86/include/asm/e820/api.h
+@@ -12,7 +12,7 @@ extern unsigned long pci_mem_start;
+ 
+ extern bool e820__mapped_raw_any(u64 start, u64 end, enum e820_type type);
+ extern bool e820__mapped_any(u64 start, u64 end, enum e820_type type);
+-extern bool e820__mapped_all(u64 start, u64 end, enum e820_type type);
++extern bool e820__mapped_all(u64 start, u64 end, unsigned type);
+ 
+ extern void e820__range_add   (u64 start, u64 size, enum e820_type type);
+ extern u64  e820__range_update(u64 start, u64 size, enum e820_type old_type, enum e820_type new_type);
+diff --git a/arch/x86/kernel/e820.c b/arch/x86/kernel/e820.c
+index 7da2bcd2b8eb..b18904910f4d 100644
+--- a/arch/x86/kernel/e820.c
++++ b/arch/x86/kernel/e820.c
+@@ -145,7 +145,7 @@ static struct e820_entry *__e820__mapped_all(u64 start, u64 end,
+ /*
+  * This function checks if the entire range <start,end> is mapped with type.
+  */
+-bool __init e820__mapped_all(u64 start, u64 end, enum e820_type type)
++bool __init e820__mapped_all(u64 start, u64 end, unsigned type)
+ {
+ 	return __e820__mapped_all(start, end, type);
+ }
+-- 
+2.17.1
+


### PR DESCRIPTION
e820__mapped_all is passed as a callback to is_mmconf_reserved, which
expects a function of type:

  typedef bool (*check_reserved_t)(u64 start, u64 end, unsigned type);

This trips indirect call checking with Clang's Control-Flow Integrity
(CFI). Change the last argument from enum e820_type to unsigned to fix
the type mismatch.

Tracked-On: OAM-94510
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>