### PR TITLE
sepolicy: allow system_server to read /proc/locks

### DIFF
--- a/aosp_diff/preliminary/system/sepolicy/04_0004-sepolicy-allow-system_server-to-read-proc-locks.patch
+++ b/aosp_diff/preliminary/system/sepolicy/04_0004-sepolicy-allow-system_server-to-read-proc-locks.patch
@@ -1,0 +1,126 @@
+From d00b005ee49c94040fd8e5084e8685f458f9a925 Mon Sep 17 00:00:00 2001
+From: Marco Ballesio <balejs@google.com>
+Date: Thu, 6 May 2021 13:07:05 +0530
+Subject: [PATCH] sepolicy: allow system_server to read /proc/locks
+
+Access to /proc/locks is necessary to activity manager to 
+determine wheter a process holds a lock or not prior freezing it
+
+Original CommitId: 99a51b23b1c3d3e4ebdeda358ac2167ceed3bc8f
+Author: Marco Ballesio <balejs@google.com>
+
+Test: verified access of /proc/locks while testing other CLs in the same
+topic.
+Bug: 176928302
+
+Signed-off-by: Salini Venate <salini.venate@intel.com>
+---
+ prebuilts/api/30.0/private/compat/29.0/29.0.ignore.cil | 1 +
+ prebuilts/api/30.0/private/genfs_contexts              | 1 +
+ prebuilts/api/30.0/private/system_server.te            | 1 +
+ prebuilts/api/30.0/public/file.te                      | 1 +
+ private/compat/29.0/29.0.ignore.cil                    | 1 +
+ private/genfs_contexts                                 | 1 +
+ private/system_server.te                               | 1 +
+ public/file.te                                         | 1 +
+ 8 files changed, 8 insertions(+)
+
+diff --git a/prebuilts/api/30.0/private/compat/29.0/29.0.ignore.cil b/prebuilts/api/30.0/private/compat/29.0/29.0.ignore.cil
+index fdea691ea..f8e9b091a 100644
+--- a/prebuilts/api/30.0/private/compat/29.0/29.0.ignore.cil
++++ b/prebuilts/api/30.0/private/compat/29.0/29.0.ignore.cil
+@@ -88,6 +88,7 @@
+     ota_metadata_file
+     ota_prop
+     prereboot_data_file
++    proc_locks
+     art_apex_dir
+     rebootescrow_hal_prop
+     securityfs
+diff --git a/prebuilts/api/30.0/private/genfs_contexts b/prebuilts/api/30.0/private/genfs_contexts
+index 89232bc01..d05e907c4 100644
+--- a/prebuilts/api/30.0/private/genfs_contexts
++++ b/prebuilts/api/30.0/private/genfs_contexts
+@@ -13,6 +13,7 @@ genfscon proc /iomem u:object_r:proc_iomem:s0
+ genfscon proc /keys u:object_r:proc_keys:s0
+ genfscon proc /kmsg u:object_r:proc_kmsg:s0
+ genfscon proc /loadavg u:object_r:proc_loadavg:s0
++genfscon proc /locks u:object_r:proc_locks:s0
+ genfscon proc /lowmemorykiller u:object_r:proc_lowmemorykiller:s0
+ genfscon proc /meminfo u:object_r:proc_meminfo:s0
+ genfscon proc /misc u:object_r:proc_misc:s0
+diff --git a/prebuilts/api/30.0/private/system_server.te b/prebuilts/api/30.0/private/system_server.te
+index 213b3c80f..3c1d192d7 100644
+--- a/prebuilts/api/30.0/private/system_server.te
++++ b/prebuilts/api/30.0/private/system_server.te
+@@ -902,6 +902,7 @@ r_dir_file(system_server, proc_qtaguid_stat)
+ allow system_server {
+   proc_cmdline
+   proc_loadavg
++  proc_locks
+   proc_meminfo
+   proc_pagetypeinfo
+   proc_pipe_conf
+diff --git a/prebuilts/api/30.0/public/file.te b/prebuilts/api/30.0/public/file.te
+index 91257e237..7ed8baab6 100644
+--- a/prebuilts/api/30.0/public/file.te
++++ b/prebuilts/api/30.0/public/file.te
+@@ -36,6 +36,7 @@ type proc_iomem, fs_type, proc_type;
+ type proc_keys, fs_type, proc_type;
+ type proc_kmsg, fs_type, proc_type;
+ type proc_loadavg, fs_type, proc_type;
++type proc_locks, fs_type, proc_type;
+ type proc_lowmemorykiller, fs_type, proc_type;
+ type proc_max_map_count, fs_type, proc_type;
+ type proc_meminfo, fs_type, proc_type;
+diff --git a/private/compat/29.0/29.0.ignore.cil b/private/compat/29.0/29.0.ignore.cil
+index fdea691ea..f8e9b091a 100644
+--- a/private/compat/29.0/29.0.ignore.cil
++++ b/private/compat/29.0/29.0.ignore.cil
+@@ -88,6 +88,7 @@
+     ota_metadata_file
+     ota_prop
+     prereboot_data_file
++    proc_locks
+     art_apex_dir
+     rebootescrow_hal_prop
+     securityfs
+diff --git a/private/genfs_contexts b/private/genfs_contexts
+index 89232bc01..d05e907c4 100644
+--- a/private/genfs_contexts
++++ b/private/genfs_contexts
+@@ -13,6 +13,7 @@ genfscon proc /iomem u:object_r:proc_iomem:s0
+ genfscon proc /keys u:object_r:proc_keys:s0
+ genfscon proc /kmsg u:object_r:proc_kmsg:s0
+ genfscon proc /loadavg u:object_r:proc_loadavg:s0
++genfscon proc /locks u:object_r:proc_locks:s0
+ genfscon proc /lowmemorykiller u:object_r:proc_lowmemorykiller:s0
+ genfscon proc /meminfo u:object_r:proc_meminfo:s0
+ genfscon proc /misc u:object_r:proc_misc:s0
+diff --git a/private/system_server.te b/private/system_server.te
+index 213b3c80f..3c1d192d7 100644
+--- a/private/system_server.te
++++ b/private/system_server.te
+@@ -902,6 +902,7 @@ r_dir_file(system_server, proc_qtaguid_stat)
+ allow system_server {
+   proc_cmdline
+   proc_loadavg
++  proc_locks
+   proc_meminfo
+   proc_pagetypeinfo
+   proc_pipe_conf
+diff --git a/public/file.te b/public/file.te
+index 91257e237..7ed8baab6 100644
+--- a/public/file.te
++++ b/public/file.te
+@@ -36,6 +36,7 @@ type proc_iomem, fs_type, proc_type;
+ type proc_keys, fs_type, proc_type;
+ type proc_kmsg, fs_type, proc_type;
+ type proc_loadavg, fs_type, proc_type;
++type proc_locks, fs_type, proc_type;
+ type proc_lowmemorykiller, fs_type, proc_type;
+ type proc_max_map_count, fs_type, proc_type;
+ type proc_meminfo, fs_type, proc_type;
+-- 
+2.29.0
+


### PR DESCRIPTION
Access to /proc/locks is necessary to activity manager to determine
wheter a process holds a lock or not prior freezing it.

Tracked-On: OAM-96736
Signed-off-by: Salini Venate <salini.venate@intel.com>