### PR TITLE
Reset window insets for some apps and hide status bar

### DIFF
--- a/aosp_diff/caas_cfc/frameworks/base/0002-Disable-the-Status-Bar-and-grant-runtime-permissions.patch
+++ b/aosp_diff/caas_cfc/frameworks/base/0002-Disable-the-Status-Bar-and-grant-runtime-permissions.patch
@@ -1,32 +1,16 @@
-From 72061ab7e2293e507ede50bcdc2d56f573b33f2e Mon Sep 17 00:00:00 2001
+From 5c3683f28a878759544536f80735ebe0f1f57dd8 Mon Sep 17 00:00:00 2001
 From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
 Date: Fri, 10 Sep 2021 09:13:41 +0800
-Subject: [PATCH] Disable the Status Bar and grant runtime permissions by
- default
+Subject: [PATCH] Grant runtime permissions by default
 
-Based on the customer requirement, we need to remove the
-status bar and disable the permission grant pop-up
-window.
+Based on the customer requirement, we need to disable the
+permission grant pop-up window.
 
 Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
 ---
- .../src/com/android/systemui/statusbar/CommandQueue.java        | 1 +
  .../android/server/pm/permission/PermissionManagerService.java  | 2 ++
- services/core/java/com/android/server/wm/DisplayPolicy.java     | 2 +-
- 3 files changed, 4 insertions(+), 1 deletion(-)
+ 1 file changed, 2 insertions(+)
 
-diff --git a/packages/SystemUI/src/com/android/systemui/statusbar/CommandQueue.java b/packages/SystemUI/src/com/android/systemui/statusbar/CommandQueue.java
-index 96d6ecbcc07f..b1984998f6d1 100644
---- a/packages/SystemUI/src/com/android/systemui/statusbar/CommandQueue.java
-+++ b/packages/SystemUI/src/com/android/systemui/statusbar/CommandQueue.java
-@@ -447,6 +447,7 @@ public class CommandQueue extends IStatusBar.Stub implements CallbackController<
-     public void recomputeDisableFlags(int displayId, boolean animate) {
-         int disabled1 = getDisabled1(displayId);
-         int disabled2 = getDisabled2(displayId);
-+        disabled1 = StatusBarManager.DISABLE_MASK;
-         disable(displayId, disabled1, disabled2, animate);
-     }
- 
 diff --git a/services/core/java/com/android/server/pm/permission/PermissionManagerService.java b/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
 index 8d2363b6e831..0b50e353956f 100644
 --- a/services/core/java/com/android/server/pm/permission/PermissionManagerService.java
@@ -40,19 +24,6 @@ index 8d2363b6e831..0b50e353956f 100644
                  if (grant != GRANT_DENIED) {
                      if (!ps.isSystem() && ps.areInstallPermissionsFixed() && !bp.isRuntime()) {
                          // If this is an existing, non-system package, then
-diff --git a/services/core/java/com/android/server/wm/DisplayPolicy.java b/services/core/java/com/android/server/wm/DisplayPolicy.java
-index 29881cc761b2..4d8857d2fb0b 100644
---- a/services/core/java/com/android/server/wm/DisplayPolicy.java
-+++ b/services/core/java/com/android/server/wm/DisplayPolicy.java
-@@ -3621,7 +3621,7 @@ public class DisplayPolicy {
-             StatusBarManagerInternal statusBar = getStatusBarManagerInternal();
-             if (statusBar != null) {
-                 final int displayId = getDisplayId();
--                statusBar.setDisableFlags(displayId, visibility & StatusBarManager.DISABLE_MASK,
-+                statusBar.setDisableFlags(displayId, StatusBarManager.DISABLE_MASK,
-                         cause);
-                 if (transientState.first.length > 0) {
-                     statusBar.showTransient(displayId, transientState.first);
 -- 
 2.25.1
 

--- a/aosp_diff/caas_cfc/frameworks/base/0011-Set-status-bar-height-to-0-and-reset-window-insets-f.patch
+++ b/aosp_diff/caas_cfc/frameworks/base/0011-Set-status-bar-height-to-0-and-reset-window-insets-f.patch
@@ -1,0 +1,126 @@
+From c1d4852314ba217f68f26152bcb0f6eae1820d9e Mon Sep 17 00:00:00 2001
+From: "ji, zhenlong z" <zhenlong.z.ji@intel.com>
+Date: Fri, 11 Mar 2022 10:49:33 +0800
+Subject: [PATCH] Set status bar height to 0 and reset window insets for
+ wechat/xes
+
+1. Some activity UI of wechat/xueersi display abnormally in the
+secondary display windows, seems some activity layouts of
+wechat/xueersi have dependency on the status bar. Reset the
+windowinsets of the secondary displays to incorporate the height
+of status bar.
+2. Set status bar height to 0.
+
+Tracked-On: OAM-100827
+Tracked-On: OAM-100860
+Tracked-On: OAM-101404
+Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>
+---
+ core/java/android/view/ViewRootImpl.java         | 16 +++++++++++++++-
+ .../statusbar/phone/PhoneStatusBarView.java      |  2 +-
+ .../phone/StatusBarWindowController.java         |  6 ++----
+ .../com/android/systemui/wm/DisplayLayout.java   |  5 +----
+ .../com/android/server/wm/DisplayPolicy.java     |  6 ++----
+ 5 files changed, 21 insertions(+), 14 deletions(-)
+
+diff --git a/core/java/android/view/ViewRootImpl.java b/core/java/android/view/ViewRootImpl.java
+index 18e9ef0e4d05..1ac55adb7857 100644
+--- a/core/java/android/view/ViewRootImpl.java
++++ b/core/java/android/view/ViewRootImpl.java
+@@ -2306,7 +2306,21 @@ public final class ViewRootImpl implements ViewParent,
+             // clearing the cutout, so we don't need to dispatch the cutout to the hierarchy.
+             insets = insets.consumeDisplayCutout();
+         }
+-        host.dispatchApplyWindowInsets(insets);
++
++        int wechatLogin = View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR | View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
++        if (("com.tencent.mm".equals(mContext.getPackageName())
++                  || "com.xueersi.parentsmeeting".equals(mContext.getPackageName()))
++                  && mWindowAttributes.type == WindowManager.LayoutParams.TYPE_BASE_APPLICATION
++                  && mWindowAttributes.subtreeSystemUiVisibility != wechatLogin) {
++             WindowInsets tmpInsets = insets.replaceSystemWindowInsets(insets.getSystemWindowInsetLeft(),
++                       66,
++                       insets.getSystemWindowInsetRight(),
++                       insets.getSystemWindowInsetBottom());
++             host.dispatchApplyWindowInsets(tmpInsets);
++        } else {
++             host.dispatchApplyWindowInsets(insets);
++        }
++
+         mAttachInfo.delayNotifyContentCaptureInsetsEvent(insets.getInsets(Type.all()));
+         Trace.traceEnd(Trace.TRACE_TAG_VIEW);
+     }
+diff --git a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarView.java b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarView.java
+index 7c41bcd09b57..22586652a503 100644
+--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarView.java
++++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarView.java
+@@ -297,7 +297,7 @@ public class PhoneStatusBarView extends PanelBar {
+         final int waterfallTopInset =
+                 mDisplayCutout == null ? 0 : mDisplayCutout.getWaterfallInsets().top;
+         ViewGroup.LayoutParams layoutParams = getLayoutParams();
+-        mStatusBarHeight = getResources().getDimensionPixelSize(R.dimen.status_bar_height);
++        mStatusBarHeight = 0;
+         layoutParams.height = mStatusBarHeight - waterfallTopInset;
+ 
+         int statusBarPaddingTop = getResources().getDimensionPixelSize(
+diff --git a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarWindowController.java b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarWindowController.java
+index d4e1aa4d3d27..06d39c424e43 100644
+--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarWindowController.java
++++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarWindowController.java
+@@ -66,8 +66,7 @@ public class StatusBarWindowController {
+         mResources = resources;
+ 
+         if (mBarHeight < 0) {
+-            mBarHeight = mResources.getDimensionPixelSize(
+-                    com.android.internal.R.dimen.status_bar_height);
++            mBarHeight = 0;
+         }
+     }
+ 
+@@ -80,8 +79,7 @@ public class StatusBarWindowController {
+      * is different.
+      */
+     public void refreshStatusBarHeight() {
+-        int heightFromConfig = mResources.getDimensionPixelSize(
+-                com.android.internal.R.dimen.status_bar_height);
++        int heightFromConfig = 0;
+ 
+         if (mBarHeight != heightFromConfig) {
+             mBarHeight = heightFromConfig;
+diff --git a/packages/SystemUI/src/com/android/systemui/wm/DisplayLayout.java b/packages/SystemUI/src/com/android/systemui/wm/DisplayLayout.java
+index a341f3050ea6..905de2fdfd39 100644
+--- a/packages/SystemUI/src/com/android/systemui/wm/DisplayLayout.java
++++ b/packages/SystemUI/src/com/android/systemui/wm/DisplayLayout.java
+@@ -344,10 +344,7 @@ public class DisplayLayout {
+ 
+     /** Retrieve the statusbar height from resources. */
+     static int getStatusBarHeight(boolean landscape, Resources res) {
+-        return landscape ? res.getDimensionPixelSize(
+-                    com.android.internal.R.dimen.status_bar_height_landscape)
+-                    : res.getDimensionPixelSize(
+-                            com.android.internal.R.dimen.status_bar_height_portrait);
++        return 0;
+     }
+ 
+     /** Calculate the DisplayCutout for a particular display size/rotation. */
+diff --git a/services/core/java/com/android/server/wm/DisplayPolicy.java b/services/core/java/com/android/server/wm/DisplayPolicy.java
+index 29881cc761b2..af8b24173661 100644
+--- a/services/core/java/com/android/server/wm/DisplayPolicy.java
++++ b/services/core/java/com/android/server/wm/DisplayPolicy.java
+@@ -3033,11 +3033,9 @@ public class DisplayPolicy {
+ 
+         if (hasStatusBar()) {
+             mStatusBarHeightForRotation[portraitRotation] =
+-                    mStatusBarHeightForRotation[upsideDownRotation] =
+-                            res.getDimensionPixelSize(R.dimen.status_bar_height_portrait);
++                    mStatusBarHeightForRotation[upsideDownRotation] = 0;
+             mStatusBarHeightForRotation[landscapeRotation] =
+-                    mStatusBarHeightForRotation[seascapeRotation] =
+-                            res.getDimensionPixelSize(R.dimen.status_bar_height_landscape);
++                    mStatusBarHeightForRotation[seascapeRotation] = 0;
+         } else {
+             mStatusBarHeightForRotation[portraitRotation] =
+                     mStatusBarHeightForRotation[upsideDownRotation] =
+-- 
+2.25.1
+


### PR DESCRIPTION
1. Some app's UI display abnormally in the secondary display windows, seems 
    some activity layouts of the apps have dependency on the status bar. Reset
    the windowinsets of the secondary displays to incorporate the height of status bar.
2. Set the status bar's height to 0.

Tracked-On: OAM-100827
Tracked-On: OAM-100860
Tracked-On: OAM-101404
Signed-off-by: ji, zhenlong z <zhenlong.z.ji@intel.com>