### PR TITLE
Keymaster: Add new keymaster error code for provisioning

### DIFF
--- a/aosp_diff/preliminary/hardware/libhardware/0001-Keymaster-Add-new-keymaster-error-code-for-provision.patch
+++ b/aosp_diff/preliminary/hardware/libhardware/0001-Keymaster-Add-new-keymaster-error-code-for-provision.patch
@@ -1,0 +1,29 @@
+From fd244dd548b6575db7aafd6512b564964dad73db Mon Sep 17 00:00:00 2001
+From: "Zhong,Fangjian" <fangjian.zhong@intel.com>
+Date: Mon, 8 Feb 2021 09:33:18 +0800
+Subject: [PATCH] Keymaster: Add new keymaster error code for provisioning
+
+Add new error code KM_ERROR_KEYBOX_ALREADY_PROVISIONED to indicate error
+type of trying to provision device which has been already provisioned.
+
+Tracked-On: OAM-95939
+Signed-off-by: Zhong,Fangjian <fangjian.zhong@intel.com>
+---
+ include/hardware/keymaster_defs.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/include/hardware/keymaster_defs.h b/include/hardware/keymaster_defs.h
+index 2fbfe46d..8cd82abf 100644
+--- a/include/hardware/keymaster_defs.h
++++ b/include/hardware/keymaster_defs.h
+@@ -474,6 +474,7 @@ typedef enum {
+     KM_ERROR_UNIMPLEMENTED = -100,
+     KM_ERROR_VERSION_MISMATCH = -101,
+ 
++    KM_ERROR_KEYBOX_ALREADY_PROVISIONED = -900,
+     KM_ERROR_UNKNOWN_ERROR = -1000,
+ } keymaster_error_t;
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
Add new error code KM_ERROR_KEYBOX_ALREADY_PROVISIONED to indicate the error
type of trying to provision device which has been already provisioned.

Tracked-On: OAM-95939
Signed-off-by: Zhong,Fangjian <fangjian.zhong@intel.com>