### PR TITLE
use private libdrm instead of external libdrm

### DIFF
--- a/aosp_diff/preliminary/external/libdrm/0001-use-private-libdrm-instead-of-external-libdrm.patch
+++ b/aosp_diff/preliminary/external/libdrm/0001-use-private-libdrm-instead-of-external-libdrm.patch
@@ -1,6 +1,6 @@
-From 5a04f7d40192a1ae0c5dba364f6f1641601619e1 Mon Sep 17 00:00:00 2001
-From: yifang ma <yifangx.ma@intel.com>
-Date: Tue, 3 Dec 2019 15:51:42 +0800
+From b32fdde901c10cda223648c125654fbf577b4886 Mon Sep 17 00:00:00 2001
+From: "wei, wushuangx" <wushuangx.wei@intel.com>
+Date: Wed, 23 Feb 2022 23:17:40 +0800
 Subject: [PATCH] use private libdrm instead of external libdrm
 
 Rename lib names to libxxx_orig, so that we use
@@ -11,40 +11,59 @@ be removed.
 Tracked-On: OAM-88717
 Signed-off-by: yifang ma <yifangx.ma@intel.com>
 Signed-off-by: Chenglei Ren <chenglei.ren@intel.com>
+Signed-off-by: wei, wushuangx <wushuangx.wei@intel.com>
 ---
- Android.bp                        |  8 ++++----
+ Android.bp                        | 14 +++++++-------
  Android.sources.bp                |  2 +-
- amdgpu/Android.bp                 |  8 ++++----
+ amdgpu/Android.bp                 | 10 +++++-----
  amdgpu/Android.sources.bp         |  2 +-
- data/Android.bp                   |  2 +-
- etnaviv/Android.bp                |  8 ++++----
+ data/Android.bp                   |  4 ++--
+ etnaviv/Android.bp                | 10 +++++-----
  etnaviv/Android.sources.bp        |  2 +-
- freedreno/Android.bp              |  8 ++++----
+ freedreno/Android.bp              | 10 +++++-----
  freedreno/Android.sources.bp      |  2 +-
- intel/Android.bp                  |  8 ++++----
+ intel/Android.bp                  | 10 +++++-----
  intel/Android.sources.bp          |  2 +-
- libkms/Android.bp                 | 16 ++++++++--------
+ libkms/Android.bp                 | 18 +++++++++---------
  libkms/Android.sources.bp         | 10 +++++-----
- nouveau/Android.bp                |  8 ++++----
+ nouveau/Android.bp                | 10 +++++-----
  nouveau/Android.sources.bp        |  2 +-
- omap/Android.bp                   |  4 ++--
+ omap/Android.bp                   |  6 +++---
  omap/Android.sources.bp           |  2 +-
- radeon/Android.bp                 |  4 ++--
+ radeon/Android.bp                 |  6 +++---
  radeon/Android.sources.bp         |  2 +-
- tegra/Android.bp                  |  4 ++--
- tests/Android.bp                  |  2 +-
- tests/modetest/Android.bp         | 10 +++++-----
+ tegra/Android.bp                  |  6 +++---
+ tests/Android.bp                  |  4 ++--
+ tests/modetest/Android.bp         | 12 ++++++------
  tests/modetest/Android.sources.bp |  2 +-
- tests/proptest/Android.bp         |  6 +++---
- tests/util/Android.bp             | 12 ++++++------
+ tests/proptest/Android.bp         |  8 ++++----
+ tests/util/Android.bp             | 14 +++++++-------
  tests/util/Android.sources.bp     |  2 +-
- 26 files changed, 69 insertions(+), 69 deletions(-)
+ 26 files changed, 86 insertions(+), 86 deletions(-)
 
 diff --git a/Android.bp b/Android.bp
-index 6fe434c6ee66..a075d8e55ee1 100644
+index dbac5626..cbd98379 100644
 --- a/Android.bp
 +++ b/Android.bp
-@@ -25,7 +25,7 @@ subdirs = ["*"]
+@@ -22,7 +22,7 @@
+ //
+ 
+ package {
+-    default_applicable_licenses: ["external_libdrm_license"],
++    default_applicable_licenses: ["external_libdrm_license_orig"],
+ }
+ 
+ // Added automatically by a large-scale-change that took the approach of
+@@ -40,7 +40,7 @@ package {
+ // used in the current project.
+ // See: http://go/android-license-faq
+ license {
+-    name: "external_libdrm_license",
++    name: "external_libdrm_license_orig",
+     visibility: [":__subpackages__"],
+     license_kinds: [
+         "SPDX-license-identifier-BSD",
+@@ -54,7 +54,7 @@ subdirs = ["*"]
  build = ["Android.sources.bp"]
  
  cc_defaults {
@@ -53,7 +72,16 @@ index 6fe434c6ee66..a075d8e55ee1 100644
      cflags: [
          // XXX: Consider moving these to config.h analogous to autoconf.
          "-DMAJOR_IN_SYSMACROS=1",
-@@ -47,12 +47,12 @@ cc_defaults {
+@@ -77,7 +77,7 @@ cc_defaults {
+ }
+ 
+ cc_library_headers {
+-    name: "libdrm_headers",
++    name: "libdrm_headers_orig",
+     vendor_available: true,
+     host_supported: true,
+     defaults: ["libdrm_defaults"],
+@@ -86,13 +86,13 @@ cc_library_headers {
  
  // Library for the device
  cc_library {
@@ -61,6 +89,7 @@ index 6fe434c6ee66..a075d8e55ee1 100644
 +    name: "libdrm_orig",
      recovery_available: true,
      vendor_available: true,
+     host_supported: true,
      defaults: [
 -        "libdrm_defaults",
 -        "libdrm_sources",
@@ -70,7 +99,7 @@ index 6fe434c6ee66..a075d8e55ee1 100644
  
      export_include_dirs: ["include/drm", "android"],
 diff --git a/Android.sources.bp b/Android.sources.bp
-index 73356dd80a37..1e4f8013ed4c 100644
+index 73356dd8..1e4f8013 100644
 --- a/Android.sources.bp
 +++ b/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -83,10 +112,17 @@ index 73356dd80a37..1e4f8013ed4c 100644
          "xf86drm.c",
          "xf86drmHash.c",
 diff --git a/amdgpu/Android.bp b/amdgpu/Android.bp
-index 976f03e9d617..e999edae900e 100644
+index 94f5668d..370a0abe 100644
 --- a/amdgpu/Android.bp
 +++ b/amdgpu/Android.bp
-@@ -1,16 +1,16 @@
+@@ -4,22 +4,22 @@ package {
+     // all of the 'license_kinds' from "external_libdrm_license"
+     // to get the below license kinds:
+     //   SPDX-license-identifier-MIT
+-    default_applicable_licenses: ["external_libdrm_license"],
++    default_applicable_licenses: ["external_libdrm_license_orig"],
+ }
+ 
  build = ["Android.sources.bp"]
  
  cc_library_shared {
@@ -108,7 +144,7 @@ index 976f03e9d617..e999edae900e 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/amdgpu/Android.sources.bp b/amdgpu/Android.sources.bp
-index ed85682aaa2f..62952f95cce1 100644
+index be85283d..653ef89b 100644
 --- a/amdgpu/Android.sources.bp
 +++ b/amdgpu/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -121,10 +157,17 @@ index ed85682aaa2f..62952f95cce1 100644
  	"amdgpu_asic_id.c",
          "amdgpu_bo.c",
 diff --git a/data/Android.bp b/data/Android.bp
-index 47f64371a4ca..a83777fdcb07 100644
+index 8bb59211..6faf6066 100644
 --- a/data/Android.bp
 +++ b/data/Android.bp
-@@ -1,5 +1,5 @@
+@@ -4,11 +4,11 @@ package {
+     // all of the 'license_kinds' from "external_libdrm_license"
+     // to get the below license kinds:
+     //   SPDX-license-identifier-MIT
+-    default_applicable_licenses: ["external_libdrm_license"],
++    default_applicable_licenses: ["external_libdrm_license_orig"],
+ }
+ 
  prebuilt_etc {
 -    name: "amdgpu.ids",
 +    name: "amdgpu.ids_orig",
@@ -132,10 +175,17 @@ index 47f64371a4ca..a83777fdcb07 100644
      sub_dir: "hwdata",
      src: "amdgpu.ids",
 diff --git a/etnaviv/Android.bp b/etnaviv/Android.bp
-index 21deda99900d..fdddc6532120 100644
+index d8d04af1..1c5ebdef 100644
 --- a/etnaviv/Android.bp
 +++ b/etnaviv/Android.bp
-@@ -1,11 +1,11 @@
+@@ -4,17 +4,17 @@ package {
+     // all of the 'license_kinds' from "external_libdrm_license"
+     // to get the below license kinds:
+     //   SPDX-license-identifier-MIT
+-    default_applicable_licenses: ["external_libdrm_license"],
++    default_applicable_licenses: ["external_libdrm_license_orig"],
+ }
+ 
  build = ["Android.sources.bp"]
  
  cc_library_shared {
@@ -152,7 +202,7 @@ index 21deda99900d..fdddc6532120 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/etnaviv/Android.sources.bp b/etnaviv/Android.sources.bp
-index aa8289009b93..aaed1558f329 100644
+index aa828900..aaed1558 100644
 --- a/etnaviv/Android.sources.bp
 +++ b/etnaviv/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -165,10 +215,17 @@ index aa8289009b93..aaed1558f329 100644
          "etnaviv_device.c",
          "etnaviv_gpu.c",
 diff --git a/freedreno/Android.bp b/freedreno/Android.bp
-index 9fca9b1260d6..3d20772e5338 100644
+index ca7f3e28..9aeefa6d 100644
 --- a/freedreno/Android.bp
 +++ b/freedreno/Android.bp
-@@ -1,11 +1,11 @@
+@@ -4,17 +4,17 @@ package {
+     // all of the 'license_kinds' from "external_libdrm_license"
+     // to get the below license kinds:
+     //   SPDX-license-identifier-MIT
+-    default_applicable_licenses: ["external_libdrm_license"],
++    default_applicable_licenses: ["external_libdrm_license_orig"],
+ }
+ 
  build = ["Android.sources.bp"]
  
  cc_library_shared {
@@ -185,7 +242,7 @@ index 9fca9b1260d6..3d20772e5338 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/freedreno/Android.sources.bp b/freedreno/Android.sources.bp
-index 3c1ca316a5c9..808608c50bf0 100644
+index 3c1ca316..808608c5 100644
 --- a/freedreno/Android.sources.bp
 +++ b/freedreno/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -198,10 +255,17 @@ index 3c1ca316a5c9..808608c50bf0 100644
          "freedreno_device.c",
          "freedreno_pipe.c",
 diff --git a/intel/Android.bp b/intel/Android.bp
-index 22713acc8405..05aba7f77f72 100644
+index 7c82f1e6..58b7a55b 100644
 --- a/intel/Android.bp
 +++ b/intel/Android.bp
-@@ -24,13 +24,13 @@
+@@ -28,19 +28,19 @@ package {
+     // to get the below license kinds:
+     //   SPDX-license-identifier-BSD
+     //   SPDX-license-identifier-MIT
+-    default_applicable_licenses: ["external_libdrm_license"],
++    default_applicable_licenses: ["external_libdrm_license_orig"],
+ }
+ 
  build = ["Android.sources.bp"]
  
  cc_library_shared {
@@ -220,7 +284,7 @@ index 22713acc8405..05aba7f77f72 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/intel/Android.sources.bp b/intel/Android.sources.bp
-index 459c070fa580..a6e789ab7f4d 100644
+index 46e0328f..e968e2e7 100644
 --- a/intel/Android.sources.bp
 +++ b/intel/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -233,10 +297,17 @@ index 459c070fa580..a6e789ab7f4d 100644
          "intel_bufmgr.c",
          "intel_bufmgr_fake.c",
 diff --git a/libkms/Android.bp b/libkms/Android.bp
-index b09dbf42f885..65219110f123 100644
+index d46bab4f..d7042b3a 100644
 --- a/libkms/Android.bp
 +++ b/libkms/Android.bp
-@@ -1,15 +1,15 @@
+@@ -4,21 +4,21 @@ package {
+     // all of the 'license_kinds' from "external_libdrm_license"
+     // to get the below license kinds:
+     //   SPDX-license-identifier-MIT
+-    default_applicable_licenses: ["external_libdrm_license"],
++    default_applicable_licenses: ["external_libdrm_license_orig"],
+ }
+ 
  build = ["Android.sources.bp"]
  
  cc_library_shared {
@@ -261,7 +332,7 @@ index b09dbf42f885..65219110f123 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/libkms/Android.sources.bp b/libkms/Android.sources.bp
-index 5582f2356cae..3addc57dd1bb 100644
+index 5582f235..3addc57d 100644
 --- a/libkms/Android.sources.bp
 +++ b/libkms/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -307,10 +378,17 @@ index 5582f2356cae..3addc57dd1bb 100644
          "radeon.c",
      ],
 diff --git a/nouveau/Android.bp b/nouveau/Android.bp
-index 12c37e3dc29b..a8a504dcbc56 100644
+index b844fdde..84d7ae4a 100644
 --- a/nouveau/Android.bp
 +++ b/nouveau/Android.bp
-@@ -1,11 +1,11 @@
+@@ -4,17 +4,17 @@ package {
+     // all of the 'license_kinds' from "external_libdrm_license"
+     // to get the below license kinds:
+     //   SPDX-license-identifier-MIT
+-    default_applicable_licenses: ["external_libdrm_license"],
++    default_applicable_licenses: ["external_libdrm_license_orig"],
+ }
+ 
  build = ["Android.sources.bp"]
  
  cc_library_shared {
@@ -327,7 +405,7 @@ index 12c37e3dc29b..a8a504dcbc56 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/nouveau/Android.sources.bp b/nouveau/Android.sources.bp
-index 5ecdb53c80a8..72012e55d652 100644
+index 5ecdb53c..72012e55 100644
 --- a/nouveau/Android.sources.bp
 +++ b/nouveau/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -340,10 +418,17 @@ index 5ecdb53c80a8..72012e55d652 100644
          "nouveau.c",
          "pushbuf.c",
 diff --git a/omap/Android.bp b/omap/Android.bp
-index 05ca7d2db79b..9c06cb4e8fa3 100644
+index a3a5a9e3..ccabfbd6 100644
 --- a/omap/Android.bp
 +++ b/omap/Android.bp
-@@ -1,12 +1,12 @@
+@@ -4,18 +4,18 @@ package {
+     // all of the 'license_kinds' from "external_libdrm_license"
+     // to get the below license kinds:
+     //   SPDX-license-identifier-MIT
+-    default_applicable_licenses: ["external_libdrm_license"],
++    default_applicable_licenses: ["external_libdrm_license_orig"],
+ }
+ 
  build = ["Android.sources.bp"]
  
  cc_library_shared {
@@ -359,7 +444,7 @@ index 05ca7d2db79b..9c06cb4e8fa3 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/omap/Android.sources.bp b/omap/Android.sources.bp
-index 3c7da94a4b18..2491fa9a35c9 100644
+index 3c7da94a..2491fa9a 100644
 --- a/omap/Android.sources.bp
 +++ b/omap/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -372,10 +457,17 @@ index 3c7da94a4b18..2491fa9a35c9 100644
  	"omap_drm.c",
      ],
 diff --git a/radeon/Android.bp b/radeon/Android.bp
-index 9d0a09ec718a..f2bd52e9779a 100644
+index 6c52084f..540f3947 100644
 --- a/radeon/Android.bp
 +++ b/radeon/Android.bp
-@@ -1,11 +1,11 @@
+@@ -4,17 +4,17 @@ package {
+     // all of the 'license_kinds' from "external_libdrm_license"
+     // to get the below license kinds:
+     //   SPDX-license-identifier-MIT
+-    default_applicable_licenses: ["external_libdrm_license"],
++    default_applicable_licenses: ["external_libdrm_license_orig"],
+ }
+ 
  build = ["Android.sources.bp"]
  
  cc_library_shared {
@@ -390,7 +482,7 @@ index 9d0a09ec718a..f2bd52e9779a 100644
 +    shared_libs: ["libdrm_orig"],
  }
 diff --git a/radeon/Android.sources.bp b/radeon/Android.sources.bp
-index 820ac4d6d4ed..3d004f02003f 100644
+index 820ac4d6..3d004f02 100644
 --- a/radeon/Android.sources.bp
 +++ b/radeon/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -403,10 +495,17 @@ index 820ac4d6d4ed..3d004f02003f 100644
          "radeon_bo_gem.c",
          "radeon_cs_gem.c",
 diff --git a/tegra/Android.bp b/tegra/Android.bp
-index 33eaf6c50eb5..3839ebde8039 100644
+index 297c0193..6bb9dde2 100644
 --- a/tegra/Android.bp
 +++ b/tegra/Android.bp
-@@ -1,7 +1,7 @@
+@@ -4,13 +4,13 @@ package {
+     // all of the 'license_kinds' from "external_libdrm_license"
+     // to get the below license kinds:
+     //   SPDX-license-identifier-MIT
+-    default_applicable_licenses: ["external_libdrm_license"],
++    default_applicable_licenses: ["external_libdrm_license_orig"],
+ }
+ 
  cc_library_shared {
 -    name: "libdrm_tegra",
 +    name: "libdrm_tegra_orig",
@@ -417,10 +516,17 @@ index 33eaf6c50eb5..3839ebde8039 100644
      srcs: ["tegra.c"],
  
 diff --git a/tests/Android.bp b/tests/Android.bp
-index cdc6c2cf350f..696bcac4f7f7 100644
+index bff7f991..666d2347 100644
 --- a/tests/Android.bp
 +++ b/tests/Android.bp
-@@ -1,6 +1,6 @@
+@@ -4,12 +4,12 @@ package {
+     // all of the 'license_kinds' from "external_libdrm_license"
+     // to get the below license kinds:
+     //   SPDX-license-identifier-MIT
+-    default_applicable_licenses: ["external_libdrm_license"],
++    default_applicable_licenses: ["external_libdrm_license_orig"],
+ }
+ 
  subdirs = ["*"]
  
  cc_library_headers {
@@ -429,10 +535,17 @@ index cdc6c2cf350f..696bcac4f7f7 100644
      export_include_dirs: ["."],
  }
 diff --git a/tests/modetest/Android.bp b/tests/modetest/Android.bp
-index ca811fee05e9..791f9a21f256 100644
+index 02a17fe9..172f8799 100644
 --- a/tests/modetest/Android.bp
 +++ b/tests/modetest/Android.bp
-@@ -1,12 +1,12 @@
+@@ -4,18 +4,18 @@ package {
+     // all of the 'license_kinds' from "external_libdrm_license"
+     // to get the below license kinds:
+     //   SPDX-license-identifier-MIT
+-    default_applicable_licenses: ["external_libdrm_license"],
++    default_applicable_licenses: ["external_libdrm_license_orig"],
+ }
+ 
  build = ["Android.sources.bp"]
  
  cc_test {
@@ -451,7 +564,7 @@ index ca811fee05e9..791f9a21f256 100644
 +    static_libs: ["libdrm_util_orig"],
  }
 diff --git a/tests/modetest/Android.sources.bp b/tests/modetest/Android.sources.bp
-index c6aca2ef757e..e510bfe84b7b 100644
+index c6aca2ef..e510bfe8 100644
 --- a/tests/modetest/Android.sources.bp
 +++ b/tests/modetest/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -464,10 +577,17 @@ index c6aca2ef757e..e510bfe84b7b 100644
          "buffers.c",
          "cursor.c",
 diff --git a/tests/proptest/Android.bp b/tests/proptest/Android.bp
-index 28c87e91040a..89affae20b2a 100644
+index e13d060b..61aacfdf 100644
 --- a/tests/proptest/Android.bp
 +++ b/tests/proptest/Android.bp
-@@ -1,8 +1,8 @@
+@@ -4,14 +4,14 @@ package {
+     // all of the 'license_kinds' from "external_libdrm_license"
+     // to get the below license kinds:
+     //   SPDX-license-identifier-MIT
+-    default_applicable_licenses: ["external_libdrm_license"],
++    default_applicable_licenses: ["external_libdrm_license_orig"],
+ }
+ 
  cc_test {
 -    name: "proptest",
 +    name: "proptest_orig",
@@ -480,10 +600,17 @@ index 28c87e91040a..89affae20b2a 100644
 +    static_libs: ["libdrm_util_orig"],
  }
 diff --git a/tests/util/Android.bp b/tests/util/Android.bp
-index 36d18206d6bb..4aac168f49cc 100644
+index 0322c2ac..4f6f3d94 100644
 --- a/tests/util/Android.bp
 +++ b/tests/util/Android.bp
-@@ -24,12 +24,12 @@
+@@ -27,18 +27,18 @@ package {
+     // all of the 'license_kinds' from "external_libdrm_license"
+     // to get the below license kinds:
+     //   SPDX-license-identifier-MIT
+-    default_applicable_licenses: ["external_libdrm_license"],
++    default_applicable_licenses: ["external_libdrm_license_orig"],
+ }
+ 
  build = ["Android.sources.bp"]
  
  cc_library_static {
@@ -503,7 +630,7 @@ index 36d18206d6bb..4aac168f49cc 100644
 +    export_header_lib_headers: ["libdrm_test_headers_orig"],
  }
 diff --git a/tests/util/Android.sources.bp b/tests/util/Android.sources.bp
-index 529e1124ed9f..c9a6f1a06ee1 100644
+index 529e1124..c9a6f1a0 100644
 --- a/tests/util/Android.sources.bp
 +++ b/tests/util/Android.sources.bp
 @@ -1,7 +1,7 @@
@@ -516,5 +643,5 @@ index 529e1124ed9f..c9a6f1a06ee1 100644
          "format.c",
          "kms.c",
 -- 
-2.17.1
+2.34.1
 


### PR DESCRIPTION
Rename external libdrm from libxxx to libxxx_orig, so that we use can
libdrm-intel instead of external libdrm, and bunches of libdrm_pri
renaming patches could also be removed.

Tracked-On: OAM-101163
Signed-off-by: yifang ma <yifangx.ma@intel.com>
Signed-off-by: Chenglei Ren <chenglei.ren@intel.com>
Signed-off-by: wei, wushuangx <wushuangx.wei@intel.com>