### PR TITLE
Ignore start and stop offloading packet request

### DIFF
--- a/bsp_diff/common/hardware/intel/wlan/libwifihal/open/02_0002-Ignore-start-and-stop-offloading-packet-request.patch
+++ b/bsp_diff/common/hardware/intel/wlan/libwifihal/open/02_0002-Ignore-start-and-stop-offloading-packet-request.patch
@@ -1,0 +1,44 @@
+From 849ad3850324ab868013658c84404021d125ff33 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Mon, 22 Feb 2021 16:11:42 +0530
+Subject: [PATCH] Ignore start and stop offloading packet request
+
+Following test cases in CtsNetTestCases module is failing
+as  wifi_start_sending_offloaded_packet and
+wifi_stop_sending_offloaded_packet requestes are completed
+with not supported error code.
+- testSocketKeepaliveUnprivileged, testCreateTcpKeepalive
+and testSocketKeepaliveLimitWifi.
+
+As network will still work even if we drop start/stop
+offload packet request, complete the start/stop requests with
+WIFI_SUCCESS to pass the CTS tests
+
+Tracked-On: OAM-96073
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ lib/wifi_hal.cpp | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/lib/wifi_hal.cpp b/lib/wifi_hal.cpp
+index 726841b..c9060e1 100644
+--- a/lib/wifi_hal.cpp
++++ b/lib/wifi_hal.cpp
+@@ -548,11 +548,12 @@ wifi_error wifi_start_sending_offloaded_packet(wifi_request_id id,
+ 		wifi_interface_handle iface, u16 ether_type, u8 *ip_packet,
+ 		u16 ip_packet_len, u8 *src_mac_addr, u8 *dst_mac_addr,
+ 		u32 period_msec) {
+-	return WIFI_ERROR_NOT_SUPPORTED;
++	// Network will still work even if we drop drop the packet and pretend everything is fine.
++	return WIFI_SUCCESS;
+ }
+ 
+ wifi_error wifi_stop_sending_offloaded_packet(wifi_request_id id, wifi_interface_handle iface) {
+-	return WIFI_ERROR_NOT_SUPPORTED;
++	return WIFI_SUCCESS;
+ }
+ 
+ wifi_error wifi_set_scanning_mac_oui(wifi_interface_handle iface, unsigned char *buffer) {
+-- 
+2.17.1
+


### PR DESCRIPTION
Following test cases in CtsNetTestCases module is failing
as  wifi_start_sending_offloaded_packet and
wifi_stop_sending_offloaded_packet requestes are completed
with not supported error code.
- testSocketKeepaliveUnprivileged, testCreateTcpKeepalive
and testSocketKeepaliveLimitWifi.

As network will still work even if we drop start/stop
offload packet request, complete the start/stop requests with
WIFI_SUCCESS to pass the CTS tests

Tracked-On: OAM-96073
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>