### PR TITLE
libui: fixed boot issue when gralloc4 is not available

### DIFF
--- a/aosp_diff/preliminary/frameworks/native/0002-libui-fixed-boot-issue-when-gralloc4-is-not-availabl.patch
+++ b/aosp_diff/preliminary/frameworks/native/0002-libui-fixed-boot-issue-when-gralloc4-is-not-availabl.patch
@@ -1,0 +1,60 @@
+From 43afba0aa0c152446166e76fb859d54fa2fbcaae Mon Sep 17 00:00:00 2001
+From: Fei Jiang <fei.jiang@intel.com>
+Date: Wed, 5 Jan 2022 18:03:02 +0800
+Subject: [PATCH] libui: fixed boot issue when gralloc4 is not available
+
+If use GetService, retry is set true, then will loop load the service,
+this is not desired behavior for gralloc HAL loading. If gralloc 4
+doesn't exist, need check gralloc3, if failed again, check gralloc2.
+So switch to use tryGetService, which will set retry as false.
+
+Tracked-On: OAM-100231
+Signed-off-by: Fei Jiang <fei.jiang@intel.com>
+---
+ libs/ui/Gralloc2.cpp | 2 +-
+ libs/ui/Gralloc3.cpp | 2 +-
+ libs/ui/Gralloc4.cpp | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/libs/ui/Gralloc2.cpp b/libs/ui/Gralloc2.cpp
+index 040a62b542..4b81f13b64 100644
+--- a/libs/ui/Gralloc2.cpp
++++ b/libs/ui/Gralloc2.cpp
+@@ -352,7 +352,7 @@ int Gralloc2Mapper::unlock(buffer_handle_t bufferHandle) const {
+ }
+ 
+ Gralloc2Allocator::Gralloc2Allocator(const Gralloc2Mapper& mapper) : mMapper(mapper) {
+-    mAllocator = IAllocator::getService();
++    mAllocator = IAllocator::tryGetService();
+     if (mAllocator == nullptr) {
+         ALOGW("allocator 2.x is not supported");
+         return;
+diff --git a/libs/ui/Gralloc3.cpp b/libs/ui/Gralloc3.cpp
+index 882674f479..5050851ed1 100644
+--- a/libs/ui/Gralloc3.cpp
++++ b/libs/ui/Gralloc3.cpp
+@@ -341,7 +341,7 @@ status_t Gralloc3Mapper::isSupported(uint32_t width, uint32_t height, android::P
+ }
+ 
+ Gralloc3Allocator::Gralloc3Allocator(const Gralloc3Mapper& mapper) : mMapper(mapper) {
+-    mAllocator = IAllocator::getService();
++    mAllocator = IAllocator::tryGetService();
+     if (mAllocator == nullptr) {
+         ALOGW("allocator 3.x is not supported");
+         return;
+diff --git a/libs/ui/Gralloc4.cpp b/libs/ui/Gralloc4.cpp
+index 9dc9beb8e7..cda2a5ba27 100644
+--- a/libs/ui/Gralloc4.cpp
++++ b/libs/ui/Gralloc4.cpp
+@@ -1058,7 +1058,7 @@ std::string Gralloc4Mapper::dumpBuffers(bool less) const {
+ }
+ 
+ Gralloc4Allocator::Gralloc4Allocator(const Gralloc4Mapper& mapper) : mMapper(mapper) {
+-    mAllocator = IAllocator::getService();
++    mAllocator = IAllocator::tryGetService();
+     if (mAllocator == nullptr) {
+         ALOGW("allocator 4.x is not supported");
+         return;
+-- 
+2.32.0
+


### PR DESCRIPTION
If use GetService, retry is set true, then will loop load the service,
this is not desired behavior for gralloc HAL loading. If gralloc 4
doesn't exist, need check gralloc3, if failed again, check gralloc2.
So switch to use tryGetService, which will set retry as false.

Tracked-On: OAM-100231
Signed-off-by: Fei Jiang <fei.jiang@intel.com>