### PR TITLE
drm/i915: enable 8K60

### DIFF
--- a/bsp_diff/common/kernel/lts2020-yocto/25_0025-drm-i915-dp-HACK-remove-TPS4-to-avoid-LT-failure-iss.patch
+++ b/bsp_diff/common/kernel/lts2020-yocto/25_0025-drm-i915-dp-HACK-remove-TPS4-to-avoid-LT-failure-iss.patch
@@ -1,0 +1,27 @@
+From dbc1d9f454537a4c4e344ef87aad25ac90452421 Mon Sep 17 00:00:00 2001
+From: Ankit Nautiyal <ankit.k.nautiyal@intel.com>
+Date: Thu, 10 Feb 2022 09:42:06 +0530
+Subject: [PATCH 8/8] drm/i915/dp: HACK: remove TPS4 to avoid LT failure issues
+
+Signed-off-by: Ankit Nautiyal <ankit.k.nautiyal@intel.com>
+---
+ drivers/gpu/drm/i915/display/intel_dp.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/i915/display/intel_dp.c b/drivers/gpu/drm/i915/display/intel_dp.c
+index be883469d2fc..eea08c626822 100644
+--- a/drivers/gpu/drm/i915/display/intel_dp.c
++++ b/drivers/gpu/drm/i915/display/intel_dp.c
+@@ -957,7 +957,8 @@ bool intel_dp_source_supports_tps3(struct drm_i915_private *i915)
+ 
+ bool intel_dp_source_supports_tps4(struct drm_i915_private *i915)
+ {
+-	return DISPLAY_VER(i915) >= 10;
++	/* Skipping TPS4 to avoid Link training failure issue */
++	return false;
+ }
+ 
+ static void snprintf_int_array(char *str, size_t len,
+-- 
+2.31.0
+

--- a/bsp_diff/common/kernel/lts2020-yocto/26-0026-drm-i915-gem-Don-t-evict-unmappable-VMAs-when-pinning-with-PIN_MAPPABLE-v2.patch
+++ b/bsp_diff/common/kernel/lts2020-yocto/26-0026-drm-i915-gem-Don-t-evict-unmappable-VMAs-when-pinning-with-PIN_MAPPABLE-v2.patch
@@ -1,0 +1,95 @@
+From patchwork Mon Mar 21 00:54:31 2022
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Subject: [v2] drm/i915/gem: Don't evict unmappable VMAs when pinning with
+ PIN_MAPPABLE (v2)
+From: Vivek Kasireddy <vivek.kasireddy@intel.com>
+X-Patchwork-Id: 478902
+Message-Id: <20220321005431.1113890-1-vivek.kasireddy@intel.com>
+To: intel-gfx@lists.freedesktop.org
+Date: Sun, 20 Mar 2022 17:54:31 -0700
+
+On platforms capable of allowing 8K (7680 x 4320) modes, pinning 2 or
+more framebuffers/scanout buffers results in only one that is mappable/
+fenceable. Therefore, pageflipping between these 2 FBs where only one
+is mappable/fenceable creates latencies large enough to miss alternate
+vblanks thereby producing less optimal framerate.
+
+This mainly happens because when i915_gem_object_pin_to_display_plane()
+is called to pin one of the FB objs, the associated vma is identified
+as misplaced -- because there is no space for it in the aperture --
+and therefore i915_vma_unbind() is called which unbinds and evicts it.
+This misplaced vma gets subseqently pinned only when
+i915_gem_object_ggtt_pin_ww() is called without PIN_MAPPABLE. This whole
+thing results in a latency of ~10ms and happens every other repaint cycle.
+Therefore, to fix this issue, we just ensure that the misplaced VMA
+does not get evicted when we try to pin it with PIN_MAPPABLE -- by
+returning early if the mappable/fenceable flag is not set.
+
+Testcase:
+Running Weston and weston-simple-egl on an Alderlake_S (ADLS) platform
+with a 8K@60 mode results in only ~40 FPS (compared to ~59 FPS with
+this patch). Since upstream Weston submits a frame ~7ms before the
+next vblank, the latencies seen between atomic commit and flip event
+are 7, 24 (7 + 16.66), 7, 24..... suggesting that it misses the
+vblank every other frame.
+
+Here is the ftrace snippet that shows the source of the ~10ms latency:
+              i915_gem_object_pin_to_display_plane() {
+0.102 us   |    i915_gem_object_set_cache_level();
+                i915_gem_object_ggtt_pin_ww() {
+0.390 us   |      i915_vma_instance();
+0.178 us   |      i915_vma_misplaced();
+                  i915_vma_unbind() {
+                  __i915_active_wait() {
+0.082 us   |        i915_active_acquire_if_busy();
+0.475 us   |      }
+                  intel_runtime_pm_get() {
+0.087 us   |        intel_runtime_pm_acquire();
+0.259 us   |      }
+                  __i915_active_wait() {
+0.085 us   |        i915_active_acquire_if_busy();
+0.240 us   |      }
+                  __i915_vma_evict() {
+                    ggtt_unbind_vma() {
+                      gen8_ggtt_clear_range() {
+10507.255 us |        }
+10507.689 us |      }
+10508.516 us |   }
+
+v2:
+- Expand the code comments to describe the ping-pong issue.
+
+Cc: Tvrtko Ursulin <tvrtko.ursulin@linux.intel.com>
+Reviewed-by: Tvrtko Ursulin <tvrtko.ursulin@intel.com>
+Signed-off-by: Vivek Kasireddy <vivek.kasireddy@intel.com>
+---
+ drivers/gpu/drm/i915/i915_gem.c | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/i915/i915_gem.c b/drivers/gpu/drm/i915/i915_gem.c
+index 9747924cc57b..44741f842852 100644
+--- a/drivers/gpu/drm/i915/i915_gem.c
++++ b/drivers/gpu/drm/i915/i915_gem.c
+@@ -939,8 +939,19 @@ i915_gem_object_ggtt_pin_ww(struct drm_i915_gem_object *obj,
+ 			if (i915_vma_is_pinned(vma) || i915_vma_is_active(vma))
+ 				return ERR_PTR(-ENOSPC);
+ 
++			/*
++			 * If this misplaced vma is too big (i.e, at-least
++			 * half the size of aperture) or hasn't been pinned
++			 * mappable before, we ignore the misplacement when
++			 * PIN_NONBLOCK is set in order to avoid the ping-pong
++			 * issue described above. In other words, we try to
++			 * avoid the costly operation of unbinding this vma
++			 * from the GGTT and rebinding it back because there
++			 * may not be enough space for this vma in the aperture.
++			 */
+ 			if (flags & PIN_MAPPABLE &&
+-			    vma->fence_size > ggtt->mappable_end / 2)
++			    (vma->fence_size > ggtt->mappable_end / 2 ||
++			    !i915_vma_is_map_and_fenceable(vma)))
+ 				return ERR_PTR(-ENOSPC);
+ 		}
+ 


### PR DESCRIPTION
This commit can enable 8K 60FPS mode and solve screen flickering problem

Tracked-On: OAM-102536
Signed-off-by: Kanli Hu <kanli.hu@intel.com>