### PR TITLE
i915: Fix CFI violation in show_dynamic_id function

### DIFF
--- a/bsp_diff/common/kernel/lts2019-chromium/69_0069-i915-Fix-CFI-violation-in-show_dynamic_id-function.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/69_0069-i915-Fix-CFI-violation-in-show_dynamic_id-function.patch
@@ -1,0 +1,49 @@
+From 3eb1c334e6318e21ed7460fb43478c24489327f2 Mon Sep 17 00:00:00 2001
+From: "Patibandla, KiranX Kumar" <kiranx.kumar.patibandla@intel.com>
+Date: Mon, 8 Nov 2021 16:12:44 +0530
+Subject: [PATCH] i915: Fix CFI violation in show_dynamic_id function
+
+clang's Control Flow Integrity requires that every indirect call has a
+valid target, which is based on the type of the function pointer. The
+show_dynamic_id()functions is written as if it will be called
+from dev_attr_show(); however, it will be called from
+sysfs_kf_seq_show() because the files were created by
+sysfs_create_group() and the sysfs ops are based on kobj_sysfs_ops
+because of kobject_add_and_create(). Because the show_dynamic_id()
+functions do not match the type of the show() member in struct
+kobj_attribute, there is a CFI violation.
+
+Tracked-On: OAM-99958
+Signed-off-by: Patibandla, KiranX Kumar <kiranx.kumar.patibandla@intel.com>
+
+diff --git a/drivers/gpu/drm/i915/i915_perf.c b/drivers/gpu/drm/i915/i915_perf.c
+index 06de39373378..3c94420c1038 100644
+--- a/drivers/gpu/drm/i915/i915_perf.c
++++ b/drivers/gpu/drm/i915/i915_perf.c
+@@ -3993,8 +3993,8 @@ static struct i915_oa_reg *alloc_oa_regs(struct i915_perf *perf,
+ 	return ERR_PTR(err);
+ }
+ 
+-static ssize_t show_dynamic_id(struct device *dev,
+-			       struct device_attribute *attr,
++static ssize_t show_dynamic_id(struct kobject *kobj,
++			       struct kobj_attribute *attr,
+ 			       char *buf)
+ {
+ 	struct i915_oa_config *oa_config =
+diff --git a/drivers/gpu/drm/i915/i915_perf_types.h b/drivers/gpu/drm/i915/i915_perf_types.h
+index de5cbb40fddf..6370aa11ea71 100644
+--- a/drivers/gpu/drm/i915/i915_perf_types.h
++++ b/drivers/gpu/drm/i915/i915_perf_types.h
+@@ -54,7 +54,7 @@ struct i915_oa_config {
+ 
+ 	struct attribute_group sysfs_metric;
+ 	struct attribute *attrs[2];
+-	struct device_attribute sysfs_metric_id;
++	struct kobj_attribute sysfs_metric_id;
+ 
+ 	struct kref ref;
+ 	struct rcu_head rcu;
+-- 
+2.33.1
+


### PR DESCRIPTION
clang's Control Flow Integrity requires that every indirect call has a
valid target, which is based on the type of the function pointer. The
show_dynamic_id()functions is written as if it will be called
from dev_attr_show(); however, it will be called from
sysfs_kf_seq_show() because the files were created by
sysfs_create_group() and the sysfs ops are based on kobj_sysfs_ops
because of kobject_add_and_create(). Because the show_dynamic_id()
functions do not match the type of the show() member in struct
kobj_attribute, there is a CFI violation.

Tracked-On: OAM-99958
Signed-off-by: Patibandla, KiranX Kumar <kiranx.kumar.patibandla@intel.com>