### PR TITLE
aosp camera target sdk version upgrade

### DIFF
--- a/aosp_diff/preliminary/packages/apps/Camera2/03_0003-google-camera-target-sdk-version-update.patch
+++ b/aosp_diff/preliminary/packages/apps/Camera2/03_0003-google-camera-target-sdk-version-update.patch
@@ -1,0 +1,25 @@
+From f8803efe2aadd3fe4191ce6cfe988fa56a562a0d Mon Sep 17 00:00:00 2001
+From: user189 <shiva.kumara.rudrappa@intel.com>
+Date: Wed, 10 Feb 2021 20:34:41 +0530
+Subject: [PATCH] google camera target sdk version update
+
+---
+ AndroidManifest.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/AndroidManifest.xml b/AndroidManifest.xml
+index 1f13e3e80..6a7bb98e1 100644
+--- a/AndroidManifest.xml
++++ b/AndroidManifest.xml
+@@ -6,7 +6,7 @@
+ 
+     <uses-sdk
+         android:minSdkVersion="19"
+-        android:targetSdkVersion="28" />
++        android:targetSdkVersion="30" />
+ 
+     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+-- 
+2.17.1
+


### PR DESCRIPTION
aosp camera application target sdk version pointing to 28

Solution: changed the target sdk version to 30

Tracked-On: OAM-95874
Signed-off-by: shiva kumara R <shiva.kumara.rudrappa@intel.com>