### PR TITLE
Fix for crash during SDP due to garbage memory access

### DIFF
--- a/aosp_diff/preliminary/system/bt/0003-Fix-for-crash-during-SDP-due-to-garbage-memory-acces.patch
+++ b/aosp_diff/preliminary/system/bt/0003-Fix-for-crash-during-SDP-due-to-garbage-memory-acces.patch
@@ -1,0 +1,116 @@
+From d2e1e0e62cb1217982550d65ba07705bf3c41ed3 Mon Sep 17 00:00:00 2001
+From: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Date: Wed, 28 Jul 2021 10:39:17 +0530
+Subject: [PATCH] Fix for crash during SDP due to garbage memory access
+
+Issue: Crash is seen when repeated connection and disconnection
+is made for OPP file transfer. crash happens during SDP result parsing
+
+Root cause: tSDP_PROTOCOL_ELEM pe is not initialized
+
+Tracked-On: OAM-97127
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+---
+ bta/ag/bta_ag_sdp.cc               | 7 ++++---
+ bta/dm/bta_dm_act.cc               | 9 ++++++---
+ bta/hf_client/bta_hf_client_sdp.cc | 5 +++--
+ bta/jv/bta_jv_act.cc               | 4 +++-
+ 4 files changed, 16 insertions(+), 9 deletions(-)
+
+diff --git a/bta/ag/bta_ag_sdp.cc b/bta/ag/bta_ag_sdp.cc
+index dd9ec3c8c..c38693506 100644
+--- a/bta/ag/bta_ag_sdp.cc
++++ b/bta/ag/bta_ag_sdp.cc
+@@ -295,8 +295,8 @@ bool bta_ag_sdp_find_attr(tBTA_AG_SCB* p_scb, tBTA_SERVICE_MASK service) {
+   tSDP_DISC_ATTR* p_attr;
+   tSDP_PROTOCOL_ELEM pe;
+   uint16_t uuid;
+-  bool result = false;
+ 
++  bool result = false;
+   if (service & BTA_HFP_SERVICE_MASK) {
+     uuid = UUID_SERVCLASS_HF_HANDSFREE;
+     /* If there is no cached peer version, use default one */
+@@ -327,10 +327,11 @@ bool bta_ag_sdp_find_attr(tBTA_AG_SCB* p_scb, tBTA_SERVICE_MASK service) {
+       } else
+         break;
+     }
+-
++    memset(&pe, 0, sizeof(tSDP_PROTOCOL_ELEM));
+     /* get scn from proto desc list if initiator */
+     if (p_scb->role == BTA_AG_INT) {
+-      if (SDP_FindProtocolListElemInRec(p_rec, UUID_PROTOCOL_RFCOMM, &pe)) {
++      if ((SDP_FindProtocolListElemInRec(p_rec, UUID_PROTOCOL_RFCOMM, &pe))
++          && (pe.num_params != 0)) {
+         p_scb->peer_scn = (uint8_t)pe.params[0];
+       } else {
+         continue;
+diff --git a/bta/dm/bta_dm_act.cc b/bta/dm/bta_dm_act.cc
+index d1b260c19..776f085b7 100644
+--- a/bta/dm/bta_dm_act.cc
++++ b/bta/dm/bta_dm_act.cc
+@@ -1358,12 +1358,15 @@ void bta_dm_sdp_result(tBTA_DM_MSG* p_data) {
+           p_sdp_rec = SDP_FindServiceUUIDInDb(bta_dm_search_cb.p_sdp_db,
+                                               bta_dm_search_cb.uuid, p_sdp_rec);
+         }
+-
+-        if (p_sdp_rec && SDP_FindProtocolListElemInRec(
+-                             p_sdp_rec, UUID_PROTOCOL_RFCOMM, &pe)) {
++        memset(&pe, 0, sizeof(tSDP_PROTOCOL_ELEM));
++        if (p_sdp_rec && (SDP_FindProtocolListElemInRec(
++                             p_sdp_rec, UUID_PROTOCOL_RFCOMM, &pe)) &&
++			     (pe.num_params != 0)) {
+           bta_dm_search_cb.peer_scn = (uint8_t)pe.params[0];
+           scn_found = true;
+         }
++        if (pe.num_params == 0)
++          APPL_TRACE_ERROR("%s pe.num_params = 0", __func__);
+       } else {
+         service =
+             bta_service_id_to_uuid_lkup_tbl[bta_dm_search_cb.service_index - 1];
+diff --git a/bta/hf_client/bta_hf_client_sdp.cc b/bta/hf_client/bta_hf_client_sdp.cc
+index 359f7acc1..51346b61a 100755
+--- a/bta/hf_client/bta_hf_client_sdp.cc
++++ b/bta/hf_client/bta_hf_client_sdp.cc
+@@ -227,7 +227,7 @@ bool bta_hf_client_sdp_find_attr(tBTA_HF_CLIENT_CB* client_cb) {
+   bool result = false;
+ 
+   client_cb->peer_version = HFP_VERSION_1_1; /* Default version */
+-
++  memset(&pe, 0, sizeof(tSDP_PROTOCOL_ELEM));
+   /* loop through all records we found */
+   while (true) {
+     /* get next record; if none found, we're done */
+@@ -239,7 +239,8 @@ bool bta_hf_client_sdp_find_attr(tBTA_HF_CLIENT_CB* client_cb) {
+ 
+     /* get scn from proto desc list if initiator */
+     if (client_cb->role == BTA_HF_CLIENT_INT) {
+-      if (SDP_FindProtocolListElemInRec(p_rec, UUID_PROTOCOL_RFCOMM, &pe)) {
++      if ((SDP_FindProtocolListElemInRec(p_rec, UUID_PROTOCOL_RFCOMM, &pe))
++          && (pe.num_params != 0)) {
+         client_cb->peer_scn = (uint8_t)pe.params[0];
+       } else {
+         continue;
+diff --git a/bta/jv/bta_jv_act.cc b/bta/jv/bta_jv_act.cc
+index 27bc7fb20..b9fd1b76a 100644
+--- a/bta/jv/bta_jv_act.cc
++++ b/bta/jv/bta_jv_act.cc
+@@ -752,12 +752,14 @@ static void bta_jv_start_discovery_cback(uint16_t result, void* user_data) {
+     if (result == SDP_SUCCESS || result == SDP_DB_FULL) {
+       tSDP_DISC_REC* p_sdp_rec = NULL;
+       tSDP_PROTOCOL_ELEM pe;
++      memset(&pe, 0, sizeof(tSDP_PROTOCOL_ELEM));
+       VLOG(2) << __func__ << ": bta_jv_cb.uuid=" << bta_jv_cb.uuid;
+       p_sdp_rec = SDP_FindServiceUUIDInDb(p_bta_jv_cfg->p_sdp_db,
+                                           bta_jv_cb.uuid, p_sdp_rec);
+       VLOG(2) << __func__ << ": p_sdp_rec=" << p_sdp_rec;
+       if (p_sdp_rec &&
+-          SDP_FindProtocolListElemInRec(p_sdp_rec, UUID_PROTOCOL_RFCOMM, &pe)) {
++          (SDP_FindProtocolListElemInRec(p_sdp_rec, UUID_PROTOCOL_RFCOMM, &pe))
++	  && (pe.num_params != 0)) {
+         dcomp.scn = (uint8_t)pe.params[0];
+         status = BTA_JV_SUCCESS;
+       }
+-- 
+2.17.1
+


### PR DESCRIPTION
Issue: Crash is seen when repeated connection and disconnection
is made for OPP file transfer. crash happens during SDP result parsing

Root cause: tSDP_PROTOCOL_ELEM pe is not initialized

Tracked-On: OAM-97127
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>