### PR TITLE
[DO-NOT-MERGE] drm/i915: program wm blocks to at least blocks required per line

### DIFF
--- a/bsp_diff/common/kernel/lts2020-yocto/21_0021-drm-i915-dp-HACK-remove-TPS4-to-avoid-LT-failure-iss.patch
+++ b/bsp_diff/common/kernel/lts2020-yocto/21_0021-drm-i915-dp-HACK-remove-TPS4-to-avoid-LT-failure-iss.patch
@@ -1,0 +1,27 @@
+From ea615eb91db0eed6a2e5412e28137736ce885329 Mon Sep 17 00:00:00 2001
+From: Ankit Nautiyal <ankit.k.nautiyal@intel.com>
+Date: Thu, 10 Feb 2022 09:42:06 +0530
+Subject: [PATCH 1/5] drm/i915/dp: HACK: remove TPS4 to avoid LT failure issues
+
+Signed-off-by: Ankit Nautiyal <ankit.k.nautiyal@intel.com>
+---
+ drivers/gpu/drm/i915/display/intel_dp.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/i915/display/intel_dp.c b/drivers/gpu/drm/i915/display/intel_dp.c
+index be883469d2fcc..eea08c626822a 100644
+--- a/drivers/gpu/drm/i915/display/intel_dp.c
++++ b/drivers/gpu/drm/i915/display/intel_dp.c
+@@ -957,7 +957,8 @@ bool intel_dp_source_supports_tps3(struct drm_i915_private *i915)
+ 
+ bool intel_dp_source_supports_tps4(struct drm_i915_private *i915)
+ {
+-	return DISPLAY_VER(i915) >= 10;
++	/* Skipping TPS4 to avoid Link training failure issue */
++	return false;
+ }
+ 
+ static void snprintf_int_array(char *str, size_t len,
+-- 
+2.31.0
+

--- a/bsp_diff/common/kernel/lts2020-yocto/22_0022-drm-i915-Split-intel_update_crtc-into-two-parts.patch
+++ b/bsp_diff/common/kernel/lts2020-yocto/22_0022-drm-i915-Split-intel_update_crtc-into-two-parts.patch
@@ -1,0 +1,104 @@
+From 41d344cac42057e9f5603bdf583c7d32b598f5a7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ville=20Syrj=C3=A4l=C3=A4?= <ville.syrjala@linux.intel.com>
+Date: Wed, 9 Mar 2022 17:09:05 +0200
+Subject: [PATCH 2/5] drm/i915: Split intel_update_crtc() into two parts
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Split intel_update_crtc() into two parts such that the first
+part performs all the non-vblank evasion preparatory stuff,
+and the second part just does the vblank evasion stuff.
+
+For now we just call these back to back so that there is
+no funcitonal change.
+
+Signed-off-by: Ville Syrjälä <ville.syrjala@linux.intel.com>
+
+ Conflicts:
+	drivers/gpu/drm/i915/display/intel_display.c
+ remove intel_crtc_planes_update_noarm
+---
+ drivers/gpu/drm/i915/display/intel_display.c | 24 +++++++++++++++-----
+ 1 file changed, 18 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/display/intel_display.c b/drivers/gpu/drm/i915/display/intel_display.c
+index 6653f00faea08..d9bb8f52f1f38 100644
+--- a/drivers/gpu/drm/i915/display/intel_display.c
++++ b/drivers/gpu/drm/i915/display/intel_display.c
+@@ -9393,17 +9393,16 @@ static void intel_enable_crtc(struct intel_atomic_state *state,
+ 	intel_crtc_enable_pipe_crc(crtc);
+ }
+ 
+-static void intel_update_crtc(struct intel_atomic_state *state,
+-			      struct intel_crtc *crtc)
++static void intel_pre_update_crtc(struct intel_atomic_state *state,
++				  struct intel_crtc *crtc)
+ {
+ 	struct drm_i915_private *dev_priv = to_i915(state->base.dev);
+ 	const struct intel_crtc_state *old_crtc_state =
+ 		intel_atomic_get_old_crtc_state(state, crtc);
+ 	struct intel_crtc_state *new_crtc_state =
+ 		intel_atomic_get_new_crtc_state(state, crtc);
+-	bool modeset = intel_crtc_needs_modeset(new_crtc_state);
+ 
+-	if (!modeset) {
++	if (!intel_crtc_needs_modeset(new_crtc_state)) {
+ 		if (new_crtc_state->preload_luts &&
+ 		    (new_crtc_state->uapi.color_mgmt_changed ||
+ 		     new_crtc_state->update_pipe))
+@@ -9416,6 +9415,16 @@ static void intel_update_crtc(struct intel_atomic_state *state,
+ 	}
+ 
+ 	intel_fbc_update(state, crtc);
++}
++
++static void intel_update_crtc(struct intel_atomic_state *state,
++			      struct intel_crtc *crtc)
++{
++	struct drm_i915_private *dev_priv = to_i915(state->base.dev);
++	const struct intel_crtc_state *old_crtc_state =
++		intel_atomic_get_old_crtc_state(state, crtc);
++	struct intel_crtc_state *new_crtc_state =
++		intel_atomic_get_new_crtc_state(state, crtc);
+ 
+ 	/* Perform vblank evasion around commit operation */
+ 	intel_pipe_update_start(new_crtc_state);
+@@ -9437,8 +9446,8 @@ static void intel_update_crtc(struct intel_atomic_state *state,
+ 	 * valid pipe configuration from the BIOS we need to take care
+ 	 * of enabling them on the CRTC's first fastset.
+ 	 */
+-	if (new_crtc_state->update_pipe && !modeset &&
+-	    old_crtc_state->inherited)
++	if (!intel_crtc_needs_modeset(new_crtc_state) &&
++	    new_crtc_state->update_pipe && old_crtc_state->inherited)
+ 		intel_crtc_arm_fifo_underrun(crtc, new_crtc_state);
+ }
+ 
+@@ -9547,6 +9556,7 @@ static void intel_commit_modeset_enables(struct intel_atomic_state *state)
+ 			continue;
+ 
+ 		intel_enable_crtc(state, crtc);
++		intel_pre_update_crtc(state, crtc);
+ 		intel_update_crtc(state, crtc);
+ 	}
+ }
+@@ -9599,6 +9609,7 @@ static void skl_commit_modeset_enables(struct intel_atomic_state *state)
+ 			entries[pipe] = new_crtc_state->wm.skl.ddb;
+ 			update_pipes &= ~BIT(pipe);
+ 
++			intel_pre_update_crtc(state, crtc);
+ 			intel_update_crtc(state, crtc);
+ 
+ 			/*
+@@ -9666,6 +9677,7 @@ static void skl_commit_modeset_enables(struct intel_atomic_state *state)
+ 		entries[pipe] = new_crtc_state->wm.skl.ddb;
+ 		update_pipes &= ~BIT(pipe);
+ 
++		intel_pre_update_crtc(state, crtc);
+ 		intel_update_crtc(state, crtc);
+ 	}
+ 
+-- 
+2.31.0
+

--- a/bsp_diff/common/kernel/lts2020-yocto/23_0023-drm-i915-Do-plane-etc.-updates-more-atomically-acros.patch
+++ b/bsp_diff/common/kernel/lts2020-yocto/23_0023-drm-i915-Do-plane-etc.-updates-more-atomically-acros.patch
@@ -1,0 +1,90 @@
+From 6e79130eecef361670b1159be80fcd1b04a31b23 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ville=20Syrj=C3=A4l=C3=A4?= <ville.syrjala@linux.intel.com>
+Date: Wed, 9 Mar 2022 17:13:54 +0200
+Subject: [PATCH 3/5] drm/i915: Do plane/etc. updates more atomically across
+ pipes
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Perform all the intel_pre_update_crtc() stuff for all pipes first,
+and only then do the intel_update_crtc() vblank evasion stuff for
+every pipe back to back. This should make it more likely that
+the plane updates from multiple pipes happen on the same frame
+(assuming the pipes are running in sync, eg. due to bigjoiner
+or port sync).
+
+Signed-off-by: Ville Syrjälä <ville.syrjala@linux.intel.com>
+---
+ drivers/gpu/drm/i915/display/intel_display.c | 27 ++++++++++++++++++--
+ 1 file changed, 25 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/display/intel_display.c b/drivers/gpu/drm/i915/display/intel_display.c
+index d9bb8f52f1f38..d930b2261f3ae 100644
+--- a/drivers/gpu/drm/i915/display/intel_display.c
++++ b/drivers/gpu/drm/i915/display/intel_display.c
+@@ -9557,6 +9557,12 @@ static void intel_commit_modeset_enables(struct intel_atomic_state *state)
+ 
+ 		intel_enable_crtc(state, crtc);
+ 		intel_pre_update_crtc(state, crtc);
++	}
++
++	for_each_new_intel_crtc_in_state(state, crtc, new_crtc_state, i) {
++		if (!new_crtc_state->hw.active)
++			continue;
++
+ 		intel_update_crtc(state, crtc);
+ 	}
+ }
+@@ -9594,6 +9600,16 @@ static void skl_commit_modeset_enables(struct intel_atomic_state *state)
+ 	 * So first lets enable all pipes that do not need a fullmodeset as
+ 	 * those don't have any external dependency.
+ 	 */
++	for_each_oldnew_intel_crtc_in_state(state, crtc, old_crtc_state,
++					    new_crtc_state, i) {
++		enum pipe pipe = crtc->pipe;
++
++		if ((update_pipes & BIT(pipe)) == 0)
++			continue;
++
++		intel_pre_update_crtc(state, crtc);
++	}
++
+ 	while (update_pipes) {
+ 		for_each_oldnew_intel_crtc_in_state(state, crtc, old_crtc_state,
+ 						    new_crtc_state, i) {
+@@ -9609,7 +9625,6 @@ static void skl_commit_modeset_enables(struct intel_atomic_state *state)
+ 			entries[pipe] = new_crtc_state->wm.skl.ddb;
+ 			update_pipes &= ~BIT(pipe);
+ 
+-			intel_pre_update_crtc(state, crtc);
+ 			intel_update_crtc(state, crtc);
+ 
+ 			/*
+@@ -9665,6 +9680,15 @@ static void skl_commit_modeset_enables(struct intel_atomic_state *state)
+ 	/*
+ 	 * Finally we do the plane updates/etc. for all pipes that got enabled.
+ 	 */
++	for_each_new_intel_crtc_in_state(state, crtc, new_crtc_state, i) {
++		enum pipe pipe = crtc->pipe;
++
++		if ((update_pipes & BIT(pipe)) == 0)
++			continue;
++
++		intel_pre_update_crtc(state, crtc);
++	}
++
+ 	for_each_new_intel_crtc_in_state(state, crtc, new_crtc_state, i) {
+ 		enum pipe pipe = crtc->pipe;
+ 
+@@ -9677,7 +9701,6 @@ static void skl_commit_modeset_enables(struct intel_atomic_state *state)
+ 		entries[pipe] = new_crtc_state->wm.skl.ddb;
+ 		update_pipes &= ~BIT(pipe);
+ 
+-		intel_pre_update_crtc(state, crtc);
+ 		intel_update_crtc(state, crtc);
+ 	}
+ 
+-- 
+2.31.0
+

--- a/bsp_diff/common/kernel/lts2020-yocto/24_0024-drm-i915-Allow-a-way-to-disable-watermark-for-debugi.patch
+++ b/bsp_diff/common/kernel/lts2020-yocto/24_0024-drm-i915-Allow-a-way-to-disable-watermark-for-debugi.patch
@@ -1,0 +1,111 @@
+From ed547ed381d53544171a0b613d0dd7d421c123b0 Mon Sep 17 00:00:00 2001
+From: kanlihu <kanli.hu@intel.com>
+Date: Wed, 11 May 2022 23:52:16 +0800
+Subject: [PATCH 4/5] drm/i915: Allow a way to disable watermark for debuging
+ purposes.
+
+Without watermark the power consumption will blow up, but
+when enabling platforms and dealing with different kinds of
+crashes, screen corruptions, pipe underuns, etc we need to be
+able to easily disable watermark to see if we are on the right
+investigation track.
+
+Another possibility was to skip at the beginning and avoid all
+calculations, but I'm not sure about it. Maybe it might be still
+useful to know the calculated values when debuging.
+
+v2
+---
+ .../drm/i915/display/intel_display_debugfs.c  | 19 +++++++++++++++++++
+ drivers/gpu/drm/i915/i915_params.c            |  2 ++
+ drivers/gpu/drm/i915/i915_params.h            |  1 +
+ drivers/gpu/drm/i915/intel_pm.c               |  4 ++--
+ 4 files changed, 24 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/display/intel_display_debugfs.c b/drivers/gpu/drm/i915/display/intel_display_debugfs.c
+index e04767695530d..66c6249b6798b 100644
+--- a/drivers/gpu/drm/i915/display/intel_display_debugfs.c
++++ b/drivers/gpu/drm/i915/display/intel_display_debugfs.c
+@@ -144,6 +144,24 @@ static int i915_ips_status(struct seq_file *m, void *unused)
+ 	return 0;
+ }
+ 
++static int i915_enable_watermark(struct seq_file *m, void *unused)
++{
++	struct drm_i915_private *dev_priv = node_to_i915(m->private);
++	intel_wakeref_t wakeref;
++
++	if (!HAS_IPS(dev_priv))
++		return -ENODEV;
++
++	wakeref = intel_runtime_pm_get(&dev_priv->runtime_pm);
++
++	seq_printf(m, "Enabled by kernel parameter: %s\n",
++		   yesno(dev_priv->params.enable_watermark));
++
++	intel_runtime_pm_put(&dev_priv->runtime_pm, wakeref);
++
++	return 0;
++}
++
+ static int i915_sr_status(struct seq_file *m, void *unused)
+ {
+ 	struct drm_i915_private *dev_priv = node_to_i915(m->private);
+@@ -2113,6 +2131,7 @@ static const struct drm_info_list intel_display_debugfs_list[] = {
+ 	{"i915_frontbuffer_tracking", i915_frontbuffer_tracking, 0},
+ 	{"i915_fbc_status", i915_fbc_status, 0},
+ 	{"i915_ips_status", i915_ips_status, 0},
++	{"i915_enable_watermark", i915_enable_watermark, 0},
+ 	{"i915_sr_status", i915_sr_status, 0},
+ 	{"i915_opregion", i915_opregion, 0},
+ 	{"i915_vbt", i915_vbt, 0},
+diff --git a/drivers/gpu/drm/i915/i915_params.c b/drivers/gpu/drm/i915/i915_params.c
+index 8ceb454947d61..1fe92b392aa83 100644
+--- a/drivers/gpu/drm/i915/i915_params.c
++++ b/drivers/gpu/drm/i915/i915_params.c
+@@ -120,6 +120,8 @@ i915_param_named_unsafe(disable_power_well, int, 0400,
+ 
+ i915_param_named_unsafe(enable_ips, int, 0400, "Enable IPS (default: true)");
+ 
++i915_param_named_unsafe(enable_watermark, int, 0600, "Enable Watermark (default: true)");
++
+ i915_param_named(fastboot, int, 0400,
+ 	"Try to skip unnecessary mode sets at boot time "
+ 	"(0=disabled, 1=enabled) "
+diff --git a/drivers/gpu/drm/i915/i915_params.h b/drivers/gpu/drm/i915/i915_params.h
+index af6cbd3155ebb..56d38098e3e63 100644
+--- a/drivers/gpu/drm/i915/i915_params.h
++++ b/drivers/gpu/drm/i915/i915_params.h
+@@ -59,6 +59,7 @@ struct drm_printer;
+ 	param(bool, enable_psr2_sel_fetch, true, 0400) \
+ 	param(int, disable_power_well, -1, 0400) \
+ 	param(int, enable_ips, 1, 0600) \
++	param(int, enable_watermark, 1, 0600) \
+ 	param(int, invert_brightness, 0, 0600) \
+ 	param(int, enable_guc, -1, 0400) \
+ 	param(unsigned int, guc_feature_flags, 0, 0400) \
+diff --git a/drivers/gpu/drm/i915/intel_pm.c b/drivers/gpu/drm/i915/intel_pm.c
+index ebc006ed90c02..71ddb54e40daf 100644
+--- a/drivers/gpu/drm/i915/intel_pm.c
++++ b/drivers/gpu/drm/i915/intel_pm.c
+@@ -3427,7 +3427,7 @@ static void ilk_compute_wm_results(struct drm_i915_private *dev_priv,
+ 			(r->pri_val << WM1_LP_SR_SHIFT) |
+ 			r->cur_val;
+ 
+-		if (r->enable)
++		if (r->enable && dev_priv->params.enable_watermark)
+ 			results->wm_lp[wm_lp - 1] |= WM1_LP_SR_EN;
+ 
+ 		if (DISPLAY_VER(dev_priv) >= 8)
+@@ -5884,7 +5884,7 @@ static void skl_write_wm_level(struct drm_i915_private *dev_priv,
+ {
+ 	u32 val = 0;
+ 
+-	if (level->enable)
++	if (level->enable && dev_priv->params.enable_watermark)
+ 		val |= PLANE_WM_EN;
+ 	if (level->ignore_lines)
+ 		val |= PLANE_WM_IGNORE_LINES;
+-- 
+2.31.0
+

--- a/bsp_diff/common/kernel/lts2020-yocto/25_0025-drm-i915-program-wm-blocks-to-at-least-blocks-requir.patch
+++ b/bsp_diff/common/kernel/lts2020-yocto/25_0025-drm-i915-program-wm-blocks-to-at-least-blocks-requir.patch
@@ -1,0 +1,67 @@
+From 7625d8ae25503307aa9b9518fa3c7128aa436204 Mon Sep 17 00:00:00 2001
+From: Vinod Govindapillai <vinod.govindapillai@intel.com>
+Date: Sun, 17 Apr 2022 12:31:05 +0300
+Subject: [PATCH 5/5] drm/i915: program wm blocks to at least blocks required
+ per line
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In configurations with single DRAM channel, for usecases like
+4K 60 Hz, FIFO underruns are observed quite frequently. Looks
+like the wm0 watermark values need to bumped up because the wm0
+memory latency calculations are probably not taking the DRAM
+channel's impact into account.
+
+As per the Bspec 49325, if the ddb allocation can hold at least
+one plane_blocks_per_line we should have selected method2.
+Assuming that modern HW versions have enough dbuf to hold
+at least one line, set the wm blocks to equivalent to blocks
+per line.
+
+v2: styling and comments changes (Ville)
+v3: Updated the reviewed-by tag
+v4: max_t to max and patch styling (Ville)
+
+References: https://gitlab.freedesktop.org/drm/intel/-/issues/4321
+Cc: Ville Syrjälä <ville.syrjala@linux.intel.com>
+Cc: Stanislav Lisovskiy <stanislav.lisovskiy@intel.com>
+Signed-off-by: Vinod Govindapillai <vinod.govindapillai@intel.com>
+Reviewed-by: Stanislav Lisovskiy <stanislav.lisovskiy@intel.com>
+---
+ drivers/gpu/drm/i915/intel_pm.c | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/drivers/gpu/drm/i915/intel_pm.c b/drivers/gpu/drm/i915/intel_pm.c
+index 71ddb54e40daf..2e68bd6eaa954 100644
+--- a/drivers/gpu/drm/i915/intel_pm.c
++++ b/drivers/gpu/drm/i915/intel_pm.c
+@@ -5545,6 +5545,25 @@ static void skl_compute_plane_wm(const struct intel_crtc_state *crtc_state,
+ 	}
+ 
+ 	blocks = fixed16_to_u32_round_up(selected_result) + 1;
++	/*
++	 * Lets have blocks at minimum equivalent to plane_blocks_per_line
++	 * as there will be at minimum one line for lines configuration. This
++	 * is a work around for FIFO underruns observed with resolutions like
++	 * 4k 60 Hz in single channel DRAM configurations.
++	 *
++	 * As per the Bspec 49325, if the ddb allocation can hold at least
++	 * one plane_blocks_per_line, we should have selected method2 in
++	 * the above logic. Assuming that modern versions have enough dbuf
++	 * and method2 guarantees blocks equivalent to at least 1 line,
++	 * select the blocks as plane_blocks_per_line.
++	 *
++	 * TODO: Revisit the logic when we have better understanding on DRAM
++	 * channels' impact on the level 0 memory latency and the relevant
++	 * wm calculations.
++	 */
++	if (skl_wm_has_lines(dev_priv, level))
++		blocks = max(blocks,
++			     fixed16_to_u32_round_up(wp->plane_blocks_per_line));
+ 	lines = div_round_up_fixed16(selected_result,
+ 				     wp->plane_blocks_per_line);
+ 
+-- 
+2.31.0
+


### PR DESCRIPTION
21_0021-drm-i915-dp-HACK-remove-TPS4-to-avoid-LT-failure-iss.patch
FOR 8K@60 mode

22_0022-drm-i915-Split-intel_update_crtc-into-two-parts.patch
23_0023-drm-i915-Do-plane-etc.-updates-more-atomically-acros.patch
Split intel_update_crtc() into two parts

24_0024-drm-i915-Allow-a-way-to-disable-watermark-for-debugi.patch
disable watermark

25_0025-drm-i915-program-wm-blocks-to-at-least-blocks-requir.patch
drm/i915: program wm blocks to at least blocks required per line

In configurations with single DRAM channel, for usecases like
4K 60 Hz, FIFO underruns are observed quite frequently. Looks
like the wm0 watermark values need to bumped up because the wm0
memory latency calculations are probably not taking the DRAM
channel's impact into account.

As per the Bspec 49325, if the ddb allocation can hold at least
one plane_blocks_per_line we should have selected method2.
Assuming that modern HW versions have enough dbuf to hold
at least one line, set the wm blocks to equivalent to blocks
per line.

v2: styling and comments changes (Ville)
v3: Updated the reviewed-by tag
v4: max_t to max and patch styling (Ville)

References: https://gitlab.freedesktop.org/drm/intel/-/issues/4321
Cc: Ville Syrjälä <ville.syrjala@linux.intel.com>
Cc: Stanislav Lisovskiy <stanislav.lisovskiy@intel.com>
Signed-off-by: Vinod Govindapillai <vinod.govindapillai@intel.com>
Reviewed-by: Stanislav Lisovskiy <stanislav.lisovskiy@intel.com>