### PR TITLE
change policy of REQUEST_INSTALL_PACKAGES to ALLOWED

### DIFF
--- a/aosp_diff/caas_cfc/frameworks/base/0001-change-policy-of-REQUEST_INSTALL_PACKAGES-to-ALLOWED.patch
+++ b/aosp_diff/caas_cfc/frameworks/base/0001-change-policy-of-REQUEST_INSTALL_PACKAGES-to-ALLOWED.patch
@@ -3,6 +3,7 @@ From: "Ruan, Hongfu" <hongfu.ruan@intel.com>
 Date: Wed, 24 Nov 2021 09:50:57 +0800
 Subject: [PATCH] change policy of REQUEST_INSTALL_PACKAGES to ALLOWED
 
+Tracked-On: OAM-100139
 Signed-off-by: Ruan, Hongfu <hongfu.ruan@intel.com>
 ---
  core/java/android/app/AppOpsManager.java | 2 +-

--- a/aosp_diff/caas_cfc/frameworks/base/0001-change-policy-of-REQUEST_INSTALL_PACKAGES-to-ALLOWED.patch
+++ b/aosp_diff/caas_cfc/frameworks/base/0001-change-policy-of-REQUEST_INSTALL_PACKAGES-to-ALLOWED.patch
@@ -3,6 +3,8 @@ From: "Ruan, Hongfu" <hongfu.ruan@intel.com>
 Date: Wed, 24 Nov 2021 09:50:57 +0800
 Subject: [PATCH] change policy of REQUEST_INSTALL_PACKAGES to ALLOWED
 
+this is required for 3rd-party app upgrade.
+
 Tracked-On: OAM-100139
 Signed-off-by: Ruan, Hongfu <hongfu.ruan@intel.com>
 ---

--- a/aosp_diff/caas_cfc/frameworks/base/0001-change-policy-of-REQUEST_INSTALL_PACKAGES-to-ALLOWED.patch
+++ b/aosp_diff/caas_cfc/frameworks/base/0001-change-policy-of-REQUEST_INSTALL_PACKAGES-to-ALLOWED.patch
@@ -1,0 +1,26 @@
+From 1fb94f5d8a9b8409f4199c8c0b7a5e1cd0698707 Mon Sep 17 00:00:00 2001
+From: "Ruan, Hongfu" <hongfu.ruan@intel.com>
+Date: Wed, 24 Nov 2021 09:50:57 +0800
+Subject: [PATCH] change policy of REQUEST_INSTALL_PACKAGES to ALLOWED
+
+Signed-off-by: Ruan, Hongfu <hongfu.ruan@intel.com>
+---
+ core/java/android/app/AppOpsManager.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/core/java/android/app/AppOpsManager.java b/core/java/android/app/AppOpsManager.java
+index 6baabb69e028..3872f1af1833 100644
+--- a/core/java/android/app/AppOpsManager.java
++++ b/core/java/android/app/AppOpsManager.java
+@@ -2305,7 +2305,7 @@ public class AppOpsManager {
+             AppOpsManager.MODE_ALLOWED, // RUN_IN_BACKGROUND
+             AppOpsManager.MODE_ALLOWED, // AUDIO_ACCESSIBILITY_VOLUME
+             AppOpsManager.MODE_ALLOWED, // READ_PHONE_NUMBERS
+-            AppOpsManager.MODE_DEFAULT, // REQUEST_INSTALL_PACKAGES
++            AppOpsManager.MODE_ALLOWED, // REQUEST_INSTALL_PACKAGES
+             AppOpsManager.MODE_ALLOWED, // PICTURE_IN_PICTURE
+             AppOpsManager.MODE_DEFAULT, // INSTANT_APP_START_FOREGROUND
+             AppOpsManager.MODE_ALLOWED, // ANSWER_PHONE_CALLS
+-- 
+2.29.2
+


### PR DESCRIPTION
on PGP, 3rd App installation is allowed by default. The reminder msg to user is skipped, so the setting in AppOpsManager gets no chance to update. This PR changes such information in AppOpsManager from DEFAULT to ALLOWED, which is required to start App upgrade.

Tracked-On: OAM-100139
Signed-off-by: Ruan, Hongfu <hongfu.ruan@intel.com>