### PR TITLE
Enable vendor specific initrc for RPMB Mock but not AOSP initrc

### DIFF
--- a/aosp_diff/preliminary/system/core/03-Enable-vendor-specific-initrc-for-RPMB-Mock-but-not-.patch
+++ b/aosp_diff/preliminary/system/core/03-Enable-vendor-specific-initrc-for-RPMB-Mock-but-not-.patch
@@ -1,0 +1,26 @@
+From 100cbaede3806e251b47d1362d179229d4f787da Mon Sep 17 00:00:00 2001
+From: Yang Huang <yang.huang@intel.com>
+Date: Thu, 9 Jun 2022 03:05:30 +0800
+Subject: [PATCH] Enable vendor specific initrc for RPMB Mock but not AOSP init
+ rc
+
+Signed-off-by: Yang Huang <yang.huang@intel.com>
+---
+ trusty/utils/rpmb_dev/Android.bp | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/trusty/utils/rpmb_dev/Android.bp b/trusty/utils/rpmb_dev/Android.bp
+index c5853efcb..61a82b45b 100644
+--- a/trusty/utils/rpmb_dev/Android.bp
++++ b/trusty/utils/rpmb_dev/Android.bp
+@@ -37,7 +37,4 @@ cc_binary {
+         "-Wall",
+         "-Werror",
+     ],
+-    init_rc: [
+-        "rpmb_dev.rc",
+-    ],
+ }
+-- 
+2.25.1
+


### PR DESCRIPTION
Signed-off-by: Yang Huang <yang.huang@intel.com>