### PR TITLE
TrebleSysProptest VendorPropertyNames fix

### DIFF
--- a/bsp_diff/caas/device/intel/mixins/0003-TrebleSysProptest-VendorPropertyNames-fix-in-mixin.patch
+++ b/bsp_diff/caas/device/intel/mixins/0003-TrebleSysProptest-VendorPropertyNames-fix-in-mixin.patch
@@ -1,0 +1,27 @@
+From 3f5d081fe904d3266571a083fac83da10b1cd387 Mon Sep 17 00:00:00 2001
+From: "Patibandla, KiranX Kumar" <kiranx.kumar.patibandla@intel.com>
+Date: Wed, 24 Nov 2021 11:49:48 +0530
+Subject: [PATCH] TrebleSysProptest VendorPropertyNames fix in mixin
+
+Fix for testVendorPropertyNames.
+Changing sys.display.size to vendor.display.size
+
+Tracked-On: OAM-99594
+Signed-off-by: Patibandla, KiranX Kumar <kiranx.kumar.patibandla@intel.com>
+
+diff --git a/groups/aaf/cfc/init.rc b/groups/aaf/cfc/init.rc
+index 187602c..a084be9 100644
+--- a/groups/aaf/cfc/init.rc
++++ b/groups/aaf/cfc/init.rc
+@@ -3,7 +3,7 @@ on fs
+     mount 9p aaf /mnt/share
+     exec - system system -- /vendor/bin/logwrapper /vendor/bin/sh /vendor/bin/auto_detection.sh
+     setprop ro.hardware.hwcomposer remote
+-    setprop sys.display.size 600x960
++    setprop vendor.display.size 600x960
+     setprop ro.hardware.gralloc ${vendor.gralloc.set}
+     setprop ro.power.fixed_performance_scale_factor ${vendor.power.fixed_performance_scale_factor}
+     setprop ro.media.xml_variant.codecs ${ro.vendor.media.target_variant}
+-- 
+2.34.0
+

--- a/bsp_diff/caas/device/intel/sepolicy/0003-TrebleSysProptest-VendorPropertyNames-fix-in-sepolic.patch
+++ b/bsp_diff/caas/device/intel/sepolicy/0003-TrebleSysProptest-VendorPropertyNames-fix-in-sepolic.patch
@@ -1,0 +1,24 @@
+From 93e9907958ec1d4a8616f015cac67207ced5b8ec Mon Sep 17 00:00:00 2001
+From: "Patibandla, KiranX Kumar" <kiranx.kumar.patibandla@intel.com>
+Date: Wed, 24 Nov 2021 11:53:29 +0530
+Subject: [PATCH] TrebleSysProptest VendorPropertyNames fix in sepolicy
+
+Fix for testVendorPropertyNames.
+Changing sys.display.size to vendor.display.size
+
+Tracked-On: OAM-99594
+Signed-off-by: Patibandla, KiranX Kumar <kiranx.kumar.patibandla@intel.com>
+
+diff --git a/aafd/property_contexts b/aafd/property_contexts
+index ff31185..c9eccb8 100644
+--- a/aafd/property_contexts
++++ b/aafd/property_contexts
+@@ -6,4 +6,4 @@ vendor.suspend u:object_r:vendor_suspend_prop:s0
+ vendor.usb.controller u:object_r:vendor_usb_controller_prop:s0
+ vendor.power.fixed_performance_scale_factor         u:object_r:vendor_fixed_perf_prop:s0
+ vendor.mount.ep0 u:object_r:vendor_mount_ep0_prop:s0
+-sys.display.size u:object_r:vendor_display_prop:s0
++vendor.display.size u:object_r:vendor_display_prop:s0
+-- 
+2.34.0
+


### PR DESCRIPTION
Fix for testVendorPropertyNames.
Changing sys.display.size to vendor.display.size

Tracked-On: OAM-99594
Signed-off-by: Patibandla, KiranX Kumar <kiranx.kumar.patibandla@intel.com>