### PR TITLE
Launch the app directly after successful update.

### DIFF
--- a/aosp_diff/caas_cfc/frameworks/base/04_0004-Launch-the-app-directly-after-successful-update.patch
+++ b/aosp_diff/caas_cfc/frameworks/base/04_0004-Launch-the-app-directly-after-successful-update.patch
@@ -1,0 +1,64 @@
+From ba2acaf1251f71e90eb22ca89482ecc7fa52ca07 Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Thu, 24 Feb 2022 13:42:56 +0530
+Subject: [PATCH] Launch the app directly after successful update.
+
+Launch the App directly after it has been updated
+sucessfully, without giving option for user to
+select "Done" or "Launch". This is given as
+an interim fix.
+
+Tracked-On: OAM-101891
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ .../packageinstaller/InstallSuccess.java      | 27 ++++++++++++-------
+ 1 file changed, 18 insertions(+), 9 deletions(-)
+
+diff --git a/packages/PackageInstaller/src/com/android/packageinstaller/InstallSuccess.java b/packages/PackageInstaller/src/com/android/packageinstaller/InstallSuccess.java
+index 38c06dd48b85..b007c9c526b7 100644
+--- a/packages/PackageInstaller/src/com/android/packageinstaller/InstallSuccess.java
++++ b/packages/PackageInstaller/src/com/android/packageinstaller/InstallSuccess.java
+@@ -95,6 +95,24 @@ public class InstallSuccess extends AlertActivity {
+             return;
+         }
+ 
++        // Enable or disable "launch" button
++        boolean enabled = false;
++        if (mLaunchIntent != null) {
++            List<ResolveInfo> list = getPackageManager().queryIntentActivities(mLaunchIntent,
++                    0);
++            if (list != null && list.size() > 0) {
++                enabled = true;
++            }
++        }
++        if (enabled) {
++            try {
++                startActivity(mLaunchIntent);
++            } catch (ActivityNotFoundException | SecurityException e) {
++                Log.e(LOG_TAG, "Could not start activity", e);
++            }
++        }
++        finish();
++
+         mAlert.setIcon(mAppSnippet.icon);
+         mAlert.setTitle(mAppSnippet.label);
+         mAlert.setView(R.layout.install_content_view);
+@@ -109,15 +127,6 @@ public class InstallSuccess extends AlertActivity {
+                 }, null);
+         setupAlert();
+         requireViewById(R.id.install_success).setVisibility(View.VISIBLE);
+-        // Enable or disable "launch" button
+-        boolean enabled = false;
+-        if (mLaunchIntent != null) {
+-            List<ResolveInfo> list = getPackageManager().queryIntentActivities(mLaunchIntent,
+-                    0);
+-            if (list != null && list.size() > 0) {
+-                enabled = true;
+-            }
+-        }
+ 
+         Button launchButton = mAlert.getButton(DialogInterface.BUTTON_POSITIVE);
+         if (enabled) {
+-- 
+2.17.1
+


### PR DESCRIPTION
Launch the App directly after it has been updated
sucessfully, without giving option for user to
select "Done" or "Launch". This is given as
an interim fix.

Tracked-On: OAM-100841
Signed-off-by: ahs <amrita.h.s@intel.com>