### PR TITLE
update policy for 3rd party App function

### DIFF
--- a/aosp_diff/caas_cfc/system/sepolicy/0001-update-policy-for-3rd-party-App-function.patch
+++ b/aosp_diff/caas_cfc/system/sepolicy/0001-update-policy-for-3rd-party-App-function.patch
@@ -1,0 +1,123 @@
+From 8632fe972859cb20937497a67f0cba1ae24e0e09 Mon Sep 17 00:00:00 2001
+From: "Ruan, Hongfu" <hongfu.ruan@intel.com>
+Date: Thu, 25 Nov 2021 13:06:51 +0800
+Subject: [PATCH] update policy for 3rd party App function
+
+changes in device/intel/sepolicy require permissions for vendor_file, which
+was blocked here. As such vendor_file is trusted and necessary, we update
+policy here to unblock it.
+
+Tracked-On: OAM-100126
+Signed-off-by: Ruan, Hongfu <hongfu.ruan@intel.com>
+---
+ prebuilts/api/30.0/private/app_neverallows.te | 4 ++--
+ prebuilts/api/30.0/public/domain.te           | 4 ++++
+ private/app_neverallows.te                    | 4 ++--
+ public/domain.te                              | 4 ++++
+ 4 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/prebuilts/api/30.0/private/app_neverallows.te b/prebuilts/api/30.0/private/app_neverallows.te
+index 115718700..13b8d162e 100644
+--- a/prebuilts/api/30.0/private/app_neverallows.te
++++ b/prebuilts/api/30.0/private/app_neverallows.te
+@@ -194,7 +194,7 @@ neverallow all_untrusted_apps {
+   proc_stat
+   proc_swaps
+   proc_uptime
+-  proc_version
++#  proc_version
+   proc_vmallocinfo
+   proc_vmstat
+ }:file { no_rw_file_perms no_x_file_perms };
+@@ -244,7 +244,7 @@ neverallow all_untrusted_apps selinuxfs:file no_rw_file_perms;
+ # b/33214085 b/33814662 b/33791054 b/33211769
+ # https://github.com/strazzere/anti-emulator/blob/master/AntiEmulator/src/diff/strazzere/anti/emulator/FindEmulator.java
+ # This will go away in a future Android release
+-neverallow { all_untrusted_apps -untrusted_app_25 } proc_tty_drivers:file r_file_perms;
++neverallow { all_untrusted_apps -untrusted_app_25 -untrusted_app_27} proc_tty_drivers:file r_file_perms;
+ neverallow all_untrusted_apps proc_tty_drivers:file ~r_file_perms;
+ 
+ # Untrusted apps are not allowed to use cgroups.
+diff --git a/prebuilts/api/30.0/public/domain.te b/prebuilts/api/30.0/public/domain.te
+index e1ca737ce..81070f5be 100644
+--- a/prebuilts/api/30.0/public/domain.te
++++ b/prebuilts/api/30.0/public/domain.te
+@@ -972,6 +972,7 @@ full_treble_only(`
+       -vndk_sp_file
+       -vendor_app_file
+       -vendor_public_lib_file
++      -vendor_file
+     }:file execute;
+ ')
+ 
+@@ -1018,6 +1019,7 @@ full_treble_only(`
+     -vendor_public_lib_file
+     -vendor_task_profiles_file
+     -vndk_sp_file
++    -vendor_file
+   }:file *;
+ ')
+ 
+@@ -1118,6 +1120,8 @@ neverallow * {
+   -apk_data_file
+   -app_data_file
+   -asec_public_file
++  -untrusted_app_27
++  -system_lib_file
+ }:file execmod;
+ 
+ # Do not allow making the stack or heap executable.
+diff --git a/private/app_neverallows.te b/private/app_neverallows.te
+index 115718700..13b8d162e 100644
+--- a/private/app_neverallows.te
++++ b/private/app_neverallows.te
+@@ -194,7 +194,7 @@ neverallow all_untrusted_apps {
+   proc_stat
+   proc_swaps
+   proc_uptime
+-  proc_version
++#  proc_version
+   proc_vmallocinfo
+   proc_vmstat
+ }:file { no_rw_file_perms no_x_file_perms };
+@@ -244,7 +244,7 @@ neverallow all_untrusted_apps selinuxfs:file no_rw_file_perms;
+ # b/33214085 b/33814662 b/33791054 b/33211769
+ # https://github.com/strazzere/anti-emulator/blob/master/AntiEmulator/src/diff/strazzere/anti/emulator/FindEmulator.java
+ # This will go away in a future Android release
+-neverallow { all_untrusted_apps -untrusted_app_25 } proc_tty_drivers:file r_file_perms;
++neverallow { all_untrusted_apps -untrusted_app_25 -untrusted_app_27} proc_tty_drivers:file r_file_perms;
+ neverallow all_untrusted_apps proc_tty_drivers:file ~r_file_perms;
+ 
+ # Untrusted apps are not allowed to use cgroups.
+diff --git a/public/domain.te b/public/domain.te
+index e1ca737ce..81070f5be 100644
+--- a/public/domain.te
++++ b/public/domain.te
+@@ -972,6 +972,7 @@ full_treble_only(`
+       -vndk_sp_file
+       -vendor_app_file
+       -vendor_public_lib_file
++      -vendor_file
+     }:file execute;
+ ')
+ 
+@@ -1018,6 +1019,7 @@ full_treble_only(`
+     -vendor_public_lib_file
+     -vendor_task_profiles_file
+     -vndk_sp_file
++    -vendor_file
+   }:file *;
+ ')
+ 
+@@ -1118,6 +1120,8 @@ neverallow * {
+   -apk_data_file
+   -app_data_file
+   -asec_public_file
++  -untrusted_app_27
++  -system_lib_file
+ }:file execmod;
+ 
+ # Do not allow making the stack or heap executable.
+-- 
+2.29.2
+

--- a/bsp_diff/caas_cfc/device/intel/sepolicy/0001-update-policy-for-3rd-party-App-function.patch
+++ b/bsp_diff/caas_cfc/device/intel/sepolicy/0001-update-policy-for-3rd-party-App-function.patch
@@ -1,0 +1,37 @@
+From 6cdd7ee76dc39b95887d9c564975089fba0fe213 Mon Sep 17 00:00:00 2001
+From: "Ruan, Hongfu" <hongfu.ruan@intel.com>
+Date: Thu, 2 Dec 2021 10:44:50 +0800
+Subject: [PATCH] update policy for 3rd party App function
+
+this change works together with changes under system/sepolicy, or
+it doesn't pass compilation.
+
+Tracked-On: OAM-100126
+Signed-off-by: Ruan, Hongfu <hongfu.ruan@intel.com>
+---
+ houdini/vendor_init.te | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/houdini/vendor_init.te b/houdini/vendor_init.te
+index 66d5c83..71f569a 100644
+--- a/houdini/vendor_init.te
++++ b/houdini/vendor_init.te
+@@ -3,3 +3,15 @@ set_prop(vendor_init, exported_dalvik_prop)
+ 
+ allow vendor_init binfmt_miscfs:file write;
+ allow vendor_init binfmt_miscfs:chr_file { create setattr unlink rw_file_perms };
++
++allow untrusted_app_27 sysfs_net:dir search;
++allow untrusted_app_27 sysfs_rtc:dir search;
++allow untrusted_app_27 sysfs_rtc:file read;
++allow untrusted_app_27 sysfs_rtc:file open;
++allow untrusted_app_27 sysfs_rtc:file getattr;
++allow untrusted_app_27 vendor_file:file execute;
++allow untrusted_app_27 su_exec:file getattr;
++allow untrusted_app_27 sysfs:dir read;
++allow untrusted_app_27 vendor_file:file { map open read };
++allow untrusted_app_27 vendor_file:file getattr;
++
+-- 
+2.29.2
+


### PR DESCRIPTION
some 3rd-party apps have dependence on vendor_file to translate instructions
to x86, we update sepolicy in both intel and system sepolicy folder to allow that.

Tracked-On: OAM-100126
Signed-off-by: Ruan, Hongfu <hongfu.ruan@intel.com>