### PR TITLE
Set the primary display as internal display

### DIFF
--- a/aosp_diff/preliminary/external/drm_hwcomposer/0004-Set-the-primary-display-as-internal-display.patch
+++ b/aosp_diff/preliminary/external/drm_hwcomposer/0004-Set-the-primary-display-as-internal-display.patch
@@ -1,0 +1,32 @@
+From fd65e112343025d9976ea20a7c3ef68ddd8879b7 Mon Sep 17 00:00:00 2001
+From: "Li, HaihongX" <haihongx.li@intel.com>
+Date: Wed, 13 Oct 2021 10:01:58 +0800
+Subject: [PATCH] Set the primary display as internal display
+
+Celadon connect monitor with HDMI/DP/Type-C port, which is
+regarded as external display, but android by default assume
+there is one internal display, so need to set the primary
+display as internal display.
+
+Tracked-On: OAM-99729
+Signed-off-by: Li, HaihongX <haihongx.li@intel.com>
+---
+ DrmHwcTwo.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/DrmHwcTwo.cpp b/DrmHwcTwo.cpp
+index 0eadcd7..194b11e 100644
+--- a/DrmHwcTwo.cpp
++++ b/DrmHwcTwo.cpp
+@@ -907,7 +907,7 @@ DrmHwcTwo::HwcDisplay::GetOrderLayersByZPos() {
+ 
+ #if PLATFORM_SDK_VERSION > 29
+ HWC2::Error DrmHwcTwo::HwcDisplay::GetDisplayConnectionType(uint32_t *outType) {
+-  if (connector_->internal())
++  if (connector_->internal() || connector_->display() == 0)
+     *outType = static_cast<uint32_t>(HWC2::DisplayConnectionType::Internal);
+   else if (connector_->external())
+     *outType = static_cast<uint32_t>(HWC2::DisplayConnectionType::External);
+-- 
+2.32.0
+


### PR DESCRIPTION
Celadon connect monitor with HDMI/DP/Type-C port, which is
regarded as external display, but android by default assume
there is one internal display, so need to set the primary
display as internal display.

Tracked-On: OAM-99729
Signed-off-by: Li, HaihongX <haihongx.li@intel.com>