### PR TITLE
btusb : snd : crash while disconnect

### DIFF
--- a/bsp_diff/common/kernel/lts2019-chromium/66_0001-btusb-snd-crash-while-disconnect.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/66_0001-btusb-snd-crash-while-disconnect.patch
@@ -1,0 +1,31 @@
+From 94e49a7a79c0bdb6ac27fa704a27a49d7e703626 Mon Sep 17 00:00:00 2001
+From: Balaji M <m.balaji@intel.com>
+Date: Mon, 28 Dec 2020 20:57:24 +0530
+Subject: [PATCH] btusb : snd : crash while disconnect
+
+removing the duplicacy of snd_card_free_when_closed()
+function which is called inside btusb_sco_disconnect()
+function.
+
+Tracked-On: OAM-95334
+Signed-off-by: Prabhat Chand Pandey prabhat.chand.pandey@intel.com
+---
+ sound/usb/btusb/btusb_sco_snd_card.c | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/sound/usb/btusb/btusb_sco_snd_card.c b/sound/usb/btusb/btusb_sco_snd_card.c
+index 71e2059e217c..16a6dbb608e1 100644
+--- a/sound/usb/btusb/btusb_sco_snd_card.c
++++ b/sound/usb/btusb/btusb_sco_snd_card.c
+@@ -990,8 +990,6 @@ static void btusb_sco_disconnect(struct usb_interface *intf)
+ 	part needs to be checked.
+ 	kfree(data);
+ 	data = NULL; */
+-
+-	snd_card_free_when_closed(data->card);
+ }
+ 
+ static int btusb_sco_suspend(struct usb_interface *intf, pm_message_t message)
+-- 
+2.17.1
+


### PR DESCRIPTION
removing the duplicacy of snd_card_free_when_closed()
function which is called inside btusb_sco_disconnect()
function.

Tracked-On: OAM-95334
Signed-off-by: Prabhat Chand Pandey prabhat.chand.pandey@intel.com