### PR TITLE
kernel: Update build script for ref host kernel v5.10.77

### DIFF
--- a/host/kernel/lts2020-chromium/build_weekly.sh
+++ b/host/kernel/lts2020-chromium/build_weekly.sh
@@ -5,7 +5,7 @@ mkdir -p host_kernel
 cd host_kernel
 git clone https://github.com/projectceladon/linux-intel-lts2020-chromium.git
 cd linux-intel-lts2020-chromium
-git checkout e1027ee8789726b44e8ddb8f06758ac3397ad91f
+git checkout 223f3de94784582f1da1f07a265437d4e864514c
 cp ../../x86_64_defconfig .config
 patch_list=`find ../../ -iname "*.patch" | sort -u`
 for i in $patch_list


### PR DESCRIPTION
-Build script is updated to compile for weekly and on latest tip

Tracked-On: OAM-100157
Signed-off-by: Lakshmishree C <lakshmishree.c@intel.com>