### PR TITLE
drm-hwc: Fix display flickering issue occurred in clock alarming UI

### DIFF
--- a/aosp_diff/preliminary/external/drm_hwcomposer/0008-Fix-display-flickering-issue-occurred-in-clock-alarm.patch
+++ b/aosp_diff/preliminary/external/drm_hwcomposer/0008-Fix-display-flickering-issue-occurred-in-clock-alarm.patch
@@ -1,0 +1,32 @@
+From e72ca9c8622a8f956bfd6b59c77b03a9cb0536e2 Mon Sep 17 00:00:00 2001
+From: Fei Jiang <fei.jiang@intel.com>
+Date: Sat, 25 Dec 2021 00:10:37 +0800
+Subject: [PATCH] Fix display flickering issue occurred in clock alarming UI
+
+In alarming UI, only one layer presented, then it was set as "DEVICE"
+rendering type, while there is sychronization issue, just force setting
+all layers as "CLIENT" type as workaroud solution.
+
+Tracked-On: OAM-100784
+Signed-off-by: Fei Jiang <fei.jiang@intel.com>
+---
+ backend/Backend.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/backend/Backend.cpp b/backend/Backend.cpp
+index 312faed..dc82997 100644
+--- a/backend/Backend.cpp
++++ b/backend/Backend.cpp
+@@ -84,7 +84,8 @@ std::tuple<int, size_t> Backend::GetClientLayers(
+ 
+ bool Backend::IsClientLayer(DrmHwcTwo::HwcDisplay *display,
+                             DrmHwcTwo::HwcLayer *layer) {
+-  return !HardwareSupportsLayerType(layer->sf_type()) ||
++  /* FIXME: set all layers as CLIENT rendering type due to flickering issue */
++  return true || !HardwareSupportsLayerType(layer->sf_type()) ||
+          !BufferInfoGetter::GetInstance()->IsHandleUsable(layer->buffer()) ||
+          display->color_transform_hint() != HAL_COLOR_TRANSFORM_IDENTITY ||
+          (layer->RequireScalingOrPhasing() &&
+-- 
+2.32.0
+


### PR DESCRIPTION
In alarming UI, only one layer presented, then it was set as "DEVICE"
rendering type, while there is sychronization issue, just force
setting all layers as "CLIENT" type as workaroud solution.

Tracked-On: OAM-100414
Signed-off-by: Fei Jiang <fei.jiang@intel.com>