### PR TITLE
Set guest cursor visibility to false

### DIFF
--- a/aosp_diff/caas_cfc/frameworks/base/0003-set-guest-cursor-visibility-to-false.patch
+++ b/aosp_diff/caas_cfc/frameworks/base/0003-set-guest-cursor-visibility-to-false.patch
@@ -1,0 +1,29 @@
+From a88b7513d4bdd23a858e45eb54726801ca4e1114 Mon Sep 17 00:00:00 2001
+From: RajaniRanjan <rajani.ranjan@intel.com>
+Date: Tue, 12 Oct 2021 15:27:40 +0530
+Subject: [PATCH] set guest cursor visibility to false
+
+solve 2 mouse cursor issue on PGP
+
+Tracked-On: OAM-98091
+Signed-off-by: RajaniRanjan <rajani.ranjan@intel.com>
+---
+ libs/input/PointerController.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libs/input/PointerController.cpp b/libs/input/PointerController.cpp
+index 3b494e9129db..c250ac526833 100644
+--- a/libs/input/PointerController.cpp
++++ b/libs/input/PointerController.cpp
+@@ -649,7 +649,7 @@ void PointerController::updatePointerLocked() REQUIRES(mLock) {
+ 
+     if (mLocked.pointerAlpha > 0) {
+         mLocked.pointerSprite->setAlpha(mLocked.pointerAlpha);
+-        mLocked.pointerSprite->setVisible(true);
++        mLocked.pointerSprite->setVisible(false);
+     } else {
+         mLocked.pointerSprite->setVisible(false);
+     }
+-- 
+2.30.0
+


### PR DESCRIPTION
As we are using host cursor pointer, 
fix 2 mouse cursor issue by disabling android cursor pointer.

Tracked-On: OAM-98091
Signed-off-by: Rajani Ranjan <rajani.ranjan@intel.com>