### PR TITLE
kernel: Update build script with latest commit hash

### DIFF
--- a/host/kernel/lts2020-chromium/build_weekly.sh
+++ b/host/kernel/lts2020-chromium/build_weekly.sh
@@ -5,7 +5,7 @@ mkdir -p host_kernel
 cd host_kernel
 git clone https://github.com/projectceladon/linux-intel-lts2020-chromium.git
 cd linux-intel-lts2020-chromium
-git checkout 498337815dcca0fbf60def18a2a93286539b9dd0
+git checkout f95e02ec11184c4056cd523317cd0ebd814e2ded
 cp ../../x86_64_defconfig .config
 patch_list=`find ../../ -iname "*.patch" | sort -u`
 for i in $patch_list


### PR DESCRIPTION
Updated SHA ID in build script to point to latest kernel cve fix commit

Tracked-On: OAM-102862
Signed-off-by: Lakshmishree C <lakshmishree.c@intel.com>