### PR TITLE
Fixed the looking-glass refresh issue after resume from sleep

### DIFF
--- a/host/lg/0016-Fixed-the-app-window-not-refreshed-issue-after-resum.patch
+++ b/host/lg/0016-Fixed-the-app-window-not-refreshed-issue-after-resum.patch
@@ -1,0 +1,36 @@
+From 2920f45326deb15c3af2237c43e13cdf611341c7 Mon Sep 17 00:00:00 2001
+From: Wan Shuang <shuang.wan@intel.com>
+Date: Wed, 1 Sep 2021 15:34:05 +0800
+Subject: [PATCH] Fixed the app window not refreshed issue after resumed from
+ sleep
+
+The SDL_WINDOWEVENT_EXPOSED event will be emited to looking-glass
+client after desktop resumed. UI refresh is required after got
+this event.
+
+Tracked-On: OAM-99165
+Signed-off-by: Wan Shuang <shuang.wan@intel.com>
+---
+ client/src/main.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/client/src/main.c b/client/src/main.c
+index ce7d886f..b2eec621 100644
+--- a/client/src/main.c
++++ b/client/src/main.c
+@@ -682,6 +682,12 @@ int eventFilter(void * userdata, SDL_Event * event)
+     {
+       switch(event->window.event)
+       {
++	case SDL_WINDOWEVENT_EXPOSED:
++	  if (conn_initialized) {
++            frame_ready = true;
++          }
++          break;
++
+         case SDL_WINDOWEVENT_ENTER:
+           realignGuest = true;
+           break;
+-- 
+2.25.1
+


### PR DESCRIPTION
The SDL_WINDOWEVENT_EXPOSED event will be emited to looking-glass
client after desktop resumed. UI refresh is required after got
this event.

Tracked-On: OAM-99165
Signed-off-by: Wan Shuang <shuang.wan@intel.com>