### PR TITLE
Diff for setting the fixed performance mode

### DIFF
--- a/aosp_diff/preliminary/hardware/interfaces/07_0007-enable-fixed-performance-mode.patch
+++ b/aosp_diff/preliminary/hardware/interfaces/07_0007-enable-fixed-performance-mode.patch
@@ -1,0 +1,32 @@
+From 159e35869be5edd8183578f9e9b1f9a805d1e646 Mon Sep 17 00:00:00 2001
+From: Shwetha B <shwetha.b@intel.com>
+Date: Wed, 3 Feb 2021 09:17:32 +0530
+Subject: [PATCH] FIXED_PERFORMANCE mode enable
+
+Tracked-On: OAM-95866
+Signed-off-by: Shwetha B <shwetha.b@intel.com>
+---
+ power/aidl/default/Power.cpp | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/power/aidl/default/Power.cpp b/power/aidl/default/Power.cpp
+index 8610de35b..bd8484c73 100644
+--- a/power/aidl/default/Power.cpp
++++ b/power/aidl/default/Power.cpp
+@@ -31,8 +31,12 @@ ndk::ScopedAStatus Power::setMode(Mode type, bool enabled) {
+ }
+ 
+ ndk::ScopedAStatus Power::isModeSupported(Mode type, bool* _aidl_return) {
++    bool supported = false;
++    if (type == Mode::FIXED_PERFORMANCE) {
++	    supported = true;
++    }
+     LOG(INFO) << "Power isModeSupported: " << static_cast<int32_t>(type);
+-    *_aidl_return = false;
++    *_aidl_return = supported;
+     return ndk::ScopedAStatus::ok();
+ }
+ 
+-- 
+2.29.2
+

--- a/aosp_diff/preliminary/system/sepolicy/03_0003-Selinux-for-power-related-system-property.patch
+++ b/aosp_diff/preliminary/system/sepolicy/03_0003-Selinux-for-power-related-system-property.patch
@@ -1,0 +1,40 @@
+From 6adae690dd708d94d9d3028d086c257903b58d11 Mon Sep 17 00:00:00 2001
+From: Shwetha B <shwetha.b@intel.com>
+Date: Tue, 9 Feb 2021 10:26:40 +0530
+Subject: [PATCH] Selinux for power related system property
+
+Assign exported_default_prop for the system property
+ro.power.fixed_performance_scale_factor
+
+Tracked-On:
+Signed-off-by: Shwetha B <shwetha.b@intel.com>
+---
+ prebuilts/api/30.0/public/property_contexts | 3 +++
+ public/property_contexts                    | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/prebuilts/api/30.0/public/property_contexts b/prebuilts/api/30.0/public/property_contexts
+index 4607ef325..aa24f2f18 100644
+--- a/prebuilts/api/30.0/public/property_contexts
++++ b/prebuilts/api/30.0/public/property_contexts
+@@ -477,3 +477,6 @@ cache_key.telephony.                     u:object_r:binder_cache_telephony_serve
+ # Graphics related properties
+ graphics.gpu.profiler.support          u:object_r:graphics_config_prop:s0 exact bool
+ graphics.gpu.profiler.vulkan_layer_apk u:object_r:graphics_config_prop:s0 exact string
++
++#Power related properties
++ro.power.fixed_performance_scale_factor u:object_r:exported_default_prop:s0 exact int
+diff --git a/public/property_contexts b/public/property_contexts
+index 4607ef325..aa24f2f18 100644
+--- a/public/property_contexts
++++ b/public/property_contexts
+@@ -477,3 +477,6 @@ cache_key.telephony.                     u:object_r:binder_cache_telephony_serve
+ # Graphics related properties
+ graphics.gpu.profiler.support          u:object_r:graphics_config_prop:s0 exact bool
+ graphics.gpu.profiler.vulkan_layer_apk u:object_r:graphics_config_prop:s0 exact string
++
++#Power related properties
++ro.power.fixed_performance_scale_factor u:object_r:exported_default_prop:s0 exact int
+-- 
+2.29.2
+


### PR DESCRIPTION
This will be removed when Power hal Aidl is
moved to vendor/intel/hardware/interfaces

Currently in AIDL, only fixed performance mode
is enabled. Other mode/Hints are handled in
Power hal directly.

Tracked-On: OAM-95866
Signed-off-by: Shwetha B <shwetha.b@intel.com>