### PR TITLE
Grant access permissions of p9fs2 files to all apps

### DIFF
--- a/aosp_diff/caas_cfc/system/sepolicy/0001-Update-policy-for-media-provider.patch
+++ b/aosp_diff/caas_cfc/system/sepolicy/0001-Update-policy-for-media-provider.patch
@@ -1,4 +1,4 @@
-From cb819b371a58b60f4319486757ac732828bb0bae Mon Sep 17 00:00:00 2001
+From a1cc0d605d2c190c678be8460d2b7be67d9e8f5a Mon Sep 17 00:00:00 2001
 From: "Ai, Ting" <ting.a.ai@intel.com>
 Date: Mon, 17 Jan 2022 15:48:30 +0800
 Subject: [PATCH] Update policy for media provider
@@ -9,23 +9,25 @@ Allow mediaprovider to access 9p sharefolder
 Tracked-On: OAM-100644
 Signed-off-by: Ai, Ting <ting.a.ai@intel.com>
 ---
- prebuilts/api/30.0/private/app_neverallows.te          | 2 +-
+ prebuilts/api/30.0/private/app_neverallows.te          | 3 ++-
  prebuilts/api/30.0/private/compat/29.0/29.0.ignore.cil | 3 ++-
  prebuilts/api/30.0/private/genfs_contexts              | 1 +
- prebuilts/api/30.0/private/mediaprovider_app.te        | 5 +++++
+ prebuilts/api/30.0/private/mediaprovider_app.te        | 4 ++++
+ prebuilts/api/30.0/public/app.te                       | 3 +++
  prebuilts/api/30.0/public/file.te                      | 2 ++
- private/app_neverallows.te                             | 2 +-
+ private/app_neverallows.te                             | 3 ++-
  private/compat/29.0/29.0.ignore.cil                    | 3 ++-
  private/genfs_contexts                                 | 1 +
- private/mediaprovider_app.te                           | 5 +++++
+ private/mediaprovider_app.te                           | 4 ++++
+ public/app.te                                          | 3 +++
  public/file.te                                         | 2 ++
- 10 files changed, 22 insertions(+), 4 deletions(-)
+ 12 files changed, 28 insertions(+), 4 deletions(-)
 
 diff --git a/prebuilts/api/30.0/private/app_neverallows.te b/prebuilts/api/30.0/private/app_neverallows.te
-index 13b8d162e..0ee9e49be 100644
+index 115718700..7670e3c68 100644
 --- a/prebuilts/api/30.0/private/app_neverallows.te
 +++ b/prebuilts/api/30.0/private/app_neverallows.te
-@@ -130,7 +130,7 @@ neverallow { all_untrusted_apps -mediaprovider } { cache_file cache_recovery_fil
+@@ -130,9 +130,10 @@ neverallow { all_untrusted_apps -mediaprovider } { cache_file cache_recovery_fil
  # World accessible data locations allow application to fill the device
  # with unaccounted for data. This data will not get removed during
  # application un-installation.
@@ -33,7 +35,10 @@ index 13b8d162e..0ee9e49be 100644
 +neverallow { all_untrusted_apps -mediaprovider -mediaprovider_app -untrusted_app_29} {
    fs_type
    -sdcard_type
++  -p9fs2
    file_type
+   -app_data_file            # The apps sandbox itself
+   -privapp_data_file
 diff --git a/prebuilts/api/30.0/private/compat/29.0/29.0.ignore.cil b/prebuilts/api/30.0/private/compat/29.0/29.0.ignore.cil
 index e4aaef5f4..87da98e9c 100644
 --- a/prebuilts/api/30.0/private/compat/29.0/29.0.ignore.cil
@@ -55,18 +60,31 @@ index d05e907c4..1c86ef435 100644
  genfscon bpf / u:object_r:fs_bpf:s0
 +genfscon 9p / u:object_r:p9fs2:s0
 diff --git a/prebuilts/api/30.0/private/mediaprovider_app.te b/prebuilts/api/30.0/private/mediaprovider_app.te
-index 5881255c9..da6b56a71 100644
+index 5881255c9..de7b0e7a7 100644
 --- a/prebuilts/api/30.0/private/mediaprovider_app.te
 +++ b/prebuilts/api/30.0/private/mediaprovider_app.te
-@@ -47,3 +47,8 @@ allow mediaprovider_app proc_filesystems:file r_file_perms;
+@@ -47,3 +47,7 @@ allow mediaprovider_app proc_filesystems:file r_file_perms;
  
  #Allow MediaProvider to see if sdcardfs is in use
  get_prop(mediaprovider_app, storage_config_prop)
 +
 +# Talk to 9P sharefolder
-+allow mediaprovider_app p9fs2:file r_file_perms;
 +allow mediaprovider_app p9fs2:file create_file_perms;
-+allow mediaprovider_app p9fs2:dir rw_dir_perms;
++allow mediaprovider_app p9fs2:dir create_dir_perms;
+diff --git a/prebuilts/api/30.0/public/app.te b/prebuilts/api/30.0/public/app.te
+index e5b9fd670..3ecd7ec53 100644
+--- a/prebuilts/api/30.0/public/app.te
++++ b/prebuilts/api/30.0/public/app.te
+@@ -359,6 +359,9 @@ allow appdomain audioserver_tmpfs:file { getattr map read write };
+ allow appdomain system_server_tmpfs:file { getattr map read write };
+ allow appdomain zygote_tmpfs:file { map read };
+ 
++allow appdomain p9fs2:dir create_dir_perms;
++allow appdomain p9fs2:file create_file_perms;
++
+ ###
+ ### Neverallow rules
+ ###
 diff --git a/prebuilts/api/30.0/public/file.te b/prebuilts/api/30.0/public/file.te
 index 7ed8baab6..a6f786f04 100644
 --- a/prebuilts/api/30.0/public/file.te
@@ -78,10 +96,10 @@ index 7ed8baab6..a6f786f04 100644
 +
 +type p9fs2, fs_type, mlstrustedobject;
 diff --git a/private/app_neverallows.te b/private/app_neverallows.te
-index 13b8d162e..0ee9e49be 100644
+index 115718700..7670e3c68 100644
 --- a/private/app_neverallows.te
 +++ b/private/app_neverallows.te
-@@ -130,7 +130,7 @@ neverallow { all_untrusted_apps -mediaprovider } { cache_file cache_recovery_fil
+@@ -130,9 +130,10 @@ neverallow { all_untrusted_apps -mediaprovider } { cache_file cache_recovery_fil
  # World accessible data locations allow application to fill the device
  # with unaccounted for data. This data will not get removed during
  # application un-installation.
@@ -89,7 +107,10 @@ index 13b8d162e..0ee9e49be 100644
 +neverallow { all_untrusted_apps -mediaprovider -mediaprovider_app -untrusted_app_29} {
    fs_type
    -sdcard_type
++  -p9fs2
    file_type
+   -app_data_file            # The apps sandbox itself
+   -privapp_data_file
 diff --git a/private/compat/29.0/29.0.ignore.cil b/private/compat/29.0/29.0.ignore.cil
 index e4aaef5f4..87da98e9c 100644
 --- a/private/compat/29.0/29.0.ignore.cil
@@ -111,18 +132,31 @@ index d05e907c4..1c86ef435 100644
  genfscon bpf / u:object_r:fs_bpf:s0
 +genfscon 9p / u:object_r:p9fs2:s0
 diff --git a/private/mediaprovider_app.te b/private/mediaprovider_app.te
-index 5881255c9..da6b56a71 100644
+index 5881255c9..de7b0e7a7 100644
 --- a/private/mediaprovider_app.te
 +++ b/private/mediaprovider_app.te
-@@ -47,3 +47,8 @@ allow mediaprovider_app proc_filesystems:file r_file_perms;
+@@ -47,3 +47,7 @@ allow mediaprovider_app proc_filesystems:file r_file_perms;
  
  #Allow MediaProvider to see if sdcardfs is in use
  get_prop(mediaprovider_app, storage_config_prop)
 +
 +# Talk to 9P sharefolder
-+allow mediaprovider_app p9fs2:file r_file_perms;
 +allow mediaprovider_app p9fs2:file create_file_perms;
-+allow mediaprovider_app p9fs2:dir rw_dir_perms;
++allow mediaprovider_app p9fs2:dir create_dir_perms;
+diff --git a/public/app.te b/public/app.te
+index e5b9fd670..3ecd7ec53 100644
+--- a/public/app.te
++++ b/public/app.te
+@@ -359,6 +359,9 @@ allow appdomain audioserver_tmpfs:file { getattr map read write };
+ allow appdomain system_server_tmpfs:file { getattr map read write };
+ allow appdomain zygote_tmpfs:file { map read };
+ 
++allow appdomain p9fs2:dir create_dir_perms;
++allow appdomain p9fs2:file create_file_perms;
++
+ ###
+ ### Neverallow rules
+ ###
 diff --git a/public/file.te b/public/file.te
 index 7ed8baab6..a6f786f04 100644
 --- a/public/file.te

--- a/bsp_diff/caas_cfc/packages/providers/MediaProvider/0001-Set-new-umask-value-for-mediaprovider-app.patch
+++ b/bsp_diff/caas_cfc/packages/providers/MediaProvider/0001-Set-new-umask-value-for-mediaprovider-app.patch
@@ -1,0 +1,58 @@
+From 09536dbb2f2848792a99d0e30467e26ea917fca5 Mon Sep 17 00:00:00 2001
+From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
+Date: Thu, 17 Feb 2022 11:02:19 +0800
+Subject: [PATCH] Set new umask value for mediaprovider app
+
+Currently the umask value of mediaprovider app is 0077, that
+means the other and group users cannot access the files created
+by mediaprovider app. However, /sdcard/Pictures is a directory
+shared by VM and Host and 9pfs is mounted on it. The user and
+group of /sdcard/Pictures is system and ratio, so mediaprovier
+app is a other user to this directory and its files, that means
+mediaprovider app cannot access the files created by itself, this
+is unreasonable. Set the umask value of mediaprovider app to 0, so
+it can access the files created by itself.
+
+Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
+---
+ src/com/android/providers/media/MediaProvider.java  | 2 ++
+ src/com/android/providers/media/util/FileUtils.java | 3 ++-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/providers/media/MediaProvider.java b/src/com/android/providers/media/MediaProvider.java
+index 626bbb8e..46fe8e51 100644
+--- a/src/com/android/providers/media/MediaProvider.java
++++ b/src/com/android/providers/media/MediaProvider.java
+@@ -4825,6 +4825,8 @@ public class MediaProvider extends ContentProvider {
+             } catch (FileNotFoundException ignored) {
+             }
+ 
++            Os.umask(0);
++
+             final File thumbDir = thumbFile.getParentFile();
+             thumbDir.mkdirs();
+ 
+diff --git a/src/com/android/providers/media/util/FileUtils.java b/src/com/android/providers/media/util/FileUtils.java
+index 47c5bc14..e8f1e7ab 100644
+--- a/src/com/android/providers/media/util/FileUtils.java
++++ b/src/com/android/providers/media/util/FileUtils.java
+@@ -35,6 +35,7 @@ import static android.system.OsConstants.O_WRONLY;
+ import static android.system.OsConstants.R_OK;
+ import static android.system.OsConstants.S_IRWXG;
+ import static android.system.OsConstants.S_IRWXU;
++import static android.system.OsConstants.S_IRWXO;
+ import static android.system.OsConstants.W_OK;
+ 
+ import static com.android.providers.media.util.DatabaseUtils.getAsBoolean;
+@@ -99,7 +100,7 @@ public class FileUtils {
+         final int posixFlags = translateModePfdToPosix(pfdFlags) | O_CLOEXEC | O_NOFOLLOW;
+         try {
+             final FileDescriptor fd = Os.open(file.getAbsolutePath(), posixFlags,
+-                    S_IRWXU | S_IRWXG);
++                    S_IRWXU | S_IRWXG | S_IRWXO);
+             try {
+                 return ParcelFileDescriptor.dup(fd);
+             } finally {
+-- 
+2.25.1
+


### PR DESCRIPTION
1. Grant access permissions of p9fs2 files to all apps.
2. Modify the umask value of mediaprovider app to 0, so
    mediaprovider app can accsess the files created by itself
    in /sdcard/Pictures.
    Currently the umask value of mediaprovider app is 0077, that
    means the other and group users cannot access the files created
    by mediaprovider app. However, /sdcard/Pictures is a directory
    shared by VM and Host and 9pfs is mounted on it. The user and
    group of /sdcard/Pictures is system and ratio, so mediaprovier
    app is a other user to this directory and its files, that means
    mediaprovider app cannot access the files created by itself, this
    is unreasonable. Set the umask value of mediaprovider app to 0, so
    it can access the files created by itself.

Tracked-On: OAM-100485
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>