### PR TITLE
Using RGB565 in case YV12 is not supported

### DIFF
--- a/aosp_diff/caas_cfc/frameworks/av/0001-Using-RGB565-in-case-YV12-is-not-supported.patch
+++ b/aosp_diff/caas_cfc/frameworks/av/0001-Using-RGB565-in-case-YV12-is-not-supported.patch
@@ -1,0 +1,79 @@
+From 85326d6bce0834976d5f9a73800b08ec06cbbab6 Mon Sep 17 00:00:00 2001
+From: renchenglei <chenglei.ren@intel.com>
+Date: Thu, 12 Nov 2020 01:45:25 +0800
+Subject: [PATCH] Using RGB565 in case YV12 is not supported
+
+Tracked-On: OAM-98107
+---
+ .../colorconversion/SoftwareRenderer.cpp       | 18 +++++++++++++++++-
+ media/ndk/NdkImageReader.cpp                   |  4 ++++
+ 2 files changed, 21 insertions(+), 1 deletion(-)
+
+diff --git a/media/libstagefright/colorconversion/SoftwareRenderer.cpp b/media/libstagefright/colorconversion/SoftwareRenderer.cpp
+index 471131561531..756c94353de0 100644
+--- a/media/libstagefright/colorconversion/SoftwareRenderer.cpp
++++ b/media/libstagefright/colorconversion/SoftwareRenderer.cpp
+@@ -98,6 +98,15 @@ void SoftwareRenderer::resetFormatIfChanged(
+         dataSpaceChangedForPlanar16 = true;
+     }
+ 
++    char szVendorIntelVideoCodec[PROPERTY_VALUE_MAX] = {'\0'};
++    bool noYUV = false;
++
++    if(property_get("vendor.intel.video.codec", szVendorIntelVideoCodec, NULL) > 0 ) {
++        if (strncmp(szVendorIntelVideoCodec, "hardware", PROPERTY_VALUE_MAX) != 0 ) {
++            noYUV = true;
++        }
++    }
++
+     if (static_cast<int32_t>(mColorFormat) == colorFormatNew &&
+         mWidth == widthNew &&
+         mHeight == heightNew &&
+@@ -105,7 +114,8 @@ void SoftwareRenderer::resetFormatIfChanged(
+         mCropTop == cropTopNew &&
+         mCropRight == cropRightNew &&
+         mCropBottom == cropBottomNew &&
+-        !dataSpaceChangedForPlanar16) {
++        !dataSpaceChangedForPlanar16 &&
++        !noYUV) {
+         // Nothing changed, no need to reset renderer.
+         return;
+     }
+@@ -134,6 +144,9 @@ void SoftwareRenderer::resetFormatIfChanged(
+             case OMX_COLOR_FormatYUV420SemiPlanar:
+             case OMX_TI_COLOR_FormatYUV420PackedSemiPlanar:
+             {
++                if (noYUV) {
++                    break;
++                }
+                 halFormat = HAL_PIXEL_FORMAT_YV12;
+                 bufWidth = (mCropWidth + 1) & ~1;
+                 bufHeight = (mCropHeight + 1) & ~1;
+@@ -164,6 +177,9 @@ void SoftwareRenderer::resetFormatIfChanged(
+                     // use render engine to convert it to RGB if needed.
+                     halFormat = HAL_PIXEL_FORMAT_RGBA_1010102;
+                 } else {
++                    if (noYUV) {
++                        break;
++                    }
+                     halFormat = HAL_PIXEL_FORMAT_YV12;
+                 }
+                 bufWidth = (mCropWidth + 1) & ~1;
+diff --git a/media/ndk/NdkImageReader.cpp b/media/ndk/NdkImageReader.cpp
+index c0ceb3d70b84..4192fc4b1331 100644
+--- a/media/ndk/NdkImageReader.cpp
++++ b/media/ndk/NdkImageReader.cpp
+@@ -469,6 +469,10 @@ AImageReader::acquireImageLocked(/*out*/AImage** image, /*out*/int* acquireFence
+                 // YUV.
+                 mHalFormat = bufferFmt;
+                 ALOGD("%s: Overriding buffer format YUV_420_888 to 0x%x.", __FUNCTION__, bufferFmt);
++            } else if (readerFmt == HAL_PIXEL_FORMAT_YCbCr_420_888 && bufferFmt == HAL_PIXEL_FORMAT_RGB_565) {
++                //YUV format is not supported on virtio gpu, fall back to RGB565
++                mHalFormat = bufferFmt;
++                ALOGD("%s: Overriding buffer format YUV_420_888 to 0x%x.", __FUNCTION__, bufferFmt);
+             } else {
+                 // Return the buffer to the queue. No need to provide fence, as this buffer wasn't
+                 // used anywhere yet.
+-- 
+2.17.1
+


### PR DESCRIPTION
VirtIO GPU doesn't support video format, so convert
video format to RGB565

Tracked-On: OAM-98107
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>