### PR TITLE
WA Fix for BT suspend resume issue in Tasmania

### DIFF
--- a/bsp_diff/common/kernel/lts2019-chromium/24-0024-WA-Fix-for-BT-suspend-resume-issue-in-Tasmania.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/24-0024-WA-Fix-for-BT-suspend-resume-issue-in-Tasmania.patch
@@ -1,0 +1,40 @@
+From aa390073b83fb0e3436a0db2ca54e97b07e416f8 Mon Sep 17 00:00:00 2001
+From: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Date: Wed, 27 Oct 2021 15:50:20 +0530
+Subject: [PATCH] WA Fix for BT suspend resume issue in Tasmania
+
+In the specific hardware configuration power is cut to
+the Bluetooth controller every time system enter S3 suspend
+
+In some cases when frequent usb connect and disconnect
+occurs due to suspend and resume, there is a chance that hci
+dev registration happens even before cleanup is done for the
+existing hci device. Delay is added to avoid this race as it creates
+BT issues in Android
+
+Tracked-On: OAM-99203
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+---
+ drivers/bluetooth/btusb.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/bluetooth/btusb.c b/drivers/bluetooth/btusb.c
+index 55ed9f8..cd3897c 100644
+--- a/drivers/bluetooth/btusb.c
++++ b/drivers/bluetooth/btusb.c
+@@ -4869,7 +4869,11 @@ static int btusb_probe(struct usb_interface *intf,
+ 
+ 	if (enable_autosuspend)
+ 		usb_enable_autosuspend(data->udev);
+-
++	/* In some cases when frequent usb connect and disconnect
++	 * occurs, there is a chance that hci dev registration happens
++	 * even before cleanup is done for the existing hci device. Delay
++	 * is added to avoid this as this create BT issues in Android */
++	msleep(20);
+ 	err = hci_register_dev(hdev);
+ 	if (err < 0)
+ 		goto out_free_dev;
+-- 
+2.7.4
+


### PR DESCRIPTION
In the specific hardware configuration power is cut to
the Bluetooth controller every time system enter S3 suspend

In some cases when frequent usb connect and disconnect
occurs due to suspend and resume, there is a chance that hci
dev registration happens even before cleanup is done for the
existing hci device. Delay is added to avoid this race as it creates
BT issues in Android

Tracked-On: OAM-99203
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>