### PR TITLE
Shouldn't call AddFB2 in HWC for every commit

### DIFF
--- a/aosp_diff/preliminary/external/drm_hwcomposer/0011-Shouldn-t-call-AddFB2-in-HWC-for-every-commit.patch
+++ b/aosp_diff/preliminary/external/drm_hwcomposer/0011-Shouldn-t-call-AddFB2-in-HWC-for-every-commit.patch
@@ -1,0 +1,58 @@
+From 4dfefbd9b486e8382a4cb3525b12bf2efd1f883a Mon Sep 17 00:00:00 2001
+From: "Li, HaihongX" <haihongx.li@intel.com>
+Date: Thu, 14 Apr 2022 18:16:16 +0800
+Subject: [PATCH] Shouldn't call AddFB2 in HWC for every commit
+
+Cache framebuffer object into drm_fb_id_handle_cache_
+(std::map<GemHandle, std::weak_ptr<DrmFbIdHandle>>),can find
+framebuffer from cache at next time. Unfortunately framebuffer
+will be closed after composition, in order to make framebuffer
+long-time valid, so change weak_ptr to shared_ptr.
+
+Tracked-On: OAM-101868
+Signed-off-by: Li, HaihongX <haihongx.li@intel.com>
+---
+ drm/DrmFbImporter.cpp | 2 +-
+ drm/DrmFbImporter.h   | 8 ++------
+ 2 files changed, 3 insertions(+), 7 deletions(-)
+
+diff --git a/drm/DrmFbImporter.cpp b/drm/DrmFbImporter.cpp
+index cbe0c9f..80c9994 100644
+--- a/drm/DrmFbImporter.cpp
++++ b/drm/DrmFbImporter.cpp
+@@ -138,7 +138,7 @@ auto DrmFbImporter::GetOrCreateFbId(hwc_drm_bo_t *bo)
+   auto drm_fb_id_cached = drm_fb_id_handle_cache_.find(first_handle);
+ 
+   if (drm_fb_id_cached != drm_fb_id_handle_cache_.end()) {
+-    if (auto drm_fb_id_handle_shared = drm_fb_id_cached->second.lock()) {
++    if (auto drm_fb_id_handle_shared = drm_fb_id_cached->second) {
+       return drm_fb_id_handle_shared;
+     }
+     drm_fb_id_handle_cache_.erase(drm_fb_id_cached);
+diff --git a/drm/DrmFbImporter.h b/drm/DrmFbImporter.h
+index 167aa60..6d4910a 100644
+--- a/drm/DrmFbImporter.h
++++ b/drm/DrmFbImporter.h
+@@ -76,17 +76,13 @@ class DrmFbImporter {
+   void CleanupEmptyCacheElements() {
+     for (auto it = drm_fb_id_handle_cache_.begin();
+          it != drm_fb_id_handle_cache_.end();) {
+-      if (it->second.expired()) {
+-        it = drm_fb_id_handle_cache_.erase(it);
+-      } else {
+-        ++it;
+-      }
++      it = drm_fb_id_handle_cache_.erase(it);
+     }
+   }
+ 
+   const std::shared_ptr<DrmDevice> drm_;
+ 
+-  std::map<GemHandle, std::weak_ptr<DrmFbIdHandle>> drm_fb_id_handle_cache_;
++  std::map<GemHandle, std::shared_ptr<DrmFbIdHandle>> drm_fb_id_handle_cache_;
+ };
+ 
+ }  // namespace android
+-- 
+2.33.1
+


### PR DESCRIPTION
Cache framebuffer object into drm_fb_id_handle_cache_
(std::map<GemHandle, std::weak_ptr<DrmFbIdHandle>>),can find
framebuffer from cache at next time. Unfortunately framebuffer
will be closed after composition, in order to make framebuffer
long-time valid, so change weak_ptr to shared_ptr.

Tracked-On: OAM-101868
Signed-off-by: Li, HaihongX <haihongx.li@intel.com>