### PR TITLE
Excluding gki-testcases for android_x86/x86_64

### DIFF
--- a/aosp_diff/preliminary/test/vts-testcase/kernel/gki/0001-Excluding-gki-testcases-for-android_x86-x86_64.patch
+++ b/aosp_diff/preliminary/test/vts-testcase/kernel/gki/0001-Excluding-gki-testcases-for-android_x86-x86_64.patch
@@ -1,0 +1,35 @@
+From b63fa0507ed0507c0ebbdc67d31fcea5eba1d8af Mon Sep 17 00:00:00 2001
+From: rajucm <raju.mallikarjun.chegaraddi@intel.com>
+Date: Thu, 7 Jul 2022 15:28:56 +0000
+Subject: [PATCH] Excluding gki-testcases for android_x86/x86_64
+
+As we do-not have gki support for android_x86/x86_64,
+excluding gki testcases.
+
+Signed-off-by: rajucm <raju.mallikarjun.chegaraddi@intel.com>
+---
+ gki/Android.bp | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/gki/Android.bp b/gki/Android.bp
+index c16e39d..a24929a 100644
+--- a/gki/Android.bp
++++ b/gki/Android.bp
+@@ -30,6 +30,15 @@ cc_test {
+     // and above.
+     test_min_api_level: 31,
+
++    target: {
++	android_x86: {
++		enabled: false,
++	},
++	android_x86_64: {
++		enabled: false,
++	},
++    },
++
+     defaults: [
+         "libvintf_static_user_defaults",
+     ],
+--
+2.33.1


### PR DESCRIPTION
As we do-not have gki support for android_x86/x86_64.
Excluding gki test-cases.

Tracked-On: OAM-102789
Signed-off-by: rajucm <raju.mallikarjun.chegaraddi@intel.com>