### PR TITLE
Fix for btusb_sco_snd_card driver not getting probed

### DIFF
--- a/bsp_diff/common/kernel/lts2020-yocto/15_0015-Fix-for-btusb_sco_snd_card-not-getting-probed.patch
+++ b/bsp_diff/common/kernel/lts2020-yocto/15_0015-Fix-for-btusb_sco_snd_card-not-getting-probed.patch
@@ -1,0 +1,31 @@
+From 106ac273bd09a2000519b638f3c2d6f30780129a Mon Sep 17 00:00:00 2001
+From: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Date: Mon, 6 Sep 2021 14:22:00 +0530
+Subject: [PATCH] Fix for btusb_sco_snd_card not getting probed
+
+Tracked-On: OAM-99194
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+---
+ drivers/bluetooth/btusb.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
+index 41cc73a..4c3e5e0 100644
+--- a/drivers/bluetooth/btusb.c
++++ b/drivers/bluetooth/btusb.c
+@@ -4479,10 +4479,12 @@ static int btusb_probe(struct usb_interface *intf,
+ 	if (id->driver_info & BTUSB_AMP) {
+ 		/* AMP controllers do not support SCO packets */
+ 		data->isoc = NULL;
++#if (!IS_ENABLED(CONFIG_BT_SCOHCI))
+ 	} else {
+ 		/* Interface orders are hardcoded in the specification */
+ 		data->isoc = usb_ifnum_to_if(data->udev, ifnum_base + 1);
+ 		data->isoc_ifnum = ifnum_base + 1;
++#endif
+ 	}
+ 
+ 	if (IS_ENABLED(CONFIG_BT_HCIBTUSB_RTL) &&
+-- 
+2.7.4
+


### PR DESCRIPTION
Tracked-On: OAM-99194
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>