### PR TITLE
WA Fix for BT suspend resume issue in Tasmania

### DIFF
--- a/bsp_diff/common/kernel/lts2019-chromium/26_0001-WA-Fix-for-BT-suspend-resume-issue-in-Tasmania.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/26_0001-WA-Fix-for-BT-suspend-resume-issue-in-Tasmania.patch
@@ -1,0 +1,69 @@
+From ebdd31972fe20b72e38a0a30047dffd8cb79c809 Mon Sep 17 00:00:00 2001
+From: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Date: Thu, 25 Nov 2021 10:03:20 +0530
+Subject: [PATCH] WA Fix for BT suspend resume issue in Tasmania
+
+In the specific hardware configuration power is cut to
+the Bluetooth controller every time system enter S3 suspend
+
+In some cases when frequent usb connect and disconnect
+occurs, there is a chance that hci dev registration happens
+even before cleanup is done for the existing hci device. Delay
+is added in this case to allow enough time for cleanup of existing
+device before registering a new one.
+
+Tracked-On: OAM-99203
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+---
+ net/bluetooth/hci_core.c | 25 ++++++++++++++++++++++++-
+ 1 file changed, 24 insertions(+), 1 deletion(-)
+
+diff --git a/net/bluetooth/hci_core.c b/net/bluetooth/hci_core.c
+index 727a0010e57e..32bf685bdaaf 100644
+--- a/net/bluetooth/hci_core.c
++++ b/net/bluetooth/hci_core.c
+@@ -3868,10 +3868,32 @@ EXPORT_SYMBOL(hci_free_dev);
+ int hci_register_dev(struct hci_dev *hdev)
+ {
+ 	int id, error;
++	struct hci_dev *h_dev;
++	int hdev_unreg = 0;
+ 
+ 	if (!hdev->open || !hdev->close || !hdev->send)
+ 		return -EINVAL;
+-
++	/* WA: BT fix for Tasmania hw
++	 * In some cases when frequent usb connect and disconnect
++	 * occurs, there is a chance that hci dev registration happens
++	 * even before cleanup is done for the existing hci device. Delay
++	 * is added in this case to allow enough time for cleanup of existing
++	 * device before registering a new one
++	 */
++	read_lock(&hci_dev_list_lock);
++	list_for_each_entry(h_dev, &hci_dev_list, list) {
++		if (hci_dev_test_flag(h_dev, HCI_UNREGISTER)){
++			hdev_unreg = 1;
++			break;
++		}
++	}
++	read_unlock(&hci_dev_list_lock);
++	if(hdev_unreg) {
++		BT_DBG("hci_core: hci_dev unregistration in progress");
++		msleep(10);
++		hdev_unreg = 0;
++	}
++	/* WA: BT fix end */
+ 	/* Do not allow HCI_AMP devices to register at index 0,
+ 	 * so the index can be used as the AMP controller ID.
+ 	 */
+@@ -3942,6 +3964,7 @@ int hci_register_dev(struct hci_dev *hdev)
+ 		hci_dev_set_flag(hdev, HCI_BREDR_ENABLED);
+ 	}
+ 
++
+ 	write_lock(&hci_dev_list_lock);
+ 	list_add(&hdev->list, &hci_dev_list);
+ 	write_unlock(&hci_dev_list_lock);
+-- 
+2.33.0
+


### PR DESCRIPTION
In the specific hardware configuration power is cut to
the Bluetooth controller every time system enter S3 suspend

In some cases when frequent usb connect and disconnect
occurs, there is a chance that hci dev registration happens
even before cleanup is done for the existing hci device. Delay
is added in this case to allow enough time for cleanup of existing
device before registering a new one.

Tracked-On: OAM-99203
Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>