### PR TITLE
Merge 2 mandatory/strongly-recommended aosp patches

### DIFF
--- a/aosp_diff/preliminary/frameworks/av/06_0006-Add-a-null-check-in-RTSPSource-stop.patch
+++ b/aosp_diff/preliminary/frameworks/av/06_0006-Add-a-null-check-in-RTSPSource-stop.patch
@@ -1,0 +1,35 @@
+From ed5469655a4f9188a6c6963591d809f1e76b8350 Mon Sep 17 00:00:00 2001
+From: Andrew Lewis <andrewlewis@google.com>
+Date: Sun, 31 Jan 2021 16:53:51 +0000
+Subject: [PATCH] Add a null check in RTSPSource::stop
+
+This was causing a null pointer dereference in stop.
+
+Manual backport of aosp/1456267.
+
+Bug: 170643945
+Bug: 177500688
+Test: backport of aosp/1456267, tested in CTS
+Change-Id: I8c771cd68663ebb9df79584ba5dd4edb6636bdbd
+---
+ media/libmediaplayerservice/nuplayer/RTSPSource.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/media/libmediaplayerservice/nuplayer/RTSPSource.cpp b/media/libmediaplayerservice/nuplayer/RTSPSource.cpp
+index 83da092506..9533ae5279 100644
+--- a/media/libmediaplayerservice/nuplayer/RTSPSource.cpp
++++ b/media/libmediaplayerservice/nuplayer/RTSPSource.cpp
+@@ -146,7 +146,9 @@ void NuPlayer::RTSPSource::stop() {
+     }
+ 
+     // Close socket before posting message to RTSPSource message handler.
+-    close(mHandler->getARTSPConnection()->getSocket());
++    if (mHandler != NULL) {
++        close(mHandler->getARTSPConnection()->getSocket());
++    }
+ 
+     sp<AMessage> msg = new AMessage(kWhatDisconnect, this);
+ 
+-- 
+2.29.0
+

--- a/aosp_diff/preliminary/frameworks/opt/net/wifi/02_0002-ClientModeImpl-Reset-WifiInfo-on-NETWORK_DISCONNECTI.patch
+++ b/aosp_diff/preliminary/frameworks/opt/net/wifi/02_0002-ClientModeImpl-Reset-WifiInfo-on-NETWORK_DISCONNECTI.patch
@@ -1,0 +1,64 @@
+From 771b4dd25daedb13c9de736a8bca18485fcb1ab6 Mon Sep 17 00:00:00 2001
+From: Roshan Pius <rpius@google.com>
+Date: Fri, 10 Jul 2020 06:57:23 -0700
+Subject: [PATCH] ClientModeImpl: Reset WifiInfo on NETWORK_DISCONNECTION_EVENT
+
+Invoke WifiInfo.reset() on connection failure.
+
+Bug: 160787425
+Test: atest com.android.server.wifi
+Change-Id: I5c3000b4c9eefa8a264ee7ae89abd0b8039dca88
+Merged-In: I5c3000b4c9eefa8a264ee7ae89abd0b8039dca88
+---
+ .../android/server/wifi/ClientModeImpl.java   |  1 +
+ .../server/wifi/ClientModeImplTest.java       | 24 +++++++++++++++++++
+ 2 files changed, 25 insertions(+)
+
+diff --git a/service/java/com/android/server/wifi/ClientModeImpl.java b/service/java/com/android/server/wifi/ClientModeImpl.java
+index 6c31185da..fd79d8258 100644
+--- a/service/java/com/android/server/wifi/ClientModeImpl.java
++++ b/service/java/com/android/server/wifi/ClientModeImpl.java
+@@ -5695,6 +5695,7 @@ public class ClientModeImpl extends StateMachine {
+                     }
+                     clearNetworkCachedDataIfNeeded(getTargetWifiConfiguration(), message.arg2);
+                     mTargetNetworkId = WifiConfiguration.INVALID_NETWORK_ID;
++                    mWifiInfo.reset();
+                     break;
+                 case WifiMonitor.SUPPLICANT_STATE_CHANGE_EVENT:
+                     StateChangeResult stateChangeResult = (StateChangeResult) message.obj;
+diff --git a/tests/wifitests/src/com/android/server/wifi/ClientModeImplTest.java b/tests/wifitests/src/com/android/server/wifi/ClientModeImplTest.java
+index 23726786d..3048ef3d5 100644
+--- a/tests/wifitests/src/com/android/server/wifi/ClientModeImplTest.java
++++ b/tests/wifitests/src/com/android/server/wifi/ClientModeImplTest.java
+@@ -5295,4 +5295,28 @@ public class ClientModeImplTest extends WifiBaseTest {
+         assertEquals(mNetwork, mCmi.syncGetCurrentNetwork(mCmiAsyncChannel));
+         mLooper.stopAutoDispatch();
+     }
++
++    @Test
++    public void clearRequestingPackageNameInWifiInfoOnConnectionFailure() throws Exception {
++        mConnectedNetwork.fromWifiNetworkSpecifier = true;
++        mConnectedNetwork.ephemeral = true;
++        mConnectedNetwork.creatorName = OP_PACKAGE_NAME;
++
++        triggerConnect();
++
++        // association completed
++        mCmi.sendMessage(WifiMonitor.SUPPLICANT_STATE_CHANGE_EVENT, 0, 0,
++                new StateChangeResult(0, sWifiSsid, sBSSID, SupplicantState.ASSOCIATED));
++        mLooper.dispatchAll();
++
++        assertTrue(mCmi.getWifiInfo().isEphemeral());
++        assertEquals(OP_PACKAGE_NAME, mCmi.getWifiInfo().getRequestingPackageName());
++
++        // fail the connection.
++        mCmi.sendMessage(WifiMonitor.NETWORK_DISCONNECTION_EVENT, FRAMEWORK_NETWORK_ID, 0, sBSSID);
++        mLooper.dispatchAll();
++
++        assertFalse(mCmi.getWifiInfo().isEphemeral());
++        assertNull(mCmi.getWifiInfo().getRequestingPackageName());
++    }
+ }
+-- 
+2.29.0
+


### PR DESCRIPTION
This patch will integrate the following aosp patches:

1) ClientModeImpl: Reset WifiInfo on NETWORK_DISCONNECTION_EVENT
2) Add a null check in RTSPSource::stop

Tracked-On: OAM-96486
Signed-off-by: Salini Venate <salini.venate@intel.com>