### PR TITLE
lg-input support for 600x960 resolution

### DIFF
--- a/host/lg/0018-input-support-for-600x960-resolution.patch
+++ b/host/lg/0018-input-support-for-600x960-resolution.patch
@@ -1,0 +1,25 @@
+From 765c50cc39a8ec183812cfc91ebab1049a9297d5 Mon Sep 17 00:00:00 2001
+From: RajaniRanjan <rajani.ranjan@intel.com>
+Date: Wed, 29 Sep 2021 12:33:08 +0530
+Subject: [PATCH] input-support for 600x960 resolution
+
+---
+ client/include/vInputClient.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/client/include/vInputClient.h b/client/include/vInputClient.h
+index 9bfd5c02..ad81f14d 100644
+--- a/client/include/vInputClient.h
++++ b/client/include/vInputClient.h
+@@ -1,6 +1,6 @@
+-#define XRES_MAX 540.00
++#define XRES_MAX 600.00
+ #define YRES_MAX 960.00
+-#define LTRB_Y   327.00
++#define LTRB_Y   292.00
+ typedef enum {PRESS, RELEASE, MOVE} action;
+ //typedef enum {ROTATION_0, ROTATION_1} rotation;
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
touchscreen support for LG_client window 600x960

Tracked-On: OAM-99341
Signed-off-by: Rajani Ranjan <rajani.ranjan@intel.com>