### PR TITLE
Fixed the looking glass client rendering messed issue.

### DIFF
--- a/host/lg/0015-Fixed-the-looking-glass-client-rendering-messed-issu.patch
+++ b/host/lg/0015-Fixed-the-looking-glass-client-rendering-messed-issu.patch
@@ -1,0 +1,52 @@
+From ff4b0e7c82b903560dc3d1927413e39ba28bc9f5 Mon Sep 17 00:00:00 2001
+From: Wan Shuang <shuang.wan@intel.com>
+Date: Tue, 31 Aug 2021 16:10:22 +0800
+Subject: [PATCH] Fixed the looking-glass client rendering messed issue.
+
+The app window is messed when user changed the app window's size.
+The fix is to refresh the app window when app resize detected.
+
+Signed-off-by: Wan Shuang <shuang.wan@intel.com>
+Tracked-On: OAM-98766
+---
+ client/src/main.c | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/client/src/main.c b/client/src/main.c
+index 34489884..ce7d886f 100644
+--- a/client/src/main.c
++++ b/client/src/main.c
+@@ -49,7 +49,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
+ 
+ static bool spice_running = true;
+ static bool frame_ready = false;
+-
++static bool conn_initialized = false;
+ // forwards
+ static int cursorThread(void * unused);
+ static int renderThread(void * unused);
+@@ -320,6 +320,10 @@ static int frameThread(void * unused)
+     }
+     frame_ready = true;
+ 
++    if (!conn_initialized) {
++	conn_initialized = true;
++    }
++
+     // we must take a copy of the header to prevent the contained
+     // arguments from being abused to overflow buffers.
+     memcpy(&header, &state.shm->frame, sizeof(struct KVMFRFrame));
+@@ -686,6 +690,10 @@ int eventFilter(void * userdata, SDL_Event * event)
+           SDL_GetWindowSize(state.window, &state.windowW, &state.windowH);
+           updatePositionInfo();
+           realignGuest = true;
++	  if (conn_initialized) {
++	      frame_ready = true;
++	  }
++
+           break;
+ 
+         // allow a window close event to close the application even if ignoreQuit is set
+-- 
+2.25.1
+


### PR DESCRIPTION
The fix is to refresh the app window if resize detected.

Tracked-On: OAM-98766
Signed-off-by: Wan Shuang <shuang.wan@intel.com>