### PR TITLE
Allow batteryless device for system update.

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/21_0021-Allow-batteryless-device-for-system-update.patch
+++ b/aosp_diff/preliminary/frameworks/base/21_0021-Allow-batteryless-device-for-system-update.patch
@@ -1,0 +1,52 @@
+From 474379e98aee362dc9029febacaa4f4c5f46cbb4 Mon Sep 17 00:00:00 2001
+From: Jaikrishna Nemallapudi <nemallapudi.jaikrishna@intel.com>
+Date: Fri, 19 Mar 2021 16:24:32 +0530
+Subject: [PATCH] Allow batteryless device for system update.
+
+SytemUpdate CTS tests will pass only if battery is available.
+Fixed it to allow for batteryless device also.
+
+Tracked-On: OAM-97111
+Signed-off-by: Jaikrishna Nemallapudi <nemallapudi.jaikrishna@intel.com>
+---
+ .../server/devicepolicy/UpdateInstaller.java  | 22 ++++++++++++++++---
+ 1 file changed, 19 insertions(+), 3 deletions(-)
+
+diff --git a/services/devicepolicy/java/com/android/server/devicepolicy/UpdateInstaller.java b/services/devicepolicy/java/com/android/server/devicepolicy/UpdateInstaller.java
+index 7148ed4523d..36984c00d33 100644
+--- a/services/devicepolicy/java/com/android/server/devicepolicy/UpdateInstaller.java
++++ b/services/devicepolicy/java/com/android/server/devicepolicy/UpdateInstaller.java
+@@ -90,11 +90,27 @@ abstract class UpdateInstaller {
+         Intent batteryStatus = mContext.registerReceiver(
+                 /* receiver= */ null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+         float batteryPercentage = calculateBatteryPercentage(batteryStatus);
+-        boolean isBatteryPluggedIn =
+-                batteryStatus.getIntExtra(BatteryManager.EXTRA_PLUGGED, /* defaultValue= */ -1) > 0;
+-        return isBatteryPluggedIn
++        int batteryLevel = batteryStatus.getIntExtra(BatteryManager.EXTRA_LEVEL,
++                                                    /* defaultValue= */ -1);
++        int powerType = batteryStatus.getIntExtra(BatteryManager.EXTRA_PLUGGED,
++                                                    /* defaultValue= */ -1);
++        int batteryHealth = batteryStatus.getIntExtra(BatteryManager.EXTRA_HEALTH,
++                                                    /* defaultValue= */ -1);
++        int batteryStat = batteryStatus.getIntExtra(BatteryManager.EXTRA_STATUS,
++                                                    /* defaultValue= */ -1);
++
++        boolean isBatteryPluggedIn = powerType > 0;
++
++        /* Condition to allow batteryless deivce */
++        if (batteryLevel == 0 && powerType == BatteryManager.BATTERY_PLUGGED_AC
++                    && batteryHealth == BatteryManager.BATTERY_HEALTH_UNKNOWN
++                    && batteryStat == BatteryManager.BATTERY_STATUS_UNKNOWN) {
++            return true;
++        } else {
++            return isBatteryPluggedIn
+                 ? batteryPercentage >= mConstants.BATTERY_THRESHOLD_CHARGING
+                 : batteryPercentage >= mConstants.BATTERY_THRESHOLD_NOT_CHARGING;
++        }
+     }
+ 
+     private float calculateBatteryPercentage(Intent batteryStatus) {
+-- 
+2.31.1
+


### PR DESCRIPTION
SytemUpdate CTS tests will pass only if battery is available.
Fixed it to allow for batteryless device also. Identified the
batteryless device based on the below document.
https://source.android.com/devices/tech/power/batteryless

Tracked-On: OAM-97111
Signed-off-by: Jaikrishna Nemallapudi <nemallapudi.jaikrishna@intel.com>