### PR TITLE
Update logic to program AUD_FREQ_CNTRL register based on new guidance.

### DIFF
--- a/bsp_diff/common/kernel/lts2019-chromium/16_0016-FROMLIST-Update-logic-to-program-AUD_FREQ_CNTRL-reg.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/16_0016-FROMLIST-Update-logic-to-program-AUD_FREQ_CNTRL-reg.patch
@@ -1,0 +1,120 @@
+From 0c27931a4b7fabc00a271c17be49b344aa8e5c09 Mon Sep 17 00:00:00 2001
+From: gkdeepa <g.k.deepa@intel.com>
+Date: Wed, 27 Jan 2021 13:40:21 +0530
+Subject: [PATCH] [REVERT ME]Update logic to program AUD_FREQ_CNTRL register 
+ based on new guidance.
+
+Earlier this register was configured by BIOS and driver discovered the
+value at init. This is no longer recommended and instead for driver
+should set the values based on the hardware revision. This change
+applies for all GEN12+ hardware.
+
+Add the recommended values for all supported hardware. Extend the debug
+print to also include values of the register as written by BIOS. This
+can help debug rare cases where an older BIOS configures an incorrect
+value.
+
+Bspec: 49279
+
+once the patch gets reviewed we need to back port the patch
+http://intel-gfx-pw.fi.intel.com/series/7315/
+
+Tracked-On: OAM-95837
+Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>
+Signed-off-by: Deepa G K <g.k.deepa@intel.com>
+---
+ ...-logic-to-program-AUD_FREQ_CNTRL-reg.patch | 82 +++++++++++++++++++
+ 1 file changed, 82 insertions(+)
+ create mode 100644 bsp_diff/common/kernel/lts2019-chromium/68_0001-REVERT-ME-Update-logic-to-program-AUD_FREQ_CNTRL-reg.patch
+
+diff --git a/bsp_diff/common/kernel/lts2019-chromium/68_0001-REVERT-ME-Update-logic-to-program-AUD_FREQ_CNTRL-reg.patch b/bsp_diff/common/kernel/lts2019-chromium/68_0001-REVERT-ME-Update-logic-to-program-AUD_FREQ_CNTRL-reg.patch
+new file mode 100644
+index 0000000..672317f
+--- /dev/null
++++ b/bsp_diff/common/kernel/lts2019-chromium/68_0001-REVERT-ME-Update-logic-to-program-AUD_FREQ_CNTRL-reg.patch
+@@ -0,0 +1,82 @@
++From 37b8db582dfa21ecfb50a0e8762713488af6a497 Mon Sep 17 00:00:00 2001
++From: gkdeepa <g.k.deepa@intel.com>
++Date: Thu, 21 Jan 2021 18:15:24 +0530
++Subject: [PATCH] [REVERT ME]Update logic to program AUD_FREQ_CNTRL register
++ based on new guidance.
++
++Earlier this register was configured by BIOS and driver discovered the
++value at init. This is no longer recommended and instead for driver
++should set the values based on the hardware revision. This change
++applies for all GEN12+ hardware.
++
++Add the recommended values for all supported hardware. Extend the debug
++print to also include values of the register as written by BIOS. This
++can help debug rare cases where an older BIOS configures an incorrect
++value.
++
++Bspec: 49279
++
++once the patch gets reviewed we need to back port the patch
++http://intel-gfx-pw.fi.intel.com/series/7315/
++
++Tracked-On: OAM-95837
++Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>
++Signed-off-by: Deepa G K <g.k.deepa@intel.com>
++---
++ drivers/gpu/drm/i915/display/intel_audio.c | 26 ++++++++++++++++------
++ 1 file changed, 19 insertions(+), 7 deletions(-)
++
++diff --git a/drivers/gpu/drm/i915/display/intel_audio.c b/drivers/gpu/drm/i915/display/intel_audio.c
++index 8f144605ed39..1cb71801a61a 100644
++--- a/drivers/gpu/drm/i915/display/intel_audio.c
+++++ b/drivers/gpu/drm/i915/display/intel_audio.c
++@@ -1145,6 +1145,13 @@ static const struct component_ops i915_audio_component_bind_ops = {
++ 	.unbind	= i915_audio_component_unbind,
++ };
++ 
+++#define AUD_FREQ_TMODE_SHIFT	14
+++#define AUD_FREQ_4T		0
+++#define AUD_FREQ_8T		(2 << AUD_FREQ_TMODE_SHIFT)
+++#define AUD_FREQ_PULLCLKS(x)	(((x) & 0x3) << 11)
+++#define AUD_FREQ_BCLK_96M	BIT(4)
+++#define AUD_FREQ_DEFAULTS       (AUD_FREQ_BCLK_96M)
+++
++ /**
++  * i915_audio_component_init - initialize and register the audio component
++  * @dev_priv: i915 device instance
++@@ -1163,6 +1170,7 @@ static const struct component_ops i915_audio_component_bind_ops = {
++  */
++ static void i915_audio_component_init(struct drm_i915_private *dev_priv)
++ {
+++	u32 aud_freq = AUD_FREQ_DEFAULTS, aud_freq_init = 0;
++ 	int ret;
++ 
++ 	ret = component_add_typed(dev_priv->drm.dev,
++@@ -1175,13 +1183,17 @@ static void i915_audio_component_init(struct drm_i915_private *dev_priv)
++ 		return;
++ 	}
++ 
++-	if (INTEL_GEN(dev_priv) >= 9) {
++-		dev_priv->audio_freq_cntrl = intel_de_read(dev_priv,
++-							   AUD_FREQ_CNTRL);
++-		drm_dbg_kms(&dev_priv->drm,
++-			    "init value of AUD_FREQ_CNTRL of 0x%x\n",
++-			    dev_priv->audio_freq_cntrl);
++-	}
+++	if (INTEL_GEN(dev_priv) >= 9)
+++		aud_freq_init = intel_de_read(dev_priv, AUD_FREQ_CNTRL);
+++
+++	if (INTEL_GEN(dev_priv) >= 12)
+++		aud_freq |= AUD_FREQ_8T | AUD_FREQ_PULLCLKS(0);
+++	else
+++		aud_freq = aud_freq_init;
+++
+++	drm_dbg_kms(&dev_priv->drm, "use AUD_FREQ_CNTRL of 0x%x (init value 0x%x)\n",
+++		    aud_freq, aud_freq_init);
+++	dev_priv->audio_freq_cntrl = aud_freq;
++ 
++ 	dev_priv->audio_component_registered = true;
++ }
++-- 
++2.17.1
++
+-- 
+2.17.1
+


### PR DESCRIPTION
Earlier this register was configured by BIOS and driver discovered the
value at init. This is no longer recommended and instead for driver
should set the values based on the hardware revision. This change
applies for all GEN12+ hardware.

Add the recommended values for all supported hardware. Extend the debug
print to also include values of the register as written by BIOS. This
can help debug rare cases where an older BIOS configures an incorrect
value.

Bspec: 49279

once the patch gets reviewed we need to back port the patch
http://intel-gfx-pw.fi.intel.com/series/7315/

Tracked-On: OAM-95960
Signed-off-by: Deepa G K <g.k.deepa@intel.com>