### PR TITLE
Bluetooth: btusb: Add reset on close quirk for Intel adapters

### DIFF
--- a/bsp_diff/common/kernel/lts2020-yocto/27_0027-Bluetooth-btusb-Add-reset-on-close-quirk-for-Intel-a.patch
+++ b/bsp_diff/common/kernel/lts2020-yocto/27_0027-Bluetooth-btusb-Add-reset-on-close-quirk-for-Intel-a.patch
@@ -1,0 +1,34 @@
+From 08d146c36fd7f3e2477ca20cf7476710a59dd46b Mon Sep 17 00:00:00 2001
+From: "Suresh, Prashanth" <prashanth.suresh@intel.com>
+Date: Tue, 5 Jul 2022 23:58:22 +0530
+Subject: [PATCH] Bluetooth: btusb: Add reset on close quirk for Intel adapters
+
+Intel Bluetooth adapter is not exiting the loopback mode on bluetooth
+socket closure. So, when bluetooth socket is opened again, bluetooth is
+not working.
+
+As per Bluetooth core specification, bluetooth adapter should exit loop
+back mode on hci reset. Add HCI quirk reset to make sure adapter exits
+loopback mode on bluetooth socket closure.
+
+Tracked-On: OAM-102732
+Signed-off-by: Suresh, Prashanth <prashanth.suresh@intel.com>
+---
+ drivers/bluetooth/btintel.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/bluetooth/btintel.c b/drivers/bluetooth/btintel.c
+index f1705b46fc88..b684cb147210 100644
+--- a/drivers/bluetooth/btintel.c
++++ b/drivers/bluetooth/btintel.c
+@@ -2228,6 +2228,7 @@ static int btintel_setup_combined(struct hci_dev *hdev)
+ 	}
+ 
+ 	/* Apply the common HCI quirks for Intel device */
++	set_bit(HCI_QUIRK_RESET_ON_CLOSE, &hdev->quirks);
+ 	set_bit(HCI_QUIRK_STRICT_DUPLICATE_FILTER, &hdev->quirks);
+ 	set_bit(HCI_QUIRK_SIMULTANEOUS_DISCOVERY, &hdev->quirks);
+ 	set_bit(HCI_QUIRK_NON_PERSISTENT_DIAG, &hdev->quirks);
+-- 
+2.37.0
+


### PR DESCRIPTION
Intel Bluetooth adapter is not exiting the loopback mode on bluetooth
socket closure. So, when bluetooth socket is opened again, bluetooth is
not working.

As per Bluetooth core specification, bluetooth adapter should exit loop
back mode on hci reset. Add HCI quirk reset to make sure adapter exits
loopback mode on bluetooth socket closure.

Tracked-On: OAM-102732
Signed-off-by: Suresh, Prashanth <prashanth.suresh@intel.com>