### PR TITLE
Revert back changes for ieee80211_if_remove()

### DIFF
--- a/bsp_diff/common/kernel/lts2019-chromium/71_0071-Revert-back-changes-for-ieee80211_if_remove.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/71_0071-Revert-back-changes-for-ieee80211_if_remove.patch
@@ -1,0 +1,47 @@
+From c122eb1249a134552682138fb1fb7e82b7a1bc17 Mon Sep 17 00:00:00 2001
+From: Zhuo Peng <zhuo.peng@intel.com>
+Date: Thu, 18 Nov 2021 18:35:19 +0800
+Subject: [PATCH] Revert back changes for ieee80211_if_remove()
+
+Below patch is not merged properly for iwl7000 driver
+So revert it back
+====================================================
+commit 2fe8ef106238b274c505c480ecf00d8765abf0d8
+Author: Johannes Berg <johannes.berg@intel.com>
+Date:   Fri Jan 22 16:19:42 2021 +0100
+
+cfg80211: change netdev registration/unregistration
+semantics
+====================================================
+
+Tracked-On: OAM-100104
+Signed-off-by: Zhuo Peng <zhuo.peng@intel.com>
+---
+ drivers/net/wireless/iwl7000/mac80211/iface.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/wireless/iwl7000/mac80211/iface.c b/drivers/net/wireless/iwl7000/mac80211/iface.c
+index 006452ff678d..5aec53ea5c5d 100644
+--- a/drivers/net/wireless/iwl7000/mac80211/iface.c
++++ b/drivers/net/wireless/iwl7000/mac80211/iface.c
+@@ -2137,12 +2137,14 @@ void ieee80211_if_remove(struct ieee80211_sub_if_data *sdata)
+
+ 	synchronize_rcu();
+
+-	cfg80211_unregister_wdev(&sdata->wdev);
+-
+-	if (!sdata->dev) {
++	if (sdata->dev) {
++		unregister_netdevice(sdata->dev);
++	} else {
++		cfg80211_unregister_wdev(&sdata->wdev);
+ 		ieee80211_teardown_sdata(sdata);
+ 		kfree(sdata);
+ 	}
++
+ }
+
+ void ieee80211_sdata_stop(struct ieee80211_sub_if_data *sdata)
+--
+2.17.1
+


### PR DESCRIPTION
Below patch is not merged properly for iwl7000 driver
So revert it back
====================================================
commit 2fe8ef106238b274c505c480ecf00d8765abf0d8
Author: Johannes Berg <johannes.berg@intel.com>
Date:   Fri Jan 22 16:19:42 2021 +0100

cfg80211: change netdev registration/unregistration
semantics
====================================================

Tracked-On: OAM-100104
Signed-off-by: Zhuo Peng <zhuo.peng@intel.com>