### PR TITLE
Allow split command to split images

### DIFF
--- a/aosp_diff/preliminary/build/soong/0010-Allow-sgdisk-and-mmd-to-make-USB-disk-installer-imag.patch
+++ b/aosp_diff/preliminary/build/soong/0010-Allow-sgdisk-and-mmd-to-make-USB-disk-installer-imag.patch
@@ -1,4 +1,4 @@
-From c4107e345584fad07a17c90e8df4afda0510342d Mon Sep 17 00:00:00 2001
+From 0c110957ffbc563f1f7c5531695987af7e35bba2 Mon Sep 17 00:00:00 2001
 From: "Chen, Gang G" <gang.g.chen@intel.com>
 Date: Wed, 6 Jul 2022 18:15:36 +0800
 Subject: [PATCH] Allow sgdisk and mmd to make USB disk installer image
@@ -7,19 +7,20 @@ Sgdisk command is used to make GPT bootable images
 
 Signed-off-by: Chen, Gang G <gang.g.chen@intel.com>
 ---
- ui/build/paths/config.go | 2 ++
- 1 file changed, 2 insertions(+)
+ ui/build/paths/config.go | 3 +++
+ 1 file changed, 3 insertions(+)
 
 diff --git a/ui/build/paths/config.go b/ui/build/paths/config.go
-index 3ddd25ada..b55eb847f 100644
+index 3ddd25ada..7aac20890 100644
 --- a/ui/build/paths/config.go
 +++ b/ui/build/paths/config.go
-@@ -99,6 +99,8 @@ var Configuration = map[string]PathConfig{
+@@ -99,6 +99,9 @@ var Configuration = map[string]PathConfig{
         "repo":    Allowed,
         "mkdosfs": Allowed,
         "mcopy":   Allowed,
 +       "mmd":     Allowed,
 +       "sgdisk":  Allowed,
++       "split":   Allowed,
         "x86_64-linux-androidkernel-as": Allowed,
         "x86_64-linux-androidkernel-ld": Allowed,
         "file":    Allowed,


### PR DESCRIPTION
Fat32 only supports no bigger than 4GB files. So the file
need to be splittd if bigger than that

Tracked-On: OAM-102809
Signed-off-by: Chen, Gang G <gang.g.chen@intel.com>