### PR TITLE
x86, relocs: Ignore L4_PAGE_OFFSET relocations

### DIFF
--- a/bsp_diff/common/kernel/lts2019-chromium/67_0067-x86-relocs-Ignore-L4_PAGE_OFFSET-relocations.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/67_0067-x86-relocs-Ignore-L4_PAGE_OFFSET-relocations.patch
@@ -1,0 +1,30 @@
+From 30fb81948cb4dc94c47467847072a9732b7c9c7d Mon Sep 17 00:00:00 2001
+From: Sami Tolvanen <samitolvanen@google.com>
+Date: Tue, 29 Dec 2020 12:48:52 +0530
+Subject: [PATCH] x86, relocs: Ignore L4_PAGE_OFFSET relocations
+
+L4_PAGE_OFFSET is a constant value, so don't warn about absolute
+relocations.
+
+Tracked-On: OAM-95581
+Signed-off-by: Sami Tolvanen <samitolvanen@google.com>
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ arch/x86/tools/relocs.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/x86/tools/relocs.c b/arch/x86/tools/relocs.c
+index ce7188cbdae5..8f3bf34840ce 100644
+--- a/arch/x86/tools/relocs.c
++++ b/arch/x86/tools/relocs.c
+@@ -47,6 +47,7 @@ static const char * const sym_regex_kernel[S_NSYMTYPES] = {
+ 	[S_ABS] =
+ 	"^(xen_irq_disable_direct_reloc$|"
+ 	"xen_save_fl_direct_reloc$|"
++	"L4_PAGE_OFFSET|"
+ 	"VDSO|"
+ 	"__crc_)",
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
L4_PAGE_OFFSET is a constant value, so don't warn about absolute
relocations.

Tracked-On: OAM-95581
Signed-off-by: Sami Tolvanen <samitolvanen@google.com>
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>