### PR TITLE
Enable adb in user build by default for caas_cfc

### DIFF
--- a/aosp_diff/caas_cfc/system/core/0001-Disable-adb-authentication-for-PGP.patch
+++ b/aosp_diff/caas_cfc/system/core/0001-Disable-adb-authentication-for-PGP.patch
@@ -1,0 +1,30 @@
+From ea90a79686baf352bb6b4b365317d7b33834a438 Mon Sep 17 00:00:00 2001
+From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
+Date: Fri, 16 Jul 2021 15:06:24 +0800
+Subject: [PATCH] Disable adb authentication for PGP
+
+Since the looking glass in PGP has dependence on adb, so
+we need to enable adb and disable the adb authentication on
+PGP's user build.
+
+Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
+---
+ adb/daemon/auth.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/adb/daemon/auth.cpp b/adb/daemon/auth.cpp
+index 1a1e4ad62..cbf4360ec 100644
+--- a/adb/daemon/auth.cpp
++++ b/adb/daemon/auth.cpp
+@@ -63,7 +63,7 @@ static struct adisconnect adb_disconnect = {adb_disconnected, nullptr};
+ static android::base::NoDestructor<std::map<uint32_t, weak_ptr<atransport>>> transports;
+ static uint32_t transport_auth_id = 0;
+ 
+-bool auth_required = true;
++bool auth_required = false;
+ 
+ static void* transport_to_callback_arg(atransport* transport) {
+     uint32_t id = transport_auth_id++;
+-- 
+2.25.1
+


### PR DESCRIPTION
Looking Glass of PGP has dependence on adb. In user build
the adb is disabled by default, so the UI cannot be displayed
by LG. And to turn on adb, we need to access the UI, we are
stuck in a deadlock.

Tracked-On: OAM-98789
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>