### PR TITLE
wifi: Enable DEBUG_ERROR_ALERTS capability

### DIFF
--- a/aosp_diff/preliminary/hardware/interfaces/06_0006-wifi-Disable-capabilities-not-yet-supported.patch
+++ b/aosp_diff/preliminary/hardware/interfaces/06_0006-wifi-Disable-capabilities-not-yet-supported.patch
@@ -1,4 +1,4 @@
-From 4444fd32bad011c90b75c32bb46f502597d0a1e8 Mon Sep 17 00:00:00 2001
+From dab5e75a1a0a72ee3c97814c736dad6c44087c32 Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Wed, 13 Jan 2021 14:30:45 +0530
 Subject: [PATCH] wifi: Disable capabilities not yet supported
@@ -6,40 +6,29 @@ Subject: [PATCH] wifi: Disable capabilities not yet supported
 As E2E support is not yet implemented for following capabilities,
 removing them.
 DEBUG_RING_BUFFER_VENDOR_DATA, DEBUG_HOST_WAKE_REASON_STATS,
-DEBUG_ERROR_ALERTS and APF.
+and APF.
 
 Tracked-On: OAM-95699
 Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 ---
- wifi/1.4/default/hidl_struct_util.cpp | 12 ++++++------
- 1 file changed, 6 insertions(+), 6 deletions(-)
+ wifi/1.4/default/hidl_struct_util.cpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/wifi/1.4/default/hidl_struct_util.cpp b/wifi/1.4/default/hidl_struct_util.cpp
-index fd1d5b112..fe06612a9 100644
+index fd1d5b112..081257113 100644
 --- a/wifi/1.4/default/hidl_struct_util.cpp
 +++ b/wifi/1.4/default/hidl_struct_util.cpp
-@@ -132,7 +132,7 @@ bool convertLegacyFeaturesToHidlChipCapabilities(
-         return false;
-     }
-     *hidl_caps = {};
--    using HidlChipCaps = IWifiChip::ChipCapabilityMask;
-+    //using HidlChipCaps = IWifiChip::ChipCapabilityMask;
-     for (const auto feature : {legacy_hal::WIFI_LOGGER_MEMORY_DUMP_SUPPORTED,
-                                legacy_hal::WIFI_LOGGER_DRIVER_DUMP_SUPPORTED,
-                                legacy_hal::WIFI_LOGGER_CONNECT_EVENT_SUPPORTED,
-@@ -157,9 +157,9 @@ bool convertLegacyFeaturesToHidlChipCapabilities(
+@@ -157,8 +157,8 @@ bool convertLegacyFeaturesToHidlChipCapabilities(
  
      // There are no flags for these 3 in the legacy feature set. Adding them to
      // the set because all the current devices support it.
 -    *hidl_caps |= HidlChipCaps::DEBUG_RING_BUFFER_VENDOR_DATA;
 -    *hidl_caps |= HidlChipCaps::DEBUG_HOST_WAKE_REASON_STATS;
--    *hidl_caps |= HidlChipCaps::DEBUG_ERROR_ALERTS;
 +    //*hidl_caps |= HidlChipCaps::DEBUG_RING_BUFFER_VENDOR_DATA;
 +    //*hidl_caps |= HidlChipCaps::DEBUG_HOST_WAKE_REASON_STATS;
-+    //*hidl_caps |= HidlChipCaps::DEBUG_ERROR_ALERTS;
+     *hidl_caps |= HidlChipCaps::DEBUG_ERROR_ALERTS;
      return true;
  }
- 
 @@ -379,7 +379,7 @@ bool convertLegacyFeaturesToHidlStaCapabilities(
          return false;
      }


### PR DESCRIPTION
VTS test case GetCapabilities_1_3 is failing as the capabilities
returned is 0. Fix the issue by enabling DEBUG_ERROR_ALERTS
capability.

Tracked-On: OAM-95901
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>