### PR TITLE
Hide status bar and grant runtime permission by default

### DIFF
--- a/aosp_diff/caas_cfc/frameworks/base/0002-Hide-the-Status-Bar-and-grant-runtime-permissions-by.patch
+++ b/aosp_diff/caas_cfc/frameworks/base/0002-Hide-the-Status-Bar-and-grant-runtime-permissions-by.patch
@@ -1,0 +1,43 @@
+From 64b13b52ef49d88404280c767114ebb9e569cbdc Mon Sep 17 00:00:00 2001
+From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
+Date: Fri, 10 Sep 2021 09:13:41 +0800
+Subject: [PATCH] Hide the Status Bar and grant runtime permissions by default
+
+Based on the customer requirement, we need to remove the
+status bar and disable the permission grant pop-up
+window.
+
+Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
+---
+ .../src/com/android/systemui/statusbar/phone/StatusBar.java     | 1 +
+ .../android/server/pm/permission/PermissionManagerService.java  | 2 ++
+ 2 files changed, 3 insertions(+)
+
+diff --git a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+index f125b7d10035..a40b5c3304e0 100644
+--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
++++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+@@ -1010,6 +1010,7 @@ public class StatusBar extends SystemUI implements DemoMode,
+         updateTheme();
+ 
+         inflateStatusBarWindow();
++        mPhoneStatusBarWindow.setVisibility(View.INVISIBLE);
+         mNotificationShadeWindowViewController.setService(this, mNotificationShadeWindowController);
+         mNotificationShadeWindowView.setOnTouchListener(getStatusBarWindowTouchListener());
+ 
+diff --git a/services/core/java/com/android/server/pm/permission/PermissionManagerService.java b/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
+index 8d2363b6e831..0b50e353956f 100644
+--- a/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
++++ b/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
+@@ -2845,6 +2845,8 @@ public class PermissionManagerService extends IPermissionManager.Stub {
+                             + friendlyName);
+                 }
+ 
++                grant = GRANT_INSTALL;
++
+                 if (grant != GRANT_DENIED) {
+                     if (!ps.isSystem() && ps.areInstallPermissionsFixed() && !bp.isRuntime()) {
+                         // If this is an existing, non-system package, then
+-- 
+2.25.1
+


### PR DESCRIPTION
Based on the customer requirement, we need to remove the
status bar and disable the permission grant pop-up window.

Tracked-On: OAM-96162
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>