### PR TITLE
ISH driver Support for AlderLake

### DIFF
--- a/host/kernel/lts2020-chromium/0009-ISH-driver-Support-for-AlderLake.patch
+++ b/host/kernel/lts2020-chromium/0009-ISH-driver-Support-for-AlderLake.patch
@@ -1,0 +1,45 @@
+From c8e110ce36c9bdfa7a7454a4d1adda94b1253bb1 Mon Sep 17 00:00:00 2001
+From: Vilas R K <vilas.r.k@intel.com>
+Date: Fri, 29 Apr 2022 12:17:58 +0530
+Subject: [PATCH] ISH driver Support for AlderLake
+
+Added Alderlake configurations to create
+IIO entry in sys/bus
+
+Signed-off-by: Vilas R K <vilas.r.k@intel.com>
+---
+ drivers/hid/intel-ish-hid/ipc/hw-ish.h  | 3 +++
+ drivers/hid/intel-ish-hid/ipc/pci-ish.c | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/drivers/hid/intel-ish-hid/ipc/hw-ish.h b/drivers/hid/intel-ish-hid/ipc/hw-ish.h
+index 1fb294ca463e..31124bcd1901 100644
+--- a/drivers/hid/intel-ish-hid/ipc/hw-ish.h
++++ b/drivers/hid/intel-ish-hid/ipc/hw-ish.h
+@@ -27,6 +27,9 @@
+ #define CMP_H_DEVICE_ID		0x06FC
+ #define EHL_Ax_DEVICE_ID	0x4BB3
+ #define TGL_LP_DEVICE_ID	0xA0FC
++#define TGL_H_DEVICE_ID		0x43FC
++#define ADL_S_DEVICE_ID		0x7AF8
++#define ADL_P_DEVICE_ID		0x51FC
+ 
+ #define	REVISION_ID_CHT_A0	0x6
+ #define	REVISION_ID_CHT_Ax_SI	0x0
+diff --git a/drivers/hid/intel-ish-hid/ipc/pci-ish.c b/drivers/hid/intel-ish-hid/ipc/pci-ish.c
+index c6d48a8648b7..fecbcca13b94 100644
+--- a/drivers/hid/intel-ish-hid/ipc/pci-ish.c
++++ b/drivers/hid/intel-ish-hid/ipc/pci-ish.c
+@@ -37,6 +37,9 @@ static const struct pci_device_id ish_pci_tbl[] = {
+ 	{PCI_DEVICE(PCI_VENDOR_ID_INTEL, CMP_H_DEVICE_ID)},
+ 	{PCI_DEVICE(PCI_VENDOR_ID_INTEL, EHL_Ax_DEVICE_ID)},
+ 	{PCI_DEVICE(PCI_VENDOR_ID_INTEL, TGL_LP_DEVICE_ID)},
++	{PCI_DEVICE(PCI_VENDOR_ID_INTEL, TGL_H_DEVICE_ID)},
++	{PCI_DEVICE(PCI_VENDOR_ID_INTEL, ADL_S_DEVICE_ID)},
++	{PCI_DEVICE(PCI_VENDOR_ID_INTEL, ADL_P_DEVICE_ID)},
+ 	{0, }
+ };
+ MODULE_DEVICE_TABLE(pci, ish_pci_tbl);
+-- 
+2.17.1
+


### PR DESCRIPTION
Added Alderlake configurations to create
IIO entry in sys/bus which will be used
by Sensor devices

Tracked-On: OAM-102023
Signed-off-by: Vilas R K <vilas.r.k@intel.com>