### PR TITLE
[PATCH] Fix setLightState VTS failure

### DIFF
--- a/aosp_diff/preliminary/hardware/interfaces/0002-Fix-setLightState-VTS-failure.patch
+++ b/aosp_diff/preliminary/hardware/interfaces/0002-Fix-setLightState-VTS-failure.patch
@@ -1,0 +1,35 @@
+From df538abd4a525a17790b656bc27c35f5d2905134 Mon Sep 17 00:00:00 2001
+From: Swee Yee Fonn <swee.yee.fonn@intel.com>
+Date: Tue, 13 Apr 2021 14:36:49 +0800
+Subject: [PATCH] Fix setLightState VTS failure
+
+Make setLightState return UNSUPPORTED for invalid light ID
+
+Tracked-On: OAM-96770
+Change-Id: Ifad4568e3d8575950df7e067d0e90ebf8091db00
+Signed-off-by: Swee Yee Fonn <swee.yee.fonn@intel.com>
+---
+ light/aidl/default/Lights.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/light/aidl/default/Lights.cpp b/light/aidl/default/Lights.cpp
+index 580928c32..f18b542fe 100644
+--- a/light/aidl/default/Lights.cpp
++++ b/light/aidl/default/Lights.cpp
+@@ -48,10 +48,12 @@ Lights::Lights(std::map<int, light_device_t*> &&lights)
+   : mLights(std::move(lights)) {}
+ 
+ ndk::ScopedAStatus Lights::setLightState(int id, const HwLightState& state) {
++    ALOGI("Lights setting state for id=%d to color %x\n", id, state.color);
+     auto it = mLights.find(id);
+ 
+     if (it == mLights.end()) {
+-        return ndk::ScopedAStatus::fromStatus(STATUS_BAD_VALUE);
++        ALOGE("Light id %d does not exist.", id);
++        return ndk::ScopedAStatus::fromExceptionCode(EX_UNSUPPORTED_OPERATION);
+     }
+ 
+     light_device_t* hwLight = it->second;
+-- 
+2.17.1
+


### PR DESCRIPTION
Make setLightState return UNSUPPORTED for invalid light ID

Tracked-On: OAM-96799
Signed-off-by: Swee Yee Fonn <swee.yee.fonn@intel.com>