### PR TITLE
Bluetooth: btusb: Add reset on close quirk for Intel adapters

### DIFF
--- a/bsp_diff/common/kernel/lts2019-chromium/17_0017-Bluetooth-btusb-Add-reset-on-close-quirk-for-Intel-a.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/17_0017-Bluetooth-btusb-Add-reset-on-close-quirk-for-Intel-a.patch
@@ -1,0 +1,36 @@
+From ee2d0704e096c11b8f94e96934a21d9772d2a173 Mon Sep 17 00:00:00 2001
+From: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Date: Thu, 18 Mar 2021 15:48:32 +0530
+Subject: [PATCH] Bluetooth: btusb: Add reset on close quirk for Intel adapters
+
+Intel Bluetooth adapter is not exiting the loopback mode on bluetooth
+socket closure. So, when bluetooth socket is opened again, bluetooth is
+not working.
+
+As per Bluetooth core specification, bluetooth adapter should exit loop
+back mode on hci reset. Add HCI quirk reset to make sure adapter exits
+loopback mode on bluetooth socket closure.
+
+Tracked-On: OAM-96067
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Signed-off-by: Amrita Raju <amrita.raju@intel.com>
+---
+ drivers/bluetooth/btusb.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
+index a74f0faea6f2..b551b0d004e8 100644
+--- a/drivers/bluetooth/btusb.c
++++ b/drivers/bluetooth/btusb.c
+@@ -4055,7 +4055,7 @@ static int btusb_probe(struct usb_interface *intf,
+ 
+ 		if (btusb_find_altsetting(data, 6))
+ 			hdev->wbs_pkt_len = hci_packet_size_usb_alt[6];
+-
++		set_bit(HCI_QUIRK_RESET_ON_CLOSE, &hdev->quirks);
+ 		set_bit(HCI_QUIRK_STRICT_DUPLICATE_FILTER, &hdev->quirks);
+ 		set_bit(HCI_QUIRK_SIMULTANEOUS_DISCOVERY, &hdev->quirks);
+ 		set_bit(HCI_QUIRK_NON_PERSISTENT_DIAG, &hdev->quirks);
+-- 
+2.17.1
+


### PR DESCRIPTION
Intel Bluetooth adapter is not exiting the loopback mode on bluetooth
socket closure. So, when bluetooth socket is opened again, bluetooth is
not working.

As per Bluetooth core specification, bluetooth adapter should exit loop
back mode on hci reset. Add HCI quirk reset to make sure adapter exits
loopback mode on bluetooth socket closure.

Tracked-On: OAM-96067
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>