### PR TITLE
Fix UI refresh rate regression caused by drm-hwc

### DIFF
--- a/aosp_diff/preliminary/external/drm_hwcomposer/0003-Fix-hotplug-issue-and-add-vsync2.4-callback.patch
+++ b/aosp_diff/preliminary/external/drm_hwcomposer/0003-Fix-hotplug-issue-and-add-vsync2.4-callback.patch
@@ -1,7 +1,7 @@
-From e2a49640c385500d9978a3b07901b14f976a7980 Mon Sep 17 00:00:00 2001
+From 73a0328e8cbf3d5fa26b22c95286e05bb15a7d33 Mon Sep 17 00:00:00 2001
 From: "Li, HaihongX" <haihongx.li@intel.com>
 Date: Thu, 9 Sep 2021 15:04:23 +0800
-Subject: [PATCH 3/3] Fix hotplug issue and add vsync2.4 callback
+Subject: [PATCH] Fix hotplug issue and add vsync2.4 callback
 
 1. Once unplug event comes, display.ClearDisplay() will be invoked.
    Then DrmDisplayCompositor::active_composition_ will be set to
@@ -15,8 +15,10 @@ Subject: [PATCH 3/3] Fix hotplug issue and add vsync2.4 callback
    DRM_MODE_DPMS_ON if pluging,to enable irq,fix type-c hotplug issue.
 5. Set DrmDevice::mode_id_ with 0 at beginning of
    DrmConnector::UpdateModes().
+6. Set 3rd parameter of vsync2.4 callback with vsync period value.
+   Can visit https://www.testufo.com/ for testing.
 
-Tracked-On: OAM-99705
+Tracked-On: OAM-99923
 Signed-off-by: Li, HaihongX <haihongx.li@intel.com>
 ---
  DrmHwcTwo.cpp                       | 23 +++++++++++++++++++++--
@@ -26,9 +28,9 @@ Signed-off-by: Li, HaihongX <haihongx.li@intel.com>
  drm/DrmDevice.cpp                   |  4 ++++
  drm/DrmDevice.h                     |  1 +
  drm/DrmEventListener.cpp            |  4 ++--
- drm/VSyncWorker.cpp                 | 12 ++++++++++++
+ drm/VSyncWorker.cpp                 | 23 +++++++++++++++++++++++
  drm/VSyncWorker.h                   |  5 +++++
- 9 files changed, 53 insertions(+), 5 deletions(-)
+ 9 files changed, 64 insertions(+), 5 deletions(-)
 
 diff --git a/DrmHwcTwo.cpp b/DrmHwcTwo.cpp
 index 2273303..0eadcd7 100644
@@ -182,7 +184,7 @@ index b303653..d59bd07 100644
        return;
  
 diff --git a/drm/VSyncWorker.cpp b/drm/VSyncWorker.cpp
-index 25eeeab..b7ceb4c 100644
+index 25eeeab..acf4988 100644
 --- a/drm/VSyncWorker.cpp
 +++ b/drm/VSyncWorker.cpp
 @@ -24,6 +24,7 @@
@@ -208,13 +210,24 @@ index 25eeeab..b7ceb4c 100644
  void VSyncWorker::VSyncControl(bool enabled) {
    Lock();
    enabled_ = enabled;
-@@ -171,6 +180,9 @@ void VSyncWorker::Routine() {
+@@ -171,6 +180,20 @@ void VSyncWorker::Routine() {
    Lock();
    if (enabled_ && vsync_callback_hook_ && vsync_callback_data_)
      vsync_callback_hook_(vsync_callback_data_, display, timestamp);
 +  
++  uint32_t vsyncPeriodNanos = 1000.0 * 1000.0 * 1000.0 / 60.0F;  // Default to 60Hz refresh rate
++  if (last_timestamp_ == -1) {
++    DrmConnector *  connector = drm_->GetConnectorForDisplay(display_);
++    if (connector != nullptr) {
++      DrmMode const &mode = connector ->active_mode();
++      if (mode.id() != 0)
++        vsyncPeriodNanos = 1000.0 * 1000.0 * 1000.0 / mode.v_refresh();
++    }
++  } else {
++    vsyncPeriodNanos = timestamp - last_timestamp_;
++  }
 +  if (enabled_ && vsync_2_4_callback_hook_ && vsync_2_4_callback_data_)
-+    vsync_2_4_callback_hook_(vsync_2_4_callback_data_, display, timestamp, 0);
++    vsync_2_4_callback_hook_(vsync_2_4_callback_data_, display, timestamp, vsyncPeriodNanos);
    Unlock();
  
    last_timestamp_ = timestamp;


### PR DESCRIPTION
Set 3rd parameter of vsync2.4 callback with vsync period value.
Can visit https://www.testufo.com/ for testing.

Tracked-On: OAM-99923
Signed-off-by: Li, HaihongX <haihongx.li@intel.com>