### PR TITLE
Adding Google patch to fix STS issue

### DIFF
--- a/aosp_diff/preliminary/frameworks/native/05_0005-servicemanager-restart-more-services-on-crash.patch
+++ b/aosp_diff/preliminary/frameworks/native/05_0005-servicemanager-restart-more-services-on-crash.patch
@@ -1,0 +1,57 @@
+From 10a91c920b7e3e3c984499c98ec120c77f6420f4 Mon Sep 17 00:00:00 2001
+From: Steven Moreland <smoreland@google.com>
+Date: Fri, 15 May 2020 18:55:14 +0000
+Subject: [PATCH] servicemanager: restart more services on crash
+
+We haven't seen this service crash really, but when killed the system
+doesn't recover very well. Part of the reason is additional services
+being added over time. Now, copying the same restart rules from
+hwservicemanager which gives better behavior.
+
+Bug: 156380383
+Test: cuttlefish device recovers
+Change-Id: Iaa85c4f007885b8a44ecbf30314f62989b405aff
+---
+ cmds/servicemanager/servicemanager.rc    | 13 ++++---------
+ cmds/servicemanager/vndservicemanager.rc |  3 +++
+ 2 files changed, 7 insertions(+), 9 deletions(-)
+
+diff --git a/cmds/servicemanager/servicemanager.rc b/cmds/servicemanager/servicemanager.rc
+index 152ac28ba4..6d5070fa04 100644
+--- a/cmds/servicemanager/servicemanager.rc
++++ b/cmds/servicemanager/servicemanager.rc
+@@ -3,16 +3,11 @@ service servicemanager /system/bin/servicemanager
+     user system
+     group system readproc
+     critical
+-    onrestart restart healthd
+-    onrestart restart zygote
++    onrestart restart apexd
+     onrestart restart audioserver
+-    onrestart restart media
+-    onrestart restart surfaceflinger
+-    onrestart restart inputflinger
+-    onrestart restart drm
+-    onrestart restart cameraserver
+-    onrestart restart keystore
+     onrestart restart gatekeeperd
+-    onrestart restart thermalservice
++    onrestart class_restart main
++    onrestart class_restart hal
++    onrestart class_restart early_hal
+     writepid /dev/cpuset/system-background/tasks
+     shutdown critical
+diff --git a/cmds/servicemanager/vndservicemanager.rc b/cmds/servicemanager/vndservicemanager.rc
+index 3fa4d7debd..756f6c3bc8 100644
+--- a/cmds/servicemanager/vndservicemanager.rc
++++ b/cmds/servicemanager/vndservicemanager.rc
+@@ -3,4 +3,7 @@ service vndservicemanager /vendor/bin/vndservicemanager /dev/vndbinder
+     user system
+     group system readproc
+     writepid /dev/cpuset/system-background/tasks
++    onrestart class_restart main
++    onrestart class_restart hal
++    onrestart class_restart early_hal
+     shutdown critical
+-- 
+2.34.1


### PR DESCRIPTION
This patch is available in Android 12 and
not available in Android 11. But it is needed
for fixing STS issue:
TC:  android.security.sts.CVE_2021_0310#testPocCVE_2021_0310

Tracked-On: OAM-100715
Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>