### PR TITLE
i915/drm: civ-vts if we use the emulated device on TGL, skip the check/warning

### DIFF
--- a/bsp_diff/common/kernel/lts2019-chromium/23_0023-i915-drm-civ-vts-if-we-use-the-emulated-device-on-TG.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/23_0023-i915-drm-civ-vts-if-we-use-the-emulated-device-on-TG.patch
@@ -1,0 +1,56 @@
+From 718e2418ba0559fbbf9e2dad4ca3ffe1f4293b87 Mon Sep 17 00:00:00 2001
+From: kanlihu <kanli.hu@intel.com>
+Date: Thu, 9 Sep 2021 19:28:47 +0800
+Subject: [PATCH] i915/drm: civ-vts if we use the emulated device on TGL, skip
+ the check/warning
+
+The commit ab22227679950117082f368a72361a26a186310a is to help differentiate TGL-U and TGL-Y.
+
+On CIV, some of PCI devices are simulated by Qemu, so it can't get host device info rightly,
+which the first pci device is simulated by Qemu instead of reading from host.
+
+if Qemu simulates the first PCI device, we skip the check/warning.
+
+Tracked-On: OAM-98234
+Signed-off-by: Kanli Hu <kanli.hu@intel.com>
+---
+ drivers/gpu/drm/i915/intel_device_info.c | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/drivers/gpu/drm/i915/intel_device_info.c b/drivers/gpu/drm/i915/intel_device_info.c
+index 5a9639fd9cd0..d1ad5958b8fa 100644
+--- a/drivers/gpu/drm/i915/intel_device_info.c
++++ b/drivers/gpu/drm/i915/intel_device_info.c
+@@ -352,6 +352,21 @@ void intel_device_info_subplatform_init(struct drm_i915_private *i915)
+ 
+ 		root = list_first_entry(&pdev->bus->devices, typeof(*root), bus_list);
+ 
++		/**
++		 * Workaround for CIV, android vts.
++		 * On CIV, some of PCI devices are simulated by Qemu,
++		 * so it can't get host device info rightly,
++		 * which the first pci device is simulated by Qemu instead of reading directly from host,
++		 *
++		 * if Qemu simulates the first PCI device,  we skip the check/warning.
++		 *
++		 * qemu-4.2.0
++		 * hw/pci-host/q35.c:628
++		 * static void mch_class_init(ObjectClass *klass, void *data)
++		 */
++#define PCI_DEVICE_ID_INTEL_P35_MCH 0x29c0
++		if (root->device != PCI_DEVICE_ID_INTEL_P35_MCH) {
++#undef PCI_DEVICE_ID_INTEL_P35_MCH
+ 		drm_WARN_ON(&i915->drm, mask);
+ 		drm_WARN_ON(&i915->drm, (root->device & TGL_ROOT_DEVICE_MASK) !=
+ 			    TGL_ROOT_DEVICE_ID);
+@@ -364,6 +379,7 @@ void intel_device_info_subplatform_init(struct drm_i915_private *i915)
+ 			mask = BIT(INTEL_SUBPLATFORM_ULT);
+ 			break;
+ 		}
++		}
+ 	}
+ 
+ 	GEM_BUG_ON(mask & ~INTEL_SUBPLATFORM_BITS);
+-- 
+2.31.0
+


### PR DESCRIPTION
…k/warning

The commit ab22227679950117082f368a72361a26a186310a is to help differentiate TGL-U and TGL-Y.

On CIV, some of PCI devices are simulated by Qemu, so it can't get host device info rightly,
which the first pci device is simulated by Qemu instead of reading from host.

if Qemu simulates the first PCI device, we skip the check/warning.

Tracked-On: OAM-98234
Signed-off-by: Kanli Hu <kanli.hu@intel.com>