### PR TITLE
Disable HWC

### DIFF
--- a/bsp_diff/common/vendor/intel/external/hwcomposer-intel/0001-Disable-HWC.patch
+++ b/bsp_diff/common/vendor/intel/external/hwcomposer-intel/0001-Disable-HWC.patch
@@ -1,0 +1,30 @@
+From 260358030731b5864ec9f8350ae902a126901479 Mon Sep 17 00:00:00 2001
+From: renchenglei <chenglei.ren@intel.com>
+Date: Tue, 29 Dec 2020 18:03:03 +0800
+Subject: [PATCH] Disable HWC
+
+We may encounter HWC crash when playing video with
+Allocator & Mapper 4.0 on GVT-d, here we disable HWC
+for a WA.
+
+Tracked-On:
+---
+ common/core/gpudevice.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/common/core/gpudevice.cpp b/common/core/gpudevice.cpp
+index 4e65d55da093..48dc86530c06 100644
+--- a/common/core/gpudevice.cpp
++++ b/common/core/gpudevice.cpp
+@@ -101,7 +101,7 @@ uint32_t GpuDevice::GetFD() const {
+ }
+ 
+ bool GpuDevice::IsGvtActive() const {
+-  return gvt_active_;
++  return true;
+ }
+ 
+ NativeDisplay *GpuDevice::GetDisplay(uint32_t display_id) {
+-- 
+2.17.1
+


### PR DESCRIPTION
With Allocator & Mapper 4.0, we may encounter HWC crash when
playing video. To quick wa this issue, we disable HWC here.

Tracked-On: OAM-95365
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>