### PR TITLE
Add dumpBuffer feature in drm-hwc

### DIFF
--- a/aosp_diff/preliminary/external/drm_hwcomposer/0005-Add-dumpBuffer-feature-in-drm-hwc.patch
+++ b/aosp_diff/preliminary/external/drm_hwcomposer/0005-Add-dumpBuffer-feature-in-drm-hwc.patch
@@ -1,0 +1,236 @@
+From ef92dcad8ccb87d3f3e45eba327534c247d255a7 Mon Sep 17 00:00:00 2001
+From: "wei, wushuangx" <wushuangx.wei@intel.com>
+Date: Tue, 5 Jul 2022 21:33:20 +0800
+Subject: [PATCH] Add dumpBuffer feature in drm-hwc
+
+Enable dumpBuffer for debug purpose. when necessary, DumpBuffer() function is called to execute.
+After "setenforce 0" and "setprop drm.dumpbuffer.on(or "drm.dumpvideo.on") 1" is executed in the adb shell,
+dumpfiles will be generated in the /data/local/tarce directory
+
+Tracked-On: OAM-102488
+Signed-off-by: wei, wushuangx <wushuangx.wei@intel.com>
+---
+ DrmHwcTwo.cpp                           | 11 +++
+ bufferinfo/legacy/BufferInfoMinigbm.cpp | 94 ++++++++++++++++++++++++-
+ bufferinfo/legacy/BufferInfoMinigbm.h   | 32 +++++++++
+ utils/hwcutils.cpp                      |  9 +++
+ 4 files changed, 145 insertions(+), 1 deletion(-)
+
+diff --git a/DrmHwcTwo.cpp b/DrmHwcTwo.cpp
+index 194b11e..13243da 100644
+--- a/DrmHwcTwo.cpp
++++ b/DrmHwcTwo.cpp
+@@ -35,6 +35,7 @@
+ #include "compositor/DrmDisplayComposition.h"
+ #include "utils/log.h"
+ #include "utils/properties.h"
++#include "bufferinfo/legacy/BufferInfoMinigbm.h"
+ 
+ namespace android {
+ 
+@@ -1083,6 +1084,16 @@ HWC2::Error DrmHwcTwo::HwcLayer::SetLayerBuffer(buffer_handle_t buffer,
+   supported(__func__);
+ 
+   set_buffer(buffer);
++  char status[PROPERTY_VALUE_MAX];
++  if (property_get("drm.dumpvideo.on", status, NULL) > 0) {
++    if (status != "0") {
++      hwc_drm_bo bo{};
++      BufferInfoGetter::GetInstance()->ConvertBoInfo(buffer, &bo);
++      if (bo.format == DRM_BO_FORMAT_YUV) {
++        BufferInfoMinigbm::DumpBuffer(buffer, bo);
++      }
++    }
++  }
+   acquire_fence_ = UniqueFd(acquire_fence);
+   return HWC2::Error::None;
+ }
+diff --git a/bufferinfo/legacy/BufferInfoMinigbm.cpp b/bufferinfo/legacy/BufferInfoMinigbm.cpp
+index d030dff..54e9576 100644
+--- a/bufferinfo/legacy/BufferInfoMinigbm.cpp
++++ b/bufferinfo/legacy/BufferInfoMinigbm.cpp
+@@ -55,4 +55,96 @@ int BufferInfoMinigbm::ConvertBoInfo(buffer_handle_t handle, hwc_drm_bo_t *bo) {
+   return 0;
+ }
+ 
+-}  // namespace android
++void BufferInfoMinigbm::DumpBuffer(buffer_handle_t handle, hwc_drm_bo_t buffer_info) {
++  if (NULL == handle)
++    return;
++  char dump_file[256] = {0};
++  buffer_handle_t handle_copy;
++  uint8_t* pixels = nullptr;
++  gralloc1_rect_t accessRegion = {0, 0, (int32_t)buffer_info.width, (int32_t)buffer_info.height};
++  struct dri2_drm_display *dri_drm = InitializeGralloc1();
++
++  assert (dri_drm == nullptr ||
++          dri_drm->pfn_importBuffer  == nullptr ||
++          dri_drm->pfn_lock  == nullptr ||
++          dri_drm->pfn_unlock  == nullptr ||
++          dri_drm->pfn_release  == nullptr ||
++          dri_drm->pfn_get_stride);
++
++  int ret = dri_drm->pfn_importBuffer(dri_drm->gralloc1_dvc, handle, &handle_copy);
++  if (ret) {
++    ALOGE("Drm Minigbm importBuffer failed");
++    return;
++  }
++
++  ret = dri_drm->pfn_lock(dri_drm->gralloc1_dvc, handle_copy,
++                          GRALLOC1_CONSUMER_USAGE_CPU_READ_OFTEN, GRALLOC1_PRODUCER_USAGE_CPU_WRITE_NEVER,
++                          &accessRegion, reinterpret_cast<void**>(&pixels), 0);
++  if (ret) {
++    ALOGE("gralloc->lock failed: %d", ret);
++    return;
++  } else {
++    char ctime[32];
++    time_t t = time(0);
++    static int i = 0;
++    if (i >= 1000) {
++      i = 0;
++    }
++    strftime(ctime, sizeof(ctime), "%Y-%m-%d", localtime(&t));
++    sprintf(dump_file, "/data/local/traces/dump_%dx%d_0x%x_%s_%d", buffer_info.width, buffer_info.height, buffer_info.format, ctime,i++);
++    int file_fd = 0;
++    file_fd = open(dump_file, O_RDWR|O_CREAT, 0666);
++    if (file_fd == -1) {
++      ALOGE("Failed to open %s while dumping", dump_file);
++    } else {
++      size_t size = buffer_info.width * buffer_info.height * 4;
++      ALOGE("write file buffer_info.size = %zu", size);
++      write(file_fd, pixels, size);
++      close(file_fd);
++    }
++    int outReleaseFence = 0;
++    dri_drm->pfn_unlock(dri_drm->gralloc1_dvc, handle_copy, &outReleaseFence);
++    dri_drm->pfn_release(dri_drm->gralloc1_dvc, handle_copy);
++  }
++}
++
++dri2_drm_display* BufferInfoMinigbm::InitializeGralloc1() {
++  if (!switchinit) {
++    hw_device_t *device;
++    struct dri2_drm_display *drm_display = (dri2_drm_display *)calloc(1, sizeof(*drm_display));
++    if (!drm_display)
++      return NULL;
++
++    drm_display->fd = -1;
++    int ret = hw_get_module(GRALLOC_HARDWARE_MODULE_ID,
++                        (const hw_module_t **)&drm_display->gralloc);
++    if (ret) {
++      return NULL;
++    }
++
++    drm_display->gralloc_version = drm_display->gralloc->common.module_api_version;
++    if (drm_display->gralloc_version == HARDWARE_MODULE_API_VERSION(1, 0)) {
++      ret = drm_display->gralloc->common.methods->open(&drm_display->gralloc->common, GRALLOC_HARDWARE_MODULE_ID, &device);
++      if (ret) {
++        ALOGE("Failed to open device");
++      } else {
++        ALOGE("success to open device, Initialize");
++        drm_display->gralloc1_dvc = (gralloc1_device_t *)device;
++        drm_display->pfn_lock = (GRALLOC1_PFN_LOCK)drm_display->gralloc1_dvc->getFunction(drm_display->gralloc1_dvc, GRALLOC1_FUNCTION_LOCK);
++        drm_display->pfn_lock_flex = (GRALLOC1_PFN_LOCK_FLEX)drm_display->gralloc1_dvc->getFunction(drm_display->gralloc1_dvc, GRALLOC1_FUNCTION_LOCK_FLEX);
++        drm_display->pfn_importBuffer = (GRALLOC1_PFN_IMPORT_BUFFER)drm_display->gralloc1_dvc->getFunction(drm_display->gralloc1_dvc, GRALLOC1_FUNCTION_IMPORT_BUFFER);
++        drm_display->pfn_release = (GRALLOC1_PFN_RELEASE)drm_display->gralloc1_dvc->getFunction(drm_display->gralloc1_dvc, GRALLOC1_FUNCTION_RELEASE);
++        drm_display->pfn_unlock = (GRALLOC1_PFN_UNLOCK)drm_display->gralloc1_dvc->getFunction(drm_display->gralloc1_dvc, GRALLOC1_FUNCTION_UNLOCK);
++        drm_display->pfn_get_stride = (GRALLOC1_PFN_GET_STRIDE)drm_display->gralloc1_dvc->getFunction(drm_display->gralloc1_dvc, GRALLOC1_FUNCTION_GET_STRIDE);
++        switchinit = true;
++        grallocinit = drm_display;
++        return drm_display;
++        }
++      }
++    return NULL;
++  } else {
++    ALOGE("Drm Minigbm InitializeGralloc1 switchinit true");
++    return grallocinit;
++  }
++}
++}  // namespace android
+\ No newline at end of file
+diff --git a/bufferinfo/legacy/BufferInfoMinigbm.h b/bufferinfo/legacy/BufferInfoMinigbm.h
+index bff9d74..1c1e51f 100644
+--- a/bufferinfo/legacy/BufferInfoMinigbm.h
++++ b/bufferinfo/legacy/BufferInfoMinigbm.h
+@@ -18,15 +18,47 @@
+ #define BUFFERINFOMINIGBM_H_
+ 
+ #include <hardware/gralloc.h>
++#include <hardware/gralloc1.h>
+ 
+ #include "bufferinfo/BufferInfoGetter.h"
+ 
++#define DRV_MAX_PLANES 4
++#define DRV_MAX_FDS (DRV_MAX_PLANES + 1)
++#define DRM_BO_FORMAT_YUV 926497081
++
++enum INITIALIZE_ERROR{
++	INITIALIZE_CALLOC_ERROR = 1,
++	INITIALIZE_GET_MODULE_ERROR,
++	INITIALIZE_OPEN_DEVICE_ERROR,
++	INITIALIZE_NONE = 0,
++};
++
++struct dri2_drm_display
++{
++   int fd;
++   const gralloc_module_t *gralloc;
++   uint16_t gralloc_version;
++   gralloc1_device_t *gralloc1_dvc;
++   GRALLOC1_PFN_LOCK pfn_lock;
++   GRALLOC1_PFN_LOCK_FLEX pfn_lock_flex;
++   GRALLOC1_PFN_GET_FORMAT pfn_getFormat;
++   GRALLOC1_PFN_UNLOCK pfn_unlock;
++   GRALLOC1_PFN_IMPORT_BUFFER pfn_importBuffer;
++   GRALLOC1_PFN_RELEASE pfn_release;
++   GRALLOC1_PFN_GET_STRIDE pfn_get_stride;
++};
++
+ namespace android {
+ 
++static bool switchinit = false;
++static dri2_drm_display *grallocinit;
++
+ class BufferInfoMinigbm : public LegacyBufferInfoGetter {
+  public:
+   using LegacyBufferInfoGetter::LegacyBufferInfoGetter;
+   int ConvertBoInfo(buffer_handle_t handle, hwc_drm_bo_t *bo) override;
++  static dri2_drm_display* InitializeGralloc1();
++  static void DumpBuffer(buffer_handle_t handle, hwc_drm_bo_t buffer_info);
+ };
+ 
+ }  // namespace android
+diff --git a/utils/hwcutils.cpp b/utils/hwcutils.cpp
+index 6de6500..4beba46 100644
+--- a/utils/hwcutils.cpp
++++ b/utils/hwcutils.cpp
+@@ -20,10 +20,12 @@
+ #include <log/log.h>
+ #include <ui/Gralloc.h>
+ #include <ui/GraphicBufferMapper.h>
++#include <cutils/properties.h>
+ 
+ #include "bufferinfo/BufferInfoGetter.h"
+ #include "drm/DrmFbImporter.h"
+ #include "drmhwcomposer.h"
++#include "bufferinfo/legacy/BufferInfoMinigbm.h"
+ 
+ #define UNUSED(x) (void)(x)
+ 
+@@ -39,6 +41,13 @@ int DrmHwcLayer::ImportBuffer(DrmDevice *drmDevice) {
+     return ret;
+   }
+ 
++  char status[PROPERTY_VALUE_MAX];
++  if (property_get("drm.dumpbuffer.on", status, NULL) > 0) {
++    if (status != "0") {
++      BufferInfoMinigbm::DumpBuffer(sf_handle, buffer_info);
++    }
++  }
++
+   FbIdHandle = drmDevice->GetDrmFbImporter().GetOrCreateFbId(&buffer_info);
+   if (!FbIdHandle) {
+     ALOGE("Failed to import buffer");
+-- 
+2.36.0
+


### PR DESCRIPTION
Enable dumpBuffer for debug purpose. when necessary, DumpBuffer() function is called to execute.
After "setenforce 0" and "setprop drm.dumpbuffer.on(or "drm.dumpvideo.on") 1" is executed in the adb shell,
dumpfiles will be generated in the /data/local/tarce directory

Tracked-On: OAM-102488
Signed-off-by: wei, wushuangx <wushuangx.wei@intel.com>