### PR TITLE
kernel: Update build script for ref host kernel v5.10.91

### DIFF
--- a/host/kernel/lts2020-chromium/build_weekly.sh
+++ b/host/kernel/lts2020-chromium/build_weekly.sh
@@ -5,7 +5,7 @@ mkdir -p host_kernel
 cd host_kernel
 git clone https://github.com/projectceladon/linux-intel-lts2020-chromium.git
 cd linux-intel-lts2020-chromium
-git checkout 3fb1b64aaaa2073fdf79e823623d68274778aa47
+git checkout ad94eeeb0553206bf9fe9ac174d59408cc636e59
 cp ../../x86_64_defconfig .config
 patch_list=`find ../../ -iname "*.patch" | sort -u`
 for i in $patch_list


### PR DESCRIPTION
-Build script is updated to compile for weekly and on latest tip

Tracked-On: OAM-100712
Signed-off-by: Lakshmishree C <lakshmishree.c@intel.com>