### PR TITLE
adding api support for sensor HAL.

### DIFF
--- a/aosp_diff/caas/hardware/interfaces/0001-Isensor-poll-re-entry-causes-issue.patch
+++ b/aosp_diff/caas/hardware/interfaces/0001-Isensor-poll-re-entry-causes-issue.patch
@@ -1,0 +1,44 @@
+From 67caa1031687b922b35b39480fc7215b0c350c49 Mon Sep 17 00:00:00 2001
+From: rajucm <raju.mallikarjun.chegaraddi@intel.com>
+Date: Tue, 16 Nov 2021 11:37:17 +0530
+Subject: [PATCH] Isensor poll re-entry causes issue
+
+poll re-entry is not expected in passthrough implementation.
+setDelay - is deprecated in Hal version 1.3 and
+will not be called by fwk any more. where as
+setDelay functionalities are handled by batch api
+in pass through mode. re-entry should not be called by fwk.
+but its getting called and sensor service dies
+thats the reason we comment portion of the code in Sensor.cpp
+
+Tracked-On: OAM-99160
+Signed-off-by: rajucm <raju.mallikarjun.chegaraddi@intel.com>
+---
+ sensors/1.0/default/Sensors.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/sensors/1.0/default/Sensors.cpp b/sensors/1.0/default/Sensors.cpp
+index 1100dd6a2..700ae84b6 100644
+--- a/sensors/1.0/default/Sensors.cpp
++++ b/sensors/1.0/default/Sensors.cpp
+@@ -166,7 +166,7 @@ Return<void> Sensors::poll(int32_t maxCount, poll_cb _hidl_cb) {
+     int err = android::NO_ERROR;
+ 
+     { // scope of reentry lock
+-
++#if 0
+         // This enforces a single client, meaning that a maximum of one client can call poll().
+         // If this function is re-entred, it means that we are stuck in a state that may prevent
+         // the system from proceeding normally.
+@@ -182,7 +182,7 @@ Return<void> Sensors::poll(int32_t maxCount, poll_cb _hidl_cb) {
+                     "ISensors::poll() re-entry. I do not know what to do except killing myself.";
+             ::exit(-1);
+         }
+-
++#endif
+         if (maxCount <= 0) {
+             err = android::BAD_VALUE;
+         } else {
+-- 
+2.30.0
+


### PR DESCRIPTION
poll
batch
activate
flush

setDelay - is deprecated in Hal version 1.3 and
will not be called by fwk any more. where as
setDelay functionalities are handled by batch api

in pass through mode. re-entry should not be called by fwk. but its getting called and sensor service dies
thats the reason we comment portion of the code in Sensor.cpp


Tracked-On: OAM-99160
Signed-off-by: raju.mallikarjun.chegaraddi@intel.com
Signed-off-by: rranjan rajani.ranjan@intel.com