### PR TITLE
Disable the status bar

### DIFF
--- a/aosp_diff/caas_cfc/frameworks/base/0002-Disable-the-Status-Bar-and-grant-runtime-permissions.patch
+++ b/aosp_diff/caas_cfc/frameworks/base/0002-Disable-the-Status-Bar-and-grant-runtime-permissions.patch
@@ -1,7 +1,8 @@
-From 64b13b52ef49d88404280c767114ebb9e569cbdc Mon Sep 17 00:00:00 2001
+From 6807f610931a5909c19565a5f842548342ac302d Mon Sep 17 00:00:00 2001
 From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
 Date: Fri, 10 Sep 2021 09:13:41 +0800
-Subject: [PATCH] Hide the Status Bar and grant runtime permissions by default
+Subject: [PATCH] Disable the Status Bar and grant runtime permissions by
+ default
 
 Based on the customer requirement, we need to remove the
 status bar and disable the permission grant pop-up
@@ -9,22 +10,10 @@ window.
 
 Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
 ---
- .../src/com/android/systemui/statusbar/phone/StatusBar.java     | 1 +
  .../android/server/pm/permission/PermissionManagerService.java  | 2 ++
- 2 files changed, 3 insertions(+)
+ services/core/java/com/android/server/wm/DisplayPolicy.java     | 2 +-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
 
-diff --git a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
-index f125b7d10035..a40b5c3304e0 100644
---- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
-+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
-@@ -1010,6 +1010,7 @@ public class StatusBar extends SystemUI implements DemoMode,
-         updateTheme();
- 
-         inflateStatusBarWindow();
-+        mPhoneStatusBarWindow.setVisibility(View.INVISIBLE);
-         mNotificationShadeWindowViewController.setService(this, mNotificationShadeWindowController);
-         mNotificationShadeWindowView.setOnTouchListener(getStatusBarWindowTouchListener());
- 
 diff --git a/services/core/java/com/android/server/pm/permission/PermissionManagerService.java b/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
 index 8d2363b6e831..0b50e353956f 100644
 --- a/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
@@ -38,6 +27,19 @@ index 8d2363b6e831..0b50e353956f 100644
                  if (grant != GRANT_DENIED) {
                      if (!ps.isSystem() && ps.areInstallPermissionsFixed() && !bp.isRuntime()) {
                          // If this is an existing, non-system package, then
+diff --git a/services/core/java/com/android/server/wm/DisplayPolicy.java b/services/core/java/com/android/server/wm/DisplayPolicy.java
+index 29881cc761b2..4d8857d2fb0b 100644
+--- a/services/core/java/com/android/server/wm/DisplayPolicy.java
++++ b/services/core/java/com/android/server/wm/DisplayPolicy.java
+@@ -3621,7 +3621,7 @@ public class DisplayPolicy {
+             StatusBarManagerInternal statusBar = getStatusBarManagerInternal();
+             if (statusBar != null) {
+                 final int displayId = getDisplayId();
+-                statusBar.setDisableFlags(displayId, visibility & StatusBarManager.DISABLE_MASK,
++                statusBar.setDisableFlags(displayId, StatusBarManager.DISABLE_MASK,
+                         cause);
+                 if (transientState.first.length > 0) {
+                     statusBar.showTransient(displayId, transientState.first);
 -- 
 2.25.1
 


### PR DESCRIPTION
Disable the status bar, it will be unresponsive for the
user's click actions. Set the status bar's height to a
very small value in the overlay configuration, this is
a workaround to hide the status bar.

Tracked-On: OAM-99354
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>