### PR TITLE
Switch to use dirty fb for plane update

### DIFF
--- a/aosp_diff/preliminary/external/drm_hwcomposer/0013-Switch-to-use-dirty-fb-for-plane-update.patch
+++ b/aosp_diff/preliminary/external/drm_hwcomposer/0013-Switch-to-use-dirty-fb-for-plane-update.patch
@@ -1,0 +1,51 @@
+From 240e659af7471caca08ae469984b7be98bf2fedc Mon Sep 17 00:00:00 2001
+From: "Li, HaihongX" <haihongx.li@intel.com>
+Date: Thu, 26 May 2022 16:01:02 +0800
+Subject: [PATCH] Switch to use dirty fb for plane update
+
+Switch to call function drmModeDirtyFB in
+DrmDisplayCompositor::CommitFrame.
+
+Tracked-On: OAM-102301
+Signed-off-by: Li, HaihongX <haihongx.li@intel.com>
+---
+ compositor/DrmDisplayCompositor.cpp | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/compositor/DrmDisplayCompositor.cpp b/compositor/DrmDisplayCompositor.cpp
+index f741b6f..d998061 100644
+--- a/compositor/DrmDisplayCompositor.cpp
++++ b/compositor/DrmDisplayCompositor.cpp
+@@ -221,6 +221,29 @@ int DrmDisplayCompositor::CommitFrame(DrmDisplayComposition *display_comp,
+     ALOGE("Could not locate crtc for display %d", display_);
+     return -ENODEV;
+   }
++  if (!mode_.needs_modeset) {
++    if (test_only)
++      return 0;
++    for (DrmCompositionPlane &comp_plane : comp_planes) {
++      std::vector<size_t> &source_layers = comp_plane.source_layers();
++      if (comp_plane.type() == DrmCompositionPlane::Type::kDisable)
++        continue;
++      DrmHwcLayer &layer = layers[source_layers.front()];
++      if (!layer.FbIdHandle) {
++        ALOGE("Expected a valid framebuffer for pset");
++        return -1;
++      }
++      hwc_rect_t display_frame;
++      display_frame = layer.display_frame;
++      drmModeClip clip;
++      clip.x1 = display_frame.left;
++      clip.y1 = display_frame.top;
++      clip.x2 = display_frame.right - display_frame.left;
++      clip.y2 = display_frame.bottom - display_frame.top;
++      drmModeDirtyFB(drm->fd(), layer.FbIdHandle->GetFbId(), &clip, 1);
++    }
++    return 0;
++  }
+ 
+   drmModeAtomicReqPtr pset = drmModeAtomicAlloc();
+   if (!pset) {
+-- 
+2.36.1
+


### PR DESCRIPTION
Switch to call function drmModeDirtyFB in
DrmDisplayCompositor::CommitFrame.

Tracked-On: OAM-102301
Signed-off-by: Li, HaihongX <haihongx.li@intel.com>