### PR TITLE
switch to drm AtomicCommit as non-block operation

### DIFF
--- a/aosp_diff/preliminary/external/drm_hwcomposer/0007-switch-to-drm-AtomicCommit-as-non-block-operation.patch
+++ b/aosp_diff/preliminary/external/drm_hwcomposer/0007-switch-to-drm-AtomicCommit-as-non-block-operation.patch
@@ -1,0 +1,59 @@
+From 9fd375c1edd6e6dbfd358984adc999f3c4f120b3 Mon Sep 17 00:00:00 2001
+From: Fei Jiang <fei.jiang@intel.com>
+Date: Mon, 22 Nov 2021 17:53:31 +0800
+Subject: [PATCH] switch to drm AtomicCommit as non-block operation
+
+This is used to resolve framerate downgrade issue when multiple monitors
+connected. If only add DRM_MODE_ATOMIC_NONBLOCK, flashing issue occurred.
+Then we need wait vblank and try commit again.
+For modeset, still can't add DRM_MODE_ATOMIC_NONBLOCK, otherwise,
+hotplug will fail.
+
+Tracked-On: OAM-99990
+Signed-off-by: Fei Jiang <fei.jiang@intel.com>
+---
+ compositor/DrmDisplayCompositor.cpp | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/compositor/DrmDisplayCompositor.cpp b/compositor/DrmDisplayCompositor.cpp
+index e332641..f741b6f 100644
+--- a/compositor/DrmDisplayCompositor.cpp
++++ b/compositor/DrmDisplayCompositor.cpp
+@@ -30,6 +30,7 @@
+ #include <ctime>
+ #include <sstream>
+ #include <vector>
++#include <xf86drm.h>
+ 
+ #include "drm/DrmCrtc.h"
+ #include "drm/DrmDevice.h"
+@@ -504,10 +505,26 @@ int DrmDisplayCompositor::CommitFrame(DrmDisplayComposition *display_comp,
+ 
+   if (!ret) {
+     uint32_t flags = DRM_MODE_ATOMIC_ALLOW_MODESET;
++    if (!mode_.needs_modeset)
++      flags |= DRM_MODE_ATOMIC_NONBLOCK;
++
+     if (test_only)
+       flags |= DRM_MODE_ATOMIC_TEST_ONLY;
+ 
+     ret = drmModeAtomicCommit(drm->fd(), pset, flags, drm);
++    if (ret == -EBUSY) {
++      ALOGV("failed to commit with EBUSY, wait for vblank and try again");
++      drmVBlank vblank;
++      memset(&vblank, 0, sizeof(vblank));
++      vblank.request.sequence = 1;
++      uint32_t high_crtc = (crtc->pipe() << DRM_VBLANK_HIGH_CRTC_SHIFT);
++      drmVBlankSeqType type_ = (drmVBlankSeqType)(DRM_VBLANK_RELATIVE |
++      				 (high_crtc & DRM_VBLANK_HIGH_CRTC_MASK));
++      vblank.request.type = type_;
++      drmWaitVBlank(drm->fd(), &vblank);
++      ret = drmModeAtomicCommit(drm->fd(), pset, flags, drm);
++    }
++
+     if (ret) {
+       if (!test_only)
+         ALOGE("Failed to commit pset ret=%d\n", ret);
+-- 
+2.32.0
+


### PR DESCRIPTION
This is used to resolve framerate downgrade issue when multiple monitors
connected. If only add DRM_MODE_ATOMIC_NONBLOCK, flashing issue occurred.
Then we need additionally poll the out fence after commit.

Tracked-On: OAM-99990
Signed-off-by: Fei Jiang <fei.jiang@intel.com>