### PR TITLE
Bluetooth: btintel: Fix bdaddress comparison with garbage value

### DIFF
--- a/bsp_diff/common/kernel/lts2020-chromium/19_0019-Bluetooth-btintel-Fix-bdaddress-comparison-with-garb.patch
+++ b/bsp_diff/common/kernel/lts2020-chromium/19_0019-Bluetooth-btintel-Fix-bdaddress-comparison-with-garb.patch
@@ -1,0 +1,61 @@
+From c31ceafd9adebd8efe63a8e8a87acbac8b4898da Mon Sep 17 00:00:00 2001
+From: Kiran K <kiran.k@intel.com>
+Date: Wed, 13 Oct 2021 13:35:11 +0530
+Subject: [PATCH] Bluetooth: btintel: Fix bdaddress comparison with garbage
+ value
+
+Intel Read Verision(TLV) data is parsed into a local structure variable
+and it contains a field for bd address. Bd address is returned only in
+bootloader mode and hence bd address in TLV structure needs to be validated
+only if controller is present in boot loader mode.
+
+Signed-off-by: Kiran K <kiran.k@intel.com>
+Reviewed-by: Tedd Ho-Jeong An <tedd.an@intel.com>
+Signed-off-by: Marcel Holtmann <marcel@holtmann.org>
+---
+ drivers/bluetooth/btintel.c | 22 ++++++++++++++--------
+ 1 file changed, 14 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/bluetooth/btintel.c b/drivers/bluetooth/btintel.c
+index 1dab29a73f98..2b047c5b6599 100644
+--- a/drivers/bluetooth/btintel.c
++++ b/drivers/bluetooth/btintel.c
+@@ -2094,14 +2094,16 @@ static int btintel_prepare_fw_download_tlv(struct hci_dev *hdev,
+ 	if (ver->img_type == 0x03) {
+ 		btintel_clear_flag(hdev, INTEL_BOOTLOADER);
+ 		btintel_check_bdaddr(hdev);
+-	}
+-
+-	/* If the OTP has no valid Bluetooth device address, then there will
+-	 * also be no valid address for the operational firmware.
+-	 */
+-	if (!bacmp(&ver->otp_bd_addr, BDADDR_ANY)) {
+-		bt_dev_info(hdev, "No device address configured");
+-		set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
++	} else {
++		/*
++		 * Check for valid bd address in boot loader mode. Device
++		 * will be marked as unconfigured if empty bd address is
++		 * found.
++		 */
++		if (!bacmp(&ver->otp_bd_addr, BDADDR_ANY)) {
++			bt_dev_info(hdev, "No device address configured");
++			set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
++		}
+ 	}
+ 
+ 	btintel_get_fw_name_tlv(ver, fwname, sizeof(fwname), "sfi");
+@@ -2391,6 +2393,10 @@ static int btintel_setup_combined(struct hci_dev *hdev)
+ 		goto exit_error;
+ 	}
+ 
++	/* memset ver_tlv to start with clean state as few fields are exclusive
++	 * to bootloader mode and are not populated in operational mode
++	 */
++	memset(&ver_tlv, 0, sizeof(ver_tlv));
+ 	/* For TLV type device, parse the tlv data */
+ 	err = btintel_parse_version_tlv(hdev, &ver_tlv, skb);
+ 	if (err) {
+-- 
+2.33.0
+


### PR DESCRIPTION
Intel Read Verision(TLV) data is parsed into a local structure variable
and it contains a field for bd address. Bd address is returned only in
bootloader mode and hence bd address in TLV structure needs to be validated
only if controller is present in boot loader mode.

Signed-off-by: Kiran K <kiran.k@intel.com>
Reviewed-by: Tedd Ho-Jeong An <tedd.an@intel.com>
Signed-off-by: Marcel Holtmann <marcel@holtmann.org>