### PR TITLE
libm_avx2_patch_S_no_reg

### DIFF
--- a/aosp_diff/preliminary/bionic/0010-Enable-only-log-sin-and-cos-avx2-apis.patch
+++ b/aosp_diff/preliminary/bionic/0010-Enable-only-log-sin-and-cos-avx2-apis.patch
@@ -1,0 +1,117 @@
+From 946d87a90dcd49fbd9a6815f78024b51bb72672d Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Thu, 7 Jul 2022 17:03:30 +0530
+Subject: [PATCH] Enable only log, sin and cos avx2 apis
+
+Enable only log10, log10f, log1p, log1pf,
+sin, cos and hypot avx2 apis. Disable cbrt,
+floor, ceil, rint as they are regressing.
+
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ libm/x86_64/dynamic_function_dispatch.cpp | 40 +++++++++++------------
+ 1 file changed, 20 insertions(+), 20 deletions(-)
+
+diff --git a/libm/x86_64/dynamic_function_dispatch.cpp b/libm/x86_64/dynamic_function_dispatch.cpp
+index 94f6a3f1c..2874ce49a 100644
+--- a/libm/x86_64/dynamic_function_dispatch.cpp
++++ b/libm/x86_64/dynamic_function_dispatch.cpp
+@@ -34,43 +34,43 @@ extern "C" {
+ 
+ typedef double ceil_func(double __x);
+ DEFINE_IFUNC_FOR(ceil) {
+-    __builtin_cpu_init();
+-    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(ceil_func, ceil_avx2);
++    //__builtin_cpu_init();
++    //if (__builtin_cpu_supports("avx2")) RETURN_FUNC(ceil_func, ceil_avx2);
+     RETURN_FUNC(ceil_func, ceil_generic);
+ }
+ 
+ typedef float ceilf_func(float __x);
+ DEFINE_IFUNC_FOR(ceilf) {
+-    __builtin_cpu_init();
+-    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(ceilf_func, ceilf_avx2);
++    //__builtin_cpu_init();
++    //if (__builtin_cpu_supports("avx2")) RETURN_FUNC(ceilf_func, ceilf_avx2);
+     RETURN_FUNC(ceilf_func, ceilf_generic);
+ }
+ 
+ typedef double floor_func(double __x);
+ DEFINE_IFUNC_FOR(floor) {
+-    __builtin_cpu_init();
+-    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(floor_func, floor_avx2);
++    //__builtin_cpu_init();
++    //if (__builtin_cpu_supports("avx2")) RETURN_FUNC(floor_func, floor_avx2);
+     RETURN_FUNC(floor_func, floor_generic);
+ }
+ 
+ typedef float floorf_func(float __x);
+ DEFINE_IFUNC_FOR(floorf) {
+-    __builtin_cpu_init();
+-    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(floorf_func, floorf_avx2);
++    //__builtin_cpu_init();
++    //if (__builtin_cpu_supports("avx2")) RETURN_FUNC(floorf_func, floorf_avx2);
+     RETURN_FUNC(floorf_func, floorf_generic);
+ }
+ 
+ typedef double rint_func(double __x);
+ DEFINE_IFUNC_FOR(rint) {
+-    __builtin_cpu_init();
+-    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(rint_func, rint_avx2);
++    //__builtin_cpu_init();
++    //if (__builtin_cpu_supports("avx2")) RETURN_FUNC(rint_func, rint_avx2);
+     RETURN_FUNC(rint_func, rint_generic);
+ }
+ 
+ typedef float rintf_func(float __x);
+ DEFINE_IFUNC_FOR(rintf) {
+-    __builtin_cpu_init();
+-    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(rintf_func, rintf_avx2);
++    //__builtin_cpu_init();
++    //if (__builtin_cpu_supports("avx2")) RETURN_FUNC(rintf_func, rintf_avx2);
+     RETURN_FUNC(rintf_func, rintf_generic);
+ }
+ 
+@@ -111,15 +111,15 @@ DEFINE_IFUNC_FOR(log1pf) {
+ 
+ typedef double cbrt_func(double __x);
+ DEFINE_IFUNC_FOR(cbrt) {
+-    __builtin_cpu_init();
+-    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(cbrt_func, cbrt_avx2);
++    //__builtin_cpu_init();
++    //if (__builtin_cpu_supports("avx2")) RETURN_FUNC(cbrt_func, cbrt_avx2);
+     RETURN_FUNC(cbrt_func, cbrt_generic);
+ }
+ 
+ typedef float cbrtf_func(float __x);
+ DEFINE_IFUNC_FOR(cbrtf) {
+-    __builtin_cpu_init();
+-    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(cbrtf_func, cbrtf_avx2);
++    //__builtin_cpu_init();
++    //if (__builtin_cpu_supports("avx2")) RETURN_FUNC(cbrtf_func, cbrtf_avx2);
+     RETURN_FUNC(cbrtf_func, cbrtf_generic);
+ }
+ 
+@@ -153,15 +153,15 @@ DEFINE_IFUNC_FOR(sinf) {
+ 
+ typedef double sinh_func(double __x);
+ DEFINE_IFUNC_FOR(sinh) {
+-    __builtin_cpu_init();
+-    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(sinh_func, sinh_avx2);
++    //__builtin_cpu_init();
++    //if (__builtin_cpu_supports("avx2")) RETURN_FUNC(sinh_func, sinh_avx2);
+     RETURN_FUNC(sinh_func, sinh_generic);
+ }
+ 
+ typedef float sinhf_func(float __x);
+ DEFINE_IFUNC_FOR(sinhf) {
+-    __builtin_cpu_init();
+-    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(sinhf_func, sinhf_avx2);
++    //__builtin_cpu_init();
++    //if (__builtin_cpu_supports("avx2")) RETURN_FUNC(sinhf_func, sinhf_avx2);
+     RETURN_FUNC(sinhf_func, sinhf_generic);
+ }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
Enable only log10, log10f, log1p, log1pf,
sin, cos and hypot avx2 apis. Disable cbrt,
floor, ceil, rint as they are regressing.

Signed-off-by: ahs <amrita.h.s@intel.com>