### PR TITLE
Fixed screen flicking caused by display mirror mechanism.

### DIFF
--- a/aosp_diff/caas_cfc/frameworks/base/0010-Fixed-screen-flicking-caused-by-display-mirror-mecha.patch
+++ b/aosp_diff/caas_cfc/frameworks/base/0010-Fixed-screen-flicking-caused-by-display-mirror-mecha.patch
@@ -1,0 +1,46 @@
+From bdf81e3a60f9a4959908c5f0603c1c6c284ea28e Mon Sep 17 00:00:00 2001
+From: Wan Shuang <shuang.wan@intel.com>
+Date: Sun, 13 Feb 2022 01:30:14 +0800
+Subject: [PATCH] Fixed screen flicking caused by display mirror mechanism.
+
+Display 0 mirror to display 1 caused UI flicking and more bad
+case that 2 displays showed the same content. The fix is only
+do display mirror on very limited conditions.
+
+Tracked-On: OAM-101229
+Signed-off-by: Wan Shuang <shuang.wan@intel.com>
+---
+ .../android/server/display/DisplayManagerService.java    | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/services/core/java/com/android/server/display/DisplayManagerService.java b/services/core/java/com/android/server/display/DisplayManagerService.java
+index 713f9c8f173d..d7b9b3d0d19d 100644
+--- a/services/core/java/com/android/server/display/DisplayManagerService.java
++++ b/services/core/java/com/android/server/display/DisplayManagerService.java
+@@ -1552,16 +1552,21 @@ public final class DisplayManagerService extends SystemService {
+         final DisplayDeviceInfo info = device.getDisplayDeviceInfoLocked();
+         final boolean ownContent = (info.flags & DisplayDeviceInfo.FLAG_OWN_CONTENT_ONLY) != 0;
+ 
++        boolean isDefault = (info.flags & DisplayDeviceInfo.FLAG_DEFAULT_DISPLAY) != 0;
++
++        Slog.d(TAG, "isDefault: " + isDefault);
+         // Find the logical display that the display device is showing.
+         // Certain displays only ever show their own content.
+         LogicalDisplay display = findLogicalDisplayForDeviceLocked(device);
+         if (!ownContent) {
+-            if (display != null && !display.hasContentLocked()) {
++            if (display != null && !display.hasContentLocked() && isDefault) {
+                 // If the display does not have any content of its own, then
+                 // automatically mirror the requested logical display contents if possible.
++                Slog.d(TAG, "Primary display's logical display is not NULL but no content to show at this moment. Get the default logical display for it.");
+                 display = mLogicalDisplays.get(device.getDisplayIdToMirrorLocked());
+             }
+-            if (display == null) {
++            if (display == null && isDefault) {
++                Slog.d(TAG, "Primary display's logical display is NULL, get one for it.");
+                 display = mLogicalDisplays.get(Display.DEFAULT_DISPLAY);
+             }
+         }
+-- 
+2.17.1
+


### PR DESCRIPTION
Display 0 mirror to display 1 caused UI flicking and more bad
case that 2 displays showed the same content. The fix is do
display mirror on very limited conditions.

Tracked-On: OAM-101229
Signed-off-by: Wan Shuang <shuang.wan@intel.com>