### PR TITLE
Disable the status bar in activity layout context

### DIFF
--- a/aosp_diff/caas_cfc/frameworks/base/0002-Disable-the-Status-Bar-and-grant-runtime-permissions.patch
+++ b/aosp_diff/caas_cfc/frameworks/base/0002-Disable-the-Status-Bar-and-grant-runtime-permissions.patch
@@ -1,4 +1,4 @@
-From 6807f610931a5909c19565a5f842548342ac302d Mon Sep 17 00:00:00 2001
+From 72061ab7e2293e507ede50bcdc2d56f573b33f2e Mon Sep 17 00:00:00 2001
 From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
 Date: Fri, 10 Sep 2021 09:13:41 +0800
 Subject: [PATCH] Disable the Status Bar and grant runtime permissions by
@@ -10,10 +10,23 @@ window.
 
 Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
 ---
+ .../src/com/android/systemui/statusbar/CommandQueue.java        | 1 +
  .../android/server/pm/permission/PermissionManagerService.java  | 2 ++
  services/core/java/com/android/server/wm/DisplayPolicy.java     | 2 +-
- 2 files changed, 3 insertions(+), 1 deletion(-)
+ 3 files changed, 4 insertions(+), 1 deletion(-)
 
+diff --git a/packages/SystemUI/src/com/android/systemui/statusbar/CommandQueue.java b/packages/SystemUI/src/com/android/systemui/statusbar/CommandQueue.java
+index 96d6ecbcc07f..b1984998f6d1 100644
+--- a/packages/SystemUI/src/com/android/systemui/statusbar/CommandQueue.java
++++ b/packages/SystemUI/src/com/android/systemui/statusbar/CommandQueue.java
+@@ -447,6 +447,7 @@ public class CommandQueue extends IStatusBar.Stub implements CallbackController<
+     public void recomputeDisableFlags(int displayId, boolean animate) {
+         int disabled1 = getDisabled1(displayId);
+         int disabled2 = getDisabled2(displayId);
++        disabled1 = StatusBarManager.DISABLE_MASK;
+         disable(displayId, disabled1, disabled2, animate);
+     }
+ 
 diff --git a/services/core/java/com/android/server/pm/permission/PermissionManagerService.java b/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
 index 8d2363b6e831..0b50e353956f 100644
 --- a/services/core/java/com/android/server/pm/permission/PermissionManagerService.java


### PR DESCRIPTION
Previously status bar is disabled in DisplayPolicy, however,
the status bar still appear in some scenarios. Do the
disable operation in the activity layout context to cover more
circumstances.

Tracked-On: OAM-101104
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>