### PR TITLE
Bluetooth: btusb: Fix failing to init controllers with operation firmware

### DIFF
--- a/bsp_diff/common/kernel/lts2019-chromium/21-0021-Bluetooth-btusb-Fix-failing-to-init-controllers-with.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/21-0021-Bluetooth-btusb-Fix-failing-to-init-controllers-with.patch
@@ -1,0 +1,65 @@
+From a4f5abb9a0917baf6aa7a1a0c350199641879aaa Mon Sep 17 00:00:00 2001
+From: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Date: Thu, 10 Jun 2021 09:36:35 +0530
+Subject: [PATCH] Bluetooth: btusb: Fix failing to init controllers with
+ operation firmware
+
+Some firmware when operation don't may have broken versions leading to
+error like the following:
+
+[    6.176482] Bluetooth: hci0: Firmware revision 0.0 build 121 week 7 2021
+[    6.177906] bluetooth hci0: Direct firmware load for intel/ibt-20-0-0.sfi failed with error -2
+[    6.177910] Bluetooth: hci0: Failed to load Intel firmware file intel/ibt-20-0-0.sfi (-2)
+
+Since we load the firmware file just to check if its version had changed
+comparing to the one already loaded we can just skip since the firmware
+is already operation.
+
+Signed-off-by: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
+Signed-off-by: Marcel Holtmann <marcel@holtmann.org>
+---
+ drivers/bluetooth/btusb.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
+index 2a7655f8c499..974b5ec43485 100644
+--- a/drivers/bluetooth/btusb.c
++++ b/drivers/bluetooth/btusb.c
+@@ -2480,6 +2480,11 @@ static int btusb_intel_download_firmware_newgen(struct hci_dev *hdev,
+ 	btusb_setup_intel_newgen_get_fw_name(ver, fwname, sizeof(fwname), "sfi");
+ 	err = request_firmware(&fw, fwname, &hdev->dev);
+ 	if (err < 0) {
++		if (!test_bit(BTUSB_BOOTLOADER, &data->flags)) {
++                        /* Firmware has already been loaded */
++                        set_bit(BTUSB_FIRMWARE_LOADED, &data->flags);
++                        return 0;
++                }
+ 		bt_dev_err(hdev, "Failed to load Intel firmware file %s (%d)",
+ 			   fwname, err);
+ 		return err;
+@@ -2631,12 +2636,22 @@ static int btusb_intel_download_firmware(struct hci_dev *hdev,
+ 	err = btusb_setup_intel_new_get_fw_name(ver, params, fwname,
+ 						sizeof(fwname), "sfi");
+ 	if (err < 0) {
++		if (!test_bit(BTUSB_BOOTLOADER, &data->flags)) {
++			/* Firmware has already been loaded */
++			set_bit(BTUSB_FIRMWARE_LOADED, &data->flags);
++			return 0;
++		}
+ 		bt_dev_err(hdev, "Unsupported Intel firmware naming");
+ 		return -EINVAL;
+ 	}
+ 
+ 	err = request_firmware(&fw, fwname, &hdev->dev);
+ 	if (err < 0) {
++		if (!test_bit(BTUSB_BOOTLOADER, &data->flags)) {
++                        /* Firmware has already been loaded */
++                        set_bit(BTUSB_FIRMWARE_LOADED, &data->flags);
++                        return 0;
++		}
+ 		bt_dev_err(hdev, "Failed to load Intel firmware file %s (%d)",
+ 			   fwname, err);
+ 		return err;
+-- 
+2.31.1
+


### PR DESCRIPTION
BT is not working in CIV with 5.4.121 kernel as it is unable
to get the required firmware file. BT chip will be operational
mode when CIV is launched. In the new firmware download flow, the
firmware version and revision are checked to see if the firmware
in the device is latest. But the firmware returns wrong device
information, which leads to error in BT firmware download flow

Fix: Soft links are created so that ibt-19-16-0* pointing to
ibt-19-0-4*

Patch will be reverted once the firmware changes are available

Tracked-On: OAM-97192
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>