### PR TITLE
drm/i915: port upstream fastset fixes req for eDP

### DIFF
--- a/bsp_diff/common/kernel/lts2019-chromium/72_0072-drm-i915-ehl-Implement-W-A-22010492432.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/72_0072-drm-i915-ehl-Implement-W-A-22010492432.patch
@@ -1,0 +1,85 @@
+From fcc6aa8f3e9695a4dfb6e3c4c3002adba21a2ced Mon Sep 17 00:00:00 2001
+From: Tejas Upadhyay <tejaskumarx.surendrakumar.upadhyay@intel.com>
+Date: Wed, 4 Nov 2020 10:36:55 +0530
+Subject: [PATCH] drm/i915/ehl: Implement W/A 22010492432
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+As per W/A implemented for TGL to program half of the nominal
+DCO divider fraction value which is also applicable on EHL.
+
+Changes since V2:
+	- Apply stepping B0 till FOREVER
+	- B0 - revid update as per Bspec 29153
+Changes since V1:
+        - ehl_ used as to keep earliest platform prefix
+        - WA required B0 stepping onwards
+
+Cc: Deak Imre <imre.deak@intel.com>
+Signed-off-by: Tejas Upadhyay <tejaskumarx.surendrakumar.upadhyay@intel.com>
+Reviewed-by: Imre Deak <imre.deak@intel.com>
+Signed-off-by: José Roberto de Souza <jose.souza@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20201104050655.171185-1-tejaskumarx.surendrakumar.upadhyay@intel.com
+---
+ drivers/gpu/drm/i915/display/intel_dpll_mgr.c | 13 ++++++++-----
+ drivers/gpu/drm/i915/i915_drv.h               |  1 +
+ 2 files changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/display/intel_dpll_mgr.c b/drivers/gpu/drm/i915/display/intel_dpll_mgr.c
+index eaef7a2d041f..a95e6a2ac698 100644
+--- a/drivers/gpu/drm/i915/display/intel_dpll_mgr.c
++++ b/drivers/gpu/drm/i915/display/intel_dpll_mgr.c
+@@ -2636,13 +2636,16 @@ static bool cnl_ddi_hdmi_pll_dividers(struct intel_crtc_state *crtc_state)
+ }
+ 
+ /*
+- * Display WA #22010492432: tgl
++ * Display WA #22010492432: ehl, tgl
+  * Program half of the nominal DCO divider fraction value.
+  */
+ static bool
+-tgl_combo_pll_div_frac_wa_needed(struct drm_i915_private *i915)
++ehl_combo_pll_div_frac_wa_needed(struct drm_i915_private *i915)
+ {
+-	return IS_TIGERLAKE(i915) && i915->dpll.ref_clks.nssc == 38400;
++	return ((IS_PLATFORM(i915, INTEL_ELKHARTLAKE) &&
++		 IS_JSL_EHL_REVID(i915, EHL_REVID_B0, REVID_FOREVER)) ||
++		 IS_TIGERLAKE(i915)) &&
++		 i915->dpll.ref_clks.nssc == 38400;
+ }
+ 
+ static int __cnl_ddi_wrpll_get_freq(struct drm_i915_private *dev_priv,
+@@ -2696,7 +2699,7 @@ static int __cnl_ddi_wrpll_get_freq(struct drm_i915_private *dev_priv,
+ 	dco_fraction = (pll_state->cfgcr0 & DPLL_CFGCR0_DCO_FRACTION_MASK) >>
+ 		       DPLL_CFGCR0_DCO_FRACTION_SHIFT;
+ 
+-	if (tgl_combo_pll_div_frac_wa_needed(dev_priv))
++	if (ehl_combo_pll_div_frac_wa_needed(dev_priv))
+ 		dco_fraction *= 2;
+ 
+ 	dco_freq += (dco_fraction * ref_clock) / 0x8000;
+@@ -3086,7 +3089,7 @@ static void icl_calc_dpll_state(struct drm_i915_private *i915,
+ 
+ 	memset(pll_state, 0, sizeof(*pll_state));
+ 
+-	if (tgl_combo_pll_div_frac_wa_needed(i915))
++	if (ehl_combo_pll_div_frac_wa_needed(i915))
+ 		dco_fraction = DIV_ROUND_CLOSEST(dco_fraction, 2);
+ 
+ 	pll_state->cfgcr0 = DPLL_CFGCR0_DCO_FRACTION(dco_fraction) |
+diff --git a/drivers/gpu/drm/i915/i915_drv.h b/drivers/gpu/drm/i915/i915_drv.h
+index 80940887d250..bfc8e4575e69 100644
+--- a/drivers/gpu/drm/i915/i915_drv.h
++++ b/drivers/gpu/drm/i915/i915_drv.h
+@@ -1559,6 +1559,7 @@ extern const struct i915_rev_steppings kbl_revids[];
+ 	(IS_ICELAKE(p) && IS_REVID(p, since, until))
+ 
+ #define EHL_REVID_A0            0x0
++#define EHL_REVID_B0            0x1
+ 
+ #define IS_JSL_EHL_REVID(p, since, until) \
+ 	(IS_JSL_EHL(p) && IS_REVID(p, since, until))
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/73_0073-UPSTREAM-drm-i915-display-Ensure-that-ret-is-always-.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/73_0073-UPSTREAM-drm-i915-display-Ensure-that-ret-is-always-.patch
@@ -1,0 +1,64 @@
+From 9ef81926ea302121570fa245de5d27078b30775f Mon Sep 17 00:00:00 2001
+From: Nathan Chancellor <natechancellor@gmail.com>
+Date: Fri, 28 Aug 2020 13:28:30 -0700
+Subject: [PATCH] [UPSTREAM] drm/i915/display: Ensure that ret is always
+ initialized in icl_combo_phy_verify_state
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Clang warns:
+
+drivers/gpu/drm/i915/display/intel_combo_phy.c:268:3: warning: variable
+'ret' is uninitialized when used here [-Wuninitialized]
+                ret &= check_phy_reg(dev_priv, phy, ICL_PORT_TX_DW8_LN0(phy),
+                ^~~
+drivers/gpu/drm/i915/display/intel_combo_phy.c:261:10: note: initialize
+the variable 'ret' to silence this warning
+        bool ret;
+                ^
+                 = 0
+1 warning generated.
+
+In practice, the bug this warning appears to be concerned with would not
+actually matter because ret gets initialized to the return value of
+cnl_verify_procmon_ref_values. However, that does appear to be a bug
+since it means the first hunk of the patch this fixes won't actually do
+anything (since the values of check_phy_reg won't factor into the final
+ret value). Initialize ret to true then make all of the assignments a
+bitwise AND with itself so that the function always does what it should
+do.
+
+Fixes: 239bef676d8e ("drm/i915/display: Implement new combo phy initialization step")
+Link: https://github.com/ClangBuiltLinux/linux/issues/1094
+Signed-off-by: Nathan Chancellor <natechancellor@gmail.com>
+Reviewed-by: Matt Roper <matthew.d.roper@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20200828202830.7165-1-jose.souza@intel.com
+Signed-off-by: José Roberto de Souza <jose.souza@intel.com>
+---
+ drivers/gpu/drm/i915/display/intel_combo_phy.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/display/intel_combo_phy.c b/drivers/gpu/drm/i915/display/intel_combo_phy.c
+index 39ae124aaf92..c9c9b08e2331 100644
+--- a/drivers/gpu/drm/i915/display/intel_combo_phy.c
++++ b/drivers/gpu/drm/i915/display/intel_combo_phy.c
+@@ -279,13 +279,13 @@ static bool verify_wa14011224835(struct drm_i915_private *i915)
+ static bool icl_combo_phy_verify_state(struct drm_i915_private *dev_priv,
+ 				       enum phy phy)
+ {
+-	bool ret;
++	bool ret = true;
+ 	u32 expected_val = 0;
+ 
+ 	if (!icl_combo_phy_enabled(dev_priv, phy))
+ 		return false;
+ 
+-	ret = cnl_verify_procmon_ref_values(dev_priv, phy);
++	ret &= cnl_verify_procmon_ref_values(dev_priv, phy);
+ 
+ 	if (phy_is_master(dev_priv, phy)) {
+ 		ret &= check_phy_reg(dev_priv, phy, ICL_PORT_COMP_DW8(phy),
+-- 
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/74_0074-drm-i915-display-Allow-fastsets-when-DP_SDP_VSC-info.p.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/74_0074-drm-i915-display-Allow-fastsets-when-DP_SDP_VSC-info.p.patch
@@ -1,0 +1,67 @@
+From 1d074089fd1df5f3f5486780cb3f6a27430a3027 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jos=C3=A9=20Roberto=20de=20Souza?= <jose.souza@intel.com>
+Date: Fri, 14 May 2021 16:22:45 -0700
+Subject: [PATCH] drm/i915/display: Allow fastsets when DP_SDP_VSC infoframe do
+ not match with PSR enabled
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When PSR is enabled it handles DP_SDP_VSC, changing revision and all
+the other fields as necessary.
+It can also enabled and disable this SDP as needed without a full
+modeset.
+
+So here masking DP_SDP_VSC bit when previous and future state PSR
+enabled, it will still be checked when comparing the asked state
+to what was programmed to hardware.
+
+Cc: Gwan-gyeong Mun <gwan-gyeong.mun@intel.com>
+Cc: Radhakrishna Sripada <radhakrishna.sripada@intel.com>
+Reported-by: Ville Syrjälä <ville.syrjala@linux.intel.com>
+Fixes: 78b772e1a01f ("drm/i915/display: Fill PSR state during hardware configuration read out")
+Signed-off-by: José Roberto de Souza <jose.souza@intel.com>
+Reviewed-by: Gwan-gyeong Mun <gwan-gyeong.mun@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20210514232247.144542-2-jose.souza@intel.com
+---
+ drivers/gpu/drm/i915/display/intel_display.c | 17 ++++++++++++++++-
+ 1 file changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/i915/display/intel_display.c b/drivers/gpu/drm/i915/display/intel_display.c
+index 91b6f73c8fe5..ceef9e3f1dd6 100644
+--- a/drivers/gpu/drm/i915/display/intel_display.c
++++ b/drivers/gpu/drm/i915/display/intel_display.c
+@@ -13675,6 +13675,16 @@ intel_pipe_config_compare(const struct intel_crtc_state *current_config,
+ 	} \
+ } while (0)
+ 
++#define PIPE_CONF_CHECK_X_WITH_MASK(name, mask) do { \
++	if ((current_config->name & (mask)) != (pipe_config->name & (mask))) { \
++		pipe_config_mismatch(fastset, crtc, __stringify(name), \
++				     "(expected 0x%08x, found 0x%08x)", \
++				     current_config->name & (mask), \
++				     pipe_config->name & (mask)); \
++		ret = false; \
++	} \
++} while (0)
++
+ #define PIPE_CONF_CHECK_I(name) do { \
+ 	if (current_config->name != pipe_config->name) { \
+ 		pipe_config_mismatch(fastset, crtc, __stringify(name), \
+@@ -13987,7 +13997,12 @@ intel_pipe_config_compare(const struct intel_crtc_state *current_config,
+ 
+ 	PIPE_CONF_CHECK_I(min_voltage_level);
+ 
+-	PIPE_CONF_CHECK_X(infoframes.enable);
++	if (fastset && (current_config->has_psr || pipe_config->has_psr))
++		PIPE_CONF_CHECK_X_WITH_MASK(infoframes.enable,
++					    ~intel_hdmi_infoframe_enable(DP_SDP_VSC));
++	else
++		PIPE_CONF_CHECK_X(infoframes.enable);
++
+ 	PIPE_CONF_CHECK_X(infoframes.gcp);
+ 	PIPE_CONF_CHECK_INFOFRAME(avi);
+ 	PIPE_CONF_CHECK_INFOFRAME(spd);
+-- 
+2.17.1
+


### PR DESCRIPTION
Port drm/i915 upstream patches below required
for fastset mismatches upon boot on eDP panel.

EHL:
https://patchwork.freedesktop.org/patch/398860/
https://patchwork.freedesktop.org/patch/388431/

TGL:
https://patchwork.freedesktop.org/patch/433819/

Tracked-On: OAM-100698
Signed-off-by: Swee Yee Fonn <swee.yee.fonn@intel.com>