### PR TITLE
screensaver target sdk version change

### DIFF
--- a/aosp_diff/preliminary/packages/screensavers/PhotoTable/01_0001-target-version-upgrade-for-screen-saver.patch
+++ b/aosp_diff/preliminary/packages/screensavers/PhotoTable/01_0001-target-version-upgrade-for-screen-saver.patch
@@ -1,0 +1,25 @@
+From 1c1c287e3dcaf12af8d3059b4ebbb2426074a9b1 Mon Sep 17 00:00:00 2001
+From: user189 <shiva.kumara.rudrappa@intel.com>
+Date: Mon, 15 Feb 2021 12:26:00 +0530
+Subject: [PATCH] target version upgrade for screen saver
+
+---
+ AndroidManifest.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/AndroidManifest.xml b/AndroidManifest.xml
+index d820c87..1e7fbdd 100644
+--- a/AndroidManifest.xml
++++ b/AndroidManifest.xml
+@@ -6,7 +6,7 @@
+   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+   <uses-permission android:name="android.permission.WAKE_LOCK" />
+   <uses-permission android:name="com.google.android.gallery3d.permission.PICASA_STORE" />
+-  <uses-sdk android:minSdkVersion="17" android:targetSdkVersion="28"/>
++  <uses-sdk android:minSdkVersion="17" android:targetSdkVersion="30"/>
+ 
+   <application
+       android:label="@string/app_name"
+-- 
+2.17.1
+


### PR DESCRIPTION
screensaver application target sdk version points to 28

Solution: changed the target sdk version to 30

Tracked-On: OAM-95874
Signed-off-by: shiva kumara R <shiva.kumara.rudrappa@intel.com>