### PR TITLE
Enable AIDL Interface for Lights HAL

### DIFF
--- a/aosp_diff/preliminary/hardware/interfaces/0001-Enable-AIDL-interface-for-Light-HAL.patch
+++ b/aosp_diff/preliminary/hardware/interfaces/0001-Enable-AIDL-interface-for-Light-HAL.patch
@@ -1,0 +1,28 @@
+From dce1da449ac9dbd1a107de742df5d63661755377 Mon Sep 17 00:00:00 2001
+From: svenate <salini.venate@intel.com>
+Date: Fri, 11 Dec 2020 15:04:03 +0530
+Subject: [PATCH] Enable AIDL interface for Light HAL
+
+Eanbling the AIDL interface for Light HAL
+
+Tracked-On: OAM-95426
+Signed-off-by: svenate <salini.venate@intel.com>
+---
+ light/aidl/default/lights-default.rc | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git light/aidl/default/lights-default.rc light/aidl/default/lights-default.rc
+index 687ec97dd..4cdd038ad 100644
+--- light/aidl/default/lights-default.rc
++++ light/aidl/default/lights-default.rc
+@@ -1,5 +1,5 @@
+ service vendor.light-default /vendor/bin/hw/android.hardware.lights-service.example
+     class hal
+-    user nobody
+-    group nobody
++    user system
++    group system
+     shutdown critical
+-- 
+2.17.1
+


### PR DESCRIPTION
Enable the Google default implementation of AIDL
interface for Light HAL. This is a requirement for
migration to target level 5 and API level 30.

Tracked-On: OAM-95426
Signed-off-by: svenate <salini.venate@intel.com>