### PR TITLE
Add fake network connection info to fix app compatibility issue

### DIFF
--- a/aosp_diff/caas_cfc/frameworks/base/01_0001-Add-fake-network-connection-info-to-fix-app-compatib.patch
+++ b/aosp_diff/caas_cfc/frameworks/base/01_0001-Add-fake-network-connection-info-to-fix-app-compatib.patch
@@ -1,0 +1,263 @@
+From 950f1ad04b920e7ec609e546220c312cfee76acd Mon Sep 17 00:00:00 2001
+From: "Wang, Liang" <liang.wang@intel.com>
+Date: Fri, 23 Nov 2018 15:52:31 +0800
+Subject: [PATCH] Add fake network connection info to fix app compatibility
+ issue.
+
+Some apps cannot work on ethernet network environment. So we create
+fake Wifi connection in ConnectivityManager and WifiManager to fix it.
+
+Change-Id: Id86f95f2efeefe83c3e12ed2badf1aafb82d9a5a
+Tracked-On:
+Signed-off-by: Wang, Liang <liang.wang@intel.com>
+---
+ .../java/android/net/ConnectivityManager.java |  33 +++---
+ wifi/java/android/net/wifi/WifiManager.java   | 101 ++++++++++++++++--
+ 2 files changed, 109 insertions(+), 25 deletions(-)
+
+diff --git a/core/java/android/net/ConnectivityManager.java b/core/java/android/net/ConnectivityManager.java
+index ed03f5198d6f..18341114f269 100644
+--- a/core/java/android/net/ConnectivityManager.java
++++ b/core/java/android/net/ConnectivityManager.java
+@@ -784,7 +784,6 @@ public class ConnectivityManager {
+      * @hide
+      */
+     public static final int NETID_UNSET = 0;
+-
+     /**
+      * Private DNS Mode values.
+      *
+@@ -975,6 +974,13 @@ public class ConnectivityManager {
+         return TYPE_NONE;
+     }
+ 
++    private NetworkInfo generateFakeWifiNetworkInfo() {
++        NetworkInfo ni = new NetworkInfo(ConnectivityManager.TYPE_WIFI, 0, "WIFI", null);
++        ni.setDetailedState(NetworkInfo.DetailedState.CONNECTED, null, null);
++        ni.setIsAvailable(true);
++        return ni;
++    }
++
+     /**
+      * Returns details about the currently active default data network. When
+      * connected, this network is the default route for outgoing connections.
+@@ -994,11 +1000,8 @@ public class ConnectivityManager {
+     @RequiresPermission(android.Manifest.permission.ACCESS_NETWORK_STATE)
+     @Nullable
+     public NetworkInfo getActiveNetworkInfo() {
+-        try {
+-            return mService.getActiveNetworkInfo();
+-        } catch (RemoteException e) {
+-            throw e.rethrowFromSystemServer();
+-        }
++        Log.e(TAG, "[CAAS] **getActiveNetworkInfo** use fake Networkinfo");
++        return generateFakeWifiNetworkInfo();
+     }
+ 
+     /**
+@@ -1170,11 +1173,8 @@ public class ConnectivityManager {
+ 
+     /** {@hide} */
+     public NetworkInfo getActiveNetworkInfoForUid(int uid, boolean ignoreBlocked) {
+-        try {
+-            return mService.getActiveNetworkInfoForUid(uid, ignoreBlocked);
+-        } catch (RemoteException e) {
+-            throw e.rethrowFromSystemServer();
+-        }
++        Log.e(TAG, "[CAAS] **getActiveNetworkInfoForUid** use fake Networkinfo");
++        return generateFakeWifiNetworkInfo();
+     }
+ 
+     /**
+@@ -1199,6 +1199,10 @@ public class ConnectivityManager {
+     @RequiresPermission(android.Manifest.permission.ACCESS_NETWORK_STATE)
+     @Nullable
+     public NetworkInfo getNetworkInfo(int networkType) {
++        if (networkType == ConnectivityManager.TYPE_WIFI) {
++            Log.e(TAG, "[CAAS] **getNetworkInfo** use fake Networkinfo");
++            return generateFakeWifiNetworkInfo();
++        }
+         try {
+             return mService.getNetworkInfo(networkType);
+         } catch (RemoteException e) {
+@@ -1248,11 +1252,8 @@ public class ConnectivityManager {
+     @RequiresPermission(android.Manifest.permission.ACCESS_NETWORK_STATE)
+     @NonNull
+     public NetworkInfo[] getAllNetworkInfo() {
+-        try {
+-            return mService.getAllNetworkInfo();
+-        } catch (RemoteException e) {
+-            throw e.rethrowFromSystemServer();
+-        }
++        Log.e(TAG, "[CAAS] **getAllNetworkInfo** use fake Networkinfo");
++        return new NetworkInfo[] {generateFakeWifiNetworkInfo()};
+     }
+ 
+     /**
+diff --git a/wifi/java/android/net/wifi/WifiManager.java b/wifi/java/android/net/wifi/WifiManager.java
+index 4a61db894b89..ce2d4f52c615 100644
+--- a/wifi/java/android/net/wifi/WifiManager.java
++++ b/wifi/java/android/net/wifi/WifiManager.java
+@@ -61,13 +61,16 @@ import android.util.SparseArray;
+ 
+ import com.android.internal.annotations.GuardedBy;
+ import com.android.internal.annotations.VisibleForTesting;
+-
+ import java.lang.annotation.Retention;
+ import java.lang.annotation.RetentionPolicy;
+ import java.lang.ref.Reference;
+ import java.lang.ref.WeakReference;
++import java.net.Inet4Address;
+ import java.net.InetAddress;
+ import java.util.ArrayList;
++import java.net.NetworkInterface;
++import java.net.SocketException;
++import java.util.Collections;
+ import java.util.Collections;
+ import java.util.HashMap;
+ import java.util.List;
+@@ -76,6 +79,7 @@ import java.util.Objects;
+ import java.util.Set;
+ import java.util.StringTokenizer;
+ import java.util.concurrent.Executor;
++import java.io.File;
+ 
+ /**
+  * This class provides the primary API for managing all aspects of Wi-Fi
+@@ -1666,6 +1670,19 @@ public class WifiManager {
+         default void reject() {}
+     }
+ 
++
++    private boolean isWlanNetdevAvailable() {
++        final File f_wlan = new File("/sys/class/net/wlan0");
++        boolean status = false ;
++        if (f_wlan.exists()) {
++            status = true;
++            Log.e(TAG, "/sys/class/net/wlan0 file exists status : " + status);
++        } else {
++            Log.e(TAG, "/sys/class/net/wlan0 file doesn't exists status : " + status);
++        }
++        return status;
++    }
++
+     /**
+      * Interface for network request callback. Should be implemented by applications and passed when
+      * calling {@link #registerNetworkRequestMatchCallback(Executor,
+@@ -2755,13 +2772,55 @@ public class WifiManager {
+      */
+     public WifiInfo getConnectionInfo() {
+         try {
+-            return mService.getConnectionInfo(mContext.getOpPackageName(),
+-                    mContext.getAttributionTag());
++            if (isWlanNetdevAvailable())  {
++                Log.e(TAG, " WiFi ConnectionInfo: " +
++                mService.getConnectionInfo(mContext.getOpPackageName(),mContext.getAttributionTag()));
++                return mService.getConnectionInfo(mContext.getOpPackageName(), mContext.getAttributionTag());
++            } else {
++                Log.e(TAG, "[CAAS] **getConnectionInfo** use fake Wifi info " +
++                generateFakeWifiInfo());
++                return generateFakeWifiInfo();
++            }
+         } catch (RemoteException e) {
+             throw e.rethrowFromSystemServer();
+         }
+     }
+ 
++    private InetAddress getInet4AddressFromEth() {
++        try {
++            if(NetworkInterface.getNetworkInterfaces() == null) {
++                Log.e(TAG, "[CAAS] **Network interfaces is null");
++                return null;
++            }
++            List<NetworkInterface> interfaces = Collections.list(NetworkInterface.getNetworkInterfaces());
++            for (NetworkInterface intf : interfaces) {
++                if (intf.getDisplayName().equals("eth0")) {
++                    for (InetAddress addr : Collections.list(intf.getInetAddresses())) {
++                        if (addr instanceof Inet4Address) {
++                            return addr;
++                        }
++                    }
++                }
++            }
++        } catch (SocketException e) {
++        }
++        return null;
++    }
++
++    private WifiInfo generateFakeWifiInfo() {
++        WifiInfo wi = new WifiInfo();
++        wi.setNetworkId(1);
++        wi.setSupplicantState(SupplicantState.COMPLETED);
++        wi.setBSSID("11:22:33:44:55:66");
++        wi.setMacAddress("66:55:44:33:22:11");
++        wi.setLinkSpeed(300);
++        wi.setFrequency(5000);
++        wi.setRssi(200);
++        wi.setSSID(WifiSsid.createFromAsciiEncoded("FakeWifi"));
++        wi.setInetAddress(getInet4AddressFromEth());
++        return wi;
++    }
++
+     /**
+      * Return the results of the latest access point scan.
+      * @return the list of access points found in the most recent scan. An app must hold
+@@ -2881,17 +2940,37 @@ public class WifiManager {
+         }
+     }
+ 
++    private static int InetAddress_to_hex(InetAddress a) {
++        int result = 0;
++        byte b[] = a.getAddress();
++        for (int i = 0; i < 4; i++)
++            result |= (b[i] & 0xff) << (8 * i);
++        return result;
++    }
++
+     /**
+      * Return the DHCP-assigned addresses from the last successful DHCP request,
+      * if any.
+      * @return the DHCP information
+      */
+     public DhcpInfo getDhcpInfo() {
+-        try {
+-            return mService.getDhcpInfo();
+-        } catch (RemoteException e) {
+-            throw e.rethrowFromSystemServer();
+-        }
++        if (isWlanNetdevAvailable()) {
++            try {
++                return mService.getDhcpInfo();
++            } catch (RemoteException e) {
++                throw e.rethrowFromSystemServer();
++            }
++        } else {
++            Log.e(TAG, "[CAAS] **getDhcpInfo** use fake Wifi info");
++            DhcpInfo i = new DhcpInfo();
++            InetAddress ip = getInet4AddressFromEth();
++            if (ip != null) {
++                i.ipAddress = InetAddress_to_hex(ip);
++                i.netmask = 16;
++                i.dns1 = 0xAC640001;
++            }
++            return i;
++       }
+     }
+ 
+     /**
+@@ -2935,7 +3014,11 @@ public class WifiManager {
+      */
+     public int getWifiState() {
+         try {
+-            return mService.getWifiEnabledState();
++            if (isWlanNetdevAvailable()) {
++                return mService.getWifiEnabledState();
++            } else {
++                return WIFI_STATE_ENABLED;
++            }
+         } catch (RemoteException e) {
+             throw e.rethrowFromSystemServer();
+         }
+-- 
+2.33.0
+


### PR DESCRIPTION
Some apps cannot work on ethernet network environment. So we create
fake Wifi connection in ConnectivityManager and WifiManager to fix it.

Tracked-On: OAM-98012
Signed-off-by: Jeevaka Prabhu Badrappan <jeevaka.badrappan@intel.com>
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>