### PR TITLE
qemu: change fence poll time from 10ms to 3ms

### DIFF
--- a/host/qemu/0001-qemu-change-fence-poll-time-from-10ms-to-3ms.patch
+++ b/host/qemu/0001-qemu-change-fence-poll-time-from-10ms-to-3ms.patch
@@ -1,0 +1,26 @@
+From 47902d8cab7b2f66abfeee4ab23a68545d79df55 Mon Sep 17 00:00:00 2001
+From: AOSP Crosvm Builder <nobody@android.com>
+Date: Fri, 25 Dec 2020 10:29:50 +0800
+Subject: [PATCH] qemu: change fence poll time from 10ms to 3ms
+
+This will improve performance while waiting the fence in 3D renderering
+---
+ hw/display/virtio-gpu-3d.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/hw/display/virtio-gpu-3d.c b/hw/display/virtio-gpu-3d.c
+index 96621576..808da109 100644
+--- a/hw/display/virtio-gpu-3d.c
++++ b/hw/display/virtio-gpu-3d.c
+@@ -582,7 +582,7 @@ static void virtio_gpu_fence_poll(void *opaque)
+     virgl_renderer_poll();
+     virtio_gpu_process_cmdq(g);
+     if (!QTAILQ_EMPTY(&g->cmdq) || !QTAILQ_EMPTY(&g->fenceq)) {
+-        timer_mod(g->fence_poll, qemu_clock_get_ms(QEMU_CLOCK_VIRTUAL) + 10);
++        timer_mod(g->fence_poll, qemu_clock_get_ms(QEMU_CLOCK_VIRTUAL) + 3);
+     }
+ }
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
This will improve performance while waiting the fence in 3D renderering

Signed-off-by: Kanli Hu <kanlix.hu@intel.com>