### PR TITLE
Fix UI refresh rate regression caused by drm-hwc

### DIFF
--- a/aosp_diff/preliminary/external/drm_hwcomposer/0006-Fix-UI-refresh-rate-regression-caused-by-drm-hwc.patch
+++ b/aosp_diff/preliminary/external/drm_hwcomposer/0006-Fix-UI-refresh-rate-regression-caused-by-drm-hwc.patch
@@ -1,0 +1,42 @@
+From e08497c15fd42392e1dd1e6fab1ac84d5a22df04 Mon Sep 17 00:00:00 2001
+From: "Li, HaihongX" <haihongx.li@intel.com>
+Date: Fri, 29 Oct 2021 11:23:31 +0800
+Subject: [PATCH] Fix UI refresh rate regression caused by drm-hwc
+
+Set 3rd parameter of vsync2.4 callback with vsync period value.
+Visit https://www.testufo.com/ for testing.
+
+Tracked-On: OAM-99923
+Signed-off-by: Li, HaihongX <haihongx.li@intel.com>
+---
+ drm/VSyncWorker.cpp | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/drm/VSyncWorker.cpp b/drm/VSyncWorker.cpp
+index b7ceb4c..acf4988 100644
+--- a/drm/VSyncWorker.cpp
++++ b/drm/VSyncWorker.cpp
+@@ -181,8 +181,19 @@ void VSyncWorker::Routine() {
+   if (enabled_ && vsync_callback_hook_ && vsync_callback_data_)
+     vsync_callback_hook_(vsync_callback_data_, display, timestamp);
+   
++  uint32_t vsyncPeriodNanos = 1000.0 * 1000.0 * 1000.0 / 60.0F;  // Default to 60Hz refresh rate
++  if (last_timestamp_ == -1) {
++    DrmConnector *  connector = drm_->GetConnectorForDisplay(display_);
++    if (connector != nullptr) {
++      DrmMode const &mode = connector ->active_mode();
++      if (mode.id() != 0)
++        vsyncPeriodNanos = 1000.0 * 1000.0 * 1000.0 / mode.v_refresh();
++    }
++  } else {
++    vsyncPeriodNanos = timestamp - last_timestamp_;
++  }
+   if (enabled_ && vsync_2_4_callback_hook_ && vsync_2_4_callback_data_)
+-    vsync_2_4_callback_hook_(vsync_2_4_callback_data_, display, timestamp, 0);
++    vsync_2_4_callback_hook_(vsync_2_4_callback_data_, display, timestamp, vsyncPeriodNanos);
+   Unlock();
+ 
+   last_timestamp_ = timestamp;
+-- 
+2.32.0
+


### PR DESCRIPTION
Set 3rd parameter of vsync2.4 callback with vsync period value.
Visit https://www.testufo.com/ for testing.

Tracked-On: OAM-99923
Signed-off-by: Li, HaihongX <haihongx.li@intel.com>