### PR TITLE
add cd success checks back in from sundar latest pull req

### DIFF
--- a/autopatch.sh
+++ b/autopatch.sh
@@ -92,7 +92,8 @@ function fpnat() # find patch files and apply them
     # and bsp_diff/preliminary bsp_diff/${TARGET_PRODUCT} directories.
     cd ${patch_top_dir}
     if [ $? -ne 0 ]; then
-        fi
+	return
+    fi
 
     patch_file_number=`find . -iname "*.patch" |wc -l`
     echo "Path: `basename ${patch_top_dir}` has ${patch_file_number} patch file(s) to apply!"

--- a/autopatch.sh
+++ b/autopatch.sh
@@ -99,7 +99,6 @@ function fpnat() # find patch files and apply them
     # arg #1 should be the .patch files' top directory,
     # either aosp_diff/preliminary or aosp_diff/${TARGET_PRODUCT}
     # and bsp_diff/preliminary bsp_diff/${TARGET_PRODUCT} directories.
-    echo "fpnat cd " ${patch_top_dir}
     cd ${patch_top_dir}
     if [ $? -ne 0 ]; then
 	return

--- a/autopatch.sh
+++ b/autopatch.sh
@@ -46,6 +46,10 @@ apply_patch() {
     previous_project=$current_project
 
     cd $top_dir/$current_project
+    if [ $? -ne 0 ]; then
+        return
+    fi
+
     remote=`git remote -v | grep "https://android.googlesource.com/"`
     if [[ -z "$remote" ]]; then
       default_revision="remotes/m/master"
@@ -87,6 +91,9 @@ function fpnat() # find patch files and apply them
     # either aosp_diff/preliminary or aosp_diff/${TARGET_PRODUCT}
     # and bsp_diff/preliminary bsp_diff/${TARGET_PRODUCT} directories.
     cd ${patch_top_dir}
+    if [ $? -ne 0 ]; then
+        fi
+
     patch_file_number=`find . -iname "*.patch" |wc -l`
     echo "Path: `basename ${patch_top_dir}` has ${patch_file_number} patch file(s) to apply!"
     if [[ ${patch_file_number} != 0 ]];then


### PR DESCRIPTION
The cd checks are necessary as I do one run without any code sync so I can parse the output and find all projects that are patched for the target.
first cd check changed from return to continue since it's in a loop (oops...).