### PR TITLE
Lg render fix

### DIFF
--- a/host/lg/0016-Fixed-the-app-window-not-refreshed-issue-after-resum.patch
+++ b/host/lg/0016-Fixed-the-app-window-not-refreshed-issue-after-resum.patch
@@ -1,0 +1,36 @@
+From 6181e77d3d41a9afdf38de68ea0cf138465a7e79 Mon Sep 17 00:00:00 2001
+From: Wan Shuang <shuang.wan@intel.com>
+Date: Wed, 1 Sep 2021 15:34:05 +0800
+Subject: [PATCH 1/2] Fixed the app window not refreshed issue after resumed
+ from sleep
+
+The SDL_WINDOWEVENT_EXPOSED event will be emited to looking-glass
+client after desktop resumed. UI refresh is required after got
+this event.
+
+Tracked-On: OAM-99165
+Signed-off-by: Wan Shuang <shuang.wan@intel.com>
+---
+ client/src/main.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/client/src/main.c b/client/src/main.c
+index ce7d886f..5fe58359 100644
+--- a/client/src/main.c
++++ b/client/src/main.c
+@@ -682,6 +682,12 @@ int eventFilter(void * userdata, SDL_Event * event)
+     {
+       switch(event->window.event)
+       {
++        case SDL_WINDOWEVENT_EXPOSED:
++          if (conn_initialized) {
++            frame_ready = true;
++          }
++          break;
++
+         case SDL_WINDOWEVENT_ENTER:
+           realignGuest = true;
+           break;
+-- 
+2.25.1
+

--- a/host/lg/0017-Fixed-the-render-thread-frame-thread-race-codition.patch
+++ b/host/lg/0017-Fixed-the-render-thread-frame-thread-race-codition.patch
@@ -1,0 +1,64 @@
+From fd0b11ae9e6aaa70cb634031ec2a420d17f1d4ef Mon Sep 17 00:00:00 2001
+From: Wan Shuang <shuang.wan@intel.com>
+Date: Fri, 3 Sep 2021 14:31:27 +0800
+Subject: [PATCH 2/2] Fixed the render thread & frame thread race codition
+
+Sometime the frame_ready flag is consmed before frame ready in
+shared buffer. This may cause the new frame not rendered into
+app window. Users may feel the screen is freezed.
+
+Traced-On: OAM-98782
+Signed-off-by: Wan Shuang <shuang.wan@intel.com>
+---
+ client/src/main.c | 21 +++++++++++++++++++--
+ 1 file changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/client/src/main.c b/client/src/main.c
+index 5fe58359..bd738f1b 100644
+--- a/client/src/main.c
++++ b/client/src/main.c
+@@ -60,6 +60,9 @@ struct AppState  state;
+ // this structure is initialized in config.c
+ struct AppParams params = { 0 };
+ 
++static volatile uint64_t frame_read_count = 0;
++static volatile uint64_t frame_render_count = 0;
++
+ static void updatePositionInfo()
+ {
+   if (state.haveSrcSize)
+@@ -134,8 +137,21 @@ static int renderThread(void * unused)
+       clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &time, NULL);
+       continue;
+     }
+-    else
+-      frame_ready = false;
++    else {
++      if (frame_render_count >= frame_read_count) {
++        frame_ready = false;
++      }
++    }
++
++    if (frame_render_count < frame_read_count) {
++      if (frame_render_count + 60 < frame_read_count) {
++        // the frame render lag is too large, reset it.
++        frame_render_count = frame_read_count;
++      }
++      else {
++        frame_render_count++;
++      }
++    }
+ 
+     if (state.lgrResize)
+     {
+@@ -318,6 +334,7 @@ static int frameThread(void * unused)
+       usleep(params.framePollInterval);
+       continue;
+     }
++    frame_read_count ++;
+     frame_ready = true;
+ 
+     if (!conn_initialized) {
+-- 
+2.25.1
+


### PR DESCRIPTION
Fixed 2 render issues:
1) App screen is not refreshed when resumed from sleep; 
    Tracked-On: OAM-99165
2) Webchat app screen is not refreshed when switching between contacts and discovery tabs.
   Tracked-On: OAM-98782