### PR TITLE
sepolicy: Allow adbd to use vsock socket

### DIFF
--- a/aosp_diff/preliminary/system/sepolicy/05_0005-Allow-adbd-to-use-vsock_socket.patch
+++ b/aosp_diff/preliminary/system/sepolicy/05_0005-Allow-adbd-to-use-vsock_socket.patch
@@ -1,0 +1,32 @@
+From 1ed26880cb376385f8ab3fd81300f3c3c837f616 Mon Sep 17 00:00:00 2001
+From: Inseob Kim <inseob@google.com>
+Date: Thu, 11 Mar 2021 13:06:45 +0900
+Subject: [PATCH] Allow adbd to use vsock_socket
+
+To allow microdroid's adbd connection to be forwarded, adbd should be
+able to use vsock.
+
+Bug: 181747352
+Test: try to connect adb to microdroid after turning on selinux
+Change-Id: Ia6662d5a028a82c8bbafa6c21da821e9a1144bdc
+---
+ private/adbd.te | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/private/adbd.te b/private/adbd.te
+index 2c625652a..f569ad2fb 100644
+--- a/private/adbd.te
++++ b/private/adbd.te
+@@ -44,6 +44,9 @@ dontaudit adbd self:global_capability_class_set sys_resource;
+ # this occurs. (b/123569840)
+ dontaudit adbd self:{ socket vsock_socket } create;
+ 
++# Allow adbd inside vm to forward vm's vsock.
++allow adbd self:vsock_socket { create_socket_perms_no_ioctl listen accept };
++
+ # Create and use network sockets.
+ net_domain(adbd)
+ 
+-- 
+2.25.1
+

--- a/aosp_diff/preliminary/system/sepolicy/06_0006-prebuilt-Allow-adbd-to-use-vsock_socket.patch
+++ b/aosp_diff/preliminary/system/sepolicy/06_0006-prebuilt-Allow-adbd-to-use-vsock_socket.patch
@@ -1,0 +1,30 @@
+From ec084ad18bd422d114f6cbfe4e7d9d951a658188 Mon Sep 17 00:00:00 2001
+From: Yadong Qi <yadong.qi@intel.com>
+Date: Wed, 7 Jul 2021 16:38:03 +0800
+Subject: [PATCH] prebuilt: Allow adbd to use vsock_socket
+
+Align policy in prebuilt/adbd.te to pass
+the sepolicy_freeze_test.
+
+Signed-off-by: Yadong Qi <yadong.qi@intel.com>
+---
+ prebuilts/api/30.0/private/adbd.te | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/prebuilts/api/30.0/private/adbd.te b/prebuilts/api/30.0/private/adbd.te
+index e4498b05b..5d402e81c 100644
+--- a/prebuilts/api/30.0/private/adbd.te
++++ b/prebuilts/api/30.0/private/adbd.te
+@@ -44,6 +44,9 @@ dontaudit adbd self:global_capability_class_set sys_resource;
+ # this occurs. (b/123569840)
+ dontaudit adbd self:{ socket vsock_socket } create;
+ 
++# Allow adbd inside vm to forward vm's vsock.
++allow adbd self:vsock_socket { create_socket_perms_no_ioctl listen accept };
++
+ # Create and use network sockets.
+ net_domain(adbd)
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
Backport patch to allow adbd to use vsock socket.
Origin: https://android-review.googlesource.com/c/platform/system/sepolicy/+/1626224

Tracked-On: OAM-97464
Signed-off-by: Yadong Qi <yadong.qi@intel.com>