### PR TITLE
VTS fix in thermal

### DIFF
--- a/bsp_diff/common/hardware/interfaces/thermal/0001-Fix-for-VTS-issue-in-thermal.patch
+++ b/bsp_diff/common/hardware/interfaces/thermal/0001-Fix-for-VTS-issue-in-thermal.patch
@@ -1,0 +1,40 @@
+From e948f2f5dc3ca3c85ba18714eaa620fb69ff93ca Mon Sep 17 00:00:00 2001
+From: gkdeepa <g.k.deepa@intel.com>
+Date: Tue, 27 Jul 2021 09:31:51 +0530
+Subject: [PATCH] Fix for VTS issue in thermal
+
+Removing the thermal 1.0 HAL interface from 2.0
+service.
+
+Tracked-On: OAM-97800
+Signed-off-by: Deepa g.k.deepa@intel.com
+---
+ thermal/2.0/default/android.hardware.thermal@2.0-service.rc  | 1 -
+ thermal/2.0/default/android.hardware.thermal@2.0-service.xml | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/thermal/2.0/default/android.hardware.thermal@2.0-service.rc b/thermal/2.0/default/android.hardware.thermal@2.0-service.rc
+index 4ff8bd69e..046c77176 100644
+--- a/thermal/2.0/default/android.hardware.thermal@2.0-service.rc
++++ b/thermal/2.0/default/android.hardware.thermal@2.0-service.rc
+@@ -1,5 +1,4 @@
+ service vendor.thermal-hal-2-0-mock /vendor/bin/hw/android.hardware.thermal@2.0-service.mock
+-    interface android.hardware.thermal@1.0::IThermal default
+     interface android.hardware.thermal@2.0::IThermal default
+     class hal
+     user system
+diff --git a/thermal/2.0/default/android.hardware.thermal@2.0-service.xml b/thermal/2.0/default/android.hardware.thermal@2.0-service.xml
+index bcd6344bc..c4c7d4d6e 100644
+--- a/thermal/2.0/default/android.hardware.thermal@2.0-service.xml
++++ b/thermal/2.0/default/android.hardware.thermal@2.0-service.xml
+@@ -2,7 +2,6 @@
+     <hal format="hidl">
+         <name>android.hardware.thermal</name>
+         <transport>hwbinder</transport>
+-        <version>1.0</version>
+         <version>2.0</version>
+         <interface>
+             <name>IThermal</name>
+-- 
+2.17.1
+


### PR DESCRIPTION
Removing the thermal 1.0 HAL interface from 2.0
service.

Tracked-On: OAM-97800
Signed-off-by: Deepa g.k.deepa@intel.com