### PR TITLE
Apply the correct stride for HEVC codec

### DIFF
--- a/aosp_diff/preliminary/frameworks/av/05_0005-Apply-the-correct-stride-for-HEVC-codec.patch
+++ b/aosp_diff/preliminary/frameworks/av/05_0005-Apply-the-correct-stride-for-HEVC-codec.patch
@@ -1,0 +1,34 @@
+From 600a11ced0ab0f5ca95921b4384719419cea67df Mon Sep 17 00:00:00 2001
+From: Vinay Kompella <vinay.kompella@intel.com>
+Date: Wed, 30 Dec 2020 09:01:07 +0530
+Subject: [PATCH] Apply the correct stride for HEVC codec
+
+Remember the stride decoded from the header, so that
+we can use the correct stride information when decoding
+the frame. Currently since we donot remember this, there
+is a mismatch with the stride we know and stride applied
+during decode frame.
+
+Tracked-On: OAM-95490
+Signed-off-by: Vinay Kompella <vinay.kompella@intel.com>
+---
+ media/codec2/components/hevc/C2SoftHevcDec.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/media/codec2/components/hevc/C2SoftHevcDec.cpp b/media/codec2/components/hevc/C2SoftHevcDec.cpp
+index 23104dc922..8fe5d8dd4e 100644
+--- a/media/codec2/components/hevc/C2SoftHevcDec.cpp
++++ b/media/codec2/components/hevc/C2SoftHevcDec.cpp
+@@ -911,7 +911,8 @@ void C2SoftHevcDec::process(
+         if (0 < s_decode_op.u4_pic_wd && 0 < s_decode_op.u4_pic_ht) {
+             if (mHeaderDecoded == false) {
+                 mHeaderDecoded = true;
+-                setParams(ALIGN32(s_decode_op.u4_pic_wd), IVD_DECODE_FRAME);
++                mStride = ALIGN32(s_decode_op.u4_pic_wd);
++                setParams(mStride, IVD_DECODE_FRAME);
+             }
+             if (s_decode_op.u4_pic_wd != mWidth ||  s_decode_op.u4_pic_ht != mHeight) {
+                 mWidth = s_decode_op.u4_pic_wd;
+-- 
+2.17.1
+


### PR DESCRIPTION
Remember the stride decoded from the header, so that
we can use the correct stride information when decoding
the frame. Currently since we do not remember this, there
is a mismatch with the stride we know and stride applied
during decode frame.

Tracked-On: OAM-95490
Signed-off-by: Vinay Kompella <vinay.kompella@intel.com>