### PR TITLE
ASB patches in external-v8

### DIFF
--- a/aosp_diff/preliminary/external/v8/02_0002-Update-v8-cfi-blocklist.bulletin.patch
+++ b/aosp_diff/preliminary/external/v8/02_0002-Update-v8-cfi-blocklist.bulletin.patch
@@ -1,0 +1,35 @@
+From fe8ff91822238c547aa0ea6beeb3c67dc040360c Mon Sep 17 00:00:00 2001
+From: Cindy Zhou <zhouci@google.com>
+Date: Fri, 19 Mar 2021 17:01:13 -0700
+Subject: [PATCH] Update v8 cfi blocklist
+
+The api-arguments-inl.h file seem to have been moved so the blocklist
+was not working and new cfi crashes were emerging. This commit updates
+the list so the correct file path is used.
+
+Test: proxy_resolver_v8_unittest
+Bug: 183079234
+Bug: 162604069
+Bug: 167389063
+Change-Id: I70b5cd699d33fa4eda3f76cfac1ca1c71f92547a
+(cherry picked from commit 2dc3777900fe5faa900be436bf42dd55353d189a)
+---
+ tools/cfi/blacklist.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/cfi/blacklist.txt b/tools/cfi/blacklist.txt
+index 822f83f..790f09e 100644
+--- a/tools/cfi/blacklist.txt
++++ b/tools/cfi/blacklist.txt
+@@ -15,7 +15,7 @@ type:std::*
+ fun:*LocaleConvertCase*
+ 
+ # PropertyCallbackArguments::Call methods cast function pointers
+-src:*src/api-arguments-inl.h
++src:*src/api/api-arguments-inl.h
+ 
+ # v8 callback that casts argument template parameters
+ fun:*PendingPhantomCallback*Invoke*
+-- 
+2.31.1.498.g6c1eba8ee3d-goog
+


### PR DESCRIPTION
ASB patches in external/v8 from June
ASB bulletin

Tracked-On: OAM-97168
Signed-off-by: Salini Venate <salini.venate@intel.com>