### PR TITLE
[REVERT ME] Revert LLD, LTO & CFI patches

### DIFF
--- a/aosp_diff/preliminary/system/libvintf/0001-REVERT-ME-Disable-kernel-compatibility-check.patch
+++ b/aosp_diff/preliminary/system/libvintf/0001-REVERT-ME-Disable-kernel-compatibility-check.patch
@@ -1,0 +1,40 @@
+From 7af7c3ef6305fddd508acf8be6bff5e6926d6b60 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Thu, 17 Dec 2020 17:26:01 +0530
+Subject: [PATCH] [REVERT ME] Disable kernel compatibility check
+
+As lld, lto and cfi is disabled due to suspend/resume issue,
+kernel compatibility check shows error manufaturer dialog.
+
+Disable kernel compatibility check until suspend/resume fix
+is addressed and lld, lto, cfi are enabled.
+
+Tracked-On: OAM-95489
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ RuntimeInfo.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/RuntimeInfo.cpp b/RuntimeInfo.cpp
+index df09958..680c631 100644
+--- a/RuntimeInfo.cpp
++++ b/RuntimeInfo.cpp
+@@ -89,13 +89,14 @@ bool RuntimeInfo::checkCompatibility(const CompatibilityMatrix& mat, std::string
+ 
+     // mat.mSepolicy.sepolicyVersion() is checked against static
+     // HalManifest.device.mSepolicyVersion in HalManifest::checkCompatibility.
+-
++#if 0
+     if (flags.isKernelEnabled()) {
+         if (mKernel.getMatchedKernelRequirements(mat.framework.mKernels, kernelLevel(), error)
+                 .empty()) {
+             return false;
+         }
+     }
++#endif
+ 
+     if (flags.isAvbEnabled()) {
+         const Version& matAvb = mat.framework.mAvbMetaVersion;
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/29_0029-Revert-ANDROID-kallsyms-increase-KSYM_NAME_LEN.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/29_0029-Revert-ANDROID-kallsyms-increase-KSYM_NAME_LEN.patch
@@ -1,0 +1,83 @@
+From 579dd80c2d728536c424f405a359e8c5531096d9 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:39:33 +0530
+Subject: [PATCH 04/40] Revert "ANDROID: kallsyms: increase KSYM_NAME_LEN"
+
+This reverts commit bc56965330129f00203f1438b5c3ff6c32ab85af.
+---
+ arch/x86/kernel/livepatch.c | 4 ++--
+ include/linux/kallsyms.h    | 2 +-
+ kernel/livepatch/core.c     | 4 ++--
+ scripts/kallsyms.c          | 2 +-
+ 4 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/arch/x86/kernel/livepatch.c b/arch/x86/kernel/livepatch.c
+index 35fa60d949f9..6a68e41206e7 100644
+--- a/arch/x86/kernel/livepatch.c
++++ b/arch/x86/kernel/livepatch.c
+@@ -24,12 +24,12 @@ void arch_klp_init_object_loaded(struct klp_patch *patch,
+ 	objname = obj->name ? obj->name : "vmlinux";
+ 
+ 	/* See livepatch core code for BUILD_BUG_ON() explanation */
+-	BUILD_BUG_ON(MODULE_NAME_LEN < 56 || KSYM_NAME_LEN != 192);
++	BUILD_BUG_ON(MODULE_NAME_LEN < 56 || KSYM_NAME_LEN != 128);
+ 
+ 	for (s = info->sechdrs; s < info->sechdrs + info->hdr.e_shnum; s++) {
+ 		/* Apply per-object .klp.arch sections */
+ 		cnt = sscanf(info->secstrings + s->sh_name,
+-			     ".klp.arch.%55[^.].%191s",
++			     ".klp.arch.%55[^.].%127s",
+ 			     sec_objname, secname);
+ 		if (cnt != 2)
+ 			continue;
+diff --git a/include/linux/kallsyms.h b/include/linux/kallsyms.h
+index a45f5c0bc585..1f96ce2b47df 100644
+--- a/include/linux/kallsyms.h
++++ b/include/linux/kallsyms.h
+@@ -14,7 +14,7 @@
+ 
+ #include <asm/sections.h>
+ 
+-#define KSYM_NAME_LEN 192
++#define KSYM_NAME_LEN 128
+ #define KSYM_SYMBOL_LEN (sizeof("%s+%#lx/%#lx [%s]") + (KSYM_NAME_LEN - 1) + \
+ 			 2*(BITS_PER_LONG*3/10) + (MODULE_NAME_LEN - 1) + 1)
+ 
+diff --git a/kernel/livepatch/core.c b/kernel/livepatch/core.c
+index 1a9827a11bd4..ab4a4606d19b 100644
+--- a/kernel/livepatch/core.c
++++ b/kernel/livepatch/core.c
+@@ -210,7 +210,7 @@ static int klp_resolve_symbols(Elf_Shdr *relasec, struct module *pmod)
+ 	 * we use the smallest/strictest upper bound possible (56, based on
+ 	 * the current definition of MODULE_NAME_LEN) to prevent overflows.
+ 	 */
+-	BUILD_BUG_ON(MODULE_NAME_LEN < 56 || KSYM_NAME_LEN != 192);
++	BUILD_BUG_ON(MODULE_NAME_LEN < 56 || KSYM_NAME_LEN != 128);
+ 
+ 	relas = (Elf_Rela *) relasec->sh_addr;
+ 	/* For each rela in this klp relocation section */
+@@ -224,7 +224,7 @@ static int klp_resolve_symbols(Elf_Shdr *relasec, struct module *pmod)
+ 
+ 		/* Format: .klp.sym.objname.symname,sympos */
+ 		cnt = sscanf(strtab + sym->st_name,
+-			     ".klp.sym.%55[^.].%191[^,],%lu",
++			     ".klp.sym.%55[^.].%127[^,],%lu",
+ 			     objname, symname, &sympos);
+ 		if (cnt != 3) {
+ 			pr_err("symbol %s has an incorrectly formatted name\n",
+diff --git a/scripts/kallsyms.c b/scripts/kallsyms.c
+index 4a4a05a744ef..fb15f09e0e38 100644
+--- a/scripts/kallsyms.c
++++ b/scripts/kallsyms.c
+@@ -28,7 +28,7 @@
+ #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
+ #endif
+ 
+-#define KSYM_NAME_LEN		192
++#define KSYM_NAME_LEN		128
+ 
+ struct sym_entry {
+ 	unsigned long long addr;
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/30_0030-Revert-ANDROID-kbuild-don-t-merge-.-.compoundliteral.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/30_0030-Revert-ANDROID-kbuild-don-t-merge-.-.compoundliteral.patch
@@ -1,0 +1,39 @@
+From 8bb15dd46e28a4cc603215c09344cb5a936dbe6f Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:39:46 +0530
+Subject: [PATCH 05/40] Revert "ANDROID: kbuild: don't merge
+ .*..compoundliteral in modules"
+
+This reverts commit b2e761c8d9dee0cfdd14a72ce797917198dfda97.
+---
+ scripts/module-lto.lds | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/scripts/module-lto.lds b/scripts/module-lto.lds
+index 38cd6cf87ef1..060e067e3ce0 100644
+--- a/scripts/module-lto.lds
++++ b/scripts/module-lto.lds
+@@ -15,17 +15,17 @@ SECTIONS {
+ 
+ 	.bss : {
+ 		*(.bss .bss.[0-9a-zA-Z_]*)
+-		*(.bss..L*)
++		*(.bss..L* .bss..compoundliteral*)
+ 	}
+ 
+ 	.data : {
+ 		*(.data .data.[0-9a-zA-Z_]*)
+-		*(.data..L*)
++		*(.data..L* .data..compoundliteral*)
+ 	}
+ 
+ 	.rodata : {
+ 		*(.rodata .rodata.[0-9a-zA-Z_]*)
+-		*(.rodata..L*)
++		*(.rodata..L* .rodata..compoundliteral*)
+ 	}
+ 
+ 	/*
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/31_0031-Revert-ANDROID-kbuild-merge-more-sections-with-LTO.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/31_0031-Revert-ANDROID-kbuild-merge-more-sections-with-LTO.patch
@@ -1,0 +1,50 @@
+From 5322bad18710e816e45bdd79a3c46fa9bbed3152 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:39:57 +0530
+Subject: [PATCH 06/40] Revert "ANDROID: kbuild: merge more sections with LTO"
+
+This reverts commit 70653a4bf291cc75c6bf36223f1bc3760492881a.
+---
+ scripts/module-lto.lds | 21 +++++++--------------
+ 1 file changed, 7 insertions(+), 14 deletions(-)
+
+diff --git a/scripts/module-lto.lds b/scripts/module-lto.lds
+index 060e067e3ce0..89d3b1636feb 100644
+--- a/scripts/module-lto.lds
++++ b/scripts/module-lto.lds
+@@ -13,20 +13,12 @@ SECTIONS {
+ 		*(.eh_frame)
+ 	}
+ 
+-	.bss : {
+-		*(.bss .bss.[0-9a-zA-Z_]*)
+-		*(.bss..L* .bss..compoundliteral*)
+-	}
+-
+-	.data : {
+-		*(.data .data.[0-9a-zA-Z_]*)
+-		*(.data..L* .data..compoundliteral*)
+-	}
+-
+-	.rodata : {
+-		*(.rodata .rodata.[0-9a-zA-Z_]*)
+-		*(.rodata..L* .rodata..compoundliteral*)
+-	}
++	.bss : { *(.bss .bss.[0-9a-zA-Z_]*) }
++	.data : { *(.data .data.[0-9a-zA-Z_]*) }
++	.rela.data : { *(.rela.data .rela.data.[0-9a-zA-Z_]*) }
++	.rela.rodata : { *(.rela.rodata .rela.rodata.[0-9a-zA-Z_]*) }
++	.rela.text : { *(.rela.text .rela.text.[0-9a-zA-Z_]*) }
++	.rodata : { *(.rodata .rodata.[0-9a-zA-Z_]*) }
+ 
+ 	/*
+ 	 * With CFI_CLANG, ensure __cfi_check is at the beginning of the
+@@ -36,4 +28,5 @@ SECTIONS {
+ 		*(.text.__cfi_check)
+ 		*(.text .text.[0-9a-zA-Z_]* .text..L.cfi*)
+ 	}
++
+ }
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/32_0032-Revert-ANDROID-kbuild-avoid-excessively-long-argumen.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/32_0032-Revert-ANDROID-kbuild-avoid-excessively-long-argumen.patch
@@ -1,0 +1,38 @@
+From 4321bdc30d9cded047ad3424094d8190994e7be9 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:40:07 +0530
+Subject: [PATCH 07/40] Revert "ANDROID: kbuild: avoid excessively long
+ argument lists"
+
+This reverts commit 831401602b299e126992ea4d1d081375d082681b.
+---
+ scripts/Makefile.build | 13 +++++++------
+ 1 file changed, 7 insertions(+), 6 deletions(-)
+
+diff --git a/scripts/Makefile.build b/scripts/Makefile.build
+index f63b5baccd81..e1ca92679728 100644
+--- a/scripts/Makefile.build
++++ b/scripts/Makefile.build
+@@ -397,12 +397,13 @@ $(sort $(subdir-obj-y)): $(subdir-ym) ;
+ # combine symversions for later processing
+ quiet_cmd_update_lto_symversions = SYMVER  $@
+ ifeq ($(CONFIG_LTO_CLANG) $(CONFIG_MODVERSIONS),y y)
+-      cmd_update_lto_symversions =					\
+-	rm -f $@.symversions;						\
+-	for i in $(foreach n,						\
+-			$(filter-out FORCE,$^),				\
+-			$(if $(wildcard $(n).symversions),$(n))); do	\
+-		cat $$i.symversions >> $@.symversions;			\
++      cmd_update_lto_symversions =			\
++	rm -f $@.symversions;				\
++	for i in $(filter-out FORCE,$^); do		\
++		if [ -f $$i.symversions ]; then		\
++			cat $$i.symversions 		\
++				>> $@.symversions;	\
++		fi;					\
+ 	done
+ else
+       cmd_update_lto_symversions = echo >/dev/null
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/33_0033-Revert-ANDROID-kallsyms-strip-hashes-from-static-fun.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/33_0033-Revert-ANDROID-kallsyms-strip-hashes-from-static-fun.patch
@@ -1,0 +1,116 @@
+From c75ad6e24e0cc79162262ffd157783e1fac146a8 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:40:17 +0530
+Subject: [PATCH 08/40] Revert "ANDROID: kallsyms: strip hashes from static
+ functions with ThinLTO and CFI"
+
+This reverts commit 2fd486d8f5cc893518cd5171ddd77431f4cb7b86.
+---
+ kernel/kallsyms.c | 49 +++++------------------------------------------
+ 1 file changed, 5 insertions(+), 44 deletions(-)
+
+diff --git a/kernel/kallsyms.c b/kernel/kallsyms.c
+index a005bc291ebb..61f9d781f70a 100644
+--- a/kernel/kallsyms.c
++++ b/kernel/kallsyms.c
+@@ -271,24 +271,6 @@ int kallsyms_lookup_size_offset(unsigned long addr, unsigned long *symbolsize,
+ 	       !!__bpf_address_lookup(addr, symbolsize, offset, namebuf);
+ }
+ 
+-#if defined(CONFIG_CFI_CLANG) && defined(CONFIG_THINLTO)
+-/*
+- * LLVM appends a hash to static function names when ThinLTO and CFI are
+- * both enabled, which causes confusion and potentially breaks user space
+- * tools, so we will strip the postfix from expanded symbol names.
+- */
+-static inline void cleanup_symbol_name(char *s)
+-{
+-	char *res;
+-
+-	res = strrchr(s, '$');
+-	if (res)
+-		*res = '\0';
+-}
+-#else
+-static inline void cleanup_symbol_name(char *s) {}
+-#endif
+-
+ /*
+  * Lookup an address
+  * - modname is set to NULL if it's in the kernel.
+@@ -315,9 +297,7 @@ const char *kallsyms_lookup(unsigned long addr,
+ 				       namebuf, KSYM_NAME_LEN);
+ 		if (modname)
+ 			*modname = NULL;
+-
+-		ret = namebuf;
+-		goto found;
++		return namebuf;
+ 	}
+ 
+ 	/* See if it's in a module or a BPF JITed image. */
+@@ -330,16 +310,11 @@ const char *kallsyms_lookup(unsigned long addr,
+ 	if (!ret)
+ 		ret = ftrace_mod_address_lookup(addr, symbolsize,
+ 						offset, modname, namebuf);
+-
+-found:
+-	cleanup_symbol_name(namebuf);
+ 	return ret;
+ }
+ 
+ int lookup_symbol_name(unsigned long addr, char *symname)
+ {
+-	int res;
+-
+ 	symname[0] = '\0';
+ 	symname[KSYM_NAME_LEN - 1] = '\0';
+ 
+@@ -350,23 +325,15 @@ int lookup_symbol_name(unsigned long addr, char *symname)
+ 		/* Grab name */
+ 		kallsyms_expand_symbol(get_symbol_offset(pos),
+ 				       symname, KSYM_NAME_LEN);
+-		goto found;
++		return 0;
+ 	}
+ 	/* See if it's in a module. */
+-	res = lookup_module_symbol_name(addr, symname);
+-	if (res)
+-		return res;
+-
+-found:
+-	cleanup_symbol_name(symname);
+-	return 0;
++	return lookup_module_symbol_name(addr, symname);
+ }
+ 
+ int lookup_symbol_attrs(unsigned long addr, unsigned long *size,
+ 			unsigned long *offset, char *modname, char *name)
+ {
+-	int res;
+-
+ 	name[0] = '\0';
+ 	name[KSYM_NAME_LEN - 1] = '\0';
+ 
+@@ -378,16 +345,10 @@ int lookup_symbol_attrs(unsigned long addr, unsigned long *size,
+ 		kallsyms_expand_symbol(get_symbol_offset(pos),
+ 				       name, KSYM_NAME_LEN);
+ 		modname[0] = '\0';
+-		goto found;
++		return 0;
+ 	}
+ 	/* See if it's in a module. */
+-	res = lookup_module_symbol_attrs(addr, size, offset, modname, name);
+-	if (res)
+-		return res;
+-
+-found:
+-	cleanup_symbol_name(name);
+-	return 0;
++	return lookup_module_symbol_attrs(addr, size, offset, modname, name);
+ }
+ 
+ /* Look up a kernel symbol and return it in a text buffer. */
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/34_0034-Revert-ANDROID-kbuild-don-t-preprocess-module-lto.ld.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/34_0034-Revert-ANDROID-kbuild-don-t-preprocess-module-lto.ld.patch
@@ -1,0 +1,69 @@
+From f2126d551bdbfc0913ad681ef9a6143e2194a899 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:40:26 +0530
+Subject: [PATCH 09/40] Revert "ANDROID: kbuild: don't preprocess
+ module-lto.lds"
+
+This reverts commit ef3feb510a466e2dc3f60a33a4b6ebc11bc4b670.
+---
+ Makefile                                     | 2 +-
+ scripts/Makefile                             | 2 ++
+ scripts/{module-lto.lds => module-lto.lds.S} | 6 ++++--
+ 3 files changed, 7 insertions(+), 3 deletions(-)
+ rename scripts/{module-lto.lds => module-lto.lds.S} (88%)
+
+diff --git a/Makefile b/Makefile
+index 128d3bbd6789..c748d8027ed7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -896,7 +896,7 @@ LD_FLAGS_LTO_CLANG := -mllvm -import-instr-limit=5
+ KBUILD_LDFLAGS += $(LD_FLAGS_LTO_CLANG)
+ KBUILD_LDFLAGS_MODULE += $(LD_FLAGS_LTO_CLANG)
+ 
+-KBUILD_LDS_MODULE += $(srctree)/scripts/module-lto.lds
++KBUILD_LDS_MODULE += scripts/module-lto.lds
+ endif
+ 
+ ifdef CONFIG_LTO
+diff --git a/scripts/Makefile b/scripts/Makefile
+index 3e86b300f5a1..543603e3a789 100644
+--- a/scripts/Makefile
++++ b/scripts/Makefile
+@@ -31,6 +31,8 @@ always		:= $(hostprogs-y) $(hostprogs-m)
+ # The following hostprogs-y programs are only build on demand
+ hostprogs-y += unifdef
+ 
++extra-$(CONFIG_LTO_CLANG)   += module-lto.lds
++
+ subdir-$(CONFIG_GCC_PLUGINS) += gcc-plugins
+ subdir-$(CONFIG_MODVERSIONS) += genksyms
+ subdir-$(CONFIG_SECURITY_SELINUX) += selinux
+diff --git a/scripts/module-lto.lds b/scripts/module-lto.lds.S
+similarity index 88%
+rename from scripts/module-lto.lds
+rename to scripts/module-lto.lds.S
+index 89d3b1636feb..c0f4fdeb84a0 100644
+--- a/scripts/module-lto.lds
++++ b/scripts/module-lto.lds.S
+@@ -1,4 +1,6 @@
+ /* SPDX-License-Identifier: GPL-2.0 */
++#include <asm/page.h>
++
+ /*
+  * With CONFIG_LTO_CLANG, LLD always enables -fdata-sections and
+  * -ffunction-sections, which increases the size of the final module.
+@@ -22,9 +24,9 @@ SECTIONS {
+ 
+ 	/*
+ 	 * With CFI_CLANG, ensure __cfi_check is at the beginning of the
+-	 * .text section, and that the section is aligned to 4k.
++	 * .text section, and that the section is aligned to page size.
+ 	 */
+-	.text : ALIGN(4096) {
++	.text : ALIGN(PAGE_SIZE) {
+ 		*(.text.__cfi_check)
+ 		*(.text .text.[0-9a-zA-Z_]* .text..L.cfi*)
+ 	}
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/35_0035-Revert-ANDROID-kbuild-ensure-__cfi_check-is-correctl.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/35_0035-Revert-ANDROID-kbuild-ensure-__cfi_check-is-correctl.patch
@@ -1,0 +1,73 @@
+From 3acbb65ac192fe72e178bb2ced3b4ce84a67d205 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:40:36 +0530
+Subject: [PATCH 10/40] Revert "ANDROID: kbuild: ensure __cfi_check is
+ correctly aligned"
+
+This reverts commit 471f37d877a43677aa9b21993928ecb95c9ab009.
+---
+ Makefile                                     |  2 +-
+ scripts/Makefile                             |  2 --
+ scripts/{module-lto.lds.S => module-lto.lds} | 14 +-------------
+ 3 files changed, 2 insertions(+), 16 deletions(-)
+ rename scripts/{module-lto.lds.S => module-lto.lds} (68%)
+
+diff --git a/Makefile b/Makefile
+index c748d8027ed7..128d3bbd6789 100644
+--- a/Makefile
++++ b/Makefile
+@@ -896,7 +896,7 @@ LD_FLAGS_LTO_CLANG := -mllvm -import-instr-limit=5
+ KBUILD_LDFLAGS += $(LD_FLAGS_LTO_CLANG)
+ KBUILD_LDFLAGS_MODULE += $(LD_FLAGS_LTO_CLANG)
+ 
+-KBUILD_LDS_MODULE += scripts/module-lto.lds
++KBUILD_LDS_MODULE += $(srctree)/scripts/module-lto.lds
+ endif
+ 
+ ifdef CONFIG_LTO
+diff --git a/scripts/Makefile b/scripts/Makefile
+index 543603e3a789..3e86b300f5a1 100644
+--- a/scripts/Makefile
++++ b/scripts/Makefile
+@@ -31,8 +31,6 @@ always		:= $(hostprogs-y) $(hostprogs-m)
+ # The following hostprogs-y programs are only build on demand
+ hostprogs-y += unifdef
+ 
+-extra-$(CONFIG_LTO_CLANG)   += module-lto.lds
+-
+ subdir-$(CONFIG_GCC_PLUGINS) += gcc-plugins
+ subdir-$(CONFIG_MODVERSIONS) += genksyms
+ subdir-$(CONFIG_SECURITY_SELINUX) += selinux
+diff --git a/scripts/module-lto.lds.S b/scripts/module-lto.lds
+similarity index 68%
+rename from scripts/module-lto.lds.S
+rename to scripts/module-lto.lds
+index c0f4fdeb84a0..5ba0e9461e13 100644
+--- a/scripts/module-lto.lds.S
++++ b/scripts/module-lto.lds
+@@ -1,6 +1,3 @@
+-/* SPDX-License-Identifier: GPL-2.0 */
+-#include <asm/page.h>
+-
+ /*
+  * With CONFIG_LTO_CLANG, LLD always enables -fdata-sections and
+  * -ffunction-sections, which increases the size of the final module.
+@@ -21,14 +18,5 @@ SECTIONS {
+ 	.rela.rodata : { *(.rela.rodata .rela.rodata.[0-9a-zA-Z_]*) }
+ 	.rela.text : { *(.rela.text .rela.text.[0-9a-zA-Z_]*) }
+ 	.rodata : { *(.rodata .rodata.[0-9a-zA-Z_]*) }
+-
+-	/*
+-	 * With CFI_CLANG, ensure __cfi_check is at the beginning of the
+-	 * .text section, and that the section is aligned to page size.
+-	 */
+-	.text : ALIGN(PAGE_SIZE) {
+-		*(.text.__cfi_check)
+-		*(.text .text.[0-9a-zA-Z_]* .text..L.cfi*)
+-	}
+-
++	.text : { *(.text .text.[0-9a-zA-Z_]*) }
+ }
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/36_0036-Revert-ANDROID-kbuild-do-not-merge-.section.-into-.s.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/36_0036-Revert-ANDROID-kbuild-do-not-merge-.section.-into-.s.patch
@@ -1,0 +1,37 @@
+From 18492536e1b4fc7b53245e5f37dec9420ee17203 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:40:44 +0530
+Subject: [PATCH 11/40] Revert "ANDROID: kbuild: do not merge .section..* into
+ .section in modules"
+
+This reverts commit ed3e9172a9ebad443679e66d364b7cd21b2590da.
+---
+ scripts/module-lto.lds | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/scripts/module-lto.lds b/scripts/module-lto.lds
+index 5ba0e9461e13..f5ee544a877d 100644
+--- a/scripts/module-lto.lds
++++ b/scripts/module-lto.lds
+@@ -12,11 +12,11 @@ SECTIONS {
+ 		*(.eh_frame)
+ 	}
+ 
+-	.bss : { *(.bss .bss.[0-9a-zA-Z_]*) }
+-	.data : { *(.data .data.[0-9a-zA-Z_]*) }
+-	.rela.data : { *(.rela.data .rela.data.[0-9a-zA-Z_]*) }
+-	.rela.rodata : { *(.rela.rodata .rela.rodata.[0-9a-zA-Z_]*) }
+-	.rela.text : { *(.rela.text .rela.text.[0-9a-zA-Z_]*) }
+-	.rodata : { *(.rodata .rodata.[0-9a-zA-Z_]*) }
+-	.text : { *(.text .text.[0-9a-zA-Z_]*) }
++	.bss : { *(.bss .bss[.0-9a-zA-Z_]*) }
++	.data : { *(.data .data[.0-9a-zA-Z_]*) }
++	.rela.data : { *(.rela.data .rela.data[.0-9a-zA-Z_]*) }
++	.rela.rodata : { *(.rela.rodata .rela.rodata[.0-9a-zA-Z_]*) }
++	.rela.text : { *(.rela.text .rela.text[.0-9a-zA-Z_]*) }
++	.rodata : { *(.rodata .rodata[.0-9a-zA-Z_]*) }
++	.text : { *(.text .text[.0-9a-zA-Z_]*) }
+ }
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/37_0037-Revert-ANDROID-CC_FLAGS_CFI-add-fno-sanitize-blackli.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/37_0037-Revert-ANDROID-CC_FLAGS_CFI-add-fno-sanitize-blackli.patch
@@ -1,0 +1,28 @@
+From 1b3d450833e4a9ff62c50582782c3a2fe7553cfa Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:41:40 +0530
+Subject: [PATCH 12/40] Revert "ANDROID: CC_FLAGS_CFI add
+ -fno-sanitize-blacklist"
+
+This reverts commit e221e894adeb6227a7e6eb0974c44cc2c68c4ab8.
+---
+ Makefile | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 128d3bbd6789..1aff2d4b7ff9 100644
+--- a/Makefile
++++ b/Makefile
+@@ -907,8 +907,7 @@ endif
+ 
+ ifdef CONFIG_CFI_CLANG
+ CC_FLAGS_CFI	:= -fsanitize=cfi \
+-		   -fno-sanitize-cfi-canonical-jump-tables \
+-		   -fno-sanitize-blacklist
++		   -fno-sanitize-cfi-canonical-jump-tables
+ 
+ ifdef CONFIG_MODULES
+ CC_FLAGS_CFI	+= -fsanitize-cfi-cross-dso
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/38_0038-Revert-ANDROID-Disable-wq-fp-check-in-CFI-builds.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/38_0038-Revert-ANDROID-Disable-wq-fp-check-in-CFI-builds.patch
@@ -1,0 +1,27 @@
+From 75edca3cd4d345a43eec1d15fdb14b4fd291c920 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:41:48 +0530
+Subject: [PATCH 13/40] Revert "ANDROID: Disable wq fp check in CFI builds"
+
+This reverts commit 85a3dbd2c4bf13b9382ccd5753549e54445a720b.
+---
+ kernel/workqueue.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/kernel/workqueue.c b/kernel/workqueue.c
+index 52c587c941db..4aa268582a22 100644
+--- a/kernel/workqueue.c
++++ b/kernel/workqueue.c
+@@ -1629,9 +1629,7 @@ static void __queue_delayed_work(int cpu, struct workqueue_struct *wq,
+ 	struct work_struct *work = &dwork->work;
+ 
+ 	WARN_ON_ONCE(!wq);
+-#ifndef CONFIG_CFI
+ 	WARN_ON_ONCE(timer->function != delayed_work_timer_fn);
+-#endif
+ 	WARN_ON_ONCE(timer_pending(timer));
+ 	WARN_ON_ONCE(!list_empty(&work->entry));
+ 
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/39_0039-Revert-ANDROID-x86-map-CFI-jump-tables-in-pti_clone_.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/39_0039-Revert-ANDROID-x86-map-CFI-jump-tables-in-pti_clone_.patch
@@ -1,0 +1,74 @@
+From 734e90242769ced7bce2f9fc71cf34a5195ec7bd Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:41:58 +0530
+Subject: [PATCH 14/40] Revert "ANDROID: x86: map CFI jump tables in
+ pti_clone_entry_text"
+
+This reverts commit 47f561973c776f437f3da1d9916257c4914fecde.
+---
+ arch/x86/include/asm/sections.h |  1 -
+ arch/x86/kernel/vmlinux.lds.S   | 11 -----------
+ arch/x86/mm/pti.c               |  9 ---------
+ 3 files changed, 21 deletions(-)
+
+diff --git a/arch/x86/include/asm/sections.h b/arch/x86/include/asm/sections.h
+index e1dce160d702..cdcd9e7442a4 100644
+--- a/arch/x86/include/asm/sections.h
++++ b/arch/x86/include/asm/sections.h
+@@ -6,7 +6,6 @@
+ #include <asm/extable.h>
+ 
+ extern char __brk_base[], __brk_limit[];
+-extern char __cfi_jt_start[], __cfi_jt_end[];
+ extern char __end_rodata_aligned[];
+ 
+ #if defined(CONFIG_X86_64)
+diff --git a/arch/x86/kernel/vmlinux.lds.S b/arch/x86/kernel/vmlinux.lds.S
+index 68ee5dd46493..4054e7fae3c5 100644
+--- a/arch/x86/kernel/vmlinux.lds.S
++++ b/arch/x86/kernel/vmlinux.lds.S
+@@ -141,13 +141,6 @@ SECTIONS
+ 		*(.text.__x86.indirect_thunk)
+ 		__indirect_thunk_end = .;
+ #endif
+-
+-#ifdef CONFIG_CFI_CLANG
+-		. = ALIGN(PAGE_SIZE);
+-		__cfi_jt_start = .;
+-		*(.text..L.cfi.jumptable .text..L.cfi.jumptable.*)
+-		__cfi_jt_end = .;
+-#endif
+ 	} :text = 0x9090
+ 
+ 	NOTES :text :note
+@@ -458,7 +451,3 @@ INIT_PER_CPU(irq_stack_backing_store);
+            "kexec control code size is too big");
+ #endif
+ 
+-#ifdef CONFIG_CFI_CLANG
+-. = ASSERT((__cfi_jt_end - __cfi_jt_start > 0),
+-	   "CFI jump table is empty");
+-#endif
+diff --git a/arch/x86/mm/pti.c b/arch/x86/mm/pti.c
+index 6b68c19208c9..44a9f068eee0 100644
+--- a/arch/x86/mm/pti.c
++++ b/arch/x86/mm/pti.c
+@@ -505,15 +505,6 @@ static void pti_clone_entry_text(void)
+ 	pti_clone_pgtable((unsigned long) __entry_text_start,
+ 			  (unsigned long) __irqentry_text_end,
+ 			  PTI_CLONE_PMD);
+-
+-	/*
+-	 * If CFI is enabled, also map jump tables, so the entry code can
+-	 * make indirect calls.
+-	 */
+-	if (IS_ENABLED(CONFIG_CFI_CLANG))
+-		pti_clone_pgtable((unsigned long) __cfi_jt_start,
+-				  (unsigned long) __cfi_jt_end,
+-				  PTI_CLONE_PMD);
+ }
+ 
+ /*
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/40_0040-Revert-ANDROID-x86-module-Ignore-__typeid__-relocati.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/40_0040-Revert-ANDROID-x86-module-Ignore-__typeid__-relocati.patch
@@ -1,0 +1,29 @@
+From 602cc59a1d2cf82ec919e5a52970585924f00859 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:42:07 +0530
+Subject: [PATCH 15/40] Revert "ANDROID: x86, module: Ignore __typeid__
+ relocations"
+
+This reverts commit 3dd3c10aa5cbf11cd1cad4fb499c68ca03b044ae.
+---
+ arch/x86/kernel/module.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/arch/x86/kernel/module.c b/arch/x86/kernel/module.c
+index e1399823e059..d5c72cb877b3 100644
+--- a/arch/x86/kernel/module.c
++++ b/arch/x86/kernel/module.c
+@@ -195,10 +195,6 @@ int apply_relocate_add(Elf64_Shdr *sechdrs,
+ 			val -= (u64)loc;
+ 			*(u64 *)loc = val;
+ 			break;
+-		case R_X86_64_8:
+-			if (!strncmp(strtab + sym->st_name, "__typeid__", 10))
+-				break;
+-			/* fallthrough */
+ 		default:
+ 			pr_err("%s: Unknown rela relocation: %llu\n",
+ 			       me->name, ELF64_R_TYPE(rel[i].r_info));
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/41_0041-Revert-ANDROID-x86-relocs-Ignore-__typeid__-relocati.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/41_0041-Revert-ANDROID-x86-relocs-Ignore-__typeid__-relocati.patch
@@ -1,0 +1,39 @@
+From e0d99c250f1ae45eab8aaea71b6c0bff8ed324a1 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:42:16 +0530
+Subject: [PATCH 16/40] Revert "ANDROID: x86, relocs: Ignore __typeid__
+ relocations"
+
+This reverts commit 089912e77b9da3ef971a030ade494368c0448837.
+---
+ arch/x86/tools/relocs.c | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/arch/x86/tools/relocs.c b/arch/x86/tools/relocs.c
+index fe89ab4aca44..ce7188cbdae5 100644
+--- a/arch/x86/tools/relocs.c
++++ b/arch/x86/tools/relocs.c
+@@ -48,7 +48,6 @@ static const char * const sym_regex_kernel[S_NSYMTYPES] = {
+ 	"^(xen_irq_disable_direct_reloc$|"
+ 	"xen_save_fl_direct_reloc$|"
+ 	"VDSO|"
+-	"__typeid__|"
+ 	"__crc_)",
+ 
+ /*
+@@ -809,12 +808,6 @@ static int do_reloc64(struct section *sec, Elf_Rel *rel, ElfW(Sym) *sym,
+ 			    symname);
+ 		break;
+ 
+-	case R_X86_64_8:
+-		if (!shn_abs || !is_reloc(S_ABS, symname))
+-			die("Non-whitelisted %s relocation: %s\n",
+-				rel_type(r_type), symname);
+-		break;
+-
+ 	case R_X86_64_32:
+ 	case R_X86_64_32S:
+ 	case R_X86_64_64:
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/42_0042-Revert-ANDROID-x86-alternatives-Use-C-int3-selftest-.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/42_0042-Revert-ANDROID-x86-alternatives-Use-C-int3-selftest-.patch
@@ -1,0 +1,46 @@
+From ceebf39e5ff7f15e98a596d6cd36ebaae9f17086 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:42:30 +0530
+Subject: [PATCH 17/40] Revert "ANDROID: x86/alternatives: Use C int3 selftest
+ but disable KASAN"
+
+This reverts commit 8a82b7f20061cac41353bf0471075c4d1ff831b0.
+---
+ arch/x86/kernel/alternative.c | 21 +++++++++++++++++----
+ 1 file changed, 17 insertions(+), 4 deletions(-)
+
+diff --git a/arch/x86/kernel/alternative.c b/arch/x86/kernel/alternative.c
+index efb5ef8a7885..9d3a971ea364 100644
+--- a/arch/x86/kernel/alternative.c
++++ b/arch/x86/kernel/alternative.c
+@@ -625,10 +625,23 @@ extern struct paravirt_patch_site __start_parainstructions[],
+  *
+  * See entry_{32,64}.S for more details.
+  */
+-static void __init __no_sanitize_address notrace int3_magic(unsigned int *ptr)
+-{
+-	*ptr = 1;
+-}
++
++/*
++ * We define the int3_magic() function in assembly to control the calling
++ * convention such that we can 'call' it from assembly.
++ */
++
++extern void int3_magic(unsigned int *ptr); /* defined in asm */
++
++asm (
++"	.pushsection	.init.text, \"ax\", @progbits\n"
++"	.type		int3_magic, @function\n"
++"int3_magic:\n"
++"	movl	$1, (%" _ASM_ARG1 ")\n"
++"	ret\n"
++"	.size		int3_magic, .-int3_magic\n"
++"	.popsection\n"
++);
+ 
+ extern __initdata unsigned long int3_selftest_ip; /* defined in asm below */
+ 
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/43_0043-Revert-ANDROID-x86-extable-Do-not-mark-exception-cal.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/43_0043-Revert-ANDROID-x86-extable-Do-not-mark-exception-cal.patch
@@ -1,0 +1,26 @@
+From c49f1cea96246bdd47b7d57bae399fd7a21f7089 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:42:39 +0530
+Subject: [PATCH 18/40] Revert "ANDROID: x86/extable: Do not mark exception
+ callback as CFI"
+
+This reverts commit fea23ded4601fe9777134fba2d7323f86dd48062.
+---
+ arch/x86/mm/extable.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/arch/x86/mm/extable.c b/arch/x86/mm/extable.c
+index 3cacb49a54e8..4d75bc656f97 100644
+--- a/arch/x86/mm/extable.c
++++ b/arch/x86/mm/extable.c
+@@ -199,7 +199,6 @@ __visible bool ex_has_fault_handler(unsigned long ip)
+ 	return handler == ex_handler_fault;
+ }
+ 
+-__nocfi
+ int fixup_exception(struct pt_regs *regs, int trapnr, unsigned long error_code,
+ 		    unsigned long fault_addr)
+ {
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/44_0044-Revert-ANDROID-x86-build-allow-LTO_CLANG-and-THINLTO.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/44_0044-Revert-ANDROID-x86-build-allow-LTO_CLANG-and-THINLTO.patch
@@ -1,0 +1,44 @@
+From cfa5f6d676d7bef8daee51562e61954c51607220 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:42:49 +0530
+Subject: [PATCH 19/40] Revert "ANDROID: x86, build: allow LTO_CLANG and
+ THINLTO to be selected"
+
+This reverts commit 6ca045ab401a466e9a5d52e5419a81753cdf3449.
+---
+ arch/x86/Kconfig  | 2 --
+ arch/x86/Makefile | 5 -----
+ 2 files changed, 7 deletions(-)
+
+diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
+index 4d77e6072f47..1c4c705cda2f 100644
+--- a/arch/x86/Kconfig
++++ b/arch/x86/Kconfig
+@@ -90,8 +90,6 @@ config X86
+ 	select ARCH_SUPPORTS_ACPI
+ 	select ARCH_SUPPORTS_ATOMIC_RMW
+ 	select ARCH_SUPPORTS_NUMA_BALANCING	if X86_64
+-	select ARCH_SUPPORTS_LTO_CLANG		if X86_64
+-	select ARCH_SUPPORTS_THINLTO		if X86_64
+ 	select ARCH_USE_BUILTIN_BSWAP
+ 	select ARCH_USE_QUEUED_RWLOCKS
+ 	select ARCH_USE_QUEUED_SPINLOCKS
+diff --git a/arch/x86/Makefile b/arch/x86/Makefile
+index 3bafa7ce52af..94df0868804b 100644
+--- a/arch/x86/Makefile
++++ b/arch/x86/Makefile
+@@ -209,11 +209,6 @@ ifdef CONFIG_X86_64
+ KBUILD_LDFLAGS += $(call ld-option, -z max-page-size=0x200000)
+ endif
+ 
+-ifdef CONFIG_LTO_CLANG
+-KBUILD_LDFLAGS	+= -plugin-opt=-code-model=kernel \
+-		   -plugin-opt=-stack-alignment=$(if $(CONFIG_X86_32),4,8)
+-endif
+-
+ # Workaround for a gcc prelease that unfortunately was shipped in a suse release
+ KBUILD_CFLAGS += -Wno-sign-compare
+ #
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/45_0045-Revert-ANDROID-x86-disable-UNWINDER_ORC-with-LTO_CLA.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/45_0045-Revert-ANDROID-x86-disable-UNWINDER_ORC-with-LTO_CLA.patch
@@ -1,0 +1,27 @@
+From c7c96a2fe8022f6664196bfb89e2bf149379e453 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:42:58 +0530
+Subject: [PATCH 20/40] Revert "ANDROID: x86: disable UNWINDER_ORC with
+ LTO_CLANG"
+
+This reverts commit 02865f81dc3e73e7d35e08dd6c061a47f10b0709.
+---
+ arch/x86/Kconfig.debug | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/x86/Kconfig.debug b/arch/x86/Kconfig.debug
+index 49b2dc240db3..bf9cd83de777 100644
+--- a/arch/x86/Kconfig.debug
++++ b/arch/x86/Kconfig.debug
+@@ -291,7 +291,7 @@ choice
+ 
+ config UNWINDER_ORC
+ 	bool "ORC unwinder"
+-	depends on X86_64 && !LTO_CLANG
++	depends on X86_64
+ 	select STACK_VALIDATION
+ 	---help---
+ 	  This option enables the ORC (Oops Rewind Capability) unwinder for
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/46_0046-Revert-ANDROID-x86-disable-STACK_VALIDATION-with-LTO.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/46_0046-Revert-ANDROID-x86-disable-STACK_VALIDATION-with-LTO.patch
@@ -1,0 +1,27 @@
+From 31fd3921f5a0d21285f5ab76ae5def8a6fea4a16 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:44:40 +0530
+Subject: [PATCH 21/40] Revert "ANDROID: x86: disable STACK_VALIDATION with
+ LTO_CLANG"
+
+This reverts commit 6d689ed27dcc0f10acfb549f0e30812ee2655d37.
+---
+ arch/x86/Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
+index 1c4c705cda2f..76ae264e04ff 100644
+--- a/arch/x86/Kconfig
++++ b/arch/x86/Kconfig
+@@ -204,7 +204,7 @@ config X86
+ 	select HAVE_RELIABLE_STACKTRACE		if X86_64 && (UNWINDER_FRAME_POINTER || UNWINDER_ORC) && STACK_VALIDATION
+ 	select HAVE_FUNCTION_ARG_ACCESS_API
+ 	select HAVE_STACKPROTECTOR		if CC_HAS_SANE_STACKPROTECTOR
+-	select HAVE_STACK_VALIDATION		if X86_64 && !LTO_CLANG
++	select HAVE_STACK_VALIDATION		if X86_64
+ 	select HAVE_RSEQ
+ 	select HAVE_SYSCALL_TRACEPOINTS
+ 	select HAVE_UNSTABLE_SCHED_CLOCK
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/47_0047-Revert-ANDROID-x86-disable-HAVE_ARCH_PREL32_RELOCATI.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/47_0047-Revert-ANDROID-x86-disable-HAVE_ARCH_PREL32_RELOCATI.patch
@@ -1,0 +1,27 @@
+From 517249b488de0ae313a7e0c7d56c436810464c42 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:44:53 +0530
+Subject: [PATCH 22/40] Revert "ANDROID: x86: disable
+ HAVE_ARCH_PREL32_RELOCATIONS with LTO_CLANG"
+
+This reverts commit c316b38057ce347ccf99f537b0d6bc8c8058630e.
+---
+ arch/x86/Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
+index 76ae264e04ff..70914ea99407 100644
+--- a/arch/x86/Kconfig
++++ b/arch/x86/Kconfig
+@@ -139,7 +139,7 @@ config X86
+ 	select HAVE_ARCH_MMAP_RND_BITS		if MMU
+ 	select HAVE_ARCH_MMAP_RND_COMPAT_BITS	if MMU && COMPAT
+ 	select HAVE_ARCH_COMPAT_MMAP_BASES	if MMU && COMPAT
+-	select HAVE_ARCH_PREL32_RELOCATIONS	if !LTO_CLANG
++	select HAVE_ARCH_PREL32_RELOCATIONS
+ 	select HAVE_ARCH_SECCOMP_FILTER
+ 	select HAVE_ARCH_THREAD_STRUCT_WHITELIST
+ 	select HAVE_ARCH_STACKLEAK
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/48_0048-Revert-ANDROID-x86-vdso-disable-LTO-only-for-VDSO.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/48_0048-Revert-ANDROID-x86-vdso-disable-LTO-only-for-VDSO.patch
@@ -1,0 +1,42 @@
+From 45ea57dfda725c24f757f750aa2effd0ce1eac6a Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:45:00 +0530
+Subject: [PATCH 23/40] Revert "ANDROID: x86/vdso: disable LTO only for VDSO"
+
+This reverts commit 557ce7d38b3334738e3fd059a2c028734a804c75.
+---
+ arch/x86/entry/vdso/Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/x86/entry/vdso/Makefile b/arch/x86/entry/vdso/Makefile
+index a3d4cf597173..0f2154106d01 100644
+--- a/arch/x86/entry/vdso/Makefile
++++ b/arch/x86/entry/vdso/Makefile
+@@ -9,6 +9,7 @@ ARCH_REL_TYPE_ABS := R_X86_64_JUMP_SLOT|R_X86_64_GLOB_DAT|R_X86_64_RELATIVE|
+ ARCH_REL_TYPE_ABS += R_386_GLOB_DAT|R_386_JMP_SLOT|R_386_RELATIVE
+ include $(srctree)/lib/vdso/Makefile
+ 
++KBUILD_CFLAGS += $(DISABLE_LTO)
+ KASAN_SANITIZE			:= n
+ UBSAN_SANITIZE			:= n
+ OBJECT_FILES_NON_STANDARD	:= y
+@@ -81,7 +82,7 @@ ifneq ($(RETPOLINE_VDSO_CFLAGS),)
+ endif
+ endif
+ 
+-$(vobjs): KBUILD_CFLAGS := $(filter-out $(CC_FLAGS_LTO) $(GCC_PLUGINS_CFLAGS) $(RETPOLINE_CFLAGS),$(KBUILD_CFLAGS)) $(CFL)
++$(vobjs): KBUILD_CFLAGS := $(filter-out $(GCC_PLUGINS_CFLAGS) $(RETPOLINE_CFLAGS),$(KBUILD_CFLAGS)) $(CFL)
+ 
+ #
+ # vDSO code runs in userspace and -pg doesn't help with profiling anyway.
+@@ -145,7 +146,6 @@ KBUILD_CFLAGS_32 := $(filter-out -fno-pic,$(KBUILD_CFLAGS_32))
+ KBUILD_CFLAGS_32 := $(filter-out -mfentry,$(KBUILD_CFLAGS_32))
+ KBUILD_CFLAGS_32 := $(filter-out $(GCC_PLUGINS_CFLAGS),$(KBUILD_CFLAGS_32))
+ KBUILD_CFLAGS_32 := $(filter-out $(RETPOLINE_CFLAGS),$(KBUILD_CFLAGS_32))
+-KBUILD_CFLAGS_32 := $(filter-out $(CC_FLAGS_LTO),$(KBUILD_CFLAGS_32))
+ KBUILD_CFLAGS_32 += -m32 -msoft-float -mregparm=0 -fpic
+ KBUILD_CFLAGS_32 += $(call cc-option, -fno-stack-protector)
+ KBUILD_CFLAGS_32 += $(call cc-option, -foptimize-sibling-calls)
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/49_0049-Revert-FROMLIST-crypto-x86-sha-Eliminate-casts-on-as.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/49_0049-Revert-FROMLIST-crypto-x86-sha-Eliminate-casts-on-as.patch
@@ -1,0 +1,537 @@
+From 175ec61c248de87d9e6042e3bb2f504446e43282 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:45:09 +0530
+Subject: [PATCH 24/40] Revert "FROMLIST: crypto, x86/sha: Eliminate casts on
+ asm implementations"
+
+This reverts commit 6acaabf192539b95ded786cd6e146b9f59f55847.
+---
+ arch/x86/crypto/sha1_avx2_x86_64_asm.S |  6 +--
+ arch/x86/crypto/sha1_ssse3_asm.S       | 14 ++----
+ arch/x86/crypto/sha1_ssse3_glue.c      | 70 +++++++++++++++-----------
+ arch/x86/crypto/sha256-avx-asm.S       |  4 +-
+ arch/x86/crypto/sha256-avx2-asm.S      |  4 +-
+ arch/x86/crypto/sha256-ssse3-asm.S     |  6 +--
+ arch/x86/crypto/sha256_ssse3_glue.c    | 34 ++++++-------
+ arch/x86/crypto/sha512-avx-asm.S       | 11 ++--
+ arch/x86/crypto/sha512-avx2-asm.S      | 11 ++--
+ arch/x86/crypto/sha512-ssse3-asm.S     | 13 ++---
+ arch/x86/crypto/sha512_ssse3_glue.c    | 31 ++++++------
+ 11 files changed, 102 insertions(+), 102 deletions(-)
+
+diff --git a/arch/x86/crypto/sha1_avx2_x86_64_asm.S b/arch/x86/crypto/sha1_avx2_x86_64_asm.S
+index 7e578fa5d0a7..9f712a7dfd79 100644
+--- a/arch/x86/crypto/sha1_avx2_x86_64_asm.S
++++ b/arch/x86/crypto/sha1_avx2_x86_64_asm.S
+@@ -62,11 +62,11 @@
+  *Visit http://software.intel.com/en-us/articles/
+  *and refer to improving-the-performance-of-the-secure-hash-algorithm-1/
+  *
+- *Updates 20-byte SHA-1 record at start of 'state', from 'input', for
+- *even number of 'blocks' consecutive 64-byte blocks.
++ *Updates 20-byte SHA-1 record in 'hash' for even number of
++ *'num_blocks' consecutive 64-byte blocks
+  *
+  *extern "C" void sha1_transform_avx2(
+- *	struct sha1_state *state, const u8* input, int blocks );
++ *	int *hash, const char* input, size_t num_blocks );
+  */
+ 
+ #include <linux/linkage.h>
+diff --git a/arch/x86/crypto/sha1_ssse3_asm.S b/arch/x86/crypto/sha1_ssse3_asm.S
+index 031e27130694..99c5b8c4dc38 100644
+--- a/arch/x86/crypto/sha1_ssse3_asm.S
++++ b/arch/x86/crypto/sha1_ssse3_asm.S
+@@ -457,13 +457,9 @@ W_PRECALC_SSSE3
+ 	movdqu	\a,\b
+ .endm
+ 
+-/*
+- * SSSE3 optimized implementation:
+- *
+- * extern "C" void sha1_transform_ssse3(struct sha1_state *state,
+- *					const u8 *data, int blocks);
+- *
+- * Note that struct sha1_state is assumed to begin with u32 state[5].
++/* SSSE3 optimized implementation:
++ *  extern "C" void sha1_transform_ssse3(u32 *digest, const char *data, u32 *ws,
++ *                                       unsigned int rounds);
+  */
+ SHA1_VECTOR_ASM     sha1_transform_ssse3
+ 
+@@ -549,8 +545,8 @@ W_PRECALC_AVX
+ 
+ 
+ /* AVX optimized implementation:
+- *  extern "C" void sha1_transform_avx(struct sha1_state *state,
+- *				       const u8 *data, int blocks);
++ *  extern "C" void sha1_transform_avx(u32 *digest, const char *data, u32 *ws,
++ *                                     unsigned int rounds);
+  */
+ SHA1_VECTOR_ASM     sha1_transform_avx
+ 
+diff --git a/arch/x86/crypto/sha1_ssse3_glue.c b/arch/x86/crypto/sha1_ssse3_glue.c
+index d70b40ad594c..639d4c2fd6a8 100644
+--- a/arch/x86/crypto/sha1_ssse3_glue.c
++++ b/arch/x86/crypto/sha1_ssse3_glue.c
+@@ -27,8 +27,11 @@
+ #include <crypto/sha1_base.h>
+ #include <asm/simd.h>
+ 
++typedef void (sha1_transform_fn)(u32 *digest, const char *data,
++				unsigned int rounds);
++
+ static int sha1_update(struct shash_desc *desc, const u8 *data,
+-			     unsigned int len, sha1_block_fn *sha1_xform)
++			     unsigned int len, sha1_transform_fn *sha1_xform)
+ {
+ 	struct sha1_state *sctx = shash_desc_ctx(desc);
+ 
+@@ -36,47 +39,48 @@ static int sha1_update(struct shash_desc *desc, const u8 *data,
+ 	    (sctx->count % SHA1_BLOCK_SIZE) + len < SHA1_BLOCK_SIZE)
+ 		return crypto_sha1_update(desc, data, len);
+ 
+-	/*
+-	 * Make sure struct sha1_state begins directly with the SHA1
+-	 * 160-bit internal state, as this is what the asm functions expect.
+-	 */
++	/* make sure casting to sha1_block_fn() is safe */
+ 	BUILD_BUG_ON(offsetof(struct sha1_state, state) != 0);
+ 
+ 	kernel_fpu_begin();
+-	sha1_base_do_update(desc, data, len, sha1_xform);
++	sha1_base_do_update(desc, data, len,
++			    (sha1_block_fn *)sha1_xform);
+ 	kernel_fpu_end();
+ 
+ 	return 0;
+ }
+ 
+ static int sha1_finup(struct shash_desc *desc, const u8 *data,
+-		      unsigned int len, u8 *out, sha1_block_fn *sha1_xform)
++		      unsigned int len, u8 *out, sha1_transform_fn *sha1_xform)
+ {
+ 	if (!crypto_simd_usable())
+ 		return crypto_sha1_finup(desc, data, len, out);
+ 
+ 	kernel_fpu_begin();
+ 	if (len)
+-		sha1_base_do_update(desc, data, len, sha1_xform);
+-	sha1_base_do_finalize(desc, sha1_xform);
++		sha1_base_do_update(desc, data, len,
++				    (sha1_block_fn *)sha1_xform);
++	sha1_base_do_finalize(desc, (sha1_block_fn *)sha1_xform);
+ 	kernel_fpu_end();
+ 
+ 	return sha1_base_finish(desc, out);
+ }
+ 
+-asmlinkage void sha1_transform_ssse3(struct sha1_state *state,
+-				     const u8 *data, int blocks);
++asmlinkage void sha1_transform_ssse3(u32 *digest, const char *data,
++				     unsigned int rounds);
+ 
+ static int sha1_ssse3_update(struct shash_desc *desc, const u8 *data,
+ 			     unsigned int len)
+ {
+-	return sha1_update(desc, data, len, sha1_transform_ssse3);
++	return sha1_update(desc, data, len,
++			(sha1_transform_fn *) sha1_transform_ssse3);
+ }
+ 
+ static int sha1_ssse3_finup(struct shash_desc *desc, const u8 *data,
+ 			      unsigned int len, u8 *out)
+ {
+-	return sha1_finup(desc, data, len, out, sha1_transform_ssse3);
++	return sha1_finup(desc, data, len, out,
++			(sha1_transform_fn *) sha1_transform_ssse3);
+ }
+ 
+ /* Add padding and return the message digest. */
+@@ -115,19 +119,21 @@ static void unregister_sha1_ssse3(void)
+ }
+ 
+ #ifdef CONFIG_AS_AVX
+-asmlinkage void sha1_transform_avx(struct sha1_state *state,
+-				   const u8 *data, int blocks);
++asmlinkage void sha1_transform_avx(u32 *digest, const char *data,
++				   unsigned int rounds);
+ 
+ static int sha1_avx_update(struct shash_desc *desc, const u8 *data,
+ 			     unsigned int len)
+ {
+-	return sha1_update(desc, data, len, sha1_transform_avx);
++	return sha1_update(desc, data, len,
++			(sha1_transform_fn *) sha1_transform_avx);
+ }
+ 
+ static int sha1_avx_finup(struct shash_desc *desc, const u8 *data,
+ 			      unsigned int len, u8 *out)
+ {
+-	return sha1_finup(desc, data, len, out, sha1_transform_avx);
++	return sha1_finup(desc, data, len, out,
++			(sha1_transform_fn *) sha1_transform_avx);
+ }
+ 
+ static int sha1_avx_final(struct shash_desc *desc, u8 *out)
+@@ -184,8 +190,8 @@ static inline void unregister_sha1_avx(void) { }
+ #if defined(CONFIG_AS_AVX2) && (CONFIG_AS_AVX)
+ #define SHA1_AVX2_BLOCK_OPTSIZE	4	/* optimal 4*64 bytes of SHA1 blocks */
+ 
+-asmlinkage void sha1_transform_avx2(struct sha1_state *state,
+-				    const u8 *data, int blocks);
++asmlinkage void sha1_transform_avx2(u32 *digest, const char *data,
++				    unsigned int rounds);
+ 
+ static bool avx2_usable(void)
+ {
+@@ -197,26 +203,28 @@ static bool avx2_usable(void)
+ 	return false;
+ }
+ 
+-static void sha1_apply_transform_avx2(struct sha1_state *state,
+-				      const u8 *data, int blocks)
++static void sha1_apply_transform_avx2(u32 *digest, const char *data,
++				unsigned int rounds)
+ {
+ 	/* Select the optimal transform based on data block size */
+-	if (blocks >= SHA1_AVX2_BLOCK_OPTSIZE)
+-		sha1_transform_avx2(state, data, blocks);
++	if (rounds >= SHA1_AVX2_BLOCK_OPTSIZE)
++		sha1_transform_avx2(digest, data, rounds);
+ 	else
+-		sha1_transform_avx(state, data, blocks);
++		sha1_transform_avx(digest, data, rounds);
+ }
+ 
+ static int sha1_avx2_update(struct shash_desc *desc, const u8 *data,
+ 			     unsigned int len)
+ {
+-	return sha1_update(desc, data, len, sha1_apply_transform_avx2);
++	return sha1_update(desc, data, len,
++		(sha1_transform_fn *) sha1_apply_transform_avx2);
+ }
+ 
+ static int sha1_avx2_finup(struct shash_desc *desc, const u8 *data,
+ 			      unsigned int len, u8 *out)
+ {
+-	return sha1_finup(desc, data, len, out, sha1_apply_transform_avx2);
++	return sha1_finup(desc, data, len, out,
++		(sha1_transform_fn *) sha1_apply_transform_avx2);
+ }
+ 
+ static int sha1_avx2_final(struct shash_desc *desc, u8 *out)
+@@ -259,19 +267,21 @@ static inline void unregister_sha1_avx2(void) { }
+ #endif
+ 
+ #ifdef CONFIG_AS_SHA1_NI
+-asmlinkage void sha1_ni_transform(struct sha1_state *digest, const u8 *data,
+-				  int rounds);
++asmlinkage void sha1_ni_transform(u32 *digest, const char *data,
++				   unsigned int rounds);
+ 
+ static int sha1_ni_update(struct shash_desc *desc, const u8 *data,
+ 			     unsigned int len)
+ {
+-	return sha1_update(desc, data, len, sha1_ni_transform);
++	return sha1_update(desc, data, len,
++		(sha1_transform_fn *) sha1_ni_transform);
+ }
+ 
+ static int sha1_ni_finup(struct shash_desc *desc, const u8 *data,
+ 			      unsigned int len, u8 *out)
+ {
+-	return sha1_finup(desc, data, len, out, sha1_ni_transform);
++	return sha1_finup(desc, data, len, out,
++		(sha1_transform_fn *) sha1_ni_transform);
+ }
+ 
+ static int sha1_ni_final(struct shash_desc *desc, u8 *out)
+diff --git a/arch/x86/crypto/sha256-avx-asm.S b/arch/x86/crypto/sha256-avx-asm.S
+index b6e037ee6661..001bbcf93c79 100644
+--- a/arch/x86/crypto/sha256-avx-asm.S
++++ b/arch/x86/crypto/sha256-avx-asm.S
+@@ -341,8 +341,8 @@ a = TMP_
+ .endm
+ 
+ ########################################################################
+-## void sha256_transform_avx(state sha256_state *state, const u8 *data, int blocks)
+-## arg 1 : pointer to state
++## void sha256_transform_avx(void *input_data, UINT32 digest[8], UINT64 num_blks)
++## arg 1 : pointer to digest
+ ## arg 2 : pointer to input data
+ ## arg 3 : Num blocks
+ ########################################################################
+diff --git a/arch/x86/crypto/sha256-avx2-asm.S b/arch/x86/crypto/sha256-avx2-asm.S
+index 2e6ebc904a3a..1420db15dcdd 100644
+--- a/arch/x86/crypto/sha256-avx2-asm.S
++++ b/arch/x86/crypto/sha256-avx2-asm.S
+@@ -520,8 +520,8 @@ STACK_SIZE	= _RSP      + _RSP_SIZE
+ .endm
+ 
+ ########################################################################
+-## void sha256_transform_rorx(struct sha256_state *state, const u8 *data, int blocks)
+-## arg 1 : pointer to state
++## void sha256_transform_rorx(void *input_data, UINT32 digest[8], UINT64 num_blks)
++## arg 1 : pointer to digest
+ ## arg 2 : pointer to input data
+ ## arg 3 : Num blocks
+ ########################################################################
+diff --git a/arch/x86/crypto/sha256-ssse3-asm.S b/arch/x86/crypto/sha256-ssse3-asm.S
+index ab7d9f05ff78..c6c05ed2c16a 100644
+--- a/arch/x86/crypto/sha256-ssse3-asm.S
++++ b/arch/x86/crypto/sha256-ssse3-asm.S
+@@ -347,10 +347,8 @@ a = TMP_
+ .endm
+ 
+ ########################################################################
+-## void sha256_transform_ssse3(struct sha256_state *state, const u8 *data,
+-##			       int blocks);
+-## arg 1 : pointer to state
+-##	   (struct sha256_state is assumed to begin with u32 state[8])
++## void sha256_transform_ssse3(void *input_data, UINT32 digest[8], UINT64 num_blks)
++## arg 1 : pointer to digest
+ ## arg 2 : pointer to input data
+ ## arg 3 : Num blocks
+ ########################################################################
+diff --git a/arch/x86/crypto/sha256_ssse3_glue.c b/arch/x86/crypto/sha256_ssse3_glue.c
+index 03ad657c04bd..f9aff31fe59e 100644
+--- a/arch/x86/crypto/sha256_ssse3_glue.c
++++ b/arch/x86/crypto/sha256_ssse3_glue.c
+@@ -41,11 +41,12 @@
+ #include <linux/string.h>
+ #include <asm/simd.h>
+ 
+-asmlinkage void sha256_transform_ssse3(struct sha256_state *state,
+-				       const u8 *data, int blocks);
++asmlinkage void sha256_transform_ssse3(u32 *digest, const char *data,
++				       u64 rounds);
++typedef void (sha256_transform_fn)(u32 *digest, const char *data, u64 rounds);
+ 
+ static int _sha256_update(struct shash_desc *desc, const u8 *data,
+-			  unsigned int len, sha256_block_fn *sha256_xform)
++			  unsigned int len, sha256_transform_fn *sha256_xform)
+ {
+ 	struct sha256_state *sctx = shash_desc_ctx(desc);
+ 
+@@ -53,29 +54,28 @@ static int _sha256_update(struct shash_desc *desc, const u8 *data,
+ 	    (sctx->count % SHA256_BLOCK_SIZE) + len < SHA256_BLOCK_SIZE)
+ 		return crypto_sha256_update(desc, data, len);
+ 
+-	/*
+-	 * Make sure struct sha256_state begins directly with the SHA256
+-	 * 256-bit internal state, as this is what the asm functions expect.
+-	 */
++	/* make sure casting to sha256_block_fn() is safe */
+ 	BUILD_BUG_ON(offsetof(struct sha256_state, state) != 0);
+ 
+ 	kernel_fpu_begin();
+-	sha256_base_do_update(desc, data, len, sha256_xform);
++	sha256_base_do_update(desc, data, len,
++			      (sha256_block_fn *)sha256_xform);
+ 	kernel_fpu_end();
+ 
+ 	return 0;
+ }
+ 
+ static int sha256_finup(struct shash_desc *desc, const u8 *data,
+-	      unsigned int len, u8 *out, sha256_block_fn *sha256_xform)
++	      unsigned int len, u8 *out, sha256_transform_fn *sha256_xform)
+ {
+ 	if (!crypto_simd_usable())
+ 		return crypto_sha256_finup(desc, data, len, out);
+ 
+ 	kernel_fpu_begin();
+ 	if (len)
+-		sha256_base_do_update(desc, data, len, sha256_xform);
+-	sha256_base_do_finalize(desc, sha256_xform);
++		sha256_base_do_update(desc, data, len,
++				      (sha256_block_fn *)sha256_xform);
++	sha256_base_do_finalize(desc, (sha256_block_fn *)sha256_xform);
+ 	kernel_fpu_end();
+ 
+ 	return sha256_base_finish(desc, out);
+@@ -145,8 +145,8 @@ static void unregister_sha256_ssse3(void)
+ }
+ 
+ #ifdef CONFIG_AS_AVX
+-asmlinkage void sha256_transform_avx(struct sha256_state *state,
+-				     const u8 *data, int blocks);
++asmlinkage void sha256_transform_avx(u32 *digest, const char *data,
++				     u64 rounds);
+ 
+ static int sha256_avx_update(struct shash_desc *desc, const u8 *data,
+ 			 unsigned int len)
+@@ -227,8 +227,8 @@ static inline void unregister_sha256_avx(void) { }
+ #endif
+ 
+ #if defined(CONFIG_AS_AVX2) && defined(CONFIG_AS_AVX)
+-asmlinkage void sha256_transform_rorx(struct sha256_state *state,
+-				      const u8 *data, int blocks);
++asmlinkage void sha256_transform_rorx(u32 *digest, const char *data,
++				      u64 rounds);
+ 
+ static int sha256_avx2_update(struct shash_desc *desc, const u8 *data,
+ 			 unsigned int len)
+@@ -307,8 +307,8 @@ static inline void unregister_sha256_avx2(void) { }
+ #endif
+ 
+ #ifdef CONFIG_AS_SHA256_NI
+-asmlinkage void sha256_ni_transform(struct sha256_state *digest,
+-				    const u8 *data, int rounds);
++asmlinkage void sha256_ni_transform(u32 *digest, const char *data,
++				   u64 rounds); /*unsigned int rounds);*/
+ 
+ static int sha256_ni_update(struct shash_desc *desc, const u8 *data,
+ 			 unsigned int len)
+diff --git a/arch/x86/crypto/sha512-avx-asm.S b/arch/x86/crypto/sha512-avx-asm.S
+index 8f6fe09cba54..39235fefe6f7 100644
+--- a/arch/x86/crypto/sha512-avx-asm.S
++++ b/arch/x86/crypto/sha512-avx-asm.S
+@@ -271,12 +271,11 @@ frame_size = frame_GPRSAVE + GPRSAVE_SIZE
+ .endm
+ 
+ ########################################################################
+-# void sha512_transform_avx(sha512_state *state, const u8 *data, int blocks)
+-# Purpose: Updates the SHA512 digest stored at "state" with the message
+-# stored in "data".
+-# The size of the message pointed to by "data" must be an integer multiple
+-# of SHA512 message blocks.
+-# "blocks" is the message length in SHA512 blocks
++# void sha512_transform_avx(void* D, const void* M, u64 L)
++# Purpose: Updates the SHA512 digest stored at D with the message stored in M.
++# The size of the message pointed to by M must be an integer multiple of SHA512
++# message blocks.
++# L is the message length in SHA512 blocks
+ ########################################################################
+ ENTRY(sha512_transform_avx)
+ 	cmp $0, msglen
+diff --git a/arch/x86/crypto/sha512-avx2-asm.S b/arch/x86/crypto/sha512-avx2-asm.S
+index 43d4d641804c..b16d56005162 100644
+--- a/arch/x86/crypto/sha512-avx2-asm.S
++++ b/arch/x86/crypto/sha512-avx2-asm.S
+@@ -563,12 +563,11 @@ frame_size = frame_GPRSAVE + GPRSAVE_SIZE
+ .endm
+ 
+ ########################################################################
+-# void sha512_transform_rorx(sha512_state *state, const u8 *data, int blocks)
+-# Purpose: Updates the SHA512 digest stored at "state" with the message
+-# stored in "data".
+-# The size of the message pointed to by "data" must be an integer multiple
+-# of SHA512 message blocks.
+-# "blocks" is the message length in SHA512 blocks
++# void sha512_transform_rorx(void* D, const void* M, uint64_t L)#
++# Purpose: Updates the SHA512 digest stored at D with the message stored in M.
++# The size of the message pointed to by M must be an integer multiple of SHA512
++#   message blocks.
++# L is the message length in SHA512 blocks
+ ########################################################################
+ ENTRY(sha512_transform_rorx)
+ 	# Allocate Stack Space
+diff --git a/arch/x86/crypto/sha512-ssse3-asm.S b/arch/x86/crypto/sha512-ssse3-asm.S
+index 46da903f5538..66bbd9058a90 100644
+--- a/arch/x86/crypto/sha512-ssse3-asm.S
++++ b/arch/x86/crypto/sha512-ssse3-asm.S
+@@ -269,14 +269,11 @@ frame_size = frame_GPRSAVE + GPRSAVE_SIZE
+ .endm
+ 
+ ########################################################################
+-## void sha512_transform_ssse3(struct sha512_state *state, const u8 *data,
+-##			       int blocks);
+-# (struct sha512_state is assumed to begin with u64 state[8])
+-# Purpose: Updates the SHA512 digest stored at "state" with the message
+-# stored in "data".
+-# The size of the message pointed to by "data" must be an integer multiple
+-# of SHA512 message blocks.
+-# "blocks" is the message length in SHA512 blocks.
++# void sha512_transform_ssse3(void* D, const void* M, u64 L)#
++# Purpose: Updates the SHA512 digest stored at D with the message stored in M.
++# The size of the message pointed to by M must be an integer multiple of SHA512
++#   message blocks.
++# L is the message length in SHA512 blocks.
+ ########################################################################
+ ENTRY(sha512_transform_ssse3)
+ 
+diff --git a/arch/x86/crypto/sha512_ssse3_glue.c b/arch/x86/crypto/sha512_ssse3_glue.c
+index 1c444f41037c..458356a3f124 100644
+--- a/arch/x86/crypto/sha512_ssse3_glue.c
++++ b/arch/x86/crypto/sha512_ssse3_glue.c
+@@ -39,11 +39,13 @@
+ #include <crypto/sha512_base.h>
+ #include <asm/simd.h>
+ 
+-asmlinkage void sha512_transform_ssse3(struct sha512_state *state,
+-				       const u8 *data, int blocks);
++asmlinkage void sha512_transform_ssse3(u64 *digest, const char *data,
++				       u64 rounds);
++
++typedef void (sha512_transform_fn)(u64 *digest, const char *data, u64 rounds);
+ 
+ static int sha512_update(struct shash_desc *desc, const u8 *data,
+-		       unsigned int len, sha512_block_fn *sha512_xform)
++		       unsigned int len, sha512_transform_fn *sha512_xform)
+ {
+ 	struct sha512_state *sctx = shash_desc_ctx(desc);
+ 
+@@ -51,29 +53,28 @@ static int sha512_update(struct shash_desc *desc, const u8 *data,
+ 	    (sctx->count[0] % SHA512_BLOCK_SIZE) + len < SHA512_BLOCK_SIZE)
+ 		return crypto_sha512_update(desc, data, len);
+ 
+-	/*
+-	 * Make sure struct sha512_state begins directly with the SHA512
+-	 * 512-bit internal state, as this is what the asm functions expect.
+-	 */
++	/* make sure casting to sha512_block_fn() is safe */
+ 	BUILD_BUG_ON(offsetof(struct sha512_state, state) != 0);
+ 
+ 	kernel_fpu_begin();
+-	sha512_base_do_update(desc, data, len, sha512_xform);
++	sha512_base_do_update(desc, data, len,
++			      (sha512_block_fn *)sha512_xform);
+ 	kernel_fpu_end();
+ 
+ 	return 0;
+ }
+ 
+ static int sha512_finup(struct shash_desc *desc, const u8 *data,
+-	      unsigned int len, u8 *out, sha512_block_fn *sha512_xform)
++	      unsigned int len, u8 *out, sha512_transform_fn *sha512_xform)
+ {
+ 	if (!crypto_simd_usable())
+ 		return crypto_sha512_finup(desc, data, len, out);
+ 
+ 	kernel_fpu_begin();
+ 	if (len)
+-		sha512_base_do_update(desc, data, len, sha512_xform);
+-	sha512_base_do_finalize(desc, sha512_xform);
++		sha512_base_do_update(desc, data, len,
++				      (sha512_block_fn *)sha512_xform);
++	sha512_base_do_finalize(desc, (sha512_block_fn *)sha512_xform);
+ 	kernel_fpu_end();
+ 
+ 	return sha512_base_finish(desc, out);
+@@ -143,8 +144,8 @@ static void unregister_sha512_ssse3(void)
+ }
+ 
+ #ifdef CONFIG_AS_AVX
+-asmlinkage void sha512_transform_avx(struct sha512_state *state,
+-				     const u8 *data, int blocks);
++asmlinkage void sha512_transform_avx(u64 *digest, const char *data,
++				     u64 rounds);
+ static bool avx_usable(void)
+ {
+ 	if (!cpu_has_xfeatures(XFEATURE_MASK_SSE | XFEATURE_MASK_YMM, NULL)) {
+@@ -224,8 +225,8 @@ static inline void unregister_sha512_avx(void) { }
+ #endif
+ 
+ #if defined(CONFIG_AS_AVX2) && defined(CONFIG_AS_AVX)
+-asmlinkage void sha512_transform_rorx(struct sha512_state *state,
+-				      const u8 *data, int blocks);
++asmlinkage void sha512_transform_rorx(u64 *digest, const char *data,
++				      u64 rounds);
+ 
+ static int sha512_avx2_update(struct shash_desc *desc, const u8 *data,
+ 		       unsigned int len)
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/50_0050-Revert-UPSTREAM-x86-vmlinux-Actually-use-_etext-for-.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/50_0050-Revert-UPSTREAM-x86-vmlinux-Actually-use-_etext-for-.patch
@@ -1,0 +1,98 @@
+From 48c2c5c09613304542c457304a87cd230bd10057 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:45:16 +0530
+Subject: [PATCH 25/40] Revert "UPSTREAM: x86/vmlinux: Actually use _etext for
+ the end of the text segment"
+
+This reverts commit 88addffba3bef374c86e2d2e8a954c4f5ad4ad9f.
+---
+ arch/x86/include/asm/sections.h | 1 +
+ arch/x86/kernel/vmlinux.lds.S   | 7 ++++---
+ arch/x86/mm/init_64.c           | 6 +++---
+ arch/x86/mm/pti.c               | 2 +-
+ 4 files changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/arch/x86/include/asm/sections.h b/arch/x86/include/asm/sections.h
+index cdcd9e7442a4..8ea1cfdbeabc 100644
+--- a/arch/x86/include/asm/sections.h
++++ b/arch/x86/include/asm/sections.h
+@@ -6,6 +6,7 @@
+ #include <asm/extable.h>
+ 
+ extern char __brk_base[], __brk_limit[];
++extern struct exception_table_entry __stop___ex_table[];
+ extern char __end_rodata_aligned[];
+ 
+ #if defined(CONFIG_X86_64)
+diff --git a/arch/x86/kernel/vmlinux.lds.S b/arch/x86/kernel/vmlinux.lds.S
+index 4054e7fae3c5..ce82eac0accc 100644
+--- a/arch/x86/kernel/vmlinux.lds.S
++++ b/arch/x86/kernel/vmlinux.lds.S
+@@ -141,16 +141,17 @@ SECTIONS
+ 		*(.text.__x86.indirect_thunk)
+ 		__indirect_thunk_end = .;
+ #endif
++
++		/* End of text section */
++		_etext = .;
+ 	} :text = 0x9090
+ 
+ 	NOTES :text :note
+ 
+ 	EXCEPTION_TABLE(16) :text = 0x9090
+ 
+-	/* End of text section, which should occupy whole number of pages */
+-	_etext = .;
++	/* .text should occupy whole number of pages */
+ 	. = ALIGN(PAGE_SIZE);
+-
+ 	X86_ALIGN_RODATA_BEGIN
+ 	RO_DATA(PAGE_SIZE)
+ 	X86_ALIGN_RODATA_END
+diff --git a/arch/x86/mm/init_64.c b/arch/x86/mm/init_64.c
+index fb2a9da70ad5..b8541d77452c 100644
+--- a/arch/x86/mm/init_64.c
++++ b/arch/x86/mm/init_64.c
+@@ -1261,7 +1261,7 @@ int kernel_set_to_readonly;
+ void set_kernel_text_rw(void)
+ {
+ 	unsigned long start = PFN_ALIGN(_text);
+-	unsigned long end = PFN_ALIGN(_etext);
++	unsigned long end = PFN_ALIGN(__stop___ex_table);
+ 
+ 	if (!kernel_set_to_readonly)
+ 		return;
+@@ -1280,7 +1280,7 @@ void set_kernel_text_rw(void)
+ void set_kernel_text_ro(void)
+ {
+ 	unsigned long start = PFN_ALIGN(_text);
+-	unsigned long end = PFN_ALIGN(_etext);
++	unsigned long end = PFN_ALIGN(__stop___ex_table);
+ 
+ 	if (!kernel_set_to_readonly)
+ 		return;
+@@ -1299,7 +1299,7 @@ void mark_rodata_ro(void)
+ 	unsigned long start = PFN_ALIGN(_text);
+ 	unsigned long rodata_start = PFN_ALIGN(__start_rodata);
+ 	unsigned long end = (unsigned long) &__end_rodata_hpage_align;
+-	unsigned long text_end = PFN_ALIGN(&_etext);
++	unsigned long text_end = PFN_ALIGN(&__stop___ex_table);
+ 	unsigned long rodata_end = PFN_ALIGN(&__end_rodata);
+ 	unsigned long all_end;
+ 
+diff --git a/arch/x86/mm/pti.c b/arch/x86/mm/pti.c
+index 44a9f068eee0..7f2140414440 100644
+--- a/arch/x86/mm/pti.c
++++ b/arch/x86/mm/pti.c
+@@ -574,7 +574,7 @@ static void pti_clone_kernel_text(void)
+ 	 */
+ 	unsigned long start = PFN_ALIGN(_text);
+ 	unsigned long end_clone  = (unsigned long)__end_rodata_aligned;
+-	unsigned long end_global = PFN_ALIGN((unsigned long)_etext);
++	unsigned long end_global = PFN_ALIGN((unsigned long)__stop___ex_table);
+ 
+ 	if (!pti_kernel_image_global_ok())
+ 		return;
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/51_0051-Revert-ANDROID-Kbuild-LLVMLinux-allow-overriding-cla.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/51_0051-Revert-ANDROID-Kbuild-LLVMLinux-allow-overriding-cla.patch
@@ -1,0 +1,47 @@
+From 124573809b091bc6193e3f988d26619f1f137f6d Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:45:25 +0530
+Subject: [PATCH 26/40] Revert "ANDROID: Kbuild, LLVMLinux: allow overriding
+ clang target triple"
+
+This reverts commit f930fc1bdcfc86d78adff9cfeb4b94d81390e1db.
+---
+ Makefile                 | 10 +++-------
+ scripts/clang-android.sh |  4 ----
+ 2 files changed, 3 insertions(+), 11 deletions(-)
+ delete mode 100755 scripts/clang-android.sh
+
+diff --git a/Makefile b/Makefile
+index 1aff2d4b7ff9..c91ba213c355 100644
+--- a/Makefile
++++ b/Makefile
+@@ -549,13 +549,9 @@ endif
+ 
+ ifneq ($(shell $(CC) --version 2>&1 | head -n 1 | grep clang),)
+ ifneq ($(CROSS_COMPILE),)
+-CLANG_TRIPLE	?= $(CROSS_COMPILE)
+-CLANG_TARGET	:= --target=$(notdir $(CLANG_TRIPLE:%-=%))
+-ifeq ($(shell $(srctree)/scripts/clang-android.sh $(CC) $(CLANG_TARGET)), y)
+-$(error "Clang with Android --target detected. Did you specify CLANG_TRIPLE?")
+-endif
+-GCC_TOOLCHAIN_DIR := $(dir $(shell which $(LD)))
+-CLANG_PREFIX	:= --prefix=$(GCC_TOOLCHAIN_DIR)
++CLANG_FLAGS	+= --target=$(notdir $(CROSS_COMPILE:%-=%))
++GCC_TOOLCHAIN_DIR := $(dir $(shell which $(CROSS_COMPILE)elfedit))
++CLANG_FLAGS	+= --prefix=$(GCC_TOOLCHAIN_DIR)$(notdir $(CROSS_COMPILE))
+ GCC_TOOLCHAIN	:= $(realpath $(GCC_TOOLCHAIN_DIR)/..)
+ endif
+ ifneq ($(GCC_TOOLCHAIN),)
+diff --git a/scripts/clang-android.sh b/scripts/clang-android.sh
+deleted file mode 100755
+index 9186c4f48576..000000000000
+--- a/scripts/clang-android.sh
++++ /dev/null
+@@ -1,4 +0,0 @@
+-#!/bin/sh
+-# SPDX-License-Identifier: GPL-2.0
+-
+-$* -dM -E - </dev/null 2>&1 | grep -q __ANDROID__ && echo "y"
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/52_0052-Revert-ANDROID-kbuild-limit-LTO-inlining.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/52_0052-Revert-ANDROID-kbuild-limit-LTO-inlining.patch
@@ -1,0 +1,30 @@
+From aadade5777cc077a1e4c0759834cd6ee62443dba Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:45:38 +0530
+Subject: [PATCH 27/40] Revert "ANDROID: kbuild: limit LTO inlining"
+
+This reverts commit a3cd6a3bc25ce3052e7f75c4bc55ded1d9ea7b94.
+---
+ Makefile | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index c91ba213c355..2359e1ce5731 100644
+--- a/Makefile
++++ b/Makefile
+@@ -886,12 +886,6 @@ CC_FLAGS_LTO_CLANG := -flto
+ endif
+ CC_FLAGS_LTO_CLANG += -fvisibility=default
+ 
+-# Limit inlining across translation units to reduce binary size
+-LD_FLAGS_LTO_CLANG := -mllvm -import-instr-limit=5
+-
+-KBUILD_LDFLAGS += $(LD_FLAGS_LTO_CLANG)
+-KBUILD_LDFLAGS_MODULE += $(LD_FLAGS_LTO_CLANG)
+-
+ KBUILD_LDS_MODULE += $(srctree)/scripts/module-lto.lds
+ endif
+ 
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/53_0053-Revert-ANDROID-kbuild-merge-module-sections-with-LTO.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/53_0053-Revert-ANDROID-kbuild-merge-module-sections-with-LTO.patch
@@ -1,0 +1,57 @@
+From 31d04289f00baadae6c5b777854db7b3e9d4311f Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:45:50 +0530
+Subject: [PATCH 28/40] Revert "ANDROID: kbuild: merge module sections with
+ LTO"
+
+This reverts commit c48504581fa6f56548b6ed5af8dd0132039d3b6c.
+---
+ Makefile               |  2 --
+ scripts/module-lto.lds | 22 ----------------------
+ 2 files changed, 24 deletions(-)
+ delete mode 100644 scripts/module-lto.lds
+
+diff --git a/Makefile b/Makefile
+index 2359e1ce5731..4b542d98dc2e 100644
+--- a/Makefile
++++ b/Makefile
+@@ -885,8 +885,6 @@ else
+ CC_FLAGS_LTO_CLANG := -flto
+ endif
+ CC_FLAGS_LTO_CLANG += -fvisibility=default
+-
+-KBUILD_LDS_MODULE += $(srctree)/scripts/module-lto.lds
+ endif
+ 
+ ifdef CONFIG_LTO
+diff --git a/scripts/module-lto.lds b/scripts/module-lto.lds
+deleted file mode 100644
+index f5ee544a877d..000000000000
+--- a/scripts/module-lto.lds
++++ /dev/null
+@@ -1,22 +0,0 @@
+-/*
+- * With CONFIG_LTO_CLANG, LLD always enables -fdata-sections and
+- * -ffunction-sections, which increases the size of the final module.
+- * Merge the split sections in the final binary.
+- */
+-SECTIONS {
+-	/*
+-	 * LLVM may emit .eh_frame with CONFIG_CFI_CLANG despite
+-	 * -fno-asynchronous-unwind-tables. Discard the section.
+-	 */
+-	/DISCARD/ : {
+-		*(.eh_frame)
+-	}
+-
+-	.bss : { *(.bss .bss[.0-9a-zA-Z_]*) }
+-	.data : { *(.data .data[.0-9a-zA-Z_]*) }
+-	.rela.data : { *(.rela.data .rela.data[.0-9a-zA-Z_]*) }
+-	.rela.rodata : { *(.rela.rodata .rela.rodata[.0-9a-zA-Z_]*) }
+-	.rela.text : { *(.rela.text .rela.text[.0-9a-zA-Z_]*) }
+-	.rodata : { *(.rodata .rodata[.0-9a-zA-Z_]*) }
+-	.text : { *(.text .text[.0-9a-zA-Z_]*) }
+-}
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/54_0054-Revert-ANDROID-bpf-validate-bpf_func-when-BPF_JIT-is.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/54_0054-Revert-ANDROID-bpf-validate-bpf_func-when-BPF_JIT-is.patch
@@ -1,0 +1,137 @@
+From dbca2f860bdaf0a2361ff0be9a04b149ce73ca45 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:46:01 +0530
+Subject: [PATCH 29/40] Revert "ANDROID: bpf: validate bpf_func when BPF_JIT is
+ enabled with CFI"
+
+This reverts commit 891df35e7c400067d3a82fe874c78d402c15f4cf.
+---
+ include/linux/filter.h | 64 ++----------------------------------------
+ kernel/bpf/core.c      |  9 ------
+ 2 files changed, 2 insertions(+), 71 deletions(-)
+
+diff --git a/include/linux/filter.h b/include/linux/filter.h
+index 4caaa97acc4a..79830bc9e45c 100644
+--- a/include/linux/filter.h
++++ b/include/linux/filter.h
+@@ -511,12 +511,7 @@ struct sock_fprog_kern {
+ 	struct sock_filter	*filter;
+ };
+ 
+-#define BPF_BINARY_HEADER_MAGIC	0x05de0e82
+-
+ struct bpf_binary_header {
+-#ifdef CONFIG_CFI_CLANG
+-	u32 magic;
+-#endif
+ 	u32 pages;
+ 	/* Some arches need word alignment for their instructions */
+ 	u8 image[] __aligned(4);
+@@ -558,75 +553,20 @@ struct sk_filter {
+ 
+ DECLARE_STATIC_KEY_FALSE(bpf_stats_enabled_key);
+ 
+-#if IS_ENABLED(CONFIG_BPF_JIT) && IS_ENABLED(CONFIG_CFI_CLANG)
+-/*
+- * With JIT, the kernel makes an indirect call to dynamically generated
+- * code. Use bpf_call_func to perform additional validation of the call
+- * target to narrow down attack surface. Architectures implementing BPF
+- * JIT can override arch_bpf_jit_check_func for arch-specific checking.
+- */
+-extern bool arch_bpf_jit_check_func(const struct bpf_prog *prog);
+-
+-static inline unsigned int __bpf_call_func(const struct bpf_prog *prog,
+-					   const void *ctx)
+-{
+-	/* Call interpreter with CFI checking. */
+-	return prog->bpf_func(ctx, prog->insnsi);
+-}
+-
+-static inline struct bpf_binary_header *
+-bpf_jit_binary_hdr(const struct bpf_prog *fp);
+-
+-static inline unsigned int __nocfi bpf_call_func(const struct bpf_prog *prog,
+-						 const void *ctx)
+-{
+-	const struct bpf_binary_header *hdr = bpf_jit_binary_hdr(prog);
+-
+-	if (!IS_ENABLED(CONFIG_BPF_JIT_ALWAYS_ON) && !prog->jited)
+-		return __bpf_call_func(prog, ctx);
+-
+-	/*
+-	 * We are about to call dynamically generated code. Check that the
+-	 * page has bpf_binary_header with a valid magic to limit possible
+-	 * call targets.
+-	 */
+-	BUG_ON(hdr->magic != BPF_BINARY_HEADER_MAGIC ||
+-		!arch_bpf_jit_check_func(prog));
+-
+-	/* Call jited function without CFI checking. */
+-	return prog->bpf_func(ctx, prog->insnsi);
+-}
+-
+-static inline void bpf_jit_set_header_magic(struct bpf_binary_header *hdr)
+-{
+-	hdr->magic = BPF_BINARY_HEADER_MAGIC;
+-}
+-#else
+-static inline unsigned int bpf_call_func(const struct bpf_prog *prog,
+-					 const void *ctx)
+-{
+-	return prog->bpf_func(ctx, prog->insnsi);
+-}
+-
+-static inline void bpf_jit_set_header_magic(struct bpf_binary_header *hdr)
+-{
+-}
+-#endif
+-
+ #define BPF_PROG_RUN(prog, ctx)	({				\
+ 	u32 ret;						\
+ 	cant_sleep();						\
+ 	if (static_branch_unlikely(&bpf_stats_enabled_key)) {	\
+ 		struct bpf_prog_stats *stats;			\
+ 		u64 start = sched_clock();			\
+-		ret = bpf_call_func(prog, ctx);			\
++		ret = (*(prog)->bpf_func)(ctx, (prog)->insnsi);	\
+ 		stats = this_cpu_ptr(prog->aux->stats);		\
+ 		u64_stats_update_begin(&stats->syncp);		\
+ 		stats->cnt++;					\
+ 		stats->nsecs += sched_clock() - start;		\
+ 		u64_stats_update_end(&stats->syncp);		\
+ 	} else {						\
+-		ret = bpf_call_func(prog, ctx);			\
++		ret = (*(prog)->bpf_func)(ctx, (prog)->insnsi);	\
+ 	}							\
+ 	ret; })
+ 
+diff --git a/kernel/bpf/core.c b/kernel/bpf/core.c
+index fe26be4760da..ef0e1e3e66f4 100644
+--- a/kernel/bpf/core.c
++++ b/kernel/bpf/core.c
+@@ -792,14 +792,6 @@ void __weak bpf_jit_free_exec(void *addr)
+ 	module_memfree(addr);
+ }
+ 
+-#if IS_ENABLED(CONFIG_BPF_JIT) && IS_ENABLED(CONFIG_CFI_CLANG)
+-bool __weak arch_bpf_jit_check_func(const struct bpf_prog *prog)
+-{
+-	return true;
+-}
+-EXPORT_SYMBOL(arch_bpf_jit_check_func);
+-#endif
+-
+ struct bpf_binary_header *
+ bpf_jit_binary_alloc(unsigned int proglen, u8 **image_ptr,
+ 		     unsigned int alignment,
+@@ -826,7 +818,6 @@ bpf_jit_binary_alloc(unsigned int proglen, u8 **image_ptr,
+ 	/* Fill space with illegal/arch-dep instructions. */
+ 	bpf_fill_ill_insns(hdr, size);
+ 
+-	bpf_jit_set_header_magic(hdr);
+ 	hdr->pages = pages;
+ 	hole = min_t(unsigned int, size - (proglen + sizeof(*hdr)),
+ 		     PAGE_SIZE - sizeof(*hdr));
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/55_0055-Revert-ANDROID-add-support-for-Clang-s-Control-Flow-.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/55_0055-Revert-ANDROID-add-support-for-Clang-s-Control-Flow-.patch
@@ -1,0 +1,652 @@
+From cd19fa13805a784268807245594a89eedeaa071f Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:46:12 +0530
+Subject: [PATCH 30/40] Revert "ANDROID: add support for Clang's Control Flow
+ Integrity (CFI)"
+
+This reverts commit 150c326d6540243c228411f3d532d9a1d3d66df8.
+---
+ Makefile                          |  19 --
+ arch/Kconfig                      |  23 ---
+ include/asm-generic/vmlinux.lds.h |   8 +-
+ include/linux/cfi.h               |  44 -----
+ include/linux/compiler-clang.h    |   3 -
+ include/linux/compiler_types.h    |   4 -
+ include/linux/init.h              |   2 +-
+ include/linux/module.h            |   5 -
+ init/Kconfig                      |   2 +-
+ kernel/Makefile                   |   4 -
+ kernel/cfi.c                      | 307 ------------------------------
+ kernel/module.c                   |  28 ---
+ 12 files changed, 6 insertions(+), 443 deletions(-)
+ delete mode 100644 include/linux/cfi.h
+ delete mode 100644 kernel/cfi.c
+
+diff --git a/Makefile b/Makefile
+index 4b542d98dc2e..c5f1dbc1c28d 100644
+--- a/Makefile
++++ b/Makefile
+@@ -893,25 +893,6 @@ KBUILD_CFLAGS	+= $(CC_FLAGS_LTO)
+ export CC_FLAGS_LTO
+ endif
+ 
+-ifdef CONFIG_CFI_CLANG
+-CC_FLAGS_CFI	:= -fsanitize=cfi \
+-		   -fno-sanitize-cfi-canonical-jump-tables
+-
+-ifdef CONFIG_MODULES
+-CC_FLAGS_CFI	+= -fsanitize-cfi-cross-dso
+-endif
+-
+-ifdef CONFIG_CFI_PERMISSIVE
+-CC_FLAGS_CFI	+= -fsanitize-recover=cfi \
+-		   -fno-sanitize-trap=cfi
+-endif
+-
+-# If LTO flags are filtered out, we must also filter out CFI.
+-CC_FLAGS_LTO	+= $(CC_FLAGS_CFI)
+-KBUILD_CFLAGS	+= $(CC_FLAGS_CFI)
+-export CC_FLAGS_CFI
+-endif
+-
+ # arch Makefile may override CC so keep this after arch Makefile is included
+ NOSTDINC_FLAGS += -nostdinc -isystem $(shell $(CC) -print-file-name=include)
+ 
+diff --git a/arch/Kconfig b/arch/Kconfig
+index 883317dd7da5..89e48d3792fc 100644
+--- a/arch/Kconfig
++++ b/arch/Kconfig
+@@ -609,29 +609,6 @@ config LTO_CLANG
+ 
+ endchoice
+ 
+-config CFI_CLANG
+-	bool "Use Clang's Control Flow Integrity (CFI)"
+-	depends on LTO_CLANG && KALLSYMS
+-	help
+-	  This option enables Clang's Control Flow Integrity (CFI), which adds
+-	  runtime checking for indirect function calls.
+-
+-config CFI_CLANG_SHADOW
+-	bool "Use CFI shadow to speed up cross-module checks"
+-	default y
+-	depends on CFI_CLANG
+-	help
+-	  If you select this option, the kernel builds a fast look-up table of
+-	  CFI check functions in loaded modules to reduce overhead.
+-
+-config CFI_PERMISSIVE
+-	bool "Use CFI in permissive mode"
+-	depends on CFI_CLANG
+-	help
+-	  When selected, Control Flow Integrity (CFI) violations result in a
+-	  warning instead of a kernel panic. This option is useful for finding
+-	  CFI violations during development.
+-
+ config HAVE_ARCH_WITHIN_STACK_FRAMES
+ 	bool
+ 	help
+diff --git a/include/asm-generic/vmlinux.lds.h b/include/asm-generic/vmlinux.lds.h
+index dd4fd51ec704..796681c59697 100644
+--- a/include/asm-generic/vmlinux.lds.h
++++ b/include/asm-generic/vmlinux.lds.h
+@@ -71,7 +71,6 @@
+  */
+ #if defined(CONFIG_LD_DEAD_CODE_DATA_ELIMINATION) || defined(CONFIG_LTO_CLANG)
+ #define TEXT_MAIN .text .text.[0-9a-zA-Z_]*
+-#define TEXT_CFI_MAIN .text.[0-9a-zA-Z_]*.cfi
+ #define DATA_MAIN .data .data.[0-9a-zA-Z_]* .data..LPBX*
+ #define SDATA_MAIN .sdata .sdata.[0-9a-zA-Z_]*
+ #define RODATA_MAIN .rodata .rodata.[0-9a-zA-Z_]*
+@@ -79,7 +78,6 @@
+ #define SBSS_MAIN .sbss .sbss.[0-9a-zA-Z_]*
+ #else
+ #define TEXT_MAIN .text
+-#define TEXT_CFI_MAIN .text.cfi
+ #define DATA_MAIN .data
+ #define SDATA_MAIN .sdata
+ #define RODATA_MAIN .rodata
+@@ -525,8 +523,10 @@
+  */
+ #define TEXT_TEXT							\
+ 		ALIGN_FUNCTION();					\
+-		*(.text.hot TEXT_MAIN .text.fixup .text.unlikely)	\
+-		*(TEXT_CFI_MAIN)					\
++		*(.text.hot .text.hot.*)				\
++		*(TEXT_MAIN .text.fixup)				\
++		*(.text.unlikely .text.unlikely.*)			\
++		*(.text.unknown .text.unknown.*)			\
+ 		*(.text..refcount)					\
+ 		*(.text..ftrace)					\
+ 		*(.ref.text)						\
+diff --git a/include/linux/cfi.h b/include/linux/cfi.h
+deleted file mode 100644
+index 6ef37b35faaa..000000000000
+--- a/include/linux/cfi.h
++++ /dev/null
+@@ -1,44 +0,0 @@
+-/* SPDX-License-Identifier: GPL-2.0 */
+-/*
+- * Clang Control Flow Integrity (CFI) support.
+- *
+- * Copyright (C) 2019 Google LLC
+- */
+-#ifndef _LINUX_CFI_H
+-#define _LINUX_CFI_H
+-
+-#include <linux/stringify.h>
+-
+-#ifdef CONFIG_CFI_CLANG
+-#ifdef CONFIG_MODULES
+-
+-typedef void (*cfi_check_fn)(uint64_t id, void *ptr, void *diag);
+-
+-/* Compiler-generated function in each module, and the kernel */
+-#define CFI_CHECK_FN		__cfi_check
+-#define CFI_CHECK_FN_NAME	__stringify(CFI_CHECK_FN)
+-
+-extern void CFI_CHECK_FN(uint64_t id, void *ptr, void *diag);
+-
+-#ifdef CONFIG_CFI_CLANG_SHADOW
+-extern void cfi_module_add(struct module *mod, unsigned long min_addr,
+-	unsigned long max_addr);
+-
+-extern void cfi_module_remove(struct module *mod, unsigned long min_addr,
+-	unsigned long max_addr);
+-#else
+-static inline void cfi_module_add(struct module *mod, unsigned long min_addr,
+-	unsigned long max_addr)
+-{
+-}
+-
+-static inline void cfi_module_remove(struct module *mod, unsigned long min_addr,
+-	unsigned long max_addr)
+-{
+-}
+-#endif /* CONFIG_CFI_CLANG_SHADOW */
+-
+-#endif /* CONFIG_MODULES */
+-#endif /* CONFIG_CFI_CLANG */
+-
+-#endif /* _LINUX_CFI_H */
+diff --git a/include/linux/compiler-clang.h b/include/linux/compiler-clang.h
+index b7eea165e5f9..5e97289e1e67 100644
+--- a/include/linux/compiler-clang.h
++++ b/include/linux/compiler-clang.h
+@@ -54,7 +54,4 @@
+ #define __norecordmcount \
+ 	__attribute__((__section__(".text..ftrace")))
+ #endif
+-
+-
+-#define __nocfi		__attribute__((__no_sanitize__("cfi")))
+ #endif
+diff --git a/include/linux/compiler_types.h b/include/linux/compiler_types.h
+index a9baeafa207a..48e7e3396656 100644
+--- a/include/linux/compiler_types.h
++++ b/include/linux/compiler_types.h
+@@ -210,10 +210,6 @@ struct ftrace_likely_data {
+ # define __norecordmcount
+ #endif
+ 
+-#ifndef __nocfi
+-# define __nocfi
+-#endif
+-
+ #ifndef asm_volatile_goto
+ #define asm_volatile_goto(x...) asm goto(x)
+ #endif
+diff --git a/include/linux/init.h b/include/linux/init.h
+index 32633ea36f96..0a16e48e6753 100644
+--- a/include/linux/init.h
++++ b/include/linux/init.h
+@@ -47,7 +47,7 @@
+ 
+ /* These are for everybody (although not all archs will actually
+    discard it in modules) */
+-#define __init		__section(.init.text) __cold  __latent_entropy __noinitretpoline __nocfi
++#define __init		__section(.init.text) __cold  __latent_entropy __noinitretpoline
+ #define __initdata	__section(.init.data)
+ #define __initconst	__section(.init.rodata)
+ #define __exitdata	__section(.exit.data)
+diff --git a/include/linux/module.h b/include/linux/module.h
+index 34027a495180..6744ffe9a727 100644
+--- a/include/linux/module.h
++++ b/include/linux/module.h
+@@ -22,7 +22,6 @@
+ #include <linux/error-injection.h>
+ #include <linux/tracepoint-defs.h>
+ #include <linux/srcu.h>
+-#include <linux/cfi.h>
+ 
+ #include <linux/percpu.h>
+ #include <asm/module.h>
+@@ -366,10 +365,6 @@ struct module {
+ 	const s32 *crcs;
+ 	unsigned int num_syms;
+ 
+-#ifdef CONFIG_CFI_CLANG
+-	cfi_check_fn cfi_check;
+-#endif
+-
+ 	/* Kernel parameters. */
+ #ifdef CONFIG_SYSFS
+ 	struct mutex param_lock;
+diff --git a/init/Kconfig b/init/Kconfig
+index 489560b374b1..a2619021a63a 100644
+--- a/init/Kconfig
++++ b/init/Kconfig
+@@ -2192,7 +2192,7 @@ endif # MODULES
+ 
+ config MODULES_TREE_LOOKUP
+ 	def_bool y
+-	depends on PERF_EVENTS || TRACING || CFI_CLANG
++	depends on PERF_EVENTS || TRACING
+ 
+ config INIT_ALL_POSSIBLE
+ 	bool
+diff --git a/kernel/Makefile b/kernel/Makefile
+index 4be39201dc55..b5c8397f2fd2 100644
+--- a/kernel/Makefile
++++ b/kernel/Makefile
+@@ -35,9 +35,6 @@ CFLAGS_kcov.o := $(call cc-option, -fno-conserve-stack -fno-stack-protector)
+ # cond_syscall is currently not LTO compatible
+ CFLAGS_sys_ni.o = $(DISABLE_LTO)
+ 
+-# Don't instrument error handlers
+-CFLAGS_REMOVE_cfi.o := $(CC_FLAGS_CFI)
+-
+ obj-y += sched/
+ obj-y += locking/
+ obj-y += power/
+@@ -109,7 +106,6 @@ obj-$(CONFIG_IRQ_WORK) += irq_work.o
+ obj-$(CONFIG_CPU_PM) += cpu_pm.o
+ obj-$(CONFIG_BPF) += bpf/
+ obj-$(CONFIG_SHADOW_CALL_STACK) += scs.o
+-obj-$(CONFIG_CFI_CLANG) += cfi.o
+ 
+ obj-$(CONFIG_PERF_EVENTS) += events/
+ 
+diff --git a/kernel/cfi.c b/kernel/cfi.c
+deleted file mode 100644
+index 05f589e24f68..000000000000
+--- a/kernel/cfi.c
++++ /dev/null
+@@ -1,307 +0,0 @@
+-// SPDX-License-Identifier: GPL-2.0
+-/*
+- * Clang Control Flow Integrity (CFI) error and slowpath handling.
+- *
+- * Copyright (C) 2019 Google LLC
+- */
+-
+-#include <linux/gfp.h>
+-#include <linux/module.h>
+-#include <linux/mutex.h>
+-#include <linux/printk.h>
+-#include <linux/ratelimit.h>
+-#include <linux/rcupdate.h>
+-#include <asm/cacheflush.h>
+-#include <asm/set_memory.h>
+-
+-/* Compiler-defined handler names */
+-#ifdef CONFIG_CFI_PERMISSIVE
+-#define cfi_failure_handler	__ubsan_handle_cfi_check_fail
+-#define cfi_slowpath_handler	__cfi_slowpath_diag
+-#else /* enforcing */
+-#define cfi_failure_handler	__ubsan_handle_cfi_check_fail_abort
+-#define cfi_slowpath_handler	__cfi_slowpath
+-#endif /* CONFIG_CFI_PERMISSIVE */
+-
+-static inline void handle_cfi_failure(void *ptr)
+-{
+-	if (IS_ENABLED(CONFIG_CFI_PERMISSIVE))
+-		WARN_RATELIMIT(1, "CFI failure (target: %pS):\n", ptr);
+-	else
+-		panic("CFI failure (target: %pS)\n", ptr);
+-}
+-
+-#ifdef CONFIG_MODULES
+-#ifdef CONFIG_CFI_CLANG_SHADOW
+-struct shadow_range {
+-	/* Module address range */
+-	unsigned long mod_min_addr;
+-	unsigned long mod_max_addr;
+-	/* Module page range */
+-	unsigned long min_page;
+-	unsigned long max_page;
+-};
+-
+-#define SHADOW_ORDER	2
+-#define SHADOW_PAGES	(1 << SHADOW_ORDER)
+-#define SHADOW_SIZE \
+-	((SHADOW_PAGES * PAGE_SIZE - sizeof(struct shadow_range)) / sizeof(u16))
+-#define SHADOW_INVALID	0xFFFF
+-
+-struct cfi_shadow {
+-	/* Page range covered by the shadow */
+-	struct shadow_range r;
+-	/* Page offsets to __cfi_check functions in modules */
+-	u16 shadow[SHADOW_SIZE];
+-};
+-
+-static DEFINE_MUTEX(shadow_update_lock);
+-static struct cfi_shadow __rcu *cfi_shadow __read_mostly;
+-
+-static inline int ptr_to_shadow(const struct cfi_shadow *s, unsigned long ptr)
+-{
+-	unsigned long index;
+-	unsigned long page = ptr >> PAGE_SHIFT;
+-
+-	if (unlikely(page < s->r.min_page))
+-		return -1; /* Outside of module area */
+-
+-	index = page - s->r.min_page;
+-
+-	if (index >= SHADOW_SIZE)
+-		return -1; /* Cannot be addressed with shadow */
+-
+-	return (int)index;
+-}
+-
+-static inline unsigned long shadow_to_ptr(const struct cfi_shadow *s,
+-	int index)
+-{
+-	if (unlikely(index < 0 || index >= SHADOW_SIZE))
+-		return 0;
+-
+-	if (unlikely(s->shadow[index] == SHADOW_INVALID))
+-		return 0;
+-
+-	return (s->r.min_page + s->shadow[index]) << PAGE_SHIFT;
+-}
+-
+-static inline unsigned long shadow_to_page(const struct cfi_shadow *s,
+-	int index)
+-{
+-	if (unlikely(index < 0 || index >= SHADOW_SIZE))
+-		return 0;
+-
+-	return (s->r.min_page + index) << PAGE_SHIFT;
+-}
+-
+-static void prepare_next_shadow(const struct cfi_shadow __rcu *prev,
+-		struct cfi_shadow *next)
+-{
+-	int i, index, check;
+-
+-	/* Mark everything invalid */
+-	memset(next->shadow, 0xFF, sizeof(next->shadow));
+-
+-	if (!prev)
+-		return; /* No previous shadow */
+-
+-	/* If the base address didn't change, update is not needed */
+-	if (prev->r.min_page == next->r.min_page) {
+-		memcpy(next->shadow, prev->shadow, sizeof(next->shadow));
+-		return;
+-	}
+-
+-	/* Convert the previous shadow to the new address range */
+-	for (i = 0; i < SHADOW_SIZE; ++i) {
+-		if (prev->shadow[i] == SHADOW_INVALID)
+-			continue;
+-
+-		index = ptr_to_shadow(next, shadow_to_page(prev, i));
+-		if (index < 0)
+-			continue;
+-
+-		check = ptr_to_shadow(next,
+-				shadow_to_ptr(prev, prev->shadow[i]));
+-		if (check < 0)
+-			continue;
+-
+-		next->shadow[index] = (u16)check;
+-	}
+-}
+-
+-static void add_module_to_shadow(struct cfi_shadow *s, struct module *mod)
+-{
+-	unsigned long ptr;
+-	unsigned long min_page_addr;
+-	unsigned long max_page_addr;
+-	unsigned long check = (unsigned long)mod->cfi_check;
+-	int check_index = ptr_to_shadow(s, check);
+-
+-	if (unlikely((check & PAGE_MASK) != check))
+-		return; /* Must be page aligned */
+-
+-	if (check_index < 0)
+-		return; /* Module not addressable with shadow */
+-
+-	min_page_addr = (unsigned long)mod->core_layout.base & PAGE_MASK;
+-	max_page_addr = (unsigned long)mod->core_layout.base +
+-				       mod->core_layout.text_size;
+-	max_page_addr &= PAGE_MASK;
+-
+-	/* For each page, store the check function index in the shadow */
+-	for (ptr = min_page_addr; ptr <= max_page_addr; ptr += PAGE_SIZE) {
+-		int index = ptr_to_shadow(s, ptr);
+-
+-		if (index >= 0) {
+-			/* Each page must only contain one module */
+-			WARN_ON(s->shadow[index] != SHADOW_INVALID);
+-			s->shadow[index] = (u16)check_index;
+-		}
+-	}
+-}
+-
+-static void remove_module_from_shadow(struct cfi_shadow *s, struct module *mod)
+-{
+-	unsigned long ptr;
+-	unsigned long min_page_addr;
+-	unsigned long max_page_addr;
+-
+-	min_page_addr = (unsigned long)mod->core_layout.base & PAGE_MASK;
+-	max_page_addr = (unsigned long)mod->core_layout.base +
+-				       mod->core_layout.text_size;
+-	max_page_addr &= PAGE_MASK;
+-
+-	for (ptr = min_page_addr; ptr <= max_page_addr; ptr += PAGE_SIZE) {
+-		int index = ptr_to_shadow(s, ptr);
+-
+-		if (index >= 0)
+-			s->shadow[index] = SHADOW_INVALID;
+-	}
+-}
+-
+-typedef void (*update_shadow_fn)(struct cfi_shadow *, struct module *);
+-
+-static void update_shadow(struct module *mod, unsigned long min_addr,
+-	unsigned long max_addr, update_shadow_fn fn)
+-{
+-	struct cfi_shadow *prev;
+-	struct cfi_shadow *next = (struct cfi_shadow *)
+-		__get_free_pages(GFP_KERNEL, SHADOW_ORDER);
+-
+-	next->r.mod_min_addr = min_addr;
+-	next->r.mod_max_addr = max_addr;
+-	next->r.min_page = min_addr >> PAGE_SHIFT;
+-	next->r.max_page = max_addr >> PAGE_SHIFT;
+-
+-	mutex_lock(&shadow_update_lock);
+-	prev = rcu_dereference_protected(cfi_shadow, 1);
+-	prepare_next_shadow(prev, next);
+-
+-	fn(next, mod);
+-	set_memory_ro((unsigned long)next, SHADOW_PAGES);
+-	rcu_assign_pointer(cfi_shadow, next);
+-
+-	mutex_unlock(&shadow_update_lock);
+-	synchronize_rcu();
+-
+-	if (prev) {
+-		set_memory_rw((unsigned long)prev, SHADOW_PAGES);
+-		free_pages((unsigned long)prev, SHADOW_ORDER);
+-	}
+-}
+-
+-void cfi_module_add(struct module *mod, unsigned long min_addr,
+-	unsigned long max_addr)
+-{
+-	update_shadow(mod, min_addr, max_addr, add_module_to_shadow);
+-}
+-EXPORT_SYMBOL(cfi_module_add);
+-
+-void cfi_module_remove(struct module *mod, unsigned long min_addr,
+-	unsigned long max_addr)
+-{
+-	update_shadow(mod, min_addr, max_addr, remove_module_from_shadow);
+-}
+-EXPORT_SYMBOL(cfi_module_remove);
+-
+-static inline cfi_check_fn ptr_to_check_fn(const struct cfi_shadow __rcu *s,
+-	unsigned long ptr)
+-{
+-	int index;
+-
+-	if (unlikely(!s))
+-		return NULL; /* No shadow available */
+-
+-	if (ptr < s->r.mod_min_addr || ptr > s->r.mod_max_addr)
+-		return NULL; /* Not in a mapped module */
+-
+-	index = ptr_to_shadow(s, ptr);
+-	if (index < 0)
+-		return NULL; /* Cannot be addressed with shadow */
+-
+-	return (cfi_check_fn)shadow_to_ptr(s, index);
+-}
+-#endif /* CONFIG_CFI_CLANG_SHADOW */
+-
+-static inline cfi_check_fn find_module_cfi_check(void *ptr)
+-{
+-	struct module *mod;
+-
+-	preempt_disable();
+-	mod = __module_address((unsigned long)ptr);
+-	preempt_enable();
+-
+-	if (mod)
+-		return mod->cfi_check;
+-
+-	return CFI_CHECK_FN;
+-}
+-
+-static inline cfi_check_fn find_cfi_check(void *ptr)
+-{
+-#ifdef CONFIG_CFI_CLANG_SHADOW
+-	cfi_check_fn f;
+-
+-	if (!rcu_access_pointer(cfi_shadow))
+-		return CFI_CHECK_FN; /* No loaded modules */
+-
+-	/* Look up the __cfi_check function to use */
+-	rcu_read_lock();
+-	f = ptr_to_check_fn(rcu_dereference(cfi_shadow), (unsigned long)ptr);
+-	rcu_read_unlock();
+-
+-	if (f)
+-		return f;
+-
+-	/*
+-	 * Fall back to find_module_cfi_check, which works also for a larger
+-	 * module address space, but is slower.
+-	 */
+-#endif /* CONFIG_CFI_CLANG_SHADOW */
+-
+-	return find_module_cfi_check(ptr);
+-}
+-
+-void cfi_slowpath_handler(uint64_t id, void *ptr, void *diag)
+-{
+-	cfi_check_fn check = find_cfi_check(ptr);
+-
+-	if (likely(check))
+-		check(id, ptr, diag);
+-	else /* Don't allow unchecked modules */
+-		handle_cfi_failure(ptr);
+-}
+-EXPORT_SYMBOL(cfi_slowpath_handler);
+-#endif /* CONFIG_MODULES */
+-
+-void cfi_failure_handler(void *data, void *ptr, void *vtable)
+-{
+-	handle_cfi_failure(ptr);
+-}
+-EXPORT_SYMBOL(cfi_failure_handler);
+-
+-void __cfi_check_fail(void *data, void *ptr)
+-{
+-	handle_cfi_failure(ptr);
+-}
+diff --git a/kernel/module.c b/kernel/module.c
+index c611faaa8bec..45513909b01d 100644
+--- a/kernel/module.c
++++ b/kernel/module.c
+@@ -2206,8 +2206,6 @@ void __weak module_arch_freeing_init(struct module *mod)
+ {
+ }
+ 
+-static void cfi_cleanup(struct module *mod);
+-
+ /* Free a module, remove from lists, etc. */
+ static void free_module(struct module *mod)
+ {
+@@ -2247,9 +2245,6 @@ static void free_module(struct module *mod)
+ 	synchronize_rcu();
+ 	mutex_unlock(&module_mutex);
+ 
+-	/* Clean up CFI for the module. */
+-	cfi_cleanup(mod);
+-
+ 	/* This may be empty, but that's OK */
+ 	module_arch_freeing_init(mod);
+ 	module_memfree(mod->init_layout.base);
+@@ -3500,8 +3495,6 @@ int __weak module_finalize(const Elf_Ehdr *hdr,
+ 	return 0;
+ }
+ 
+-static void cfi_init(struct module *mod);
+-
+ static int post_relocation(struct module *mod, const struct load_info *info)
+ {
+ 	/* Sort exception table now relocations are done. */
+@@ -3514,9 +3507,6 @@ static int post_relocation(struct module *mod, const struct load_info *info)
+ 	/* Setup kallsyms-specific fields. */
+ 	add_kallsyms(mod, info);
+ 
+-	/* Setup CFI for the module. */
+-	cfi_init(mod);
+-
+ 	/* Arch-specific module finalizing. */
+ 	return module_finalize(info->hdr, info->sechdrs, mod);
+ }
+@@ -4312,24 +4302,6 @@ int module_kallsyms_on_each_symbol(int (*fn)(void *, const char *,
+ }
+ #endif /* CONFIG_KALLSYMS */
+ 
+-static void cfi_init(struct module *mod)
+-{
+-#ifdef CONFIG_CFI_CLANG
+-	rcu_read_lock();
+-	mod->cfi_check = (cfi_check_fn)find_kallsyms_symbol_value(mod,
+-						CFI_CHECK_FN_NAME);
+-	rcu_read_unlock();
+-	cfi_module_add(mod, module_addr_min, module_addr_max);
+-#endif
+-}
+-
+-static void cfi_cleanup(struct module *mod)
+-{
+-#ifdef CONFIG_CFI_CLANG
+-	cfi_module_remove(mod, module_addr_min, module_addr_max);
+-#endif
+-}
+-
+ /* Maximum number of characters written by module_flags() */
+ #define MODULE_FLAGS_BUF_SIZE (TAINT_FLAGS_COUNT + 4)
+ 
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/56_0056-Revert-ANDROID-init-ensure-initcall-ordering-with-LT.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/56_0056-Revert-ANDROID-init-ensure-initcall-ordering-with-LT.patch
@@ -1,0 +1,388 @@
+From 15279ee5baabc7f23c9e0660b320fe74a6ea4165 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:46:22 +0530
+Subject: [PATCH 31/40] Revert "ANDROID: init: ensure initcall ordering with
+ LTO"
+
+This reverts commit 1aa5e4ad9e591eb7500f9a44e532b43c140efecd.
+---
+ include/linux/init.h               |  26 +--
+ scripts/generate_initcall_order.pl | 250 -----------------------------
+ scripts/link-vmlinux.sh            |  36 ++---
+ 3 files changed, 19 insertions(+), 293 deletions(-)
+ delete mode 100755 scripts/generate_initcall_order.pl
+
+diff --git a/include/linux/init.h b/include/linux/init.h
+index 0a16e48e6753..212fc9e2f691 100644
+--- a/include/linux/init.h
++++ b/include/linux/init.h
+@@ -192,32 +192,10 @@ extern bool initcall_debug;
+ 	    ".long	" #fn " - .			\n"	\
+ 	    ".previous					\n");
+ #else
+-#ifdef CONFIG_LTO_CLANG
+-  /*
+-   * With LTO, the compiler doesn't necessarily obey link order for
+-   * initcalls, and the initcall variable needs to be globally unique
+-   * to avoid naming collisions.  In order to preserve the correct
+-   * order, we add each variable into its own section and generate a
+-   * linker script (in scripts/link-vmlinux.sh) to ensure the order
+-   * remains correct.  We also add a __COUNTER__ prefix to the name,
+-   * so we can retain the order of initcalls within each compilation
+-   * unit, and __LINE__ to make the names more unique.
+-   */
+-  #define ___lto_initcall(c, l, fn, id, __sec) \
+-	static initcall_t __initcall_##c##_##l##_##fn##id __used \
+-		__attribute__((__section__( #__sec \
+-			__stringify(.init..##c##_##l##_##fn)))) = fn;
+-  #define __lto_initcall(c, l, fn, id, __sec) \
+-	___lto_initcall(c, l, fn, id, __sec)
+-
+-  #define ___define_initcall(fn, id, __sec) \
+-	__lto_initcall(__COUNTER__, __LINE__, fn, id, __sec)
+-#else
+-  #define ___define_initcall(fn, id, __sec) \
++#define ___define_initcall(fn, id, __sec) \
+ 	static initcall_t __initcall_##fn##id __used \
+ 		__attribute__((__section__(#__sec ".init"))) = fn;
+ #endif
+-#endif
+ 
+ #define __define_initcall(fn, id) ___define_initcall(fn, id, .initcall##id)
+ 
+@@ -258,7 +236,7 @@ extern bool initcall_debug;
+ #define __exitcall(fn)						\
+ 	static exitcall_t __exitcall_##fn __exit_call = fn
+ 
+-#define console_initcall(fn)	___define_initcall(fn, con, .con_initcall)
++#define console_initcall(fn)	___define_initcall(fn,, .con_initcall)
+ 
+ struct obs_kernel_param {
+ 	const char *str;
+diff --git a/scripts/generate_initcall_order.pl b/scripts/generate_initcall_order.pl
+deleted file mode 100755
+index f772b4a01caa..000000000000
+--- a/scripts/generate_initcall_order.pl
++++ /dev/null
+@@ -1,250 +0,0 @@
+-#!/usr/bin/env perl
+-# SPDX-License-Identifier: GPL-2.0
+-#
+-# Generates a linker script that specifies the correct initcall order.
+-#
+-# Copyright (C) 2019 Google LLC
+-
+-use strict;
+-use warnings;
+-use IO::Handle;
+-
+-my $nm = $ENV{'LLVM_NM'} || "llvm-nm";
+-my $ar = $ENV{'AR'}	 || "llvm-ar";
+-my $objtree = $ENV{'objtree'} || ".";
+-
+-## list of all object files to process, in link order
+-my @objects;
+-## currently active child processes
+-my $jobs = {};		# child process pid -> file handle
+-## results from child processes
+-my $results = {};	# object index -> { level, function }
+-
+-## reads _NPROCESSORS_ONLN to determine the number of processes to start
+-sub get_online_processors {
+-	open(my $fh, "getconf _NPROCESSORS_ONLN 2>/dev/null |")
+-		or die "$0: failed to execute getconf: $!";
+-	my $procs = <$fh>;
+-	close($fh);
+-
+-	if (!($procs =~ /^\d+$/)) {
+-		return 1;
+-	}
+-
+-	return int($procs);
+-}
+-
+-## finds initcalls defined in an object file, parses level and function name,
+-## and prints it out to the parent process
+-sub find_initcalls {
+-	my ($object) = @_;
+-
+-	die "$0: object file $object doesn't exist?" if (! -f $object);
+-
+-	open(my $fh, "\"$nm\" -just-symbol-name -defined-only \"$object\" 2>/dev/null |")
+-		or die "$0: failed to execute \"$nm\": $!";
+-
+-	my $initcalls = {};
+-
+-	while (<$fh>) {
+-		chomp;
+-
+-		my ($counter, $line, $symbol) = $_ =~ /^__initcall_(\d+)_(\d+)_(.*)$/;
+-
+-		if (!defined($counter) || !defined($line) || !defined($symbol)) {
+-			next;
+-		}
+-
+-		my ($function, $level) = $symbol =~
+-			/^(.*)((early|rootfs|con|security|[0-9])s?)$/;
+-
+-		die "$0: duplicate initcall counter value in object $object: $_"
+-			if exists($initcalls->{$counter});
+-
+-		$initcalls->{$counter} = {
+-			'level'    => $level,
+-			'line'     => $line,
+-			'function' => $function
+-		};
+-	}
+-
+-	close($fh);
+-
+-	# sort initcalls in each object file numerically by the counter value
+-	# to ensure they are in the order they were defined
+-	foreach my $counter (sort { $a <=> $b } keys(%{$initcalls})) {
+-		print $initcalls->{$counter}->{"level"} . " " .
+-		      $counter . " " .
+-		      $initcalls->{$counter}->{"line"} . " " .
+-		      $initcalls->{$counter}->{"function"} . "\n";
+-	}
+-}
+-
+-## waits for any child process to complete, reads the results, and adds them to
+-## the $results array for later processing
+-sub wait_for_results {
+-	my $pid = wait();
+-	if ($pid > 0) {
+-		my $fh = $jobs->{$pid};
+-
+-		# the child process prints out results in the following format:
+-		#  line 1:    <object file index>
+-		#  line 2..n: <level> <counter> <line> <function>
+-
+-		my $index = <$fh>;
+-		chomp($index);
+-
+-		if (!($index =~ /^\d+$/)) {
+-			die "$0: child $pid returned an invalid index: $index";
+-		}
+-		$index = int($index);
+-
+-		while (<$fh>) {
+-			chomp;
+-			my ($level, $counter, $line, $function) = $_ =~
+-				/^([^\ ]+)\ (\d+)\ (\d+)\ (.*)$/;
+-
+-			if (!defined($level) ||
+-				!defined($counter) ||
+-				!defined($line) ||
+-				!defined($function)) {
+-				die "$0: child $pid returned invalid data";
+-			}
+-
+-			if (!exists($results->{$index})) {
+-				$results->{$index} = [];
+-			}
+-
+-			push (@{$results->{$index}}, {
+-				'level'    => $level,
+-				'counter'  => $counter,
+-				'line'     => $line,
+-				'function' => $function
+-			});
+-		}
+-
+-		close($fh);
+-		delete($jobs->{$pid});
+-	}
+-}
+-
+-## launches child processes to find initcalls from the object files, waits for
+-## each process to complete and collects the results
+-sub process_objects {
+-	my $index = 0;	# link order index of the object file
+-	my $njobs = get_online_processors();
+-
+-	while (scalar(@objects) > 0) {
+-		my $object = shift(@objects);
+-
+-		# fork a child process and read it's stdout
+-		my $pid = open(my $fh, '-|');
+-
+-		if (!defined($pid)) {
+-			die "$0: failed to fork: $!";
+-		} elsif ($pid) {
+-			# save the child process pid and the file handle
+-			$jobs->{$pid} = $fh;
+-		} else {
+-			STDOUT->autoflush(1);
+-			print "$index\n";
+-			find_initcalls("$objtree/$object");
+-			exit;
+-		}
+-
+-		$index++;
+-
+-		# if we reached the maximum number of processes, wait for one
+-		# to complete before launching new ones
+-		if (scalar(keys(%{$jobs})) >= $njobs && scalar(@objects) > 0) {
+-			wait_for_results();
+-		}
+-	}
+-
+-	# wait for the remaining children to complete
+-	while (scalar(keys(%{$jobs})) > 0) {
+-		wait_for_results();
+-	}
+-}
+-
+-## gets a list of actual object files from thin archives, and adds them to
+-## @objects in link order
+-sub find_objects {
+-	while (my $file = shift(@ARGV)) {
+-		my $pid = open (my $fh, "\"$ar\" t \"$file\" 2>/dev/null |")
+-			or die "$0: failed to execute $ar: $!";
+-
+-		my @output;
+-
+-		while (<$fh>) {
+-			chomp;
+-			push(@output, $_);
+-		}
+-
+-		close($fh);
+-
+-		# if $ar failed, assume we have an object file
+-		if ($? != 0) {
+-			push(@objects, $file);
+-			next;
+-		}
+-
+-		# if $ar succeeded, read the list of object files
+-		foreach (@output) {
+-			push(@objects, $_);
+-		}
+-	}
+-}
+-
+-## START
+-find_objects();
+-process_objects();
+-
+-## process results and add them to $sections in the correct order
+-my $sections = {};
+-
+-foreach my $index (sort { $a <=> $b } keys(%{$results})) {
+-	foreach my $result (@{$results->{$index}}) {
+-		my $level = $result->{'level'};
+-
+-		if (!exists($sections->{$level})) {
+-			$sections->{$level} = [];
+-		}
+-
+-		my $fsname = $result->{'counter'} . '_' .
+-			     $result->{'line'}    . '_' .
+-			     $result->{'function'};
+-
+-		push(@{$sections->{$level}}, $fsname);
+-	}
+-}
+-
+-if (!keys(%{$sections})) {
+-	exit(0); # no initcalls...?
+-}
+-
+-## print out a linker script that defines the order of initcalls for each
+-## level
+-print "SECTIONS {\n";
+-
+-foreach my $level (sort(keys(%{$sections}))) {
+-	my $section;
+-
+-	if ($level eq 'con') {
+-		$section = '.con_initcall.init';
+-	} elsif ($level eq 'security') {
+-		$section = '.security_initcall.init';
+-	} else {
+-		$section = ".initcall${level}.init";
+-	}
+-
+-	print "\t${section} : {\n";
+-
+-	foreach my $fsname (@{$sections->{$level}}) {
+-		print "\t\t*(${section}..${fsname}) ;\n"
+-	}
+-
+-	print "\t}\n";
+-}
+-
+-print "}\n";
+diff --git a/scripts/link-vmlinux.sh b/scripts/link-vmlinux.sh
+index 6694a6887b6a..5951c1eac1d0 100755
+--- a/scripts/link-vmlinux.sh
++++ b/scripts/link-vmlinux.sh
+@@ -39,30 +39,28 @@ info()
+ 	fi
+ }
+ 
+-# If CONFIG_LTO_CLANG is selected, generate a linker script to ensure correct
+-# ordering of initcalls, and with CONFIG_MODVERSIONS also enabled, collect the
+-# previously generated symbol versions into the same script.
+-lto_lds()
++# If CONFIG_LTO_CLANG is selected, collect generated symbol versions into
++# .tmp_symversions
++modversions()
+ {
+ 	if [ -z "${CONFIG_LTO_CLANG}" ]; then
+ 		return
+ 	fi
++	if [ -z "${CONFIG_MODVERSIONS}" ]; then
++		return
++	fi
+ 
+-	${srctree}/scripts/generate_initcall_order.pl \
+-		${KBUILD_VMLINUX_OBJS} ${KBUILD_VMLINUX_LIBS} \
+-		> .tmp_lto.lds
+-
+-	if [ -n "${CONFIG_MODVERSIONS}" ]; then
+-		for a in ${KBUILD_VMLINUX_OBJS} ${KBUILD_VMLINUX_LIBS}; do
+-			for o in $(${AR} t $a 2>/dev/null); do
+-				if [ -f ${o}.symversions ]; then
+-					cat ${o}.symversions >> .tmp_lto.lds
+-				fi
+-			done
++	rm -f .tmp_symversions
++
++	for a in ${KBUILD_VMLINUX_OBJS} ${KBUILD_VMLINUX_LIBS}; do
++		for o in $(${AR} t $a 2>/dev/null); do
++			if [ -f ${o}.symversions ]; then
++				cat ${o}.symversions >> .tmp_symversions
++			fi
+ 		done
+-	fi
++	done
+ 
+-	echo "-T .tmp_lto.lds"
++	echo "-T .tmp_symversions"
+ }
+ 
+ # Link of vmlinux.o used for section mismatch analysis
+@@ -86,7 +84,7 @@ modpost_link()
+ 		info LD ${1}
+ 	fi
+ 
+-	${LD} ${KBUILD_LDFLAGS} -r -o ${1} $(lto_lds) ${objects}
++	${LD} ${KBUILD_LDFLAGS} -r -o ${1} $(modversions) ${objects}
+ }
+ 
+ # If CONFIG_LTO_CLANG is selected, we postpone running recordmcount until
+@@ -255,7 +253,7 @@ cleanup()
+ 	rm -f .btf.*
+ 	rm -f .tmp_System.map
+ 	rm -f .tmp_kallsyms*
+-	rm -f .tmp_lto.lds
++	rm -f .tmp_symversions
+ 	rm -f .tmp_vmlinux*
+ 	rm -f System.map
+ 	rm -f vmlinux
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/57_0057-Revert-ANDROID-drivers-misc-lkdtm-disable-LTO-for-ro.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/57_0057-Revert-ANDROID-drivers-misc-lkdtm-disable-LTO-for-ro.patch
@@ -1,0 +1,26 @@
+From 2079b425124ba0d2a11daaa04e2a825cb0ec9fc9 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:46:32 +0530
+Subject: [PATCH 32/40] Revert "ANDROID: drivers/misc/lkdtm: disable LTO for
+ rodata.o"
+
+This reverts commit 9420c429384a546bded34b51f90a882e57bc6511.
+---
+ drivers/misc/lkdtm/Makefile | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/drivers/misc/lkdtm/Makefile b/drivers/misc/lkdtm/Makefile
+index dd4c936d4d73..c70b3822013f 100644
+--- a/drivers/misc/lkdtm/Makefile
++++ b/drivers/misc/lkdtm/Makefile
+@@ -13,7 +13,6 @@ lkdtm-$(CONFIG_LKDTM)		+= cfi.o
+ 
+ KASAN_SANITIZE_stackleak.o	:= n
+ KCOV_INSTRUMENT_rodata.o	:= n
+-CFLAGS_REMOVE_rodata.o		+= $(CC_FLAGS_LTO)
+ 
+ OBJCOPYFLAGS :=
+ OBJCOPYFLAGS_rodata_objcopy.o	:= \
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/58_0058-Revert-ANDROID-efi-libstub-disable-LTO.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/58_0058-Revert-ANDROID-efi-libstub-disable-LTO.patch
@@ -1,0 +1,27 @@
+From 7d45cfe79a28a3be2785805738ed79be06480af9 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:46:45 +0530
+Subject: [PATCH 33/40] Revert "ANDROID: efi/libstub: disable LTO"
+
+This reverts commit 4ffa389ea0399deb069b4f87be25069329810a8c.
+---
+ drivers/firmware/efi/libstub/Makefile | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/drivers/firmware/efi/libstub/Makefile b/drivers/firmware/efi/libstub/Makefile
+index 3f71cde3dcf1..8c5b5529dbc0 100644
+--- a/drivers/firmware/efi/libstub/Makefile
++++ b/drivers/firmware/efi/libstub/Makefile
+@@ -31,9 +31,6 @@ KBUILD_CFLAGS			:= $(cflags-y) -DDISABLE_BRANCH_PROFILING \
+ 				   $(call cc-option,-fno-addrsig) \
+ 				   -D__DISABLE_EXPORTS
+ 
+-# disable LTO
+-KBUILD_CFLAGS := $(filter-out $(CC_FLAGS_LTO), $(KBUILD_CFLAGS))
+-
+ GCOV_PROFILE			:= n
+ KASAN_SANITIZE			:= n
+ UBSAN_SANITIZE			:= n
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/59_0059-Revert-ANDROID-scripts-mod-disable-LTO-for-empty.c.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/59_0059-Revert-ANDROID-scripts-mod-disable-LTO-for-empty.c.patch
@@ -1,0 +1,24 @@
+From b58a354bdd59c98334ed2c8f86139e0f1236c018 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:46:53 +0530
+Subject: [PATCH 34/40] Revert "ANDROID: scripts/mod: disable LTO for empty.c"
+
+This reverts commit 4d3cc9765e4b92baf556fd7e35272b3ce6db2df7.
+---
+ scripts/mod/Makefile | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/scripts/mod/Makefile b/scripts/mod/Makefile
+index 9cbf4630ddfe..42c5d50f2bcc 100644
+--- a/scripts/mod/Makefile
++++ b/scripts/mod/Makefile
+@@ -1,6 +1,5 @@
+ # SPDX-License-Identifier: GPL-2.0
+ OBJECT_FILES_NON_STANDARD := y
+-CFLAGS_REMOVE_empty.o += $(CC_FLAGS_LTO)
+ 
+ hostprogs-y	:= modpost mk_elfconfig
+ always		:= $(hostprogs-y) empty.o
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/60_0060-Revert-ANDROID-kbuild-fix-dynamic-ftrace-with-clang-.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/60_0060-Revert-ANDROID-kbuild-fix-dynamic-ftrace-with-clang-.patch
@@ -1,0 +1,200 @@
+From 0fa1e1cc9bbf13a4276812b9632f7efdfb50a8b8 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:47:04 +0530
+Subject: [PATCH 35/40] Revert "ANDROID: kbuild: fix dynamic ftrace with clang
+ LTO"
+
+This reverts commit ce32b4c010106140614f5b916c06449c6f63d87d.
+---
+ arch/Kconfig                      |  2 +-
+ include/asm-generic/vmlinux.lds.h |  1 -
+ include/linux/compiler-clang.h    |  7 -------
+ include/linux/compiler_types.h    |  4 ----
+ kernel/trace/ftrace.c             |  6 +++---
+ scripts/Makefile.build            | 11 -----------
+ scripts/Makefile.modfinal         |  4 ----
+ scripts/link-vmlinux.sh           | 18 ------------------
+ scripts/recordmcount.c            |  4 +---
+ 9 files changed, 5 insertions(+), 52 deletions(-)
+
+diff --git a/arch/Kconfig b/arch/Kconfig
+index 89e48d3792fc..029acb2462fc 100644
+--- a/arch/Kconfig
++++ b/arch/Kconfig
+@@ -597,7 +597,7 @@ config LTO_CLANG
+ 	bool "Use Clang's Link Time Optimization (LTO) (EXPERIMENTAL)"
+ 	depends on ARCH_SUPPORTS_LTO_CLANG
+ 	depends on !KASAN
+-	depends on !FTRACE_MCOUNT_RECORD || HAVE_C_RECORDMCOUNT
++	depends on !FTRACE_MCOUNT_RECORD
+ 	depends on CC_IS_CLANG && CLANG_VERSION >= 100000 && LD_IS_LLD
+ 	select LTO
+ 	help
+diff --git a/include/asm-generic/vmlinux.lds.h b/include/asm-generic/vmlinux.lds.h
+index 796681c59697..cfd6450e9609 100644
+--- a/include/asm-generic/vmlinux.lds.h
++++ b/include/asm-generic/vmlinux.lds.h
+@@ -528,7 +528,6 @@
+ 		*(.text.unlikely .text.unlikely.*)			\
+ 		*(.text.unknown .text.unknown.*)			\
+ 		*(.text..refcount)					\
+-		*(.text..ftrace)					\
+ 		*(.ref.text)						\
+ 	MEM_KEEP(init.text*)						\
+ 	MEM_KEEP(exit.text*)						\
+diff --git a/include/linux/compiler-clang.h b/include/linux/compiler-clang.h
+index 5e97289e1e67..18fc4d29ef27 100644
+--- a/include/linux/compiler-clang.h
++++ b/include/linux/compiler-clang.h
+@@ -48,10 +48,3 @@
+ #else
+ # define __noscs
+ #endif
+-
+-#ifdef CONFIG_LTO_CLANG
+-#ifdef CONFIG_FTRACE_MCOUNT_RECORD
+-#define __norecordmcount \
+-	__attribute__((__section__(".text..ftrace")))
+-#endif
+-#endif
+diff --git a/include/linux/compiler_types.h b/include/linux/compiler_types.h
+index 48e7e3396656..be5d5be4b1ae 100644
+--- a/include/linux/compiler_types.h
++++ b/include/linux/compiler_types.h
+@@ -206,10 +206,6 @@ struct ftrace_likely_data {
+ # define __noscs
+ #endif
+ 
+-#ifndef __norecordmcount
+-# define __norecordmcount
+-#endif
+-
+ #ifndef asm_volatile_goto
+ #define asm_volatile_goto(x...) asm goto(x)
+ #endif
+diff --git a/kernel/trace/ftrace.c b/kernel/trace/ftrace.c
+index 536aadfaf59d..fbba31baef53 100644
+--- a/kernel/trace/ftrace.c
++++ b/kernel/trace/ftrace.c
+@@ -5571,9 +5571,9 @@ static int ftrace_cmp_ips(const void *a, const void *b)
+ 	return 0;
+ }
+ 
+-static int __norecordmcount ftrace_process_locs(struct module *mod,
+-						unsigned long *start,
+-						unsigned long *end)
++static int ftrace_process_locs(struct module *mod,
++			       unsigned long *start,
++			       unsigned long *end)
+ {
+ 	struct ftrace_page *start_pg;
+ 	struct ftrace_page *pg;
+diff --git a/scripts/Makefile.build b/scripts/Makefile.build
+index e1ca92679728..40b072cccdde 100644
+--- a/scripts/Makefile.build
++++ b/scripts/Makefile.build
+@@ -176,12 +176,6 @@ ifdef BUILD_C_RECORDMCOUNT
+ ifeq ("$(origin RECORDMCOUNT_WARN)", "command line")
+   RECORDMCOUNT_FLAGS = -w
+ endif
+-
+-ifdef CONFIG_LTO_CLANG
+-# With LTO, we postpone running recordmcount until after the LTO link step, so
+-# let's export the parameters for the link script.
+-export RECORDMCOUNT_FLAGS
+-else
+ # Due to recursion, we must skip empty.o.
+ # The empty.o file is created in the make process in order to determine
+ # the target endianness and word size. It is made before all other C
+@@ -190,8 +184,6 @@ sub_cmd_record_mcount =					\
+ 	if [ $(@) != "scripts/mod/empty.o" ]; then	\
+ 		$(objtree)/scripts/recordmcount $(RECORDMCOUNT_FLAGS) "$(@)";	\
+ 	fi;
+-endif
+-
+ recordmcount_source := $(srctree)/scripts/recordmcount.c \
+ 		    $(srctree)/scripts/recordmcount.h
+ else
+@@ -201,13 +193,10 @@ sub_cmd_record_mcount = perl $(srctree)/scripts/recordmcount.pl "$(ARCH)" \
+ 	"$(OBJDUMP)" "$(OBJCOPY)" "$(CC) $(KBUILD_CPPFLAGS) $(KBUILD_CFLAGS)" \
+ 	"$(LD) $(KBUILD_LDFLAGS)" "$(NM)" "$(RM)" "$(MV)" \
+ 	"$(if $(part-of-module),1,0)" "$(@)";
+-
+ recordmcount_source := $(srctree)/scripts/recordmcount.pl
+ endif # BUILD_C_RECORDMCOUNT
+-ifndef CONFIG_LTO_CLANG
+ cmd_record_mcount = $(if $(findstring $(strip $(CC_FLAGS_FTRACE)),$(_c_flags)),	\
+ 	$(sub_cmd_record_mcount))
+-endif # CONFIG_LTO_CLANG
+ endif # CC_USING_RECORD_MCOUNT
+ endif # CONFIG_FTRACE_MCOUNT_RECORD
+ 
+diff --git a/scripts/Makefile.modfinal b/scripts/Makefile.modfinal
+index 216a3f84bafe..2164a84a45a2 100644
+--- a/scripts/Makefile.modfinal
++++ b/scripts/Makefile.modfinal
+@@ -41,10 +41,6 @@ ifdef CONFIG_LTO_CLANG
+ 			echo -T $(@:.ko=.o.symversions))  		\
+ 		 -o $@ --whole-archive $(filter %.o, $^);		\
+ 	$(if $(ARCH_POSTLINK), $(MAKE) -f $(ARCH_POSTLINK) $@, true)
+-
+-  ifdef CONFIG_FTRACE_MCOUNT_RECORD
+-      cmd_ld_ko_o += ; $(objtree)/scripts/recordmcount $(RECORDMCOUNT_FLAGS) $@
+-  endif
+ else
+       cmd_ld_ko_o =                                                     \
+ 	$(LD) -r $(KBUILD_LDFLAGS)					\
+diff --git a/scripts/link-vmlinux.sh b/scripts/link-vmlinux.sh
+index 5951c1eac1d0..4bd929e8fc05 100755
+--- a/scripts/link-vmlinux.sh
++++ b/scripts/link-vmlinux.sh
+@@ -87,19 +87,6 @@ modpost_link()
+ 	${LD} ${KBUILD_LDFLAGS} -r -o ${1} $(modversions) ${objects}
+ }
+ 
+-# If CONFIG_LTO_CLANG is selected, we postpone running recordmcount until
+-# we have compiled LLVM IR to an object file.
+-recordmcount()
+-{
+-	if [ -z "${CONFIG_LTO_CLANG}" ]; then
+-		return
+-	fi
+-
+-	if [ -n "${CONFIG_FTRACE_MCOUNT_RECORD}" ]; then
+-		scripts/recordmcount ${RECORDMCOUNT_FLAGS} $*
+-	fi
+-}
+-
+ # Link of vmlinux
+ # ${1} - output file
+ # ${2}, ${3}, ... - optional extra .o files
+@@ -310,11 +297,6 @@ modpost_link vmlinux.o
+ # modpost vmlinux.o to check for section mismatches
+ ${MAKE} -f "${srctree}/scripts/Makefile.modpost" MODPOST_VMLINUX=1
+ 
+-if [ -n "${CONFIG_LTO_CLANG}" ]; then
+-	# Call recordmcount if needed
+-	recordmcount vmlinux.o
+-fi
+-
+ info MODINFO modules.builtin.modinfo
+ ${OBJCOPY} -j .modinfo -O binary vmlinux.o modules.builtin.modinfo
+ 
+diff --git a/scripts/recordmcount.c b/scripts/recordmcount.c
+index d8f5e02f1a7d..b9c2ee7ab43f 100644
+--- a/scripts/recordmcount.c
++++ b/scripts/recordmcount.c
+@@ -414,9 +414,7 @@ static int is_mcounted_section_name(char const *const txtname)
+ 		strcmp(".irqentry.text", txtname) == 0 ||
+ 		strcmp(".softirqentry.text", txtname) == 0 ||
+ 		strcmp(".kprobes.text", txtname) == 0 ||
+-		strcmp(".cpuidle.text", txtname) == 0 ||
+-		(strncmp(".text.",       txtname, 6) == 0 &&
+-		 strcmp(".text..ftrace", txtname) != 0);
++		strcmp(".cpuidle.text", txtname) == 0;
+ }
+ 
+ static char const *already_has_rel_mcount = "success"; /* our work here is done! */
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/61_0061-Revert-ANDROID-kbuild-add-support-for-Clang-LTO.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/61_0061-Revert-ANDROID-kbuild-add-support-for-Clang-LTO.patch
@@ -1,0 +1,478 @@
+From 1a4d56302a246d03013c39616290f745f94017b8 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:47:13 +0530
+Subject: [PATCH 36/40] Revert "ANDROID: kbuild: add support for Clang LTO"
+
+This reverts commit 1facdbab7294c292e2f0564a700e318653055540.
+---
+ Makefile                          | 29 +------------
+ arch/Kconfig                      | 47 ---------------------
+ include/asm-generic/vmlinux.lds.h |  5 +--
+ scripts/Makefile.build            | 68 ++-----------------------------
+ scripts/Makefile.modfinal         | 13 ------
+ scripts/Makefile.modpost          | 24 +----------
+ scripts/link-vmlinux.sh           | 60 ++++-----------------------
+ scripts/mod/modpost.c             |  7 ----
+ 8 files changed, 16 insertions(+), 237 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index c5f1dbc1c28d..4d55b594e058 100644
+--- a/Makefile
++++ b/Makefile
+@@ -668,16 +668,6 @@ RETPOLINE_VDSO_CFLAGS := $(call cc-option,$(RETPOLINE_VDSO_CFLAGS_GCC),$(call cc
+ export RETPOLINE_CFLAGS
+ export RETPOLINE_VDSO_CFLAGS
+ 
+-# Make toolchain changes before including arch/$(SRCARCH)/Makefile to ensure
+-# ar/cc/ld-* macros return correct values.
+-ifdef CONFIG_LTO_CLANG
+-# LTO produces LLVM IR instead of object files. Use llvm-ar and llvm-nm, so we
+-# can process these.
+-AR		:= llvm-ar
+-LLVM_NM		:= llvm-nm
+-export LLVM_NM
+-endif
+-
+ include arch/$(SRCARCH)/Makefile
+ 
+ ifdef need-config
+@@ -877,22 +867,6 @@ KBUILD_CFLAGS	+= $(CC_FLAGS_SCS)
+ export CC_FLAGS_SCS
+ endif
+ 
+-ifdef CONFIG_LTO_CLANG
+-ifdef CONFIG_THINLTO
+-CC_FLAGS_LTO_CLANG := -flto=thin $(call cc-option, -fsplit-lto-unit)
+-KBUILD_LDFLAGS	+= --thinlto-cache-dir=.thinlto-cache
+-else
+-CC_FLAGS_LTO_CLANG := -flto
+-endif
+-CC_FLAGS_LTO_CLANG += -fvisibility=default
+-endif
+-
+-ifdef CONFIG_LTO
+-CC_FLAGS_LTO	:= $(CC_FLAGS_LTO_CLANG)
+-KBUILD_CFLAGS	+= $(CC_FLAGS_LTO)
+-export CC_FLAGS_LTO
+-endif
+-
+ # arch Makefile may override CC so keep this after arch Makefile is included
+ NOSTDINC_FLAGS += -nostdinc -isystem $(shell $(CC) -print-file-name=include)
+ 
+@@ -1792,8 +1766,7 @@ clean: $(clean-dirs)
+ 		-o -name modules.builtin -o -name '.tmp_*.o.*' \
+ 		-o -name '*.c.[012]*.*' \
+ 		-o -name '*.ll' \
+-		-o -name '*.gcno' \
+-		-o -name '*.*.symversions' \) -type f -print | xargs rm -f
++		-o -name '*.gcno' \) -type f -print | xargs rm -f
+ 
+ # Generate tags for editors
+ # ---------------------------------------------------------------------------
+diff --git a/arch/Kconfig b/arch/Kconfig
+index 029acb2462fc..176652b2147c 100644
+--- a/arch/Kconfig
++++ b/arch/Kconfig
+@@ -561,53 +561,6 @@ config SHADOW_CALL_STACK_VMAP
+ 	  provides better stack exhaustion protection, but increases per-thread
+ 	  memory consumption as a full page is allocated for each shadow stack.
+ 
+-config LTO
+-	bool
+-
+-config ARCH_SUPPORTS_LTO_CLANG
+-	bool
+-	help
+-	  An architecture should select this option if it supports:
+-	  - compiling with Clang,
+-	  - compiling inline assembly with Clang's integrated assembler,
+-	  - and linking with LLD.
+-
+-config ARCH_SUPPORTS_THINLTO
+-	bool
+-	help
+-	  An architecture should select this if it supports Clang ThinLTO.
+-
+-config THINLTO
+-	bool "Use Clang's ThinLTO (EXPERIMENTAL)"
+-	depends on LTO_CLANG && ARCH_SUPPORTS_THINLTO
+-	default y
+-	help
+-	  Use ThinLTO to speed up Link Time Optimization.
+-
+-choice
+-	prompt "Link-Time Optimization (LTO) (EXPERIMENTAL)"
+-	default LTO_NONE
+-	help
+-	  This option turns on Link-Time Optimization (LTO).
+-
+-config LTO_NONE
+-	bool "None"
+-
+-config LTO_CLANG
+-	bool "Use Clang's Link Time Optimization (LTO) (EXPERIMENTAL)"
+-	depends on ARCH_SUPPORTS_LTO_CLANG
+-	depends on !KASAN
+-	depends on !FTRACE_MCOUNT_RECORD
+-	depends on CC_IS_CLANG && CLANG_VERSION >= 100000 && LD_IS_LLD
+-	select LTO
+-	help
+-          This option enables Clang's Link Time Optimization (LTO), which allows
+-          the compiler to optimize the kernel globally at link time. If you
+-          enable this option, the compiler generates LLVM IR instead of object
+-          files, and the actual compilation from IR occurs at the LTO link step,
+-          which may take several minutes.
+-
+-endchoice
+ 
+ config HAVE_ARCH_WITHIN_STACK_FRAMES
+ 	bool
+diff --git a/include/asm-generic/vmlinux.lds.h b/include/asm-generic/vmlinux.lds.h
+index cfd6450e9609..130f16cc0b86 100644
+--- a/include/asm-generic/vmlinux.lds.h
++++ b/include/asm-generic/vmlinux.lds.h
+@@ -63,13 +63,10 @@
+  * .data. We don't want to pull in .data..other sections, which Linux
+  * has defined. Same for text and bss.
+  *
+- * With LTO_CLANG, the linker also splits sections by default, so we need
+- * these macros to combine the sections during the final link.
+- *
+  * RODATA_MAIN is not used because existing code already defines .rodata.x
+  * sections to be brought in with rodata.
+  */
+-#if defined(CONFIG_LD_DEAD_CODE_DATA_ELIMINATION) || defined(CONFIG_LTO_CLANG)
++#ifdef CONFIG_LD_DEAD_CODE_DATA_ELIMINATION
+ #define TEXT_MAIN .text .text.[0-9a-zA-Z_]*
+ #define DATA_MAIN .data .data.[0-9a-zA-Z_]* .data..LPBX*
+ #define SDATA_MAIN .sdata .sdata.[0-9a-zA-Z_]*
+diff --git a/scripts/Makefile.build b/scripts/Makefile.build
+index 40b072cccdde..168a7e524e97 100644
+--- a/scripts/Makefile.build
++++ b/scripts/Makefile.build
+@@ -92,7 +92,7 @@ endif
+ # ---------------------------------------------------------------------------
+ 
+ quiet_cmd_cc_s_c = CC $(quiet_modtag)  $@
+-      cmd_cc_s_c = $(CC) $(filter-out $(DEBUG_CFLAGS) $(CC_FLAGS_LTO), $(c_flags)) $(DISABLE_LTO) -fverbose-asm -S -o $@ $<
++      cmd_cc_s_c = $(CC) $(filter-out $(DEBUG_CFLAGS), $(c_flags)) $(DISABLE_LTO) -fverbose-asm -S -o $@ $<
+ 
+ $(obj)/%.s: $(src)/%.c FORCE
+ 	$(call if_changed_dep,cc_s_c)
+@@ -147,15 +147,6 @@ ifdef CONFIG_MODVERSIONS
+ #   the actual value of the checksum generated by genksyms
+ # o remove .tmp_<file>.o to <file>.o
+ 
+-ifdef CONFIG_LTO_CLANG
+-# Generate .o.symversions files for each .o with exported symbols, and link these
+-# to the kernel and/or modules at the end.
+-cmd_modversions_c =								\
+-	if $(LLVM_NM) $@ | grep -q __ksymtab; then				\
+-		$(call cmd_gensymtypes_c,$(KBUILD_SYMTYPES),$(@:.o=.symtypes))	\
+-		    > $@.symversions;						\
+-	fi;
+-else
+ cmd_modversions_c =								\
+ 	if $(OBJDUMP) -h $@ | grep -q __ksymtab; then				\
+ 		$(call cmd_gensymtypes_c,$(KBUILD_SYMTYPES),$(@:.o=.symtypes))	\
+@@ -167,7 +158,6 @@ cmd_modversions_c =								\
+ 		rm -f $(@D)/.tmp_$(@F:.o=.ver);					\
+ 	fi
+ endif
+-endif
+ 
+ ifdef CONFIG_FTRACE_MCOUNT_RECORD
+ ifndef CC_USING_RECORD_MCOUNT
+@@ -383,21 +373,6 @@ $(obj)/%.asn1.c $(obj)/%.asn1.h: $(src)/%.asn1 $(objtree)/scripts/asn1_compiler
+ # To build objects in subdirs, we need to descend into the directories
+ $(sort $(subdir-obj-y)): $(subdir-ym) ;
+ 
+-# combine symversions for later processing
+-quiet_cmd_update_lto_symversions = SYMVER  $@
+-ifeq ($(CONFIG_LTO_CLANG) $(CONFIG_MODVERSIONS),y y)
+-      cmd_update_lto_symversions =			\
+-	rm -f $@.symversions;				\
+-	for i in $(filter-out FORCE,$^); do		\
+-		if [ -f $$i.symversions ]; then		\
+-			cat $$i.symversions 		\
+-				>> $@.symversions;	\
+-		fi;					\
+-	done
+-else
+-      cmd_update_lto_symversions = echo >/dev/null
+-endif
+-
+ #
+ # Rule to compile a set of .o files into one .a file (without symbol table)
+ #
+@@ -406,11 +381,8 @@ ifdef builtin-target
+ quiet_cmd_ar_builtin = AR      $@
+       cmd_ar_builtin = rm -f $@; $(AR) cDPrST $@ $(real-prereqs)
+ 
+-quiet_cmd_ar_and_symver = AR      $@
+-      cmd_ar_and_symver = $(cmd_update_lto_symversions); $(cmd_ar_builtin)
+-
+ $(builtin-target): $(real-obj-y) FORCE
+-	$(call if_changed,ar_and_symver)
++	$(call if_changed,ar_builtin)
+ 
+ targets += $(builtin-target)
+ endif # builtin-target
+@@ -430,53 +402,19 @@ $(modorder-target): $(subdir-ym) FORCE
+ #
+ ifdef lib-target
+ 
+-quiet_cmd_ar_lib = AR      $@
+-      cmd_ar_lib = $(cmd_update_lto_symversions); $(cmd_ar)
+-
+ $(lib-target): $(lib-y) FORCE
+-	$(call if_changed,ar_lib)
++	$(call if_changed,ar)
+ 
+ targets += $(lib-target)
+ 
+-dummy-object = $(obj)/.lib_exports.o
+-ksyms-lds = $(dot-target).lds
+-
+-ifdef CONFIG_LTO_CLANG
+-# Objdump doesn't understand LLVM IR. Use llvm-nm to dump symbols.
+-dump_export_list = $(LLVM_NM)
+-else
+-dump_export_list = $(OBJDUMP) -h
+-endif
+-
+-quiet_cmd_export_list = EXPORTS $@
+-cmd_export_list = $(dump_export_list) $< | \
+-	sed -ne '/___ksymtab/s/.*+\([^ ]*\).*/EXTERN(\1)/p' >$(ksyms-lds);\
+-	rm -f $(dummy-object);\
+-	echo | $(CC) $(a_flags) -c -o $(dummy-object) -x assembler -;\
+-	$(LD) $(ld_flags) -r -o $@ -T $(ksyms-lds) $(dummy-object);\
+-	rm $(dummy-object) $(ksyms-lds)
+-
+-$(obj)/lib-ksyms.o: $(lib-target) FORCE
+-	$(call if_changed,export_list)
+-
+-targets += $(obj)/lib-ksyms.o
+-
+ endif
+ 
+ # NOTE:
+ # Do not replace $(filter %.o,^) with $(real-prereqs). When a single object
+ # module is turned into a multi object module, $^ will contain header file
+ # dependencies recorded in the .*.cmd file.
+-ifdef CONFIG_LTO_CLANG
+-quiet_cmd_link_multi-m = AR [M]  $@
+-cmd_link_multi-m =						\
+-	$(cmd_update_lto_symversions);				\
+-	rm -f $@; 						\
+-	$(AR) rcsTP$(KBUILD_ARFLAGS) $@ $(filter %.o,$^)
+-else
+ quiet_cmd_link_multi-m = LD [M]  $@
+       cmd_link_multi-m = $(LD) $(ld_flags) -r -o $@ $(filter %.o,$^)
+-endif
+ 
+ $(multi-used-m): FORCE
+ 	$(call if_changed,link_multi-m)
+diff --git a/scripts/Makefile.modfinal b/scripts/Makefile.modfinal
+index 2164a84a45a2..411c1e600e7d 100644
+--- a/scripts/Makefile.modfinal
++++ b/scripts/Makefile.modfinal
+@@ -6,7 +6,6 @@
+ PHONY := __modfinal
+ __modfinal:
+ 
+-include $(objtree)/include/config/auto.conf
+ include $(srctree)/scripts/Kbuild.include
+ 
+ # for c_flags
+@@ -31,24 +30,12 @@ quiet_cmd_cc_o_c = CC [M]  $@
+ ARCH_POSTLINK := $(wildcard $(srctree)/arch/$(SRCARCH)/Makefile.postlink)
+ 
+ quiet_cmd_ld_ko_o = LD [M]  $@
+-
+-ifdef CONFIG_LTO_CLANG
+-      cmd_ld_ko_o = 							\
+-	$(LD) -r $(LDFLAGS)                                 		\
+-		 $(KBUILD_LDFLAGS_MODULE) $(LDFLAGS_MODULE) 		\
+-		 $(addprefix -T , $(KBUILD_LDS_MODULE))			\
+-		 $(shell [ -s $(@:.ko=.o.symversions) ] &&		\
+-			echo -T $(@:.ko=.o.symversions))  		\
+-		 -o $@ --whole-archive $(filter %.o, $^);		\
+-	$(if $(ARCH_POSTLINK), $(MAKE) -f $(ARCH_POSTLINK) $@, true)
+-else
+       cmd_ld_ko_o =                                                     \
+ 	$(LD) -r $(KBUILD_LDFLAGS)					\
+ 		$(KBUILD_LDFLAGS_MODULE) $(LDFLAGS_MODULE)		\
+ 		$(addprefix -T , $(KBUILD_LDS_MODULE))			\
+ 		-o $@ $(filter %.o, $^);				\
+ 	$(if $(ARCH_POSTLINK), $(MAKE) -f $(ARCH_POSTLINK) $@, true)
+-endif
+ 
+ $(modules): %.ko: %.o %.mod.o $(KBUILD_LDS_MODULE) FORCE
+ 	+$(call if_changed,ld_ko_o)
+diff --git a/scripts/Makefile.modpost b/scripts/Makefile.modpost
+index b8b447b62283..952fff485546 100644
+--- a/scripts/Makefile.modpost
++++ b/scripts/Makefile.modpost
+@@ -84,32 +84,12 @@ MODPOST += $(subst -i,-n,$(filter -i,$(MAKEFLAGS))) -s -T - $(wildcard vmlinux)
+ # find all modules listed in modules.order
+ modules := $(sort $(shell cat $(MODORDER)))
+ 
+-# With CONFIG_LTO_CLANG, .o files might be LLVM IR, so we need to link them
+-# into actual objects before passing them to modpost
+-modpost-ext = $(if $(CONFIG_LTO_CLANG),.lto,)
+-
+-ifdef CONFIG_LTO_CLANG
+-quiet_cmd_cc_lto_link_modules = LTO [M] $@
+-cmd_cc_lto_link_modules =						\
+-	$(LD) $(ld_flags) -r -o $(@)					\
+-		$(shell [ -s $(@:$(modpost-ext).o=.o.symversions) ] &&	\
+-			echo -T $(@:$(modpost-ext).o=.o.symversions))	\
+-		--whole-archive $(filter-out FORCE,$^)
+-
+-$(modules:.ko=$(modpost-ext).o): %$(modpost-ext).o: %.o FORCE
+-	$(call if_changed,cc_lto_link_modules)
+-
+-PHONY += FORCE
+-FORCE:
+-
+-endif
+-
+ # Read out modules.order instead of expanding $(modules) to pass in modpost.
+ # Otherwise, allmodconfig would fail with "Argument list too long".
+ quiet_cmd_modpost = MODPOST $(words $(modules)) modules
+-      cmd_modpost = sed 's/\.ko$$/$(modpost-ext)\.o/' $(MODORDER) | $(MODPOST)
++      cmd_modpost = sed 's/ko$$/o/' $(MODORDER) | $(MODPOST)
+ 
+-__modpost: $(modules:.ko=$(modpost-ext).o)
++__modpost:
+ 	@$(kecho) '  Building modules, stage 2.'
+ 	$(call cmd,modpost)
+ ifneq ($(KBUILD_MODPOST_NOFINAL),1)
+diff --git a/scripts/link-vmlinux.sh b/scripts/link-vmlinux.sh
+index 4bd929e8fc05..8b6325c2dfc5 100755
+--- a/scripts/link-vmlinux.sh
++++ b/scripts/link-vmlinux.sh
+@@ -39,30 +39,6 @@ info()
+ 	fi
+ }
+ 
+-# If CONFIG_LTO_CLANG is selected, collect generated symbol versions into
+-# .tmp_symversions
+-modversions()
+-{
+-	if [ -z "${CONFIG_LTO_CLANG}" ]; then
+-		return
+-	fi
+-	if [ -z "${CONFIG_MODVERSIONS}" ]; then
+-		return
+-	fi
+-
+-	rm -f .tmp_symversions
+-
+-	for a in ${KBUILD_VMLINUX_OBJS} ${KBUILD_VMLINUX_LIBS}; do
+-		for o in $(${AR} t $a 2>/dev/null); do
+-			if [ -f ${o}.symversions ]; then
+-				cat ${o}.symversions >> .tmp_symversions
+-			fi
+-		done
+-	done
+-
+-	echo "-T .tmp_symversions"
+-}
+-
+ # Link of vmlinux.o used for section mismatch analysis
+ # ${1} output file
+ modpost_link()
+@@ -76,15 +52,7 @@ modpost_link()
+ 		${KBUILD_VMLINUX_LIBS}				\
+ 		--end-group"
+ 
+-	if [ -n "${CONFIG_LTO_CLANG}" ]; then
+-		# This might take a while, so indicate that we're doing
+-		# an LTO link
+-		info LTO ${1}
+-	else
+-		info LD ${1}
+-	fi
+-
+-	${LD} ${KBUILD_LDFLAGS} -r -o ${1} $(modversions) ${objects}
++	${LD} ${KBUILD_LDFLAGS} -r -o ${1} ${objects}
+ }
+ 
+ # Link of vmlinux
+@@ -108,22 +76,13 @@ vmlinux_link()
+ 	fi
+ 
+ 	if [ "${SRCARCH}" != "um" ]; then
+-		if [ -n "${CONFIG_LTO_CLANG}" ]; then
+-			# Use vmlinux.o instead of performing the slow LTO
+-			# link again.
+-			objects="--whole-archive		\
+-				vmlinux.o 			\
+-				--no-whole-archive		\
+-				${@}"
+-		else
+-			objects="--whole-archive		\
+-				${KBUILD_VMLINUX_OBJS}		\
+-				--no-whole-archive		\
+-				--start-group			\
+-				${KBUILD_VMLINUX_LIBS}		\
+-				--end-group			\
+-				${@}"
+-		fi
++		objects="--whole-archive			\
++			${KBUILD_VMLINUX_OBJS}			\
++			--no-whole-archive			\
++			--start-group				\
++			${KBUILD_VMLINUX_LIBS}			\
++			--end-group				\
++			${@}"
+ 
+ 		${LD} ${KBUILD_LDFLAGS} ${LDFLAGS_vmlinux}	\
+ 			${strip_debug#-Wl,}			\
+@@ -239,8 +198,6 @@ cleanup()
+ {
+ 	rm -f .btf.*
+ 	rm -f .tmp_System.map
+-	rm -f .tmp_kallsyms*
+-	rm -f .tmp_symversions
+ 	rm -f .tmp_vmlinux*
+ 	rm -f System.map
+ 	rm -f vmlinux
+@@ -292,6 +249,7 @@ fi;
+ ${MAKE} -f "${srctree}/scripts/Makefile.build" obj=init
+ 
+ #link vmlinux.o
++info LD vmlinux.o
+ modpost_link vmlinux.o
+ 
+ # modpost vmlinux.o to check for section mismatches
+diff --git a/scripts/mod/modpost.c b/scripts/mod/modpost.c
+index ca1acb7d7e93..a6065f0a3254 100644
+--- a/scripts/mod/modpost.c
++++ b/scripts/mod/modpost.c
+@@ -146,9 +146,6 @@ static struct module *new_module(const char *modname)
+ 		p[strlen(p) - 2] = '\0';
+ 		mod->is_dot_o = 1;
+ 	}
+-	/* strip trailing .lto */
+-	if (strends(p, ".lto"))
+-		p[strlen(p) - 4] = '\0';
+ 
+ 	/* add to list */
+ 	mod->name = p;
+@@ -2003,10 +2000,6 @@ static char *remove_dot(char *s)
+ 		size_t m = strspn(s + n + 1, "0123456789");
+ 		if (m && (s[n + m] == '.' || s[n + m] == 0))
+ 			s[n] = 0;
+-
+-		/* strip trailing .lto */
+-		if (strends(s, ".lto"))
+-			s[strlen(s) - 4] = '\0';
+ 	}
+ 	return s;
+ }
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/62_0062-Revert-ANDROID-kbuild-add-CONFIG_LD_IS_LLD.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/62_0062-Revert-ANDROID-kbuild-add-CONFIG_LD_IS_LLD.patch
@@ -1,0 +1,27 @@
+From d32ab80eb6d7bf4d27a2e55c4ec02d633c394053 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:47:21 +0530
+Subject: [PATCH 37/40] Revert "ANDROID: kbuild: add CONFIG_LD_IS_LLD"
+
+This reverts commit 3ef735d0f39fe3ba067498183277b6a3379bbbcb.
+---
+ init/Kconfig | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/init/Kconfig b/init/Kconfig
+index a2619021a63a..4e9f17ce9e15 100644
+--- a/init/Kconfig
++++ b/init/Kconfig
+@@ -20,9 +20,6 @@ config GCC_VERSION
+ config CC_IS_CLANG
+ 	def_bool $(success,$(CC) --version | head -n 1 | grep -q clang)
+ 
+-config LD_IS_LLD
+-	def_bool $(success,$(LD) -v | head -n 1 | grep -q LLD)
+-
+ config CLANG_VERSION
+ 	int
+ 	default $(shell,$(srctree)/scripts/clang-version.sh $(CC))
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/63_0063-Revert-FROMLIST-scs-add-support-for-stack-usage-debu.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/63_0063-Revert-FROMLIST-scs-add-support-for-stack-usage-debu.patch
@@ -1,0 +1,71 @@
+From 7a38c4ab2e7ad5efe6dbf1eeca15e89d47fd5239 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:47:30 +0530
+Subject: [PATCH 38/40] Revert "FROMLIST: scs: add support for stack usage
+ debugging"
+
+This reverts commit a935e12fd613d2f27fd53e2584c1f2bbe27b6b28.
+---
+ kernel/scs.c | 39 ---------------------------------------
+ 1 file changed, 39 deletions(-)
+
+diff --git a/kernel/scs.c b/kernel/scs.c
+index ad74d13f2c0f..5245e992c692 100644
+--- a/kernel/scs.c
++++ b/kernel/scs.c
+@@ -184,44 +184,6 @@ int scs_prepare(struct task_struct *tsk, int node)
+ 	return 0;
+ }
+ 
+-#ifdef CONFIG_DEBUG_STACK_USAGE
+-static inline unsigned long scs_used(struct task_struct *tsk)
+-{
+-	unsigned long *p = __scs_base(tsk);
+-	unsigned long *end = scs_magic(p);
+-	unsigned long s = (unsigned long)p;
+-
+-	while (p < end && READ_ONCE_NOCHECK(*p))
+-		p++;
+-
+-	return (unsigned long)p - s;
+-}
+-
+-static void scs_check_usage(struct task_struct *tsk)
+-{
+-	static DEFINE_SPINLOCK(lock);
+-	static unsigned long highest;
+-	unsigned long used = scs_used(tsk);
+-
+-	if (used <= highest)
+-		return;
+-
+-	spin_lock(&lock);
+-
+-	if (used > highest) {
+-		pr_info("%s (%d): highest shadow stack usage: %lu bytes\n",
+-			tsk->comm, task_pid_nr(tsk), used);
+-		highest = used;
+-	}
+-
+-	spin_unlock(&lock);
+-}
+-#else
+-static inline void scs_check_usage(struct task_struct *tsk)
+-{
+-}
+-#endif
+-
+ bool scs_corrupted(struct task_struct *tsk)
+ {
+ 	unsigned long *magic = scs_magic(__scs_base(tsk));
+@@ -238,7 +200,6 @@ void scs_release(struct task_struct *tsk)
+ 		return;
+ 
+ 	WARN_ON(scs_corrupted(tsk));
+-	scs_check_usage(tsk);
+ 
+ 	scs_account(tsk, -1);
+ 	task_set_scs(tsk, NULL);
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/64_0064-Revert-FROMLIST-scs-add-accounting.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/64_0064-Revert-FROMLIST-scs-add-accounting.patch
@@ -1,0 +1,175 @@
+From 138bcefeb7a4ae8bbecd525fff483993146a109c Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:47:38 +0530
+Subject: [PATCH 39/40] Revert "FROMLIST: scs: add accounting"
+
+This reverts commit 4b3ddfd49edefd0347e032820469cf33fb131d06.
+---
+ drivers/base/node.c    |  6 ------
+ fs/proc/meminfo.c      |  4 ----
+ include/linux/mmzone.h |  3 ---
+ kernel/scs.c           | 20 --------------------
+ mm/page_alloc.c        |  6 ------
+ mm/vmstat.c            |  3 ---
+ 6 files changed, 42 deletions(-)
+
+diff --git a/drivers/base/node.c b/drivers/base/node.c
+index 52609c30c31b..9c6e6a7b9354 100644
+--- a/drivers/base/node.c
++++ b/drivers/base/node.c
+@@ -415,9 +415,6 @@ static ssize_t node_read_meminfo(struct device *dev,
+ 		       "Node %d AnonPages:      %8lu kB\n"
+ 		       "Node %d Shmem:          %8lu kB\n"
+ 		       "Node %d KernelStack:    %8lu kB\n"
+-#ifdef CONFIG_SHADOW_CALL_STACK
+-		       "Node %d ShadowCallStack:%8lu kB\n"
+-#endif
+ 		       "Node %d PageTables:     %8lu kB\n"
+ 		       "Node %d NFS_Unstable:   %8lu kB\n"
+ 		       "Node %d Bounce:         %8lu kB\n"
+@@ -441,9 +438,6 @@ static ssize_t node_read_meminfo(struct device *dev,
+ 		       nid, K(node_page_state(pgdat, NR_ANON_MAPPED)),
+ 		       nid, K(i.sharedram),
+ 		       nid, sum_zone_node_page_state(nid, NR_KERNEL_STACK_KB),
+-#ifdef CONFIG_SHADOW_CALL_STACK
+-		       nid, sum_zone_node_page_state(nid, NR_KERNEL_SCS_BYTES) / 1024,
+-#endif
+ 		       nid, K(sum_zone_node_page_state(nid, NR_PAGETABLE)),
+ 		       nid, K(node_page_state(pgdat, NR_UNSTABLE_NFS)),
+ 		       nid, K(sum_zone_node_page_state(nid, NR_BOUNCE)),
+diff --git a/fs/proc/meminfo.c b/fs/proc/meminfo.c
+index 49768005a79e..8c1f1bb1a5ce 100644
+--- a/fs/proc/meminfo.c
++++ b/fs/proc/meminfo.c
+@@ -103,10 +103,6 @@ static int meminfo_proc_show(struct seq_file *m, void *v)
+ 	show_val_kb(m, "SUnreclaim:     ", sunreclaim);
+ 	seq_printf(m, "KernelStack:    %8lu kB\n",
+ 		   global_zone_page_state(NR_KERNEL_STACK_KB));
+-#ifdef CONFIG_SHADOW_CALL_STACK
+-	seq_printf(m, "ShadowCallStack:%8lu kB\n",
+-		   global_zone_page_state(NR_KERNEL_SCS_BYTES) / 1024);
+-#endif
+ 	show_val_kb(m, "PageTables:     ",
+ 		    global_zone_page_state(NR_PAGETABLE));
+ 
+diff --git a/include/linux/mmzone.h b/include/linux/mmzone.h
+index 73659d470593..a90aba3d6afb 100644
+--- a/include/linux/mmzone.h
++++ b/include/linux/mmzone.h
+@@ -200,9 +200,6 @@ enum zone_stat_item {
+ 	NR_MLOCK,		/* mlock()ed pages found and moved off LRU */
+ 	NR_PAGETABLE,		/* used for pagetables */
+ 	NR_KERNEL_STACK_KB,	/* measured in KiB */
+-#if IS_ENABLED(CONFIG_SHADOW_CALL_STACK)
+-	NR_KERNEL_SCS_BYTES,	/* measured in bytes */
+-#endif
+ 	/* Second 128 byte cacheline */
+ 	NR_BOUNCE,
+ #if IS_ENABLED(CONFIG_ZSMALLOC)
+diff --git a/kernel/scs.c b/kernel/scs.c
+index 5245e992c692..28abed21950c 100644
+--- a/kernel/scs.c
++++ b/kernel/scs.c
+@@ -12,7 +12,6 @@
+ #include <linux/scs.h>
+ #include <linux/slab.h>
+ #include <linux/vmalloc.h>
+-#include <linux/vmstat.h>
+ #include <asm/scs.h>
+ 
+ static inline void *__scs_base(struct task_struct *tsk)
+@@ -90,11 +89,6 @@ static void scs_free(void *s)
+ 	vfree_atomic(s);
+ }
+ 
+-static struct page *__scs_page(struct task_struct *tsk)
+-{
+-	return vmalloc_to_page(__scs_base(tsk));
+-}
+-
+ static int scs_cleanup(unsigned int cpu)
+ {
+ 	int i;
+@@ -141,11 +135,6 @@ static inline void scs_free(void *s)
+ 	kmem_cache_free(scs_cache, s);
+ }
+ 
+-static struct page *__scs_page(struct task_struct *tsk)
+-{
+-	return virt_to_page(__scs_base(tsk));
+-}
+-
+ void __init scs_init(void)
+ {
+ 	scs_cache = kmem_cache_create("scs_cache", SCS_SIZE, SCS_SIZE,
+@@ -164,12 +153,6 @@ void scs_task_reset(struct task_struct *tsk)
+ 	task_set_scs(tsk, __scs_base(tsk));
+ }
+ 
+-static void scs_account(struct task_struct *tsk, int account)
+-{
+-	mod_zone_page_state(page_zone(__scs_page(tsk)), NR_KERNEL_SCS_BYTES,
+-		account * SCS_SIZE);
+-}
+-
+ int scs_prepare(struct task_struct *tsk, int node)
+ {
+ 	void *s;
+@@ -179,8 +162,6 @@ int scs_prepare(struct task_struct *tsk, int node)
+ 		return -ENOMEM;
+ 
+ 	task_set_scs(tsk, s);
+-	scs_account(tsk, 1);
+-
+ 	return 0;
+ }
+ 
+@@ -201,7 +182,6 @@ void scs_release(struct task_struct *tsk)
+ 
+ 	WARN_ON(scs_corrupted(tsk));
+ 
+-	scs_account(tsk, -1);
+ 	task_set_scs(tsk, NULL);
+ 	scs_free(s);
+ }
+diff --git a/mm/page_alloc.c b/mm/page_alloc.c
+index 4447b60a98f0..a1a4d81a66c7 100644
+--- a/mm/page_alloc.c
++++ b/mm/page_alloc.c
+@@ -5379,9 +5379,6 @@ void show_free_areas(unsigned int filter, nodemask_t *nodemask)
+ 			" managed:%lukB"
+ 			" mlocked:%lukB"
+ 			" kernel_stack:%lukB"
+-#ifdef CONFIG_SHADOW_CALL_STACK
+-			" shadow_call_stack:%lukB"
+-#endif
+ 			" pagetables:%lukB"
+ 			" bounce:%lukB"
+ 			" free_pcp:%lukB"
+@@ -5403,9 +5400,6 @@ void show_free_areas(unsigned int filter, nodemask_t *nodemask)
+ 			K(zone_managed_pages(zone)),
+ 			K(zone_page_state(zone, NR_MLOCK)),
+ 			zone_page_state(zone, NR_KERNEL_STACK_KB),
+-#ifdef CONFIG_SHADOW_CALL_STACK
+-			zone_page_state(zone, NR_KERNEL_SCS_BYTES) / 1024,
+-#endif
+ 			K(zone_page_state(zone, NR_PAGETABLE)),
+ 			K(zone_page_state(zone, NR_BOUNCE)),
+ 			K(free_pcp),
+diff --git a/mm/vmstat.c b/mm/vmstat.c
+index 96d39fbb9a1f..a8222041bd44 100644
+--- a/mm/vmstat.c
++++ b/mm/vmstat.c
+@@ -1118,9 +1118,6 @@ const char * const vmstat_text[] = {
+ 	"nr_mlock",
+ 	"nr_page_table_pages",
+ 	"nr_kernel_stack",
+-#if IS_ENABLED(CONFIG_SHADOW_CALL_STACK)
+-	"nr_shadow_call_stack_bytes",
+-#endif
+ 	"nr_bounce",
+ #if IS_ENABLED(CONFIG_ZSMALLOC)
+ 	"nr_zspages",
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/65_0065-Revert-FROMLIST-add-support-for-Clang-s-Shadow-Call-.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/65_0065-Revert-FROMLIST-add-support-for-Clang-s-Shadow-Call-.patch
@@ -1,0 +1,470 @@
+From f7c8d778bb4a4f42aca80fea64bdc1b1f155069f Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Sat, 5 Dec 2020 20:47:47 +0530
+Subject: [PATCH 40/40] Revert "FROMLIST: add support for Clang's Shadow Call
+ Stack (SCS)"
+
+This reverts commit 1c595c2055b9c4e534ece145154d1b14128ef39b.
+---
+ Makefile                       |   6 --
+ arch/Kconfig                   |  34 ------
+ include/linux/compiler-clang.h |   6 --
+ include/linux/compiler_types.h |   4 -
+ include/linux/scs.h            |  57 ----------
+ init/init_task.c               |   8 --
+ kernel/Makefile                |   1 -
+ kernel/fork.c                  |   8 --
+ kernel/sched/core.c            |   2 -
+ kernel/scs.c                   | 187 ---------------------------------
+ 10 files changed, 313 deletions(-)
+ delete mode 100644 include/linux/scs.h
+ delete mode 100644 kernel/scs.c
+
+diff --git a/Makefile b/Makefile
+index 4d55b594e058..9b91da8cdc32 100644
+--- a/Makefile
++++ b/Makefile
+@@ -861,12 +861,6 @@ ifdef CONFIG_LIVEPATCH
+ KBUILD_CFLAGS += $(call cc-option, -flive-patching=inline-clone)
+ endif
+ 
+-ifdef CONFIG_SHADOW_CALL_STACK
+-CC_FLAGS_SCS	:= -fsanitize=shadow-call-stack
+-KBUILD_CFLAGS	+= $(CC_FLAGS_SCS)
+-export CC_FLAGS_SCS
+-endif
+-
+ # arch Makefile may override CC so keep this after arch Makefile is included
+ NOSTDINC_FLAGS += -nostdinc -isystem $(shell $(CC) -print-file-name=include)
+ 
+diff --git a/arch/Kconfig b/arch/Kconfig
+index 176652b2147c..84653a823d3b 100644
+--- a/arch/Kconfig
++++ b/arch/Kconfig
+@@ -528,40 +528,6 @@ config STACKPROTECTOR_STRONG
+ 	  about 20% of all kernel functions, which increases the kernel code
+ 	  size by about 2%.
+ 
+-config ARCH_SUPPORTS_SHADOW_CALL_STACK
+-	bool
+-	help
+-	  An architecture should select this if it supports Clang's Shadow
+-	  Call Stack, has asm/scs.h, and implements runtime support for shadow
+-	  stack switching.
+-
+-config SHADOW_CALL_STACK
+-	bool "Clang Shadow Call Stack"
+-	depends on ARCH_SUPPORTS_SHADOW_CALL_STACK
+-	help
+-	  This option enables Clang's Shadow Call Stack, which uses a
+-	  shadow stack to protect function return addresses from being
+-	  overwritten by an attacker. More information can be found from
+-	  Clang's documentation:
+-
+-	    https://clang.llvm.org/docs/ShadowCallStack.html
+-
+-	  Note that security guarantees in the kernel differ from the ones
+-	  documented for user space. The kernel must store addresses of shadow
+-	  stacks used by other tasks and interrupt handlers in memory, which
+-	  means an attacker capable reading and writing arbitrary memory may
+-	  be able to locate them and hijack control flow by modifying shadow
+-	  stacks that are not currently in use.
+-
+-config SHADOW_CALL_STACK_VMAP
+-	bool "Use virtually mapped shadow call stacks"
+-	depends on SHADOW_CALL_STACK
+-	help
+-	  Use virtually mapped shadow call stacks. Selecting this option
+-	  provides better stack exhaustion protection, but increases per-thread
+-	  memory consumption as a full page is allocated for each shadow stack.
+-
+-
+ config HAVE_ARCH_WITHIN_STACK_FRAMES
+ 	bool
+ 	help
+diff --git a/include/linux/compiler-clang.h b/include/linux/compiler-clang.h
+index 18fc4d29ef27..333a6695a918 100644
+--- a/include/linux/compiler-clang.h
++++ b/include/linux/compiler-clang.h
+@@ -42,9 +42,3 @@
+  * compilers, like ICC.
+  */
+ #define barrier() __asm__ __volatile__("" : : : "memory")
+-
+-#if __has_feature(shadow_call_stack)
+-# define __noscs	__attribute__((__no_sanitize__("shadow-call-stack")))
+-#else
+-# define __noscs
+-#endif
+diff --git a/include/linux/compiler_types.h b/include/linux/compiler_types.h
+index be5d5be4b1ae..72393a8c1a6c 100644
+--- a/include/linux/compiler_types.h
++++ b/include/linux/compiler_types.h
+@@ -202,10 +202,6 @@ struct ftrace_likely_data {
+ # define randomized_struct_fields_end
+ #endif
+ 
+-#ifndef __noscs
+-# define __noscs
+-#endif
+-
+ #ifndef asm_volatile_goto
+ #define asm_volatile_goto(x...) asm goto(x)
+ #endif
+diff --git a/include/linux/scs.h b/include/linux/scs.h
+deleted file mode 100644
+index c5572fd770b0..000000000000
+--- a/include/linux/scs.h
++++ /dev/null
+@@ -1,57 +0,0 @@
+-/* SPDX-License-Identifier: GPL-2.0 */
+-/*
+- * Shadow Call Stack support.
+- *
+- * Copyright (C) 2019 Google LLC
+- */
+-
+-#ifndef _LINUX_SCS_H
+-#define _LINUX_SCS_H
+-
+-#include <linux/gfp.h>
+-#include <linux/sched.h>
+-#include <asm/page.h>
+-
+-#ifdef CONFIG_SHADOW_CALL_STACK
+-
+-/*
+- * In testing, 1 KiB shadow stack size (i.e. 128 stack frames on a 64-bit
+- * architecture) provided ~40% safety margin on stack usage while keeping
+- * memory allocation overhead reasonable.
+- */
+-#define SCS_SIZE	1024UL
+-#define GFP_SCS		(GFP_KERNEL | __GFP_ZERO)
+-
+-/*
+- * A random number outside the kernel's virtual address space to mark the
+- * end of the shadow stack.
+- */
+-#define SCS_END_MAGIC	0xaf0194819b1635f6UL
+-
+-#define task_scs(tsk)	(task_thread_info(tsk)->shadow_call_stack)
+-
+-static inline void task_set_scs(struct task_struct *tsk, void *s)
+-{
+-	task_scs(tsk) = s;
+-}
+-
+-extern void scs_init(void);
+-extern void scs_task_reset(struct task_struct *tsk);
+-extern int scs_prepare(struct task_struct *tsk, int node);
+-extern bool scs_corrupted(struct task_struct *tsk);
+-extern void scs_release(struct task_struct *tsk);
+-
+-#else /* CONFIG_SHADOW_CALL_STACK */
+-
+-#define task_scs(tsk)	NULL
+-
+-static inline void task_set_scs(struct task_struct *tsk, void *s) {}
+-static inline void scs_init(void) {}
+-static inline void scs_task_reset(struct task_struct *tsk) {}
+-static inline int scs_prepare(struct task_struct *tsk, int node) { return 0; }
+-static inline bool scs_corrupted(struct task_struct *tsk) { return false; }
+-static inline void scs_release(struct task_struct *tsk) {}
+-
+-#endif /* CONFIG_SHADOW_CALL_STACK */
+-
+-#endif /* _LINUX_SCS_H */
+diff --git a/init/init_task.c b/init/init_task.c
+index 2e172b4203d6..bca4b8789b0d 100644
+--- a/init/init_task.c
++++ b/init/init_task.c
+@@ -11,7 +11,6 @@
+ #include <linux/mm.h>
+ #include <linux/audit.h>
+ #include <linux/numa.h>
+-#include <linux/scs.h>
+ 
+ #include <linux/alt-syscall.h>
+ 
+@@ -188,13 +187,6 @@ struct task_struct init_task
+ };
+ EXPORT_SYMBOL(init_task);
+ 
+-#ifdef CONFIG_SHADOW_CALL_STACK
+-unsigned long init_shadow_call_stack[SCS_SIZE / sizeof(long)] __init_task_data
+-		__aligned(SCS_SIZE) = {
+-	[(SCS_SIZE / sizeof(long)) - 1] = SCS_END_MAGIC
+-};
+-#endif
+-
+ /*
+  * Initial thread structure. Alignment of this is handled by a special
+  * linker map entry.
+diff --git a/kernel/Makefile b/kernel/Makefile
+index b5c8397f2fd2..75f3550f4643 100644
+--- a/kernel/Makefile
++++ b/kernel/Makefile
+@@ -105,7 +105,6 @@ obj-$(CONFIG_TRACEPOINTS) += trace/
+ obj-$(CONFIG_IRQ_WORK) += irq_work.o
+ obj-$(CONFIG_CPU_PM) += cpu_pm.o
+ obj-$(CONFIG_BPF) += bpf/
+-obj-$(CONFIG_SHADOW_CALL_STACK) += scs.o
+ 
+ obj-$(CONFIG_PERF_EVENTS) += events/
+ 
+diff --git a/kernel/fork.c b/kernel/fork.c
+index afa63645084c..6a66519ad82e 100644
+--- a/kernel/fork.c
++++ b/kernel/fork.c
+@@ -95,7 +95,6 @@
+ #include <linux/thread_info.h>
+ #include <linux/cpufreq_times.h>
+ #include <linux/stackleak.h>
+-#include <linux/scs.h>
+ 
+ #include <asm/pgtable.h>
+ #include <asm/pgalloc.h>
+@@ -454,7 +453,6 @@ void put_task_stack(struct task_struct *tsk)
+ void free_task(struct task_struct *tsk)
+ {
+ 	cpufreq_task_times_exit(tsk);
+-	scs_release(tsk);
+ 
+ #ifndef CONFIG_THREAD_INFO_IN_TASK
+ 	/*
+@@ -841,8 +839,6 @@ void __init fork_init(void)
+ 			  NULL, free_vm_stack_cache);
+ #endif
+ 
+-	scs_init();
+-
+ 	lockdep_init_task(&init_task);
+ 	uprobes_init();
+ }
+@@ -902,10 +898,6 @@ static struct task_struct *dup_task_struct(struct task_struct *orig, int node)
+ 	if (err)
+ 		goto free_stack;
+ 
+-	err = scs_prepare(tsk, node);
+-	if (err)
+-		goto free_stack;
+-
+ #ifdef CONFIG_SECCOMP
+ 	/*
+ 	 * We must handle setting up seccomp filters once we're under
+diff --git a/kernel/sched/core.c b/kernel/sched/core.c
+index f18403eb641b..83eb26ff2f61 100644
+--- a/kernel/sched/core.c
++++ b/kernel/sched/core.c
+@@ -11,7 +11,6 @@
+ #include <linux/nospec.h>
+ 
+ #include <linux/kcov.h>
+-#include <linux/scs.h>
+ 
+ #include <asm/switch_to.h>
+ #include <asm/tlb.h>
+@@ -7258,7 +7257,6 @@ void init_idle(struct task_struct *idle, int cpu)
+ 	idle->se.exec_start = sched_clock();
+ 	idle->flags |= PF_IDLE;
+ 
+-	scs_task_reset(idle);
+ 	kasan_unpoison_task_stack(idle);
+ 
+ #ifdef CONFIG_SMP
+diff --git a/kernel/scs.c b/kernel/scs.c
+deleted file mode 100644
+index 28abed21950c..000000000000
+--- a/kernel/scs.c
++++ /dev/null
+@@ -1,187 +0,0 @@
+-// SPDX-License-Identifier: GPL-2.0
+-/*
+- * Shadow Call Stack support.
+- *
+- * Copyright (C) 2019 Google LLC
+- */
+-
+-#include <linux/cpuhotplug.h>
+-#include <linux/kasan.h>
+-#include <linux/mm.h>
+-#include <linux/mmzone.h>
+-#include <linux/scs.h>
+-#include <linux/slab.h>
+-#include <linux/vmalloc.h>
+-#include <asm/scs.h>
+-
+-static inline void *__scs_base(struct task_struct *tsk)
+-{
+-	/*
+-	 * To minimize risk the of exposure, architectures may clear a
+-	 * task's thread_info::shadow_call_stack while that task is
+-	 * running, and only save/restore the active shadow call stack
+-	 * pointer when the usual register may be clobbered (e.g. across
+-	 * context switches).
+-	 *
+-	 * The shadow call stack is aligned to SCS_SIZE, and grows
+-	 * upwards, so we can mask out the low bits to extract the base
+-	 * when the task is not running.
+-	 */
+-	return (void *)((unsigned long)task_scs(tsk) & ~(SCS_SIZE - 1));
+-}
+-
+-static inline unsigned long *scs_magic(void *s)
+-{
+-	return (unsigned long *)(s + SCS_SIZE) - 1;
+-}
+-
+-static inline void scs_set_magic(void *s)
+-{
+-	*scs_magic(s) = SCS_END_MAGIC;
+-}
+-
+-#ifdef CONFIG_SHADOW_CALL_STACK_VMAP
+-
+-/* Matches NR_CACHED_STACKS for VMAP_STACK */
+-#define NR_CACHED_SCS 2
+-static DEFINE_PER_CPU(void *, scs_cache[NR_CACHED_SCS]);
+-
+-static void *scs_alloc(int node)
+-{
+-	int i;
+-	void *s;
+-
+-	for (i = 0; i < NR_CACHED_SCS; i++) {
+-		s = this_cpu_xchg(scs_cache[i], NULL);
+-		if (s) {
+-			memset(s, 0, SCS_SIZE);
+-			goto out;
+-		}
+-	}
+-
+-	/*
+-	 * We allocate a full page for the shadow stack, which should be
+-	 * more than we need. Check the assumption nevertheless.
+-	 */
+-	BUILD_BUG_ON(SCS_SIZE > PAGE_SIZE);
+-
+-	s = __vmalloc_node_range(PAGE_SIZE, SCS_SIZE,
+-				 VMALLOC_START, VMALLOC_END,
+-				 GFP_SCS, PAGE_KERNEL, 0,
+-				 node, __builtin_return_address(0));
+-
+-out:
+-	if (s)
+-		scs_set_magic(s);
+-	/* TODO: poison for KASAN, unpoison in scs_free */
+-
+-	return s;
+-}
+-
+-static void scs_free(void *s)
+-{
+-	int i;
+-
+-	for (i = 0; i < NR_CACHED_SCS; i++)
+-		if (this_cpu_cmpxchg(scs_cache[i], 0, s) == NULL)
+-			return;
+-
+-	vfree_atomic(s);
+-}
+-
+-static int scs_cleanup(unsigned int cpu)
+-{
+-	int i;
+-	void **cache = per_cpu_ptr(scs_cache, cpu);
+-
+-	for (i = 0; i < NR_CACHED_SCS; i++) {
+-		vfree(cache[i]);
+-		cache[i] = NULL;
+-	}
+-
+-	return 0;
+-}
+-
+-void __init scs_init(void)
+-{
+-	WARN_ON(cpuhp_setup_state(CPUHP_BP_PREPARE_DYN, "scs:scs_cache", NULL,
+-			scs_cleanup) < 0);
+-}
+-
+-#else /* !CONFIG_SHADOW_CALL_STACK_VMAP */
+-
+-static struct kmem_cache *scs_cache;
+-
+-static inline void *scs_alloc(int node)
+-{
+-	void *s;
+-
+-	s = kmem_cache_alloc_node(scs_cache, GFP_SCS, node);
+-	if (s) {
+-		scs_set_magic(s);
+-		/*
+-		 * Poison the allocation to catch unintentional accesses to
+-		 * the shadow stack when KASAN is enabled.
+-		 */
+-		kasan_poison_object_data(scs_cache, s);
+-	}
+-
+-	return s;
+-}
+-
+-static inline void scs_free(void *s)
+-{
+-	kasan_unpoison_object_data(scs_cache, s);
+-	kmem_cache_free(scs_cache, s);
+-}
+-
+-void __init scs_init(void)
+-{
+-	scs_cache = kmem_cache_create("scs_cache", SCS_SIZE, SCS_SIZE,
+-				0, NULL);
+-	WARN_ON(!scs_cache);
+-}
+-
+-#endif /* CONFIG_SHADOW_CALL_STACK_VMAP */
+-
+-void scs_task_reset(struct task_struct *tsk)
+-{
+-	/*
+-	 * Reset the shadow stack to the base address in case the task
+-	 * is reused.
+-	 */
+-	task_set_scs(tsk, __scs_base(tsk));
+-}
+-
+-int scs_prepare(struct task_struct *tsk, int node)
+-{
+-	void *s;
+-
+-	s = scs_alloc(node);
+-	if (!s)
+-		return -ENOMEM;
+-
+-	task_set_scs(tsk, s);
+-	return 0;
+-}
+-
+-bool scs_corrupted(struct task_struct *tsk)
+-{
+-	unsigned long *magic = scs_magic(__scs_base(tsk));
+-
+-	return READ_ONCE_NOCHECK(*magic) != SCS_END_MAGIC;
+-}
+-
+-void scs_release(struct task_struct *tsk)
+-{
+-	void *s;
+-
+-	s = __scs_base(tsk);
+-	if (!s)
+-		return;
+-
+-	WARN_ON(scs_corrupted(tsk));
+-
+-	task_set_scs(tsk, NULL);
+-	scs_free(s);
+-}
+-- 
+2.17.1
+


### PR DESCRIPTION
With lld, LTO & CFI enabled, device resets on resume.

Until the driver causing the reset is fixed, disable
lld, lto & CFI.

Tracked-On: OAM-95489
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>