### PR TITLE
Don't show force resize warning window

### DIFF
--- a/aosp_diff/caas_cfc/frameworks/base/0008-Don-t-show-force-resize-warning-window.patch
+++ b/aosp_diff/caas_cfc/frameworks/base/0008-Don-t-show-force-resize-warning-window.patch
@@ -1,0 +1,31 @@
+From d6a4ea26a4799bcadc4a5c852754fb91493ef227 Mon Sep 17 00:00:00 2001
+From: renchenglei <chenglei.ren@intel.com>
+Date: Tue, 15 Feb 2022 14:14:02 +0800
+Subject: [PATCH] Don't show force resize warning window
+
+This is to help disable force resize warning window
+on external display
+
+Tracked-On: OAM-101227
+Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>
+---
+ .../java/com/android/server/wm/ActivityStackSupervisor.java    | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/services/core/java/com/android/server/wm/ActivityStackSupervisor.java b/services/core/java/com/android/server/wm/ActivityStackSupervisor.java
+index 7e6b7cd05762..2085119524b6 100644
+--- a/services/core/java/com/android/server/wm/ActivityStackSupervisor.java
++++ b/services/core/java/com/android/server/wm/ActivityStackSupervisor.java
+@@ -2180,7 +2180,8 @@ public class ActivityStackSupervisor implements RecentTasks.Callbacks {
+                         .notifyActivityLaunchOnSecondaryDisplayFailed(task.getTaskInfo(),
+                                 preferredDisplay.mDisplayId);
+             } else if (!forceNonResizable) {
+-                handleForcedResizableTaskIfNeeded(task, FORCED_RESIZEABLE_REASON_SECONDARY_DISPLAY);
++                //handleForcedResizableTaskIfNeeded(task, FORCED_RESIZEABLE_REASON_SECONDARY_DISPLAY);
++                Slog.w(TAG, "Do not show force resize warning window on external display");
+             }
+             // The information about not support secondary display should already be notified, we
+             // don't want to show another message on default display about split-screen. And it may
+-- 
+2.17.1
+


### PR DESCRIPTION
This is to help disable force resize warning window
on external display

Tracked-On: OAM-100858
Signed-off-by: Ren Chenglei <chenglei.ren@intel.com>