### PR TITLE
Allow sgdisk and mmd to make USB disk installer image

### DIFF
--- a/aosp_diff/preliminary/build/soong/0010-Allow-sgdisk-and-mmd-to-make-USB-disk-installer-imag.patch
+++ b/aosp_diff/preliminary/build/soong/0010-Allow-sgdisk-and-mmd-to-make-USB-disk-installer-imag.patch
@@ -1,0 +1,28 @@
+From c4107e345584fad07a17c90e8df4afda0510342d Mon Sep 17 00:00:00 2001
+From: "Chen, Gang G" <gang.g.chen@intel.com>
+Date: Wed, 6 Jul 2022 18:15:36 +0800
+Subject: [PATCH] Allow sgdisk and mmd to make USB disk installer image
+
+Sgdisk command is used to make GPT bootable images
+
+Signed-off-by: Chen, Gang G <gang.g.chen@intel.com>
+---
+ ui/build/paths/config.go | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/ui/build/paths/config.go b/ui/build/paths/config.go
+index 3ddd25ada..b55eb847f 100644
+--- a/ui/build/paths/config.go
++++ b/ui/build/paths/config.go
+@@ -99,6 +99,8 @@ var Configuration = map[string]PathConfig{
+        "repo":    Allowed,
+        "mkdosfs": Allowed,
+        "mcopy":   Allowed,
++       "mmd":     Allowed,
++       "sgdisk":  Allowed,
+        "x86_64-linux-androidkernel-as": Allowed,
+        "x86_64-linux-androidkernel-ld": Allowed,
+        "file":    Allowed,
+-- 
+2.25.1
+


### PR DESCRIPTION
The two commands is used to make USB installer image.
we can install the CIV image from USB without UEFI
shell.

Tracked-On: OAM-102736
Signed-off-by: Chen, Gang G <gang.g.chen@intel.com>