### PR TITLE
Build system support for avx variants of libs

### DIFF
--- a/aosp_diff/preliminary/art/04_0004-Modify-IA-perf-variant-of-library-to-have-same-name-.patch
+++ b/aosp_diff/preliminary/art/04_0004-Modify-IA-perf-variant-of-library-to-have-same-name-.patch
@@ -1,0 +1,70 @@
+From d96bae5d263df8bdf1f4d57a39dc174db4b1649a Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Wed, 9 Dec 2020 13:09:13 +0530
+Subject: [PATCH] Modify IA perf variant of library to have same name as
+ original
+
+Tracked-On: OAM-95425
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ build/apex/art_apex_test.py |  4 ++--
+ runtime/Android.bp          | 14 ++++----------
+ 2 files changed, 6 insertions(+), 12 deletions(-)
+
+diff --git a/build/apex/art_apex_test.py b/build/apex/art_apex_test.py
+index ee0b5860f2..929fd41a72 100755
+--- a/build/apex/art_apex_test.py
++++ b/build/apex/art_apex_test.py
+@@ -533,7 +533,7 @@ class ReleaseChecker:
+     # Check internal libraries for ART.
+     self._checker.check_native_library('libadbconnection')
+     self._checker.check_native_library('libart')
+-    self._checker.check_native_isa_perf_library('libart_avx2')
++    self._checker.check_native_isa_perf_library('libart')
+     self._checker.check_native_library('libart-compiler')
+     self._checker.check_native_library('libart-dexlayout')
+     self._checker.check_native_library('libart-disassembler')
+@@ -691,7 +691,7 @@ class DebugChecker:
+     self._checker.check_native_library('libart-disassembler')
+     self._checker.check_native_library('libartbased')
+     self._checker.check_native_library('libartd')
+-    self._checker.check_native_isa_perf_library('libartd_avx2')
++    self._checker.check_native_isa_perf_library('libartd')
+     self._checker.check_native_library('libartd-compiler')
+     self._checker.check_native_library('libartd-dexlayout')
+     self._checker.check_native_library('libartd-disassembler')
+diff --git a/runtime/Android.bp b/runtime/Android.bp
+index ab9ea08984..9232ee6a7b 100644
+--- a/runtime/Android.bp
++++ b/runtime/Android.bp
+@@ -562,11 +562,8 @@ art_cc_library {
+ 
+ art_cc_library {
+     name: "libart_avx2",
+-    target: {
+-       android: { 
+-          relative_install_path: "IA-Perf/avx2",
+-       },
+-    },
++    override_lib_name: "libart",
++    relative_install_path: "IA-Perf/avx2",
+     defaults: ["libart_defaults_generic"],
+     arch: {
+         x86: {
+@@ -582,11 +579,8 @@ art_cc_library {
+ 
+ art_cc_library {
+     name: "libartd_avx2",
+-    target: {
+-       android: { 
+-          relative_install_path: "IA-Perf/avx2",
+-       },
+-    },
++    override_lib_name: "libartd",
++    relative_install_path: "IA-Perf/avx2",
+     defaults: ["libartd_defaults_generic"],
+     arch: {
+         x86: {
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/build/soong/0006-Add-support-for-overide_lib_name-for-IA-perf-variant.patch
+++ b/aosp_diff/preliminary/build/soong/0006-Add-support-for-overide_lib_name-for-IA-perf-variant.patch
@@ -1,0 +1,103 @@
+From 823f12e40691ebf6a29dd4fce6d470169b01c72a Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Wed, 9 Dec 2020 12:51:51 +0530
+Subject: [PATCH] Add support for overide_lib_name for IA perf variants of a
+ library
+
+Tracked-On: OAM-95425
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ android/module.go | 6 +++++-
+ cc/cc.go          | 5 +++++
+ cc/library.go     | 5 +++++
+ cc/vndk.go        | 4 +++-
+ 4 files changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/android/module.go b/android/module.go
+index cd4baabb5..e910f451c 100644
+--- a/android/module.go
++++ b/android/module.go
+@@ -303,6 +303,7 @@ func newPackageId(pkg string) qualifiedModuleName {
+ type nameProperties struct {
+ 	// The name of the module.  Must be unique across all modules.
+ 	Name *string
++	Override_lib_name *string
+ }
+ 
+ type commonProperties struct {
+@@ -788,6 +789,10 @@ func (m *ModuleBase) BaseModuleName() string {
+ 	return String(m.nameProperties.Name)
+ }
+ 
++func (m *ModuleBase) OverrideLibraryName() string {
++	return String(m.nameProperties.Override_lib_name)
++}
++
+ func (m *ModuleBase) base() *ModuleBase {
+ 	return m
+ }
+@@ -1883,7 +1888,6 @@ func (m *moduleContext) installFile(installPath InstallPath, name string, srcPat
+ 	m.module.base().hooks.runInstallHooks(m, fullInstallPath, false)
+ 
+ 	if !m.skipInstall(fullInstallPath) {
+-
+ 		deps = append(deps, m.installDeps...)
+ 
+ 		var implicitDeps, orderOnlyDeps Paths
+diff --git a/cc/cc.go b/cc/cc.go
+index 0f874f13c..e52574c4a 100644
+--- a/cc/cc.go
++++ b/cc/cc.go
+@@ -330,6 +330,7 @@ type ModuleContextIntf interface {
+ 	shouldCreateSourceAbiDump() bool
+ 	selectedStl() string
+ 	baseModuleName() string
++	overrideLibraryName() string
+ 	getVndkExtendsModuleName() string
+ 	isPgoCompile() bool
+ 	isNDKStubLibrary() bool
+@@ -1241,6 +1242,10 @@ func (ctx *moduleContextImpl) baseModuleName() string {
+ 	return ctx.mod.ModuleBase.BaseModuleName()
+ }
+ 
++func (ctx *moduleContextImpl) overrideLibraryName() string {
++	return ctx.mod.ModuleBase.OverrideLibraryName()
++}
++
+ func (ctx *moduleContextImpl) getVndkExtendsModuleName() string {
+ 	return ctx.mod.getVndkExtendsModuleName()
+ }
+diff --git a/cc/library.go b/cc/library.go
+index 3deb17300..8cc8097ef 100644
+--- a/cc/library.go
++++ b/cc/library.go
+@@ -721,6 +721,11 @@ func (library *libraryDecorator) getLibNameHelper(baseModuleName string, useVndk
+ }
+ 
+ func (library *libraryDecorator) getLibName(ctx BaseModuleContext) string {
++	// If an overrideLibraryName exists => this is a proxy library
++	// We must use the overrideLibraryName
++	if ctx.overrideLibraryName() != "" {
++	        library.libName = ctx.overrideLibraryName()
++	}
+ 	name := library.getLibNameHelper(ctx.baseModuleName(), ctx.useVndk())
+ 
+ 	if ctx.isVndkExt() {
+diff --git a/cc/vndk.go b/cc/vndk.go
+index 1b8aa2d64..aca215502 100644
+--- a/cc/vndk.go
++++ b/cc/vndk.go
+@@ -615,7 +615,9 @@ func (c *vndkSnapshotSingleton) GenerateBuildActions(ctx android.SingletonContex
+ 		}
+ 
+ 		libPath := m.outputFile.Path()
+-		snapshotLibOut := filepath.Join(snapshotArchDir, targetArch, "shared", vndkType, libPath.Base())
++		qualifiedLibName := m.RelativeInstallPath()
++		qualifiedLibName = filepath.Join(qualifiedLibName, libPath.Base())
++		snapshotLibOut := filepath.Join(snapshotArchDir, targetArch, "shared", vndkType, qualifiedLibName)
+ 		ret = append(ret, copyFile(ctx, libPath, snapshotLibOut))
+ 
+ 		if ctx.Config().VndkSnapshotBuildArtifacts() {
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/frameworks/av/04_0004-Modify-IA-Perf-variants-of-library-to-have-same-name.patch
+++ b/aosp_diff/preliminary/frameworks/av/04_0004-Modify-IA-Perf-variants-of-library-to-have-same-name.patch
@@ -1,0 +1,33 @@
+From 1ea3ec0dcd063c0ecafc05f9177f03ad469d76cc Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Wed, 9 Dec 2020 13:04:52 +0530
+Subject: [PATCH] Modify IA-Perf variants of library to have same name as
+ original
+
+Tracked-On: OAM-95425
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ media/libaudioprocessing/Android.bp | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
+diff --git a/media/libaudioprocessing/Android.bp b/media/libaudioprocessing/Android.bp
+index 0b01fde868..b0b2036fea 100644
+--- a/media/libaudioprocessing/Android.bp
++++ b/media/libaudioprocessing/Android.bp
+@@ -94,11 +94,8 @@ cc_library_shared {
+ 
+ cc_library_shared {
+    name: "libaudioprocessing_avx2",
++   override_lib_name: "libaudioprocessing",
+    defaults: ["libaudioprocessing_generic", "libaudioprocessing_defaults_avx2"],
+-   target: {
+-       android: {
+-          relative_install_path: "IA-Perf/avx2",
+-       },
+-   },
++   relative_install_path: "IA-Perf/avx2",
+    whole_static_libs: ["libaudioprocessing_base_avx2"],
+ }
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/frameworks/ml/02_0002-Modify-IA-perf-variant-of-library-to-have-same-name-.patch
+++ b/aosp_diff/preliminary/frameworks/ml/02_0002-Modify-IA-perf-variant-of-library-to-have-same-name-.patch
@@ -1,0 +1,40 @@
+From 6ad9a2bcc4f2099beaab0d80809416e9c86cbf20 Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Wed, 9 Dec 2020 13:07:59 +0530
+Subject: [PATCH] Modify IA-perf variant of library to have same name as
+ original
+
+Tracked-On: OAM-95425
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ nn/runtime/Android.bp | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
+diff --git a/nn/runtime/Android.bp b/nn/runtime/Android.bp
+index b33358dea..7e579a8f9 100644
+--- a/nn/runtime/Android.bp
++++ b/nn/runtime/Android.bp
+@@ -140,6 +140,8 @@ cc_library_shared {
+ 
+ cc_library_shared {
+     name: "libneuralnetworks_avx2",
++    override_lib_name: "libneuralnetworks",
++    relative_install_path: "IA-Perf/avx2",
+     defaults: ["libneuralnetworks_generic"], 
+     arch: {
+         x86: {
+@@ -149,11 +151,6 @@ cc_library_shared {
+            cflags: [ "-mavx2", "-mfma", ],
+         },
+     },
+-    target: {
+-       android: {
+-          relative_install_path: "IA-Perf/avx2",
+-       },
+-    },
+ }
+ 
+ // Required for tests (b/147158681)
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/frameworks/rs/02_0002-Modify-IA-Perf-variants-of-library-to-have-same-name.patch
+++ b/aosp_diff/preliminary/frameworks/rs/02_0002-Modify-IA-Perf-variants-of-library-to-have-same-name.patch
@@ -1,0 +1,34 @@
+From 3a029b8413f064b12e791b604bc7edf0a89eb171 Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Wed, 9 Dec 2020 12:56:07 +0530
+Subject: [PATCH] Modify IA-Perf variants of library to have same name as
+ original
+
+Tracked-On: OAM-94525
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ cpu_ref/Android.bp | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
+diff --git a/cpu_ref/Android.bp b/cpu_ref/Android.bp
+index 5211292d..6f3abf12 100644
+--- a/cpu_ref/Android.bp
++++ b/cpu_ref/Android.bp
+@@ -134,12 +134,9 @@ cc_library_shared {
+ 
+ cc_library_shared {
+    name: "libRSCpuRef_avx2",
++   override_lib_name: "libRSCpuRef",
++   relative_install_path: "IA-Perf/avx2",
+    defaults: ["libRSCpuRef_generic"],
+-   target: {
+-       android: {
+-          relative_install_path: "IA-Perf/avx2",
+-       },
+-   },
+    arch: {
+       x86_64: {
+          cflags: ["-DARCH_X86_HAVE_AVX2", "-mavx2", "-mfma"],
+-- 
+2.17.1
+


### PR DESCRIPTION
Enable Android build system to support IA performance variants of a
shared library with same name

Tracked-On: OAM-95425
Signed-off-by: ahs <amrita.h.s@intel.com>