### PR TITLE
Modify sse2/avx2 memcpy & memmove to AOSP memmove

### DIFF
--- a/aosp_diff/preliminary/bionic/0010-Modify-sse2-avx2-memcpy-memmove-to-AOSP-memmove.patch
+++ b/aosp_diff/preliminary/bionic/0010-Modify-sse2-avx2-memcpy-memmove-to-AOSP-memmove.patch
@@ -1,0 +1,7669 @@
+From 4ceecfe13d5a4109f0028c2de916fb62e3694bcf Mon Sep 17 00:00:00 2001
+From: ahs <amrita.h.s@intel.com>
+Date: Sat, 14 May 2022 11:22:24 +0530
+Subject: [PATCH] Modify sse2/avx2 memcpy & memmove to AOSP memmove
+
+Optimization was targeted seperately for memmove
+and memcpy. But this means no support for
+overlapping copy when using memcpy. So modify
+sse2/avx2 version of memcpy and memmove to
+point to AOSP's memmove
+
+Change-Id: Ie46b8ad1e9970b2f6e6cbf3c0b5b0a4b0bacef42
+Tracked-On: OAM-101812
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ libc/Android.bp                               |    4 -
+ libc/arch-x86/dynamic_function_dispatch.cpp   |    5 +-
+ .../kabylake/string/avx2-memcpy-kbl.S         | 2052 ---------
+ .../arch-x86_64/dynamic_function_dispatch.cpp |    6 +-
+ .../kabylake/string/avx2-memcpy-kbl.S         | 3711 -----------------
+ .../kabylake/string/avx2-memmove-kbl.S        |  409 --
+ .../silvermont/string/sse2-memcpy-slm.s       | 1374 ------
+ 7 files changed, 2 insertions(+), 7559 deletions(-)
+ delete mode 100644 libc/arch-x86/kabylake/string/avx2-memcpy-kbl.S
+ delete mode 100644 libc/arch-x86_64/kabylake/string/avx2-memcpy-kbl.S
+ delete mode 100644 libc/arch-x86_64/kabylake/string/avx2-memmove-kbl.S
+ delete mode 100644 libc/arch-x86_64/silvermont/string/sse2-memcpy-slm.s
+
+diff --git a/libc/Android.bp b/libc/Android.bp
+index 4c05eca1d..b85a82f5a 100644
+--- a/libc/Android.bp
++++ b/libc/Android.bp
+@@ -950,7 +950,6 @@ cc_library_static {
+ 
+                 // avx2 functions
+                 "arch-x86/kabylake/string/avx2-wmemset-kbl.S",
+-                "arch-x86/kabylake/string/avx2-memcpy-kbl.S",
+             ],
+ 
+             exclude_srcs: [
+@@ -979,7 +978,6 @@ cc_library_static {
+                 "arch-x86_64/generic/string/wcsrchr.c",
+ 
+                 "arch-x86_64/silvermont/string/sse2-memmove-slm.S",
+-                "arch-x86_64/silvermont/string/sse2-memcpy-slm.s",
+                 "arch-x86_64/silvermont/string/sse2-memset-slm.S",
+                 "arch-x86_64/silvermont/string/sse2-stpcpy-slm.S",
+                 "arch-x86_64/silvermont/string/sse2-stpncpy-slm.S",
+@@ -993,9 +991,7 @@ cc_library_static {
+                 "arch-x86_64/silvermont/string/ssse3-strncmp-slm.S",
+ 
+                 "arch-x86_64/kabylake/string/avx2-wmemset-kbl.S",
+-                "arch-x86_64/kabylake/string/avx2-memcpy-kbl.S",
+                 "arch-x86_64/kabylake/string/avx2-memcmp-kbl.S",
+-                "arch-x86_64/kabylake/string/avx2-memmove-kbl.S",
+                 "arch-x86_64/kabylake/string/avx2-memchr-kbl.S",
+                 "arch-x86_64/kabylake/string/avx2-memrchr-kbl.S",
+                 "arch-x86_64/kabylake/string/avx2-strcmp-kbl.S",
+diff --git a/libc/arch-x86/dynamic_function_dispatch.cpp b/libc/arch-x86/dynamic_function_dispatch.cpp
+index 3f9ad347a..e94fa1f72 100644
+--- a/libc/arch-x86/dynamic_function_dispatch.cpp
++++ b/libc/arch-x86/dynamic_function_dispatch.cpp
+@@ -63,10 +63,7 @@ DEFINE_IFUNC_FOR(memmove) {
+ 
+ typedef void* memcpy_func(void*, const void*, size_t);
+ DEFINE_IFUNC_FOR(memcpy) {
+-    __builtin_cpu_init();
+-    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(memcpy_func, memcpy_avx2);
+-    RETURN_FUNC(memcpy_func, memmove_generic);
+-  	 
++    return memmove_resolver();
+ }
+ 
+ typedef char* strcpy_func(char* __dst, const char* __src);
+diff --git a/libc/arch-x86/kabylake/string/avx2-memcpy-kbl.S b/libc/arch-x86/kabylake/string/avx2-memcpy-kbl.S
+deleted file mode 100644
+index 69fca7cf1..000000000
+--- a/libc/arch-x86/kabylake/string/avx2-memcpy-kbl.S
++++ /dev/null
+@@ -1,2052 +0,0 @@
+-#define ENTRY(f) \
+-    .text; \
+-    .globl f; \
+-    .p2align    4, 0x90; \
+-    .type f,@function; \
+-    f: \
+-
+-#define END(f)
+-    .size f, .-f; \
+-    .section        .rodata,"a",@progbits; \
+-    .p2align        2 \
+-
+-ENTRY(memcpy_avx2)
+-# %bb.0:
+-	pushl	%ebp
+-	pushl	%ebx
+-	pushl	%edi
+-	pushl	%esi
+-	movl	28(%esp), %ebx
+-	movl	24(%esp), %ecx
+-	movl	20(%esp), %eax
+-	calll	.L0$pb
+-.L0$pb:
+-	popl	%esi
+-.Ltmp0:
+-	addl	$_GLOBAL_OFFSET_TABLE_+(.Ltmp0-.L0$pb), %esi
+-	cmpl	$256, %ebx              # imm = 0x100
+-	ja	.LBB0_251
+-# %bb.1:
+-	leal	-1(%ebx), %edi
+-	cmpl	$255, %edi
+-	ja	.LBB0_270
+-# %bb.2:
+-	addl	.LJTI0_1@GOTOFF(%esi,%edi,4), %esi
+-	leal	(%eax,%ebx), %edx
+-	addl	%ebx, %ecx
+-	jmpl	*%esi
+-.LBB0_251:
+-	movl	%eax, %ebp
+-	vmovups	(%ecx), %ymm0
+-	movl	%ebx, %edi
+-	negl	%ebp
+-	andl	$31, %ebp
+-	subl	%ebp, %edi
+-	addl	%ebp, %ecx
+-	leal	(%eax,%ebp), %edx
+-	cmpl	$2097152, %edi          # imm = 0x200000
+-	vmovups	%ymm0, (%eax)
+-	ja	.LBB0_256
+-# %bb.252:
+-	cmpl	$256, %edi              # imm = 0x100
+-	jb	.LBB0_260
+-# %bb.253:
+-	subl	%ebp, %ebx
+-	.p2align	4, 0x90
+-.LBB0_254:                              # =>This Inner Loop Header: Depth=1
+-	vmovups	(%ecx), %ymm0
+-	vmovups	32(%ecx), %ymm1
+-	vmovups	64(%ecx), %ymm2
+-	vmovups	96(%ecx), %ymm3
+-	vmovups	128(%ecx), %ymm4
+-	vmovups	160(%ecx), %ymm5
+-	vmovups	192(%ecx), %ymm6
+-	vmovups	224(%ecx), %ymm7
+-	prefetchnta	512(%ecx)
+-	addl	$-256, %edi
+-	addl	$256, %ecx              # imm = 0x100
+-	vmovups	%ymm0, (%edx)
+-	vmovups	%ymm1, 32(%edx)
+-	vmovups	%ymm2, 64(%edx)
+-	vmovups	%ymm3, 96(%edx)
+-	vmovups	%ymm4, 128(%edx)
+-	vmovups	%ymm5, 160(%edx)
+-	vmovups	%ymm6, 192(%edx)
+-	vmovups	%ymm7, 224(%edx)
+-	addl	$256, %edx              # imm = 0x100
+-	cmpl	$255, %edi
+-	ja	.LBB0_254
+-# %bb.255:
+-	movzbl	%bl, %edi
+-	leal	-1(%edi), %ebx
+-	cmpl	$255, %ebx
+-	jbe	.LBB0_261
+-	jmp	.LBB0_270
+-.LBB0_256:
+-	prefetchnta	(%ecx)
+-	subl	%ebp, %ebx
+-	testb	$31, %cl
+-	je	.LBB0_257
+-	.p2align	4, 0x90
+-.LBB0_258:                              # =>This Inner Loop Header: Depth=1
+-	vmovups	(%ecx), %ymm0
+-	vmovups	32(%ecx), %ymm1
+-	vmovups	64(%ecx), %ymm2
+-	vmovups	96(%ecx), %ymm3
+-	vmovups	128(%ecx), %ymm4
+-	vmovups	160(%ecx), %ymm5
+-	vmovups	192(%ecx), %ymm6
+-	vmovups	224(%ecx), %ymm7
+-	prefetchnta	512(%ecx)
+-	addl	$-256, %edi
+-	addl	$256, %ecx              # imm = 0x100
+-	vmovntps	%ymm0, (%edx)
+-	vmovntps	%ymm1, 32(%edx)
+-	vmovntps	%ymm2, 64(%edx)
+-	vmovntps	%ymm3, 96(%edx)
+-	vmovntps	%ymm4, 128(%edx)
+-	vmovntps	%ymm5, 160(%edx)
+-	vmovntps	%ymm6, 192(%edx)
+-	vmovntps	%ymm7, 224(%edx)
+-	addl	$256, %edx              # imm = 0x100
+-	cmpl	$255, %edi
+-	ja	.LBB0_258
+-	jmp	.LBB0_259
+-	.p2align	4, 0x90
+-.LBB0_257:                              # =>This Inner Loop Header: Depth=1
+-	vmovaps	(%ecx), %ymm0
+-	vmovaps	32(%ecx), %ymm1
+-	vmovaps	64(%ecx), %ymm2
+-	vmovaps	96(%ecx), %ymm3
+-	vmovaps	128(%ecx), %ymm4
+-	vmovaps	160(%ecx), %ymm5
+-	vmovaps	192(%ecx), %ymm6
+-	vmovaps	224(%ecx), %ymm7
+-	prefetchnta	512(%ecx)
+-	addl	$-256, %edi
+-	addl	$256, %ecx              # imm = 0x100
+-	vmovntps	%ymm0, (%edx)
+-	vmovntps	%ymm1, 32(%edx)
+-	vmovntps	%ymm2, 64(%edx)
+-	vmovntps	%ymm3, 96(%edx)
+-	vmovntps	%ymm4, 128(%edx)
+-	vmovntps	%ymm5, 160(%edx)
+-	vmovntps	%ymm6, 192(%edx)
+-	vmovntps	%ymm7, 224(%edx)
+-	addl	$256, %edx              # imm = 0x100
+-	cmpl	$255, %edi
+-	ja	.LBB0_257
+-.LBB0_259:
+-	sfence
+-	movzbl	%bl, %edi
+-.LBB0_260:
+-	leal	-1(%edi), %ebx
+-	cmpl	$255, %ebx
+-	ja	.LBB0_270
+-.LBB0_261:
+-	addl	.LJTI0_0@GOTOFF(%esi,%ebx,4), %esi
+-	addl	%edi, %edx
+-	addl	%edi, %ecx
+-	jmpl	*%esi
+-.LBB0_11:
+-	vmovups	-131(%ecx), %ymm0
+-	vmovups	%ymm0, -131(%edx)
+-	vmovups	-99(%ecx), %ymm0
+-	vmovups	%ymm0, -99(%edx)
+-	vmovups	-67(%ecx), %ymm0
+-	vmovups	%ymm0, -67(%edx)
+-	vmovups	-35(%ecx), %ymm0
+-	vmovups	%ymm0, -35(%edx)
+-.LBB0_12:
+-	movzwl	-3(%ecx), %esi
+-	movw	%si, -3(%edx)
+-	jmp	.LBB0_6
+-.LBB0_17:
+-	vmovups	-133(%ecx), %ymm0
+-	vmovups	%ymm0, -133(%edx)
+-	vmovups	-101(%ecx), %ymm0
+-	vmovups	%ymm0, -101(%edx)
+-	vmovups	-69(%ecx), %ymm0
+-	vmovups	%ymm0, -69(%edx)
+-	vmovups	-37(%ecx), %ymm0
+-	vmovups	%ymm0, -37(%edx)
+-.LBB0_18:
+-	movl	-5(%ecx), %esi
+-	movl	%esi, -5(%edx)
+-	jmp	.LBB0_6
+-.LBB0_19:
+-	vmovups	-134(%ecx), %ymm0
+-	vmovups	%ymm0, -134(%edx)
+-	vmovups	-102(%ecx), %ymm0
+-	vmovups	%ymm0, -102(%edx)
+-	vmovups	-70(%ecx), %ymm0
+-	vmovups	%ymm0, -70(%edx)
+-	vmovups	-38(%ecx), %ymm0
+-	vmovups	%ymm0, -38(%edx)
+-.LBB0_20:
+-	movl	-6(%ecx), %esi
+-	movl	%esi, -6(%edx)
+-	jmp	.LBB0_10
+-.LBB0_21:
+-	vmovups	-135(%ecx), %ymm0
+-	vmovups	%ymm0, -135(%edx)
+-	vmovups	-103(%ecx), %ymm0
+-	vmovups	%ymm0, -103(%edx)
+-	vmovups	-71(%ecx), %ymm0
+-	vmovups	%ymm0, -71(%edx)
+-	vmovups	-39(%ecx), %ymm0
+-	vmovups	%ymm0, -39(%edx)
+-.LBB0_22:
+-	movl	-7(%ecx), %esi
+-	movl	%esi, -7(%edx)
+-	jmp	.LBB0_16
+-.LBB0_27:
+-	vmovups	-137(%ecx), %ymm0
+-	vmovups	%ymm0, -137(%edx)
+-	vmovups	-105(%ecx), %ymm0
+-	vmovups	%ymm0, -105(%edx)
+-	vmovups	-73(%ecx), %ymm0
+-	vmovups	%ymm0, -73(%edx)
+-	vmovups	-41(%ecx), %ymm0
+-	vmovups	%ymm0, -41(%edx)
+-.LBB0_28:
+-	vmovsd	-9(%ecx), %xmm0         # xmm0 = mem[0],zero
+-	vmovsd	%xmm0, -9(%edx)
+-	jmp	.LBB0_6
+-.LBB0_29:
+-	vmovups	-138(%ecx), %ymm0
+-	vmovups	%ymm0, -138(%edx)
+-	vmovups	-106(%ecx), %ymm0
+-	vmovups	%ymm0, -106(%edx)
+-	vmovups	-74(%ecx), %ymm0
+-	vmovups	%ymm0, -74(%edx)
+-	vmovups	-42(%ecx), %ymm0
+-	vmovups	%ymm0, -42(%edx)
+-.LBB0_30:
+-	vmovsd	-10(%ecx), %xmm0        # xmm0 = mem[0],zero
+-	vmovsd	%xmm0, -10(%edx)
+-	jmp	.LBB0_10
+-.LBB0_31:
+-	vmovups	-139(%ecx), %ymm0
+-	vmovups	%ymm0, -139(%edx)
+-	vmovups	-107(%ecx), %ymm0
+-	vmovups	%ymm0, -107(%edx)
+-	vmovups	-75(%ecx), %ymm0
+-	vmovups	%ymm0, -75(%edx)
+-	vmovups	-43(%ecx), %ymm0
+-	vmovups	%ymm0, -43(%edx)
+-.LBB0_32:
+-	vmovsd	-11(%ecx), %xmm0        # xmm0 = mem[0],zero
+-	vmovsd	%xmm0, -11(%edx)
+-	jmp	.LBB0_16
+-.LBB0_33:
+-	vmovups	-140(%ecx), %ymm0
+-	vmovups	%ymm0, -140(%edx)
+-	vmovups	-108(%ecx), %ymm0
+-	vmovups	%ymm0, -108(%edx)
+-	vmovups	-76(%ecx), %ymm0
+-	vmovups	%ymm0, -76(%edx)
+-	vmovups	-44(%ecx), %ymm0
+-	vmovups	%ymm0, -44(%edx)
+-.LBB0_34:
+-	vmovsd	-12(%ecx), %xmm0        # xmm0 = mem[0],zero
+-	vmovsd	%xmm0, -12(%edx)
+-	jmp	.LBB0_16
+-.LBB0_35:
+-	vmovups	-141(%ecx), %ymm0
+-	vmovups	%ymm0, -141(%edx)
+-	vmovups	-109(%ecx), %ymm0
+-	vmovups	%ymm0, -109(%edx)
+-	vmovups	-77(%ecx), %ymm0
+-	vmovups	%ymm0, -77(%edx)
+-	vmovups	-45(%ecx), %ymm0
+-	vmovups	%ymm0, -45(%edx)
+-.LBB0_36:
+-	vmovsd	-13(%ecx), %xmm0        # xmm0 = mem[0],zero
+-	vmovsd	%xmm0, -13(%edx)
+-	jmp	.LBB0_26
+-.LBB0_37:
+-	vmovups	-142(%ecx), %ymm0
+-	vmovups	%ymm0, -142(%edx)
+-	vmovups	-110(%ecx), %ymm0
+-	vmovups	%ymm0, -110(%edx)
+-	vmovups	-78(%ecx), %ymm0
+-	vmovups	%ymm0, -78(%edx)
+-	vmovups	-46(%ecx), %ymm0
+-	vmovups	%ymm0, -46(%edx)
+-.LBB0_38:
+-	vmovsd	-14(%ecx), %xmm0        # xmm0 = mem[0],zero
+-	vmovsd	%xmm0, -14(%edx)
+-	jmp	.LBB0_26
+-.LBB0_39:
+-	vmovups	-143(%ecx), %ymm0
+-	vmovups	%ymm0, -143(%edx)
+-	vmovups	-111(%ecx), %ymm0
+-	vmovups	%ymm0, -111(%edx)
+-	vmovups	-79(%ecx), %ymm0
+-	vmovups	%ymm0, -79(%edx)
+-	vmovups	-47(%ecx), %ymm0
+-	vmovups	%ymm0, -47(%edx)
+-.LBB0_40:
+-	vmovsd	-15(%ecx), %xmm0        # xmm0 = mem[0],zero
+-	vmovsd	%xmm0, -15(%edx)
+-	jmp	.LBB0_26
+-.LBB0_45:
+-	vmovups	-145(%ecx), %ymm0
+-	vmovups	%ymm0, -145(%edx)
+-	vmovups	-113(%ecx), %ymm0
+-	vmovups	%ymm0, -113(%edx)
+-	vmovups	-81(%ecx), %ymm0
+-	vmovups	%ymm0, -81(%edx)
+-	vmovups	-49(%ecx), %ymm0
+-	vmovups	%ymm0, -49(%edx)
+-.LBB0_46:
+-	vmovups	-17(%ecx), %xmm0
+-	vmovups	%xmm0, -17(%edx)
+-	jmp	.LBB0_6
+-.LBB0_47:
+-	vmovups	-146(%ecx), %ymm0
+-	vmovups	%ymm0, -146(%edx)
+-	vmovups	-114(%ecx), %ymm0
+-	vmovups	%ymm0, -114(%edx)
+-	vmovups	-82(%ecx), %ymm0
+-	vmovups	%ymm0, -82(%edx)
+-	vmovups	-50(%ecx), %ymm0
+-	vmovups	%ymm0, -50(%edx)
+-.LBB0_48:
+-	vmovups	-18(%ecx), %xmm0
+-	vmovups	%xmm0, -18(%edx)
+-	jmp	.LBB0_10
+-.LBB0_49:
+-	vmovups	-147(%ecx), %ymm0
+-	vmovups	%ymm0, -147(%edx)
+-	vmovups	-115(%ecx), %ymm0
+-	vmovups	%ymm0, -115(%edx)
+-	vmovups	-83(%ecx), %ymm0
+-	vmovups	%ymm0, -83(%edx)
+-	vmovups	-51(%ecx), %ymm0
+-	vmovups	%ymm0, -51(%edx)
+-.LBB0_50:
+-	vmovups	-19(%ecx), %xmm0
+-	vmovups	%xmm0, -19(%edx)
+-	jmp	.LBB0_16
+-.LBB0_51:
+-	vmovups	-148(%ecx), %ymm0
+-	vmovups	%ymm0, -148(%edx)
+-	vmovups	-116(%ecx), %ymm0
+-	vmovups	%ymm0, -116(%edx)
+-	vmovups	-84(%ecx), %ymm0
+-	vmovups	%ymm0, -84(%edx)
+-	vmovups	-52(%ecx), %ymm0
+-	vmovups	%ymm0, -52(%edx)
+-.LBB0_52:
+-	vmovups	-20(%ecx), %xmm0
+-	vmovups	%xmm0, -20(%edx)
+-	jmp	.LBB0_16
+-.LBB0_53:
+-	vmovups	-149(%ecx), %ymm0
+-	vmovups	%ymm0, -149(%edx)
+-	vmovups	-117(%ecx), %ymm0
+-	vmovups	%ymm0, -117(%edx)
+-	vmovups	-85(%ecx), %ymm0
+-	vmovups	%ymm0, -85(%edx)
+-	vmovups	-53(%ecx), %ymm0
+-	vmovups	%ymm0, -53(%edx)
+-.LBB0_54:
+-	vmovups	-21(%ecx), %xmm0
+-	vmovups	%xmm0, -21(%edx)
+-	jmp	.LBB0_26
+-.LBB0_55:
+-	vmovups	-150(%ecx), %ymm0
+-	vmovups	%ymm0, -150(%edx)
+-	vmovups	-118(%ecx), %ymm0
+-	vmovups	%ymm0, -118(%edx)
+-	vmovups	-86(%ecx), %ymm0
+-	vmovups	%ymm0, -86(%edx)
+-	vmovups	-54(%ecx), %ymm0
+-	vmovups	%ymm0, -54(%edx)
+-.LBB0_56:
+-	vmovups	-22(%ecx), %xmm0
+-	vmovups	%xmm0, -22(%edx)
+-	jmp	.LBB0_26
+-.LBB0_57:
+-	vmovups	-151(%ecx), %ymm0
+-	vmovups	%ymm0, -151(%edx)
+-	vmovups	-119(%ecx), %ymm0
+-	vmovups	%ymm0, -119(%edx)
+-	vmovups	-87(%ecx), %ymm0
+-	vmovups	%ymm0, -87(%edx)
+-	vmovups	-55(%ecx), %ymm0
+-	vmovups	%ymm0, -55(%edx)
+-.LBB0_58:
+-	vmovups	-23(%ecx), %xmm0
+-	vmovups	%xmm0, -23(%edx)
+-	jmp	.LBB0_26
+-.LBB0_59:
+-	vmovups	-152(%ecx), %ymm0
+-	vmovups	%ymm0, -152(%edx)
+-	vmovups	-120(%ecx), %ymm0
+-	vmovups	%ymm0, -120(%edx)
+-	vmovups	-88(%ecx), %ymm0
+-	vmovups	%ymm0, -88(%edx)
+-	vmovups	-56(%ecx), %ymm0
+-	vmovups	%ymm0, -56(%edx)
+-.LBB0_60:
+-	vmovups	-24(%ecx), %xmm0
+-	vmovups	%xmm0, -24(%edx)
+-	jmp	.LBB0_26
+-.LBB0_61:
+-	vmovups	-153(%ecx), %ymm0
+-	vmovups	%ymm0, -153(%edx)
+-	vmovups	-121(%ecx), %ymm0
+-	vmovups	%ymm0, -121(%edx)
+-	vmovups	-89(%ecx), %ymm0
+-	vmovups	%ymm0, -89(%edx)
+-	vmovups	-57(%ecx), %ymm0
+-	vmovups	%ymm0, -57(%edx)
+-.LBB0_62:
+-	vmovups	-25(%ecx), %xmm0
+-	vmovups	%xmm0, -25(%edx)
+-	jmp	.LBB0_44
+-.LBB0_63:
+-	vmovups	-154(%ecx), %ymm0
+-	vmovups	%ymm0, -154(%edx)
+-	vmovups	-122(%ecx), %ymm0
+-	vmovups	%ymm0, -122(%edx)
+-	vmovups	-90(%ecx), %ymm0
+-	vmovups	%ymm0, -90(%edx)
+-	vmovups	-58(%ecx), %ymm0
+-	vmovups	%ymm0, -58(%edx)
+-.LBB0_64:
+-	vmovups	-26(%ecx), %xmm0
+-	vmovups	%xmm0, -26(%edx)
+-	jmp	.LBB0_44
+-.LBB0_65:
+-	vmovups	-155(%ecx), %ymm0
+-	vmovups	%ymm0, -155(%edx)
+-	vmovups	-123(%ecx), %ymm0
+-	vmovups	%ymm0, -123(%edx)
+-	vmovups	-91(%ecx), %ymm0
+-	vmovups	%ymm0, -91(%edx)
+-	vmovups	-59(%ecx), %ymm0
+-	vmovups	%ymm0, -59(%edx)
+-.LBB0_66:
+-	vmovups	-27(%ecx), %xmm0
+-	vmovups	%xmm0, -27(%edx)
+-	jmp	.LBB0_44
+-.LBB0_67:
+-	vmovups	-156(%ecx), %ymm0
+-	vmovups	%ymm0, -156(%edx)
+-	vmovups	-124(%ecx), %ymm0
+-	vmovups	%ymm0, -124(%edx)
+-	vmovups	-92(%ecx), %ymm0
+-	vmovups	%ymm0, -92(%edx)
+-	vmovups	-60(%ecx), %ymm0
+-	vmovups	%ymm0, -60(%edx)
+-.LBB0_68:
+-	vmovups	-28(%ecx), %xmm0
+-	vmovups	%xmm0, -28(%edx)
+-	jmp	.LBB0_44
+-.LBB0_69:
+-	vmovups	-157(%ecx), %ymm0
+-	vmovups	%ymm0, -157(%edx)
+-	vmovups	-125(%ecx), %ymm0
+-	vmovups	%ymm0, -125(%edx)
+-	vmovups	-93(%ecx), %ymm0
+-	vmovups	%ymm0, -93(%edx)
+-	vmovups	-61(%ecx), %ymm0
+-	vmovups	%ymm0, -61(%edx)
+-.LBB0_70:
+-	vmovups	-29(%ecx), %xmm0
+-	vmovups	%xmm0, -29(%edx)
+-	jmp	.LBB0_44
+-.LBB0_71:
+-	vmovups	-158(%ecx), %ymm0
+-	vmovups	%ymm0, -158(%edx)
+-	vmovups	-126(%ecx), %ymm0
+-	vmovups	%ymm0, -126(%edx)
+-	vmovups	-94(%ecx), %ymm0
+-	vmovups	%ymm0, -94(%edx)
+-	vmovups	-62(%ecx), %ymm0
+-	vmovups	%ymm0, -62(%edx)
+-.LBB0_72:
+-	vmovups	-30(%ecx), %xmm0
+-	vmovups	%xmm0, -30(%edx)
+-	jmp	.LBB0_44
+-.LBB0_73:
+-	vmovups	-159(%ecx), %ymm0
+-	vmovups	%ymm0, -159(%edx)
+-	vmovups	-127(%ecx), %ymm0
+-	vmovups	%ymm0, -127(%edx)
+-	vmovups	-95(%ecx), %ymm0
+-	vmovups	%ymm0, -95(%edx)
+-	vmovups	-63(%ecx), %ymm0
+-	vmovups	%ymm0, -63(%edx)
+-.LBB0_74:
+-	vmovups	-31(%ecx), %xmm0
+-	vmovups	%xmm0, -31(%edx)
+-	jmp	.LBB0_44
+-.LBB0_75:
+-	vmovups	-193(%ecx), %ymm0
+-	vmovups	%ymm0, -193(%edx)
+-.LBB0_76:
+-	vmovups	-161(%ecx), %ymm0
+-	vmovups	%ymm0, -161(%edx)
+-.LBB0_3:
+-	vmovups	-129(%ecx), %ymm0
+-	vmovups	%ymm0, -129(%edx)
+-	vmovups	-97(%ecx), %ymm0
+-	vmovups	%ymm0, -97(%edx)
+-.LBB0_4:
+-	vmovups	-65(%ecx), %ymm0
+-	vmovups	%ymm0, -65(%edx)
+-.LBB0_5:
+-	vmovups	-33(%ecx), %ymm0
+-	vmovups	%ymm0, -33(%edx)
+-.LBB0_6:
+-	movb	-1(%ecx), %cl
+-	movb	%cl, -1(%edx)
+-	jmp	.LBB0_270
+-.LBB0_77:
+-	vmovups	-194(%ecx), %ymm0
+-	vmovups	%ymm0, -194(%edx)
+-.LBB0_78:
+-	vmovups	-162(%ecx), %ymm0
+-	vmovups	%ymm0, -162(%edx)
+-.LBB0_7:
+-	vmovups	-130(%ecx), %ymm0
+-	vmovups	%ymm0, -130(%edx)
+-	vmovups	-98(%ecx), %ymm0
+-	vmovups	%ymm0, -98(%edx)
+-.LBB0_8:
+-	vmovups	-66(%ecx), %ymm0
+-	vmovups	%ymm0, -66(%edx)
+-.LBB0_9:
+-	vmovups	-34(%ecx), %ymm0
+-	vmovups	%ymm0, -34(%edx)
+-.LBB0_10:
+-	movzwl	-2(%ecx), %ecx
+-	movw	%cx, -2(%edx)
+-	jmp	.LBB0_270
+-.LBB0_79:
+-	vmovups	-195(%ecx), %ymm0
+-	vmovups	%ymm0, -195(%edx)
+-.LBB0_80:
+-	vmovups	-163(%ecx), %ymm0
+-	vmovups	%ymm0, -163(%edx)
+-	vmovups	-131(%ecx), %ymm0
+-	vmovups	%ymm0, -131(%edx)
+-	vmovups	-99(%ecx), %ymm0
+-	vmovups	%ymm0, -99(%edx)
+-.LBB0_81:
+-	vmovups	-67(%ecx), %ymm0
+-	vmovups	%ymm0, -67(%edx)
+-.LBB0_82:
+-	vmovups	-35(%ecx), %ymm0
+-	vmovups	%ymm0, -35(%edx)
+-	jmp	.LBB0_16
+-.LBB0_83:
+-	vmovups	-196(%ecx), %ymm0
+-	vmovups	%ymm0, -196(%edx)
+-.LBB0_84:
+-	vmovups	-164(%ecx), %ymm0
+-	vmovups	%ymm0, -164(%edx)
+-.LBB0_13:
+-	vmovups	-132(%ecx), %ymm0
+-	vmovups	%ymm0, -132(%edx)
+-	vmovups	-100(%ecx), %ymm0
+-	vmovups	%ymm0, -100(%edx)
+-.LBB0_14:
+-	vmovups	-68(%ecx), %ymm0
+-	vmovups	%ymm0, -68(%edx)
+-.LBB0_15:
+-	vmovups	-36(%ecx), %ymm0
+-	vmovups	%ymm0, -36(%edx)
+-.LBB0_16:
+-	movl	-4(%ecx), %ecx
+-	movl	%ecx, -4(%edx)
+-	jmp	.LBB0_270
+-.LBB0_85:
+-	vmovups	-197(%ecx), %ymm0
+-	vmovups	%ymm0, -197(%edx)
+-.LBB0_86:
+-	vmovups	-165(%ecx), %ymm0
+-	vmovups	%ymm0, -165(%edx)
+-	vmovups	-133(%ecx), %ymm0
+-	vmovups	%ymm0, -133(%edx)
+-	vmovups	-101(%ecx), %ymm0
+-	vmovups	%ymm0, -101(%edx)
+-.LBB0_87:
+-	vmovups	-69(%ecx), %ymm0
+-	vmovups	%ymm0, -69(%edx)
+-.LBB0_88:
+-	vmovups	-37(%ecx), %ymm0
+-	vmovups	%ymm0, -37(%edx)
+-	jmp	.LBB0_26
+-.LBB0_89:
+-	vmovups	-198(%ecx), %ymm0
+-	vmovups	%ymm0, -198(%edx)
+-.LBB0_90:
+-	vmovups	-166(%ecx), %ymm0
+-	vmovups	%ymm0, -166(%edx)
+-	vmovups	-134(%ecx), %ymm0
+-	vmovups	%ymm0, -134(%edx)
+-	vmovups	-102(%ecx), %ymm0
+-	vmovups	%ymm0, -102(%edx)
+-.LBB0_91:
+-	vmovups	-70(%ecx), %ymm0
+-	vmovups	%ymm0, -70(%edx)
+-.LBB0_92:
+-	vmovups	-38(%ecx), %ymm0
+-	vmovups	%ymm0, -38(%edx)
+-	jmp	.LBB0_26
+-.LBB0_93:
+-	vmovups	-199(%ecx), %ymm0
+-	vmovups	%ymm0, -199(%edx)
+-.LBB0_94:
+-	vmovups	-167(%ecx), %ymm0
+-	vmovups	%ymm0, -167(%edx)
+-	vmovups	-135(%ecx), %ymm0
+-	vmovups	%ymm0, -135(%edx)
+-	vmovups	-103(%ecx), %ymm0
+-	vmovups	%ymm0, -103(%edx)
+-.LBB0_95:
+-	vmovups	-71(%ecx), %ymm0
+-	vmovups	%ymm0, -71(%edx)
+-.LBB0_96:
+-	vmovups	-39(%ecx), %ymm0
+-	vmovups	%ymm0, -39(%edx)
+-	jmp	.LBB0_26
+-.LBB0_97:
+-	vmovups	-200(%ecx), %ymm0
+-	vmovups	%ymm0, -200(%edx)
+-.LBB0_98:
+-	vmovups	-168(%ecx), %ymm0
+-	vmovups	%ymm0, -168(%edx)
+-.LBB0_23:
+-	vmovups	-136(%ecx), %ymm0
+-	vmovups	%ymm0, -136(%edx)
+-	vmovups	-104(%ecx), %ymm0
+-	vmovups	%ymm0, -104(%edx)
+-.LBB0_24:
+-	vmovups	-72(%ecx), %ymm0
+-	vmovups	%ymm0, -72(%edx)
+-.LBB0_25:
+-	vmovups	-40(%ecx), %ymm0
+-	vmovups	%ymm0, -40(%edx)
+-.LBB0_26:
+-	vmovsd	-8(%ecx), %xmm0         # xmm0 = mem[0],zero
+-	vmovsd	%xmm0, -8(%edx)
+-	jmp	.LBB0_270
+-.LBB0_99:
+-	vmovups	-201(%ecx), %ymm0
+-	vmovups	%ymm0, -201(%edx)
+-.LBB0_100:
+-	vmovups	-169(%ecx), %ymm0
+-	vmovups	%ymm0, -169(%edx)
+-	vmovups	-137(%ecx), %ymm0
+-	vmovups	%ymm0, -137(%edx)
+-	vmovups	-105(%ecx), %ymm0
+-	vmovups	%ymm0, -105(%edx)
+-.LBB0_101:
+-	vmovups	-73(%ecx), %ymm0
+-	vmovups	%ymm0, -73(%edx)
+-.LBB0_102:
+-	vmovups	-41(%ecx), %ymm0
+-	vmovups	%ymm0, -41(%edx)
+-	jmp	.LBB0_44
+-.LBB0_103:
+-	vmovups	-202(%ecx), %ymm0
+-	vmovups	%ymm0, -202(%edx)
+-.LBB0_104:
+-	vmovups	-170(%ecx), %ymm0
+-	vmovups	%ymm0, -170(%edx)
+-	vmovups	-138(%ecx), %ymm0
+-	vmovups	%ymm0, -138(%edx)
+-	vmovups	-106(%ecx), %ymm0
+-	vmovups	%ymm0, -106(%edx)
+-.LBB0_105:
+-	vmovups	-74(%ecx), %ymm0
+-	vmovups	%ymm0, -74(%edx)
+-.LBB0_106:
+-	vmovups	-42(%ecx), %ymm0
+-	vmovups	%ymm0, -42(%edx)
+-	jmp	.LBB0_44
+-.LBB0_107:
+-	vmovups	-203(%ecx), %ymm0
+-	vmovups	%ymm0, -203(%edx)
+-.LBB0_108:
+-	vmovups	-171(%ecx), %ymm0
+-	vmovups	%ymm0, -171(%edx)
+-	vmovups	-139(%ecx), %ymm0
+-	vmovups	%ymm0, -139(%edx)
+-	vmovups	-107(%ecx), %ymm0
+-	vmovups	%ymm0, -107(%edx)
+-.LBB0_109:
+-	vmovups	-75(%ecx), %ymm0
+-	vmovups	%ymm0, -75(%edx)
+-.LBB0_110:
+-	vmovups	-43(%ecx), %ymm0
+-	vmovups	%ymm0, -43(%edx)
+-	jmp	.LBB0_44
+-.LBB0_111:
+-	vmovups	-204(%ecx), %ymm0
+-	vmovups	%ymm0, -204(%edx)
+-.LBB0_112:
+-	vmovups	-172(%ecx), %ymm0
+-	vmovups	%ymm0, -172(%edx)
+-	vmovups	-140(%ecx), %ymm0
+-	vmovups	%ymm0, -140(%edx)
+-	vmovups	-108(%ecx), %ymm0
+-	vmovups	%ymm0, -108(%edx)
+-.LBB0_113:
+-	vmovups	-76(%ecx), %ymm0
+-	vmovups	%ymm0, -76(%edx)
+-.LBB0_114:
+-	vmovups	-44(%ecx), %ymm0
+-	vmovups	%ymm0, -44(%edx)
+-	jmp	.LBB0_44
+-.LBB0_115:
+-	vmovups	-205(%ecx), %ymm0
+-	vmovups	%ymm0, -205(%edx)
+-.LBB0_116:
+-	vmovups	-173(%ecx), %ymm0
+-	vmovups	%ymm0, -173(%edx)
+-	vmovups	-141(%ecx), %ymm0
+-	vmovups	%ymm0, -141(%edx)
+-	vmovups	-109(%ecx), %ymm0
+-	vmovups	%ymm0, -109(%edx)
+-.LBB0_117:
+-	vmovups	-77(%ecx), %ymm0
+-	vmovups	%ymm0, -77(%edx)
+-.LBB0_118:
+-	vmovups	-45(%ecx), %ymm0
+-	vmovups	%ymm0, -45(%edx)
+-	jmp	.LBB0_44
+-.LBB0_119:
+-	vmovups	-206(%ecx), %ymm0
+-	vmovups	%ymm0, -206(%edx)
+-.LBB0_120:
+-	vmovups	-174(%ecx), %ymm0
+-	vmovups	%ymm0, -174(%edx)
+-	vmovups	-142(%ecx), %ymm0
+-	vmovups	%ymm0, -142(%edx)
+-	vmovups	-110(%ecx), %ymm0
+-	vmovups	%ymm0, -110(%edx)
+-.LBB0_121:
+-	vmovups	-78(%ecx), %ymm0
+-	vmovups	%ymm0, -78(%edx)
+-.LBB0_122:
+-	vmovups	-46(%ecx), %ymm0
+-	vmovups	%ymm0, -46(%edx)
+-	jmp	.LBB0_44
+-.LBB0_123:
+-	vmovups	-207(%ecx), %ymm0
+-	vmovups	%ymm0, -207(%edx)
+-.LBB0_124:
+-	vmovups	-175(%ecx), %ymm0
+-	vmovups	%ymm0, -175(%edx)
+-	vmovups	-143(%ecx), %ymm0
+-	vmovups	%ymm0, -143(%edx)
+-	vmovups	-111(%ecx), %ymm0
+-	vmovups	%ymm0, -111(%edx)
+-.LBB0_125:
+-	vmovups	-79(%ecx), %ymm0
+-	vmovups	%ymm0, -79(%edx)
+-.LBB0_126:
+-	vmovups	-47(%ecx), %ymm0
+-	vmovups	%ymm0, -47(%edx)
+-	jmp	.LBB0_44
+-.LBB0_127:
+-	vmovups	-208(%ecx), %ymm0
+-	vmovups	%ymm0, -208(%edx)
+-.LBB0_128:
+-	vmovups	-176(%ecx), %ymm0
+-	vmovups	%ymm0, -176(%edx)
+-.LBB0_41:
+-	vmovups	-144(%ecx), %ymm0
+-	vmovups	%ymm0, -144(%edx)
+-	vmovups	-112(%ecx), %ymm0
+-	vmovups	%ymm0, -112(%edx)
+-.LBB0_42:
+-	vmovups	-80(%ecx), %ymm0
+-	vmovups	%ymm0, -80(%edx)
+-.LBB0_43:
+-	vmovups	-48(%ecx), %ymm0
+-	vmovups	%ymm0, -48(%edx)
+-.LBB0_44:
+-	vmovups	-16(%ecx), %xmm0
+-	vmovups	%xmm0, -16(%edx)
+-	jmp	.LBB0_270
+-.LBB0_129:
+-	vmovups	-209(%ecx), %ymm0
+-	vmovups	%ymm0, -209(%edx)
+-.LBB0_130:
+-	vmovups	-177(%ecx), %ymm0
+-	vmovups	%ymm0, -177(%edx)
+-	vmovups	-145(%ecx), %ymm0
+-	vmovups	%ymm0, -145(%edx)
+-	vmovups	-113(%ecx), %ymm0
+-	vmovups	%ymm0, -113(%edx)
+-.LBB0_131:
+-	vmovups	-81(%ecx), %ymm0
+-	vmovups	%ymm0, -81(%edx)
+-.LBB0_132:
+-	vmovups	-49(%ecx), %ymm0
+-	vmovups	%ymm0, -49(%edx)
+-	jmp	.LBB0_269
+-.LBB0_133:
+-	vmovups	-210(%ecx), %ymm0
+-	vmovups	%ymm0, -210(%edx)
+-.LBB0_134:
+-	vmovups	-178(%ecx), %ymm0
+-	vmovups	%ymm0, -178(%edx)
+-	vmovups	-146(%ecx), %ymm0
+-	vmovups	%ymm0, -146(%edx)
+-	vmovups	-114(%ecx), %ymm0
+-	vmovups	%ymm0, -114(%edx)
+-.LBB0_135:
+-	vmovups	-82(%ecx), %ymm0
+-	vmovups	%ymm0, -82(%edx)
+-.LBB0_136:
+-	vmovups	-50(%ecx), %ymm0
+-	vmovups	%ymm0, -50(%edx)
+-	jmp	.LBB0_269
+-.LBB0_137:
+-	vmovups	-211(%ecx), %ymm0
+-	vmovups	%ymm0, -211(%edx)
+-.LBB0_138:
+-	vmovups	-179(%ecx), %ymm0
+-	vmovups	%ymm0, -179(%edx)
+-	vmovups	-147(%ecx), %ymm0
+-	vmovups	%ymm0, -147(%edx)
+-	vmovups	-115(%ecx), %ymm0
+-	vmovups	%ymm0, -115(%edx)
+-.LBB0_139:
+-	vmovups	-83(%ecx), %ymm0
+-	vmovups	%ymm0, -83(%edx)
+-.LBB0_140:
+-	vmovups	-51(%ecx), %ymm0
+-	vmovups	%ymm0, -51(%edx)
+-	jmp	.LBB0_269
+-.LBB0_141:
+-	vmovups	-212(%ecx), %ymm0
+-	vmovups	%ymm0, -212(%edx)
+-.LBB0_142:
+-	vmovups	-180(%ecx), %ymm0
+-	vmovups	%ymm0, -180(%edx)
+-	vmovups	-148(%ecx), %ymm0
+-	vmovups	%ymm0, -148(%edx)
+-	vmovups	-116(%ecx), %ymm0
+-	vmovups	%ymm0, -116(%edx)
+-.LBB0_143:
+-	vmovups	-84(%ecx), %ymm0
+-	vmovups	%ymm0, -84(%edx)
+-.LBB0_144:
+-	vmovups	-52(%ecx), %ymm0
+-	vmovups	%ymm0, -52(%edx)
+-	jmp	.LBB0_269
+-.LBB0_145:
+-	vmovups	-213(%ecx), %ymm0
+-	vmovups	%ymm0, -213(%edx)
+-.LBB0_146:
+-	vmovups	-181(%ecx), %ymm0
+-	vmovups	%ymm0, -181(%edx)
+-	vmovups	-149(%ecx), %ymm0
+-	vmovups	%ymm0, -149(%edx)
+-	vmovups	-117(%ecx), %ymm0
+-	vmovups	%ymm0, -117(%edx)
+-.LBB0_147:
+-	vmovups	-85(%ecx), %ymm0
+-	vmovups	%ymm0, -85(%edx)
+-.LBB0_148:
+-	vmovups	-53(%ecx), %ymm0
+-	vmovups	%ymm0, -53(%edx)
+-	jmp	.LBB0_269
+-.LBB0_149:
+-	vmovups	-214(%ecx), %ymm0
+-	vmovups	%ymm0, -214(%edx)
+-.LBB0_150:
+-	vmovups	-182(%ecx), %ymm0
+-	vmovups	%ymm0, -182(%edx)
+-	vmovups	-150(%ecx), %ymm0
+-	vmovups	%ymm0, -150(%edx)
+-	vmovups	-118(%ecx), %ymm0
+-	vmovups	%ymm0, -118(%edx)
+-.LBB0_151:
+-	vmovups	-86(%ecx), %ymm0
+-	vmovups	%ymm0, -86(%edx)
+-.LBB0_152:
+-	vmovups	-54(%ecx), %ymm0
+-	vmovups	%ymm0, -54(%edx)
+-	jmp	.LBB0_269
+-.LBB0_153:
+-	vmovups	-215(%ecx), %ymm0
+-	vmovups	%ymm0, -215(%edx)
+-.LBB0_154:
+-	vmovups	-183(%ecx), %ymm0
+-	vmovups	%ymm0, -183(%edx)
+-	vmovups	-151(%ecx), %ymm0
+-	vmovups	%ymm0, -151(%edx)
+-	vmovups	-119(%ecx), %ymm0
+-	vmovups	%ymm0, -119(%edx)
+-.LBB0_155:
+-	vmovups	-87(%ecx), %ymm0
+-	vmovups	%ymm0, -87(%edx)
+-.LBB0_156:
+-	vmovups	-55(%ecx), %ymm0
+-	vmovups	%ymm0, -55(%edx)
+-	jmp	.LBB0_269
+-.LBB0_157:
+-	vmovups	-216(%ecx), %ymm0
+-	vmovups	%ymm0, -216(%edx)
+-.LBB0_158:
+-	vmovups	-184(%ecx), %ymm0
+-	vmovups	%ymm0, -184(%edx)
+-	vmovups	-152(%ecx), %ymm0
+-	vmovups	%ymm0, -152(%edx)
+-	vmovups	-120(%ecx), %ymm0
+-	vmovups	%ymm0, -120(%edx)
+-.LBB0_159:
+-	vmovups	-88(%ecx), %ymm0
+-	vmovups	%ymm0, -88(%edx)
+-.LBB0_160:
+-	vmovups	-56(%ecx), %ymm0
+-	vmovups	%ymm0, -56(%edx)
+-	jmp	.LBB0_269
+-.LBB0_161:
+-	vmovups	-217(%ecx), %ymm0
+-	vmovups	%ymm0, -217(%edx)
+-.LBB0_162:
+-	vmovups	-185(%ecx), %ymm0
+-	vmovups	%ymm0, -185(%edx)
+-	vmovups	-153(%ecx), %ymm0
+-	vmovups	%ymm0, -153(%edx)
+-	vmovups	-121(%ecx), %ymm0
+-	vmovups	%ymm0, -121(%edx)
+-.LBB0_163:
+-	vmovups	-89(%ecx), %ymm0
+-	vmovups	%ymm0, -89(%edx)
+-.LBB0_164:
+-	vmovups	-57(%ecx), %ymm0
+-	vmovups	%ymm0, -57(%edx)
+-	jmp	.LBB0_269
+-.LBB0_165:
+-	vmovups	-218(%ecx), %ymm0
+-	vmovups	%ymm0, -218(%edx)
+-.LBB0_166:
+-	vmovups	-186(%ecx), %ymm0
+-	vmovups	%ymm0, -186(%edx)
+-	vmovups	-154(%ecx), %ymm0
+-	vmovups	%ymm0, -154(%edx)
+-	vmovups	-122(%ecx), %ymm0
+-	vmovups	%ymm0, -122(%edx)
+-.LBB0_167:
+-	vmovups	-90(%ecx), %ymm0
+-	vmovups	%ymm0, -90(%edx)
+-.LBB0_168:
+-	vmovups	-58(%ecx), %ymm0
+-	vmovups	%ymm0, -58(%edx)
+-	jmp	.LBB0_269
+-.LBB0_169:
+-	vmovups	-219(%ecx), %ymm0
+-	vmovups	%ymm0, -219(%edx)
+-.LBB0_170:
+-	vmovups	-187(%ecx), %ymm0
+-	vmovups	%ymm0, -187(%edx)
+-	vmovups	-155(%ecx), %ymm0
+-	vmovups	%ymm0, -155(%edx)
+-	vmovups	-123(%ecx), %ymm0
+-	vmovups	%ymm0, -123(%edx)
+-.LBB0_171:
+-	vmovups	-91(%ecx), %ymm0
+-	vmovups	%ymm0, -91(%edx)
+-.LBB0_172:
+-	vmovups	-59(%ecx), %ymm0
+-	vmovups	%ymm0, -59(%edx)
+-	jmp	.LBB0_269
+-.LBB0_173:
+-	vmovups	-220(%ecx), %ymm0
+-	vmovups	%ymm0, -220(%edx)
+-.LBB0_174:
+-	vmovups	-188(%ecx), %ymm0
+-	vmovups	%ymm0, -188(%edx)
+-	vmovups	-156(%ecx), %ymm0
+-	vmovups	%ymm0, -156(%edx)
+-	vmovups	-124(%ecx), %ymm0
+-	vmovups	%ymm0, -124(%edx)
+-.LBB0_175:
+-	vmovups	-92(%ecx), %ymm0
+-	vmovups	%ymm0, -92(%edx)
+-.LBB0_176:
+-	vmovups	-60(%ecx), %ymm0
+-	vmovups	%ymm0, -60(%edx)
+-	jmp	.LBB0_269
+-.LBB0_177:
+-	vmovups	-221(%ecx), %ymm0
+-	vmovups	%ymm0, -221(%edx)
+-.LBB0_178:
+-	vmovups	-189(%ecx), %ymm0
+-	vmovups	%ymm0, -189(%edx)
+-	vmovups	-157(%ecx), %ymm0
+-	vmovups	%ymm0, -157(%edx)
+-	vmovups	-125(%ecx), %ymm0
+-	vmovups	%ymm0, -125(%edx)
+-.LBB0_179:
+-	vmovups	-93(%ecx), %ymm0
+-	vmovups	%ymm0, -93(%edx)
+-.LBB0_180:
+-	vmovups	-61(%ecx), %ymm0
+-	vmovups	%ymm0, -61(%edx)
+-	jmp	.LBB0_269
+-.LBB0_181:
+-	vmovups	-222(%ecx), %ymm0
+-	vmovups	%ymm0, -222(%edx)
+-.LBB0_182:
+-	vmovups	-190(%ecx), %ymm0
+-	vmovups	%ymm0, -190(%edx)
+-	vmovups	-158(%ecx), %ymm0
+-	vmovups	%ymm0, -158(%edx)
+-	vmovups	-126(%ecx), %ymm0
+-	vmovups	%ymm0, -126(%edx)
+-.LBB0_183:
+-	vmovups	-94(%ecx), %ymm0
+-	vmovups	%ymm0, -94(%edx)
+-.LBB0_184:
+-	vmovups	-62(%ecx), %ymm0
+-	vmovups	%ymm0, -62(%edx)
+-	jmp	.LBB0_269
+-.LBB0_185:
+-	vmovups	-223(%ecx), %ymm0
+-	vmovups	%ymm0, -223(%edx)
+-.LBB0_186:
+-	vmovups	-191(%ecx), %ymm0
+-	vmovups	%ymm0, -191(%edx)
+-	vmovups	-159(%ecx), %ymm0
+-	vmovups	%ymm0, -159(%edx)
+-	vmovups	-127(%ecx), %ymm0
+-	vmovups	%ymm0, -127(%edx)
+-.LBB0_187:
+-	vmovups	-95(%ecx), %ymm0
+-	vmovups	%ymm0, -95(%edx)
+-.LBB0_188:
+-	vmovups	-63(%ecx), %ymm0
+-	vmovups	%ymm0, -63(%edx)
+-	jmp	.LBB0_269
+-.LBB0_189:
+-	vmovups	-225(%ecx), %ymm0
+-	vmovups	%ymm0, -225(%edx)
+-	vmovups	-193(%ecx), %ymm0
+-	vmovups	%ymm0, -193(%edx)
+-	vmovups	-161(%ecx), %ymm0
+-	vmovups	%ymm0, -161(%edx)
+-	vmovups	-129(%ecx), %ymm0
+-	vmovups	%ymm0, -129(%edx)
+-.LBB0_190:
+-	vmovups	-97(%ecx), %ymm0
+-	vmovups	%ymm0, -97(%edx)
+-	vmovups	-65(%ecx), %ymm0
+-	vmovups	%ymm0, -65(%edx)
+-	jmp	.LBB0_268
+-.LBB0_191:
+-	vmovups	-226(%ecx), %ymm0
+-	vmovups	%ymm0, -226(%edx)
+-	vmovups	-194(%ecx), %ymm0
+-	vmovups	%ymm0, -194(%edx)
+-	vmovups	-162(%ecx), %ymm0
+-	vmovups	%ymm0, -162(%edx)
+-	vmovups	-130(%ecx), %ymm0
+-	vmovups	%ymm0, -130(%edx)
+-.LBB0_192:
+-	vmovups	-98(%ecx), %ymm0
+-	vmovups	%ymm0, -98(%edx)
+-	vmovups	-66(%ecx), %ymm0
+-	vmovups	%ymm0, -66(%edx)
+-	jmp	.LBB0_268
+-.LBB0_193:
+-	vmovups	-227(%ecx), %ymm0
+-	vmovups	%ymm0, -227(%edx)
+-	vmovups	-195(%ecx), %ymm0
+-	vmovups	%ymm0, -195(%edx)
+-	vmovups	-163(%ecx), %ymm0
+-	vmovups	%ymm0, -163(%edx)
+-	vmovups	-131(%ecx), %ymm0
+-	vmovups	%ymm0, -131(%edx)
+-.LBB0_194:
+-	vmovups	-99(%ecx), %ymm0
+-	vmovups	%ymm0, -99(%edx)
+-	vmovups	-67(%ecx), %ymm0
+-	vmovups	%ymm0, -67(%edx)
+-	jmp	.LBB0_268
+-.LBB0_195:
+-	vmovups	-228(%ecx), %ymm0
+-	vmovups	%ymm0, -228(%edx)
+-	vmovups	-196(%ecx), %ymm0
+-	vmovups	%ymm0, -196(%edx)
+-	vmovups	-164(%ecx), %ymm0
+-	vmovups	%ymm0, -164(%edx)
+-	vmovups	-132(%ecx), %ymm0
+-	vmovups	%ymm0, -132(%edx)
+-.LBB0_196:
+-	vmovups	-100(%ecx), %ymm0
+-	vmovups	%ymm0, -100(%edx)
+-	vmovups	-68(%ecx), %ymm0
+-	vmovups	%ymm0, -68(%edx)
+-	jmp	.LBB0_268
+-.LBB0_197:
+-	vmovups	-229(%ecx), %ymm0
+-	vmovups	%ymm0, -229(%edx)
+-	vmovups	-197(%ecx), %ymm0
+-	vmovups	%ymm0, -197(%edx)
+-	vmovups	-165(%ecx), %ymm0
+-	vmovups	%ymm0, -165(%edx)
+-	vmovups	-133(%ecx), %ymm0
+-	vmovups	%ymm0, -133(%edx)
+-.LBB0_198:
+-	vmovups	-101(%ecx), %ymm0
+-	vmovups	%ymm0, -101(%edx)
+-	vmovups	-69(%ecx), %ymm0
+-	vmovups	%ymm0, -69(%edx)
+-	jmp	.LBB0_268
+-.LBB0_199:
+-	vmovups	-230(%ecx), %ymm0
+-	vmovups	%ymm0, -230(%edx)
+-	vmovups	-198(%ecx), %ymm0
+-	vmovups	%ymm0, -198(%edx)
+-	vmovups	-166(%ecx), %ymm0
+-	vmovups	%ymm0, -166(%edx)
+-	vmovups	-134(%ecx), %ymm0
+-	vmovups	%ymm0, -134(%edx)
+-.LBB0_200:
+-	vmovups	-102(%ecx), %ymm0
+-	vmovups	%ymm0, -102(%edx)
+-	vmovups	-70(%ecx), %ymm0
+-	vmovups	%ymm0, -70(%edx)
+-	jmp	.LBB0_268
+-.LBB0_201:
+-	vmovups	-231(%ecx), %ymm0
+-	vmovups	%ymm0, -231(%edx)
+-	vmovups	-199(%ecx), %ymm0
+-	vmovups	%ymm0, -199(%edx)
+-	vmovups	-167(%ecx), %ymm0
+-	vmovups	%ymm0, -167(%edx)
+-	vmovups	-135(%ecx), %ymm0
+-	vmovups	%ymm0, -135(%edx)
+-.LBB0_202:
+-	vmovups	-103(%ecx), %ymm0
+-	vmovups	%ymm0, -103(%edx)
+-	vmovups	-71(%ecx), %ymm0
+-	vmovups	%ymm0, -71(%edx)
+-	jmp	.LBB0_268
+-.LBB0_203:
+-	vmovups	-232(%ecx), %ymm0
+-	vmovups	%ymm0, -232(%edx)
+-	vmovups	-200(%ecx), %ymm0
+-	vmovups	%ymm0, -200(%edx)
+-	vmovups	-168(%ecx), %ymm0
+-	vmovups	%ymm0, -168(%edx)
+-	vmovups	-136(%ecx), %ymm0
+-	vmovups	%ymm0, -136(%edx)
+-.LBB0_204:
+-	vmovups	-104(%ecx), %ymm0
+-	vmovups	%ymm0, -104(%edx)
+-	vmovups	-72(%ecx), %ymm0
+-	vmovups	%ymm0, -72(%edx)
+-	jmp	.LBB0_268
+-.LBB0_205:
+-	vmovups	-233(%ecx), %ymm0
+-	vmovups	%ymm0, -233(%edx)
+-	vmovups	-201(%ecx), %ymm0
+-	vmovups	%ymm0, -201(%edx)
+-	vmovups	-169(%ecx), %ymm0
+-	vmovups	%ymm0, -169(%edx)
+-	vmovups	-137(%ecx), %ymm0
+-	vmovups	%ymm0, -137(%edx)
+-.LBB0_206:
+-	vmovups	-105(%ecx), %ymm0
+-	vmovups	%ymm0, -105(%edx)
+-	vmovups	-73(%ecx), %ymm0
+-	vmovups	%ymm0, -73(%edx)
+-	jmp	.LBB0_268
+-.LBB0_207:
+-	vmovups	-234(%ecx), %ymm0
+-	vmovups	%ymm0, -234(%edx)
+-	vmovups	-202(%ecx), %ymm0
+-	vmovups	%ymm0, -202(%edx)
+-	vmovups	-170(%ecx), %ymm0
+-	vmovups	%ymm0, -170(%edx)
+-	vmovups	-138(%ecx), %ymm0
+-	vmovups	%ymm0, -138(%edx)
+-.LBB0_208:
+-	vmovups	-106(%ecx), %ymm0
+-	vmovups	%ymm0, -106(%edx)
+-	vmovups	-74(%ecx), %ymm0
+-	vmovups	%ymm0, -74(%edx)
+-	jmp	.LBB0_268
+-.LBB0_209:
+-	vmovups	-235(%ecx), %ymm0
+-	vmovups	%ymm0, -235(%edx)
+-	vmovups	-203(%ecx), %ymm0
+-	vmovups	%ymm0, -203(%edx)
+-	vmovups	-171(%ecx), %ymm0
+-	vmovups	%ymm0, -171(%edx)
+-	vmovups	-139(%ecx), %ymm0
+-	vmovups	%ymm0, -139(%edx)
+-.LBB0_210:
+-	vmovups	-107(%ecx), %ymm0
+-	vmovups	%ymm0, -107(%edx)
+-	vmovups	-75(%ecx), %ymm0
+-	vmovups	%ymm0, -75(%edx)
+-	jmp	.LBB0_268
+-.LBB0_211:
+-	vmovups	-236(%ecx), %ymm0
+-	vmovups	%ymm0, -236(%edx)
+-	vmovups	-204(%ecx), %ymm0
+-	vmovups	%ymm0, -204(%edx)
+-	vmovups	-172(%ecx), %ymm0
+-	vmovups	%ymm0, -172(%edx)
+-	vmovups	-140(%ecx), %ymm0
+-	vmovups	%ymm0, -140(%edx)
+-.LBB0_212:
+-	vmovups	-108(%ecx), %ymm0
+-	vmovups	%ymm0, -108(%edx)
+-	vmovups	-76(%ecx), %ymm0
+-	vmovups	%ymm0, -76(%edx)
+-	jmp	.LBB0_268
+-.LBB0_213:
+-	vmovups	-237(%ecx), %ymm0
+-	vmovups	%ymm0, -237(%edx)
+-	vmovups	-205(%ecx), %ymm0
+-	vmovups	%ymm0, -205(%edx)
+-	vmovups	-173(%ecx), %ymm0
+-	vmovups	%ymm0, -173(%edx)
+-	vmovups	-141(%ecx), %ymm0
+-	vmovups	%ymm0, -141(%edx)
+-.LBB0_214:
+-	vmovups	-109(%ecx), %ymm0
+-	vmovups	%ymm0, -109(%edx)
+-	vmovups	-77(%ecx), %ymm0
+-	vmovups	%ymm0, -77(%edx)
+-	jmp	.LBB0_268
+-.LBB0_215:
+-	vmovups	-238(%ecx), %ymm0
+-	vmovups	%ymm0, -238(%edx)
+-	vmovups	-206(%ecx), %ymm0
+-	vmovups	%ymm0, -206(%edx)
+-	vmovups	-174(%ecx), %ymm0
+-	vmovups	%ymm0, -174(%edx)
+-	vmovups	-142(%ecx), %ymm0
+-	vmovups	%ymm0, -142(%edx)
+-.LBB0_216:
+-	vmovups	-110(%ecx), %ymm0
+-	vmovups	%ymm0, -110(%edx)
+-	vmovups	-78(%ecx), %ymm0
+-	vmovups	%ymm0, -78(%edx)
+-	jmp	.LBB0_268
+-.LBB0_217:
+-	vmovups	-239(%ecx), %ymm0
+-	vmovups	%ymm0, -239(%edx)
+-	vmovups	-207(%ecx), %ymm0
+-	vmovups	%ymm0, -207(%edx)
+-	vmovups	-175(%ecx), %ymm0
+-	vmovups	%ymm0, -175(%edx)
+-	vmovups	-143(%ecx), %ymm0
+-	vmovups	%ymm0, -143(%edx)
+-.LBB0_218:
+-	vmovups	-111(%ecx), %ymm0
+-	vmovups	%ymm0, -111(%edx)
+-	vmovups	-79(%ecx), %ymm0
+-	vmovups	%ymm0, -79(%edx)
+-	jmp	.LBB0_268
+-.LBB0_219:
+-	vmovups	-240(%ecx), %ymm0
+-	vmovups	%ymm0, -240(%edx)
+-	vmovups	-208(%ecx), %ymm0
+-	vmovups	%ymm0, -208(%edx)
+-	vmovups	-176(%ecx), %ymm0
+-	vmovups	%ymm0, -176(%edx)
+-	vmovups	-144(%ecx), %ymm0
+-	vmovups	%ymm0, -144(%edx)
+-.LBB0_220:
+-	vmovups	-112(%ecx), %ymm0
+-	vmovups	%ymm0, -112(%edx)
+-	vmovups	-80(%ecx), %ymm0
+-	vmovups	%ymm0, -80(%edx)
+-	jmp	.LBB0_268
+-.LBB0_221:
+-	vmovups	-241(%ecx), %ymm0
+-	vmovups	%ymm0, -241(%edx)
+-	vmovups	-209(%ecx), %ymm0
+-	vmovups	%ymm0, -209(%edx)
+-	vmovups	-177(%ecx), %ymm0
+-	vmovups	%ymm0, -177(%edx)
+-	vmovups	-145(%ecx), %ymm0
+-	vmovups	%ymm0, -145(%edx)
+-.LBB0_222:
+-	vmovups	-113(%ecx), %ymm0
+-	vmovups	%ymm0, -113(%edx)
+-	vmovups	-81(%ecx), %ymm0
+-	vmovups	%ymm0, -81(%edx)
+-	jmp	.LBB0_268
+-.LBB0_223:
+-	vmovups	-242(%ecx), %ymm0
+-	vmovups	%ymm0, -242(%edx)
+-	vmovups	-210(%ecx), %ymm0
+-	vmovups	%ymm0, -210(%edx)
+-	vmovups	-178(%ecx), %ymm0
+-	vmovups	%ymm0, -178(%edx)
+-	vmovups	-146(%ecx), %ymm0
+-	vmovups	%ymm0, -146(%edx)
+-.LBB0_224:
+-	vmovups	-114(%ecx), %ymm0
+-	vmovups	%ymm0, -114(%edx)
+-	vmovups	-82(%ecx), %ymm0
+-	vmovups	%ymm0, -82(%edx)
+-	jmp	.LBB0_268
+-.LBB0_225:
+-	vmovups	-243(%ecx), %ymm0
+-	vmovups	%ymm0, -243(%edx)
+-	vmovups	-211(%ecx), %ymm0
+-	vmovups	%ymm0, -211(%edx)
+-	vmovups	-179(%ecx), %ymm0
+-	vmovups	%ymm0, -179(%edx)
+-	vmovups	-147(%ecx), %ymm0
+-	vmovups	%ymm0, -147(%edx)
+-.LBB0_226:
+-	vmovups	-115(%ecx), %ymm0
+-	vmovups	%ymm0, -115(%edx)
+-	vmovups	-83(%ecx), %ymm0
+-	vmovups	%ymm0, -83(%edx)
+-	jmp	.LBB0_268
+-.LBB0_227:
+-	vmovups	-244(%ecx), %ymm0
+-	vmovups	%ymm0, -244(%edx)
+-	vmovups	-212(%ecx), %ymm0
+-	vmovups	%ymm0, -212(%edx)
+-	vmovups	-180(%ecx), %ymm0
+-	vmovups	%ymm0, -180(%edx)
+-	vmovups	-148(%ecx), %ymm0
+-	vmovups	%ymm0, -148(%edx)
+-.LBB0_228:
+-	vmovups	-116(%ecx), %ymm0
+-	vmovups	%ymm0, -116(%edx)
+-	vmovups	-84(%ecx), %ymm0
+-	vmovups	%ymm0, -84(%edx)
+-	jmp	.LBB0_268
+-.LBB0_229:
+-	vmovups	-245(%ecx), %ymm0
+-	vmovups	%ymm0, -245(%edx)
+-	vmovups	-213(%ecx), %ymm0
+-	vmovups	%ymm0, -213(%edx)
+-	vmovups	-181(%ecx), %ymm0
+-	vmovups	%ymm0, -181(%edx)
+-	vmovups	-149(%ecx), %ymm0
+-	vmovups	%ymm0, -149(%edx)
+-.LBB0_230:
+-	vmovups	-117(%ecx), %ymm0
+-	vmovups	%ymm0, -117(%edx)
+-	vmovups	-85(%ecx), %ymm0
+-	vmovups	%ymm0, -85(%edx)
+-	jmp	.LBB0_268
+-.LBB0_231:
+-	vmovups	-246(%ecx), %ymm0
+-	vmovups	%ymm0, -246(%edx)
+-	vmovups	-214(%ecx), %ymm0
+-	vmovups	%ymm0, -214(%edx)
+-	vmovups	-182(%ecx), %ymm0
+-	vmovups	%ymm0, -182(%edx)
+-	vmovups	-150(%ecx), %ymm0
+-	vmovups	%ymm0, -150(%edx)
+-.LBB0_232:
+-	vmovups	-118(%ecx), %ymm0
+-	vmovups	%ymm0, -118(%edx)
+-	vmovups	-86(%ecx), %ymm0
+-	vmovups	%ymm0, -86(%edx)
+-	jmp	.LBB0_268
+-.LBB0_233:
+-	vmovups	-247(%ecx), %ymm0
+-	vmovups	%ymm0, -247(%edx)
+-	vmovups	-215(%ecx), %ymm0
+-	vmovups	%ymm0, -215(%edx)
+-	vmovups	-183(%ecx), %ymm0
+-	vmovups	%ymm0, -183(%edx)
+-	vmovups	-151(%ecx), %ymm0
+-	vmovups	%ymm0, -151(%edx)
+-.LBB0_234:
+-	vmovups	-119(%ecx), %ymm0
+-	vmovups	%ymm0, -119(%edx)
+-	vmovups	-87(%ecx), %ymm0
+-	vmovups	%ymm0, -87(%edx)
+-	jmp	.LBB0_268
+-.LBB0_235:
+-	vmovups	-248(%ecx), %ymm0
+-	vmovups	%ymm0, -248(%edx)
+-	vmovups	-216(%ecx), %ymm0
+-	vmovups	%ymm0, -216(%edx)
+-	vmovups	-184(%ecx), %ymm0
+-	vmovups	%ymm0, -184(%edx)
+-	vmovups	-152(%ecx), %ymm0
+-	vmovups	%ymm0, -152(%edx)
+-.LBB0_236:
+-	vmovups	-120(%ecx), %ymm0
+-	vmovups	%ymm0, -120(%edx)
+-	vmovups	-88(%ecx), %ymm0
+-	vmovups	%ymm0, -88(%edx)
+-	jmp	.LBB0_268
+-.LBB0_237:
+-	vmovups	-249(%ecx), %ymm0
+-	vmovups	%ymm0, -249(%edx)
+-	vmovups	-217(%ecx), %ymm0
+-	vmovups	%ymm0, -217(%edx)
+-	vmovups	-185(%ecx), %ymm0
+-	vmovups	%ymm0, -185(%edx)
+-	vmovups	-153(%ecx), %ymm0
+-	vmovups	%ymm0, -153(%edx)
+-.LBB0_238:
+-	vmovups	-121(%ecx), %ymm0
+-	vmovups	%ymm0, -121(%edx)
+-	vmovups	-89(%ecx), %ymm0
+-	vmovups	%ymm0, -89(%edx)
+-	jmp	.LBB0_268
+-.LBB0_239:
+-	vmovups	-250(%ecx), %ymm0
+-	vmovups	%ymm0, -250(%edx)
+-	vmovups	-218(%ecx), %ymm0
+-	vmovups	%ymm0, -218(%edx)
+-	vmovups	-186(%ecx), %ymm0
+-	vmovups	%ymm0, -186(%edx)
+-	vmovups	-154(%ecx), %ymm0
+-	vmovups	%ymm0, -154(%edx)
+-.LBB0_240:
+-	vmovups	-122(%ecx), %ymm0
+-	vmovups	%ymm0, -122(%edx)
+-	vmovups	-90(%ecx), %ymm0
+-	vmovups	%ymm0, -90(%edx)
+-	jmp	.LBB0_268
+-.LBB0_241:
+-	vmovups	-251(%ecx), %ymm0
+-	vmovups	%ymm0, -251(%edx)
+-	vmovups	-219(%ecx), %ymm0
+-	vmovups	%ymm0, -219(%edx)
+-	vmovups	-187(%ecx), %ymm0
+-	vmovups	%ymm0, -187(%edx)
+-	vmovups	-155(%ecx), %ymm0
+-	vmovups	%ymm0, -155(%edx)
+-.LBB0_242:
+-	vmovups	-123(%ecx), %ymm0
+-	vmovups	%ymm0, -123(%edx)
+-	vmovups	-91(%ecx), %ymm0
+-	vmovups	%ymm0, -91(%edx)
+-	jmp	.LBB0_268
+-.LBB0_243:
+-	vmovups	-252(%ecx), %ymm0
+-	vmovups	%ymm0, -252(%edx)
+-	vmovups	-220(%ecx), %ymm0
+-	vmovups	%ymm0, -220(%edx)
+-	vmovups	-188(%ecx), %ymm0
+-	vmovups	%ymm0, -188(%edx)
+-	vmovups	-156(%ecx), %ymm0
+-	vmovups	%ymm0, -156(%edx)
+-.LBB0_244:
+-	vmovups	-124(%ecx), %ymm0
+-	vmovups	%ymm0, -124(%edx)
+-	vmovups	-92(%ecx), %ymm0
+-	vmovups	%ymm0, -92(%edx)
+-	jmp	.LBB0_268
+-.LBB0_245:
+-	vmovups	-253(%ecx), %ymm0
+-	vmovups	%ymm0, -253(%edx)
+-	vmovups	-221(%ecx), %ymm0
+-	vmovups	%ymm0, -221(%edx)
+-	vmovups	-189(%ecx), %ymm0
+-	vmovups	%ymm0, -189(%edx)
+-	vmovups	-157(%ecx), %ymm0
+-	vmovups	%ymm0, -157(%edx)
+-.LBB0_246:
+-	vmovups	-125(%ecx), %ymm0
+-	vmovups	%ymm0, -125(%edx)
+-	vmovups	-93(%ecx), %ymm0
+-	vmovups	%ymm0, -93(%edx)
+-	jmp	.LBB0_268
+-.LBB0_247:
+-	vmovups	-254(%ecx), %ymm0
+-	vmovups	%ymm0, -254(%edx)
+-	vmovups	-222(%ecx), %ymm0
+-	vmovups	%ymm0, -222(%edx)
+-	vmovups	-190(%ecx), %ymm0
+-	vmovups	%ymm0, -190(%edx)
+-	vmovups	-158(%ecx), %ymm0
+-	vmovups	%ymm0, -158(%edx)
+-.LBB0_248:
+-	vmovups	-126(%ecx), %ymm0
+-	vmovups	%ymm0, -126(%edx)
+-	vmovups	-94(%ecx), %ymm0
+-	vmovups	%ymm0, -94(%edx)
+-	jmp	.LBB0_268
+-.LBB0_249:
+-	vmovups	-255(%ecx), %ymm0
+-	vmovups	%ymm0, -255(%edx)
+-	vmovups	-223(%ecx), %ymm0
+-	vmovups	%ymm0, -223(%edx)
+-	vmovups	-191(%ecx), %ymm0
+-	vmovups	%ymm0, -191(%edx)
+-	vmovups	-159(%ecx), %ymm0
+-	vmovups	%ymm0, -159(%edx)
+-.LBB0_250:
+-	vmovups	-127(%ecx), %ymm0
+-	vmovups	%ymm0, -127(%edx)
+-	vmovups	-95(%ecx), %ymm0
+-	vmovups	%ymm0, -95(%edx)
+-	jmp	.LBB0_268
+-.LBB0_262:
+-	vmovups	-256(%ecx), %ymm0
+-	vmovups	%ymm0, -256(%edx)
+-.LBB0_263:
+-	vmovups	-224(%ecx), %ymm0
+-	vmovups	%ymm0, -224(%edx)
+-.LBB0_264:
+-	vmovups	-192(%ecx), %ymm0
+-	vmovups	%ymm0, -192(%edx)
+-.LBB0_265:
+-	vmovups	-160(%ecx), %ymm0
+-	vmovups	%ymm0, -160(%edx)
+-.LBB0_266:
+-	vmovups	-128(%ecx), %ymm0
+-	vmovups	%ymm0, -128(%edx)
+-.LBB0_267:
+-	vmovups	-96(%ecx), %ymm0
+-	vmovups	%ymm0, -96(%edx)
+-.LBB0_268:
+-	vmovups	-64(%ecx), %ymm0
+-	vmovups	%ymm0, -64(%edx)
+-.LBB0_269:
+-	vmovups	-32(%ecx), %ymm0
+-	vmovups	%ymm0, -32(%edx)
+-.LBB0_270:
+-	vzeroupper
+-	popl	%esi
+-	popl	%edi
+-	popl	%ebx
+-	popl	%ebp
+-	retl
+-END(memcpy_avx2)
+-
+-/*.Lfunc_end0:
+-	.size	memcpy_avx2, .Lfunc_end0-memcpy_avx2
+-	.section	.rodata,"a",@progbits
+-	.p2align	2*/
+-.LJTI0_0:
+-	.long	.LBB0_6@GOTOFF
+-	.long	.LBB0_10@GOTOFF
+-	.long	.LBB0_12@GOTOFF
+-	.long	.LBB0_16@GOTOFF
+-	.long	.LBB0_18@GOTOFF
+-	.long	.LBB0_20@GOTOFF
+-	.long	.LBB0_22@GOTOFF
+-	.long	.LBB0_26@GOTOFF
+-	.long	.LBB0_28@GOTOFF
+-	.long	.LBB0_30@GOTOFF
+-	.long	.LBB0_32@GOTOFF
+-	.long	.LBB0_34@GOTOFF
+-	.long	.LBB0_36@GOTOFF
+-	.long	.LBB0_38@GOTOFF
+-	.long	.LBB0_40@GOTOFF
+-	.long	.LBB0_44@GOTOFF
+-	.long	.LBB0_46@GOTOFF
+-	.long	.LBB0_48@GOTOFF
+-	.long	.LBB0_50@GOTOFF
+-	.long	.LBB0_52@GOTOFF
+-	.long	.LBB0_54@GOTOFF
+-	.long	.LBB0_56@GOTOFF
+-	.long	.LBB0_58@GOTOFF
+-	.long	.LBB0_60@GOTOFF
+-	.long	.LBB0_62@GOTOFF
+-	.long	.LBB0_64@GOTOFF
+-	.long	.LBB0_66@GOTOFF
+-	.long	.LBB0_68@GOTOFF
+-	.long	.LBB0_70@GOTOFF
+-	.long	.LBB0_72@GOTOFF
+-	.long	.LBB0_74@GOTOFF
+-	.long	.LBB0_269@GOTOFF
+-	.long	.LBB0_5@GOTOFF
+-	.long	.LBB0_9@GOTOFF
+-	.long	.LBB0_82@GOTOFF
+-	.long	.LBB0_15@GOTOFF
+-	.long	.LBB0_88@GOTOFF
+-	.long	.LBB0_92@GOTOFF
+-	.long	.LBB0_96@GOTOFF
+-	.long	.LBB0_25@GOTOFF
+-	.long	.LBB0_102@GOTOFF
+-	.long	.LBB0_106@GOTOFF
+-	.long	.LBB0_110@GOTOFF
+-	.long	.LBB0_114@GOTOFF
+-	.long	.LBB0_118@GOTOFF
+-	.long	.LBB0_122@GOTOFF
+-	.long	.LBB0_126@GOTOFF
+-	.long	.LBB0_43@GOTOFF
+-	.long	.LBB0_132@GOTOFF
+-	.long	.LBB0_136@GOTOFF
+-	.long	.LBB0_140@GOTOFF
+-	.long	.LBB0_144@GOTOFF
+-	.long	.LBB0_148@GOTOFF
+-	.long	.LBB0_152@GOTOFF
+-	.long	.LBB0_156@GOTOFF
+-	.long	.LBB0_160@GOTOFF
+-	.long	.LBB0_164@GOTOFF
+-	.long	.LBB0_168@GOTOFF
+-	.long	.LBB0_172@GOTOFF
+-	.long	.LBB0_176@GOTOFF
+-	.long	.LBB0_180@GOTOFF
+-	.long	.LBB0_184@GOTOFF
+-	.long	.LBB0_188@GOTOFF
+-	.long	.LBB0_268@GOTOFF
+-	.long	.LBB0_4@GOTOFF
+-	.long	.LBB0_8@GOTOFF
+-	.long	.LBB0_81@GOTOFF
+-	.long	.LBB0_14@GOTOFF
+-	.long	.LBB0_87@GOTOFF
+-	.long	.LBB0_91@GOTOFF
+-	.long	.LBB0_95@GOTOFF
+-	.long	.LBB0_24@GOTOFF
+-	.long	.LBB0_101@GOTOFF
+-	.long	.LBB0_105@GOTOFF
+-	.long	.LBB0_109@GOTOFF
+-	.long	.LBB0_113@GOTOFF
+-	.long	.LBB0_117@GOTOFF
+-	.long	.LBB0_121@GOTOFF
+-	.long	.LBB0_125@GOTOFF
+-	.long	.LBB0_42@GOTOFF
+-	.long	.LBB0_131@GOTOFF
+-	.long	.LBB0_135@GOTOFF
+-	.long	.LBB0_139@GOTOFF
+-	.long	.LBB0_143@GOTOFF
+-	.long	.LBB0_147@GOTOFF
+-	.long	.LBB0_151@GOTOFF
+-	.long	.LBB0_155@GOTOFF
+-	.long	.LBB0_159@GOTOFF
+-	.long	.LBB0_163@GOTOFF
+-	.long	.LBB0_167@GOTOFF
+-	.long	.LBB0_171@GOTOFF
+-	.long	.LBB0_175@GOTOFF
+-	.long	.LBB0_179@GOTOFF
+-	.long	.LBB0_183@GOTOFF
+-	.long	.LBB0_187@GOTOFF
+-	.long	.LBB0_267@GOTOFF
+-	.long	.LBB0_190@GOTOFF
+-	.long	.LBB0_192@GOTOFF
+-	.long	.LBB0_194@GOTOFF
+-	.long	.LBB0_196@GOTOFF
+-	.long	.LBB0_198@GOTOFF
+-	.long	.LBB0_200@GOTOFF
+-	.long	.LBB0_202@GOTOFF
+-	.long	.LBB0_204@GOTOFF
+-	.long	.LBB0_206@GOTOFF
+-	.long	.LBB0_208@GOTOFF
+-	.long	.LBB0_210@GOTOFF
+-	.long	.LBB0_212@GOTOFF
+-	.long	.LBB0_214@GOTOFF
+-	.long	.LBB0_216@GOTOFF
+-	.long	.LBB0_218@GOTOFF
+-	.long	.LBB0_220@GOTOFF
+-	.long	.LBB0_222@GOTOFF
+-	.long	.LBB0_224@GOTOFF
+-	.long	.LBB0_226@GOTOFF
+-	.long	.LBB0_228@GOTOFF
+-	.long	.LBB0_230@GOTOFF
+-	.long	.LBB0_232@GOTOFF
+-	.long	.LBB0_234@GOTOFF
+-	.long	.LBB0_236@GOTOFF
+-	.long	.LBB0_238@GOTOFF
+-	.long	.LBB0_240@GOTOFF
+-	.long	.LBB0_242@GOTOFF
+-	.long	.LBB0_244@GOTOFF
+-	.long	.LBB0_246@GOTOFF
+-	.long	.LBB0_248@GOTOFF
+-	.long	.LBB0_250@GOTOFF
+-	.long	.LBB0_266@GOTOFF
+-	.long	.LBB0_3@GOTOFF
+-	.long	.LBB0_7@GOTOFF
+-	.long	.LBB0_11@GOTOFF
+-	.long	.LBB0_13@GOTOFF
+-	.long	.LBB0_17@GOTOFF
+-	.long	.LBB0_19@GOTOFF
+-	.long	.LBB0_21@GOTOFF
+-	.long	.LBB0_23@GOTOFF
+-	.long	.LBB0_27@GOTOFF
+-	.long	.LBB0_29@GOTOFF
+-	.long	.LBB0_31@GOTOFF
+-	.long	.LBB0_33@GOTOFF
+-	.long	.LBB0_35@GOTOFF
+-	.long	.LBB0_37@GOTOFF
+-	.long	.LBB0_39@GOTOFF
+-	.long	.LBB0_41@GOTOFF
+-	.long	.LBB0_45@GOTOFF
+-	.long	.LBB0_47@GOTOFF
+-	.long	.LBB0_49@GOTOFF
+-	.long	.LBB0_51@GOTOFF
+-	.long	.LBB0_53@GOTOFF
+-	.long	.LBB0_55@GOTOFF
+-	.long	.LBB0_57@GOTOFF
+-	.long	.LBB0_59@GOTOFF
+-	.long	.LBB0_61@GOTOFF
+-	.long	.LBB0_63@GOTOFF
+-	.long	.LBB0_65@GOTOFF
+-	.long	.LBB0_67@GOTOFF
+-	.long	.LBB0_69@GOTOFF
+-	.long	.LBB0_71@GOTOFF
+-	.long	.LBB0_73@GOTOFF
+-	.long	.LBB0_265@GOTOFF
+-	.long	.LBB0_76@GOTOFF
+-	.long	.LBB0_78@GOTOFF
+-	.long	.LBB0_80@GOTOFF
+-	.long	.LBB0_84@GOTOFF
+-	.long	.LBB0_86@GOTOFF
+-	.long	.LBB0_90@GOTOFF
+-	.long	.LBB0_94@GOTOFF
+-	.long	.LBB0_98@GOTOFF
+-	.long	.LBB0_100@GOTOFF
+-	.long	.LBB0_104@GOTOFF
+-	.long	.LBB0_108@GOTOFF
+-	.long	.LBB0_112@GOTOFF
+-	.long	.LBB0_116@GOTOFF
+-	.long	.LBB0_120@GOTOFF
+-	.long	.LBB0_124@GOTOFF
+-	.long	.LBB0_128@GOTOFF
+-	.long	.LBB0_130@GOTOFF
+-	.long	.LBB0_134@GOTOFF
+-	.long	.LBB0_138@GOTOFF
+-	.long	.LBB0_142@GOTOFF
+-	.long	.LBB0_146@GOTOFF
+-	.long	.LBB0_150@GOTOFF
+-	.long	.LBB0_154@GOTOFF
+-	.long	.LBB0_158@GOTOFF
+-	.long	.LBB0_162@GOTOFF
+-	.long	.LBB0_166@GOTOFF
+-	.long	.LBB0_170@GOTOFF
+-	.long	.LBB0_174@GOTOFF
+-	.long	.LBB0_178@GOTOFF
+-	.long	.LBB0_182@GOTOFF
+-	.long	.LBB0_186@GOTOFF
+-	.long	.LBB0_264@GOTOFF
+-	.long	.LBB0_75@GOTOFF
+-	.long	.LBB0_77@GOTOFF
+-	.long	.LBB0_79@GOTOFF
+-	.long	.LBB0_83@GOTOFF
+-	.long	.LBB0_85@GOTOFF
+-	.long	.LBB0_89@GOTOFF
+-	.long	.LBB0_93@GOTOFF
+-	.long	.LBB0_97@GOTOFF
+-	.long	.LBB0_99@GOTOFF
+-	.long	.LBB0_103@GOTOFF
+-	.long	.LBB0_107@GOTOFF
+-	.long	.LBB0_111@GOTOFF
+-	.long	.LBB0_115@GOTOFF
+-	.long	.LBB0_119@GOTOFF
+-	.long	.LBB0_123@GOTOFF
+-	.long	.LBB0_127@GOTOFF
+-	.long	.LBB0_129@GOTOFF
+-	.long	.LBB0_133@GOTOFF
+-	.long	.LBB0_137@GOTOFF
+-	.long	.LBB0_141@GOTOFF
+-	.long	.LBB0_145@GOTOFF
+-	.long	.LBB0_149@GOTOFF
+-	.long	.LBB0_153@GOTOFF
+-	.long	.LBB0_157@GOTOFF
+-	.long	.LBB0_161@GOTOFF
+-	.long	.LBB0_165@GOTOFF
+-	.long	.LBB0_169@GOTOFF
+-	.long	.LBB0_173@GOTOFF
+-	.long	.LBB0_177@GOTOFF
+-	.long	.LBB0_181@GOTOFF
+-	.long	.LBB0_185@GOTOFF
+-	.long	.LBB0_263@GOTOFF
+-	.long	.LBB0_189@GOTOFF
+-	.long	.LBB0_191@GOTOFF
+-	.long	.LBB0_193@GOTOFF
+-	.long	.LBB0_195@GOTOFF
+-	.long	.LBB0_197@GOTOFF
+-	.long	.LBB0_199@GOTOFF
+-	.long	.LBB0_201@GOTOFF
+-	.long	.LBB0_203@GOTOFF
+-	.long	.LBB0_205@GOTOFF
+-	.long	.LBB0_207@GOTOFF
+-	.long	.LBB0_209@GOTOFF
+-	.long	.LBB0_211@GOTOFF
+-	.long	.LBB0_213@GOTOFF
+-	.long	.LBB0_215@GOTOFF
+-	.long	.LBB0_217@GOTOFF
+-	.long	.LBB0_219@GOTOFF
+-	.long	.LBB0_221@GOTOFF
+-	.long	.LBB0_223@GOTOFF
+-	.long	.LBB0_225@GOTOFF
+-	.long	.LBB0_227@GOTOFF
+-	.long	.LBB0_229@GOTOFF
+-	.long	.LBB0_231@GOTOFF
+-	.long	.LBB0_233@GOTOFF
+-	.long	.LBB0_235@GOTOFF
+-	.long	.LBB0_237@GOTOFF
+-	.long	.LBB0_239@GOTOFF
+-	.long	.LBB0_241@GOTOFF
+-	.long	.LBB0_243@GOTOFF
+-	.long	.LBB0_245@GOTOFF
+-	.long	.LBB0_247@GOTOFF
+-	.long	.LBB0_249@GOTOFF
+-	.long	.LBB0_262@GOTOFF
+-.LJTI0_1:
+-	.long	.LBB0_6@GOTOFF
+-	.long	.LBB0_10@GOTOFF
+-	.long	.LBB0_12@GOTOFF
+-	.long	.LBB0_16@GOTOFF
+-	.long	.LBB0_18@GOTOFF
+-	.long	.LBB0_20@GOTOFF
+-	.long	.LBB0_22@GOTOFF
+-	.long	.LBB0_26@GOTOFF
+-	.long	.LBB0_28@GOTOFF
+-	.long	.LBB0_30@GOTOFF
+-	.long	.LBB0_32@GOTOFF
+-	.long	.LBB0_34@GOTOFF
+-	.long	.LBB0_36@GOTOFF
+-	.long	.LBB0_38@GOTOFF
+-	.long	.LBB0_40@GOTOFF
+-	.long	.LBB0_44@GOTOFF
+-	.long	.LBB0_46@GOTOFF
+-	.long	.LBB0_48@GOTOFF
+-	.long	.LBB0_50@GOTOFF
+-	.long	.LBB0_52@GOTOFF
+-	.long	.LBB0_54@GOTOFF
+-	.long	.LBB0_56@GOTOFF
+-	.long	.LBB0_58@GOTOFF
+-	.long	.LBB0_60@GOTOFF
+-	.long	.LBB0_62@GOTOFF
+-	.long	.LBB0_64@GOTOFF
+-	.long	.LBB0_66@GOTOFF
+-	.long	.LBB0_68@GOTOFF
+-	.long	.LBB0_70@GOTOFF
+-	.long	.LBB0_72@GOTOFF
+-	.long	.LBB0_74@GOTOFF
+-	.long	.LBB0_269@GOTOFF
+-	.long	.LBB0_5@GOTOFF
+-	.long	.LBB0_9@GOTOFF
+-	.long	.LBB0_82@GOTOFF
+-	.long	.LBB0_15@GOTOFF
+-	.long	.LBB0_88@GOTOFF
+-	.long	.LBB0_92@GOTOFF
+-	.long	.LBB0_96@GOTOFF
+-	.long	.LBB0_25@GOTOFF
+-	.long	.LBB0_102@GOTOFF
+-	.long	.LBB0_106@GOTOFF
+-	.long	.LBB0_110@GOTOFF
+-	.long	.LBB0_114@GOTOFF
+-	.long	.LBB0_118@GOTOFF
+-	.long	.LBB0_122@GOTOFF
+-	.long	.LBB0_126@GOTOFF
+-	.long	.LBB0_43@GOTOFF
+-	.long	.LBB0_132@GOTOFF
+-	.long	.LBB0_136@GOTOFF
+-	.long	.LBB0_140@GOTOFF
+-	.long	.LBB0_144@GOTOFF
+-	.long	.LBB0_148@GOTOFF
+-	.long	.LBB0_152@GOTOFF
+-	.long	.LBB0_156@GOTOFF
+-	.long	.LBB0_160@GOTOFF
+-	.long	.LBB0_164@GOTOFF
+-	.long	.LBB0_168@GOTOFF
+-	.long	.LBB0_172@GOTOFF
+-	.long	.LBB0_176@GOTOFF
+-	.long	.LBB0_180@GOTOFF
+-	.long	.LBB0_184@GOTOFF
+-	.long	.LBB0_188@GOTOFF
+-	.long	.LBB0_268@GOTOFF
+-	.long	.LBB0_4@GOTOFF
+-	.long	.LBB0_8@GOTOFF
+-	.long	.LBB0_81@GOTOFF
+-	.long	.LBB0_14@GOTOFF
+-	.long	.LBB0_87@GOTOFF
+-	.long	.LBB0_91@GOTOFF
+-	.long	.LBB0_95@GOTOFF
+-	.long	.LBB0_24@GOTOFF
+-	.long	.LBB0_101@GOTOFF
+-	.long	.LBB0_105@GOTOFF
+-	.long	.LBB0_109@GOTOFF
+-	.long	.LBB0_113@GOTOFF
+-	.long	.LBB0_117@GOTOFF
+-	.long	.LBB0_121@GOTOFF
+-	.long	.LBB0_125@GOTOFF
+-	.long	.LBB0_42@GOTOFF
+-	.long	.LBB0_131@GOTOFF
+-	.long	.LBB0_135@GOTOFF
+-	.long	.LBB0_139@GOTOFF
+-	.long	.LBB0_143@GOTOFF
+-	.long	.LBB0_147@GOTOFF
+-	.long	.LBB0_151@GOTOFF
+-	.long	.LBB0_155@GOTOFF
+-	.long	.LBB0_159@GOTOFF
+-	.long	.LBB0_163@GOTOFF
+-	.long	.LBB0_167@GOTOFF
+-	.long	.LBB0_171@GOTOFF
+-	.long	.LBB0_175@GOTOFF
+-	.long	.LBB0_179@GOTOFF
+-	.long	.LBB0_183@GOTOFF
+-	.long	.LBB0_187@GOTOFF
+-	.long	.LBB0_267@GOTOFF
+-	.long	.LBB0_190@GOTOFF
+-	.long	.LBB0_192@GOTOFF
+-	.long	.LBB0_194@GOTOFF
+-	.long	.LBB0_196@GOTOFF
+-	.long	.LBB0_198@GOTOFF
+-	.long	.LBB0_200@GOTOFF
+-	.long	.LBB0_202@GOTOFF
+-	.long	.LBB0_204@GOTOFF
+-	.long	.LBB0_206@GOTOFF
+-	.long	.LBB0_208@GOTOFF
+-	.long	.LBB0_210@GOTOFF
+-	.long	.LBB0_212@GOTOFF
+-	.long	.LBB0_214@GOTOFF
+-	.long	.LBB0_216@GOTOFF
+-	.long	.LBB0_218@GOTOFF
+-	.long	.LBB0_220@GOTOFF
+-	.long	.LBB0_222@GOTOFF
+-	.long	.LBB0_224@GOTOFF
+-	.long	.LBB0_226@GOTOFF
+-	.long	.LBB0_228@GOTOFF
+-	.long	.LBB0_230@GOTOFF
+-	.long	.LBB0_232@GOTOFF
+-	.long	.LBB0_234@GOTOFF
+-	.long	.LBB0_236@GOTOFF
+-	.long	.LBB0_238@GOTOFF
+-	.long	.LBB0_240@GOTOFF
+-	.long	.LBB0_242@GOTOFF
+-	.long	.LBB0_244@GOTOFF
+-	.long	.LBB0_246@GOTOFF
+-	.long	.LBB0_248@GOTOFF
+-	.long	.LBB0_250@GOTOFF
+-	.long	.LBB0_266@GOTOFF
+-	.long	.LBB0_3@GOTOFF
+-	.long	.LBB0_7@GOTOFF
+-	.long	.LBB0_11@GOTOFF
+-	.long	.LBB0_13@GOTOFF
+-	.long	.LBB0_17@GOTOFF
+-	.long	.LBB0_19@GOTOFF
+-	.long	.LBB0_21@GOTOFF
+-	.long	.LBB0_23@GOTOFF
+-	.long	.LBB0_27@GOTOFF
+-	.long	.LBB0_29@GOTOFF
+-	.long	.LBB0_31@GOTOFF
+-	.long	.LBB0_33@GOTOFF
+-	.long	.LBB0_35@GOTOFF
+-	.long	.LBB0_37@GOTOFF
+-	.long	.LBB0_39@GOTOFF
+-	.long	.LBB0_41@GOTOFF
+-	.long	.LBB0_45@GOTOFF
+-	.long	.LBB0_47@GOTOFF
+-	.long	.LBB0_49@GOTOFF
+-	.long	.LBB0_51@GOTOFF
+-	.long	.LBB0_53@GOTOFF
+-	.long	.LBB0_55@GOTOFF
+-	.long	.LBB0_57@GOTOFF
+-	.long	.LBB0_59@GOTOFF
+-	.long	.LBB0_61@GOTOFF
+-	.long	.LBB0_63@GOTOFF
+-	.long	.LBB0_65@GOTOFF
+-	.long	.LBB0_67@GOTOFF
+-	.long	.LBB0_69@GOTOFF
+-	.long	.LBB0_71@GOTOFF
+-	.long	.LBB0_73@GOTOFF
+-	.long	.LBB0_265@GOTOFF
+-	.long	.LBB0_76@GOTOFF
+-	.long	.LBB0_78@GOTOFF
+-	.long	.LBB0_80@GOTOFF
+-	.long	.LBB0_84@GOTOFF
+-	.long	.LBB0_86@GOTOFF
+-	.long	.LBB0_90@GOTOFF
+-	.long	.LBB0_94@GOTOFF
+-	.long	.LBB0_98@GOTOFF
+-	.long	.LBB0_100@GOTOFF
+-	.long	.LBB0_104@GOTOFF
+-	.long	.LBB0_108@GOTOFF
+-	.long	.LBB0_112@GOTOFF
+-	.long	.LBB0_116@GOTOFF
+-	.long	.LBB0_120@GOTOFF
+-	.long	.LBB0_124@GOTOFF
+-	.long	.LBB0_128@GOTOFF
+-	.long	.LBB0_130@GOTOFF
+-	.long	.LBB0_134@GOTOFF
+-	.long	.LBB0_138@GOTOFF
+-	.long	.LBB0_142@GOTOFF
+-	.long	.LBB0_146@GOTOFF
+-	.long	.LBB0_150@GOTOFF
+-	.long	.LBB0_154@GOTOFF
+-	.long	.LBB0_158@GOTOFF
+-	.long	.LBB0_162@GOTOFF
+-	.long	.LBB0_166@GOTOFF
+-	.long	.LBB0_170@GOTOFF
+-	.long	.LBB0_174@GOTOFF
+-	.long	.LBB0_178@GOTOFF
+-	.long	.LBB0_182@GOTOFF
+-	.long	.LBB0_186@GOTOFF
+-	.long	.LBB0_264@GOTOFF
+-	.long	.LBB0_75@GOTOFF
+-	.long	.LBB0_77@GOTOFF
+-	.long	.LBB0_79@GOTOFF
+-	.long	.LBB0_83@GOTOFF
+-	.long	.LBB0_85@GOTOFF
+-	.long	.LBB0_89@GOTOFF
+-	.long	.LBB0_93@GOTOFF
+-	.long	.LBB0_97@GOTOFF
+-	.long	.LBB0_99@GOTOFF
+-	.long	.LBB0_103@GOTOFF
+-	.long	.LBB0_107@GOTOFF
+-	.long	.LBB0_111@GOTOFF
+-	.long	.LBB0_115@GOTOFF
+-	.long	.LBB0_119@GOTOFF
+-	.long	.LBB0_123@GOTOFF
+-	.long	.LBB0_127@GOTOFF
+-	.long	.LBB0_129@GOTOFF
+-	.long	.LBB0_133@GOTOFF
+-	.long	.LBB0_137@GOTOFF
+-	.long	.LBB0_141@GOTOFF
+-	.long	.LBB0_145@GOTOFF
+-	.long	.LBB0_149@GOTOFF
+-	.long	.LBB0_153@GOTOFF
+-	.long	.LBB0_157@GOTOFF
+-	.long	.LBB0_161@GOTOFF
+-	.long	.LBB0_165@GOTOFF
+-	.long	.LBB0_169@GOTOFF
+-	.long	.LBB0_173@GOTOFF
+-	.long	.LBB0_177@GOTOFF
+-	.long	.LBB0_181@GOTOFF
+-	.long	.LBB0_185@GOTOFF
+-	.long	.LBB0_263@GOTOFF
+-	.long	.LBB0_189@GOTOFF
+-	.long	.LBB0_191@GOTOFF
+-	.long	.LBB0_193@GOTOFF
+-	.long	.LBB0_195@GOTOFF
+-	.long	.LBB0_197@GOTOFF
+-	.long	.LBB0_199@GOTOFF
+-	.long	.LBB0_201@GOTOFF
+-	.long	.LBB0_203@GOTOFF
+-	.long	.LBB0_205@GOTOFF
+-	.long	.LBB0_207@GOTOFF
+-	.long	.LBB0_209@GOTOFF
+-	.long	.LBB0_211@GOTOFF
+-	.long	.LBB0_213@GOTOFF
+-	.long	.LBB0_215@GOTOFF
+-	.long	.LBB0_217@GOTOFF
+-	.long	.LBB0_219@GOTOFF
+-	.long	.LBB0_221@GOTOFF
+-	.long	.LBB0_223@GOTOFF
+-	.long	.LBB0_225@GOTOFF
+-	.long	.LBB0_227@GOTOFF
+-	.long	.LBB0_229@GOTOFF
+-	.long	.LBB0_231@GOTOFF
+-	.long	.LBB0_233@GOTOFF
+-	.long	.LBB0_235@GOTOFF
+-	.long	.LBB0_237@GOTOFF
+-	.long	.LBB0_239@GOTOFF
+-	.long	.LBB0_241@GOTOFF
+-	.long	.LBB0_243@GOTOFF
+-	.long	.LBB0_245@GOTOFF
+-	.long	.LBB0_247@GOTOFF
+-	.long	.LBB0_249@GOTOFF
+-	.long	.LBB0_262@GOTOFF
+-                                        # -- End function
+diff --git a/libc/arch-x86_64/dynamic_function_dispatch.cpp b/libc/arch-x86_64/dynamic_function_dispatch.cpp
+index 352635c36..f844a677d 100644
+--- a/libc/arch-x86_64/dynamic_function_dispatch.cpp
++++ b/libc/arch-x86_64/dynamic_function_dispatch.cpp
+@@ -41,16 +41,12 @@ DEFINE_IFUNC_FOR(memcmp) {
+ 
+ typedef void* memmove_func(void* __dst, const void* __src, size_t __n);
+ DEFINE_IFUNC_FOR(memmove) {
+-    __builtin_cpu_init();
+-    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(memmove_func, memmove_avx2);
+     RETURN_FUNC(memmove_func, memmove_generic);
+ }
+ 
+ typedef void* memcpy_func(void* __dst, const void* __src, size_t __n);
+ DEFINE_IFUNC_FOR(memcpy) {
+-    __builtin_cpu_init();
+-    if (__builtin_cpu_supports("avx2")) RETURN_FUNC(memcpy_func, memcpy_avx2);
+-    RETURN_FUNC(memcpy_func, memcpy_generic);
++    return memmove_resolver();
+ }
+ 
+ typedef void* memchr_func(const void* __s, int __ch, size_t __n);
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-memcpy-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-memcpy-kbl.S
+deleted file mode 100644
+index c481e3be0..000000000
+--- a/libc/arch-x86_64/kabylake/string/avx2-memcpy-kbl.S
++++ /dev/null
+@@ -1,3711 +0,0 @@
+-	/*.text
+-	.file	"FastMemcpy_avx_sse2.c"
+-	.globl	memcpy                  # -- Begin function memcpy
+-	.p2align	4, 0x90
+-	.type	memcpy,@function*/
+-#define ENTRY(f) \
+-    .text; \
+-    .globl f; \
+-    .p2align    4, 0x90; \
+-    .type f,@function; \
+-    f: \
+-
+-#define END(f)
+-    .size f, .-f; \
+-    .section        .rodata,"a",@progbits; \
+-    .p2align        2 \
+-
+-/*memcpy:                                 # @memcpy
+-	.cfi_startproc
+-*/
+-ENTRY(memcpy_avx2)
+-	.cfi_startproc 
+-# %bb.0:
+-	movq	%rdi, %rax
+-	cmpq	$256, %rdx              # imm = 0x100
+-	ja	.LBB0_259
+-# %bb.1:
+-	leaq	-1(%rdx), %rdi
+-	cmpq	$255, %rdi
+-	ja	.LBB0_526
+-# %bb.2:
+-	leaq	(%rax,%rdx), %rcx
+-	addq	%rdx, %rsi
+-	leaq	.LJTI0_1(%rip), %rdx
+-	movslq	(%rdx,%rdi,4), %rdi
+-	addq	%rdx, %rdi
+-	jmpq	*%rdi
+-.LBB0_11:
+-	vmovups	-131(%rsi), %ymm0
+-	vmovups	%ymm0, -131(%rcx)
+-	vmovups	-99(%rsi), %ymm0
+-	vmovups	%ymm0, -99(%rcx)
+-	vmovups	-67(%rsi), %ymm0
+-	vmovups	%ymm0, -67(%rcx)
+-	vmovups	-35(%rsi), %ymm0
+-	vmovups	%ymm0, -35(%rcx)
+-.LBB0_12:
+-	movzwl	-3(%rsi), %edx
+-	movw	%dx, -3(%rcx)
+-	movb	-1(%rsi), %dl
+-	movb	%dl, -1(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_259:
+-	movl	%eax, %ecx
+-	negl	%ecx
+-	andl	$31, %ecx
+-	vmovups	(%rsi), %ymm0
+-	vmovups	%ymm0, (%rax)
+-	leaq	(%rax,%rcx), %r8
+-	addq	%rcx, %rsi
+-	movq	%rdx, %rdi
+-	subq	%rcx, %rdi
+-	cmpq	$2097152, %rdi          # imm = 0x200000
+-	ja	.LBB0_264
+-# %bb.260:
+-	cmpq	$256, %rdi              # imm = 0x100
+-	jb	.LBB0_268
+-# %bb.261:
+-	subq	%rcx, %rdx
+-	.p2align	4, 0x90
+-.LBB0_262:                              # =>This Inner Loop Header: Depth=1
+-	vmovups	(%rsi), %ymm0
+-	vmovups	32(%rsi), %ymm1
+-	vmovups	64(%rsi), %ymm2
+-	vmovups	96(%rsi), %ymm3
+-	vmovups	128(%rsi), %ymm4
+-	vmovups	160(%rsi), %ymm5
+-	vmovups	192(%rsi), %ymm6
+-	vmovups	224(%rsi), %ymm7
+-	prefetchnta	512(%rsi)
+-	addq	$256, %rsi              # imm = 0x100
+-	vmovups	%ymm0, (%r8)
+-	vmovups	%ymm1, 32(%r8)
+-	vmovups	%ymm2, 64(%r8)
+-	vmovups	%ymm3, 96(%r8)
+-	vmovups	%ymm4, 128(%r8)
+-	vmovups	%ymm5, 160(%r8)
+-	vmovups	%ymm6, 192(%r8)
+-	vmovups	%ymm7, 224(%r8)
+-	addq	$256, %r8               # imm = 0x100
+-	addq	$-256, %rdi
+-	cmpq	$255, %rdi
+-	ja	.LBB0_262
+-# %bb.263:
+-	movzbl	%dl, %edi
+-	leaq	-1(%rdi), %rcx
+-	cmpq	$255, %rcx
+-	jbe	.LBB0_269
+-	jmp	.LBB0_526
+-.LBB0_264:
+-	prefetchnta	(%rsi)
+-	subq	%rcx, %rdx
+-	testb	$31, %sil
+-	je	.LBB0_265
+-	.p2align	4, 0x90
+-.LBB0_266:                              # =>This Inner Loop Header: Depth=1
+-	vmovups	(%rsi), %ymm0
+-	vmovups	32(%rsi), %ymm1
+-	vmovups	64(%rsi), %ymm2
+-	vmovups	96(%rsi), %ymm3
+-	vmovups	128(%rsi), %ymm4
+-	vmovups	160(%rsi), %ymm5
+-	vmovups	192(%rsi), %ymm6
+-	vmovups	224(%rsi), %ymm7
+-	prefetchnta	512(%rsi)
+-	addq	$256, %rsi              # imm = 0x100
+-	vmovntps	%ymm0, (%r8)
+-	vmovntps	%ymm1, 32(%r8)
+-	vmovntps	%ymm2, 64(%r8)
+-	vmovntps	%ymm3, 96(%r8)
+-	vmovntps	%ymm4, 128(%r8)
+-	vmovntps	%ymm5, 160(%r8)
+-	vmovntps	%ymm6, 192(%r8)
+-	vmovntps	%ymm7, 224(%r8)
+-	addq	$256, %r8               # imm = 0x100
+-	addq	$-256, %rdi
+-	cmpq	$255, %rdi
+-	ja	.LBB0_266
+-	jmp	.LBB0_267
+-	.p2align	4, 0x90
+-.LBB0_265:                              # =>This Inner Loop Header: Depth=1
+-	vmovaps	(%rsi), %ymm0
+-	vmovaps	32(%rsi), %ymm1
+-	vmovaps	64(%rsi), %ymm2
+-	vmovaps	96(%rsi), %ymm3
+-	vmovaps	128(%rsi), %ymm4
+-	vmovaps	160(%rsi), %ymm5
+-	vmovaps	192(%rsi), %ymm6
+-	vmovaps	224(%rsi), %ymm7
+-	prefetchnta	512(%rsi)
+-	addq	$256, %rsi              # imm = 0x100
+-	vmovntps	%ymm0, (%r8)
+-	vmovntps	%ymm1, 32(%r8)
+-	vmovntps	%ymm2, 64(%r8)
+-	vmovntps	%ymm3, 96(%r8)
+-	vmovntps	%ymm4, 128(%r8)
+-	vmovntps	%ymm5, 160(%r8)
+-	vmovntps	%ymm6, 192(%r8)
+-	vmovntps	%ymm7, 224(%r8)
+-	addq	$256, %r8               # imm = 0x100
+-	addq	$-256, %rdi
+-	cmpq	$255, %rdi
+-	ja	.LBB0_265
+-.LBB0_267:
+-	movzbl	%dl, %edi
+-	sfence
+-.LBB0_268:
+-	leaq	-1(%rdi), %rcx
+-	cmpq	$255, %rcx
+-	ja	.LBB0_526
+-.LBB0_269:
+-	addq	%rdi, %r8
+-	addq	%rdi, %rsi
+-	leaq	.LJTI0_0(%rip), %rdx
+-	movslq	(%rdx,%rcx,4), %rcx
+-	addq	%rdx, %rcx
+-	jmpq	*%rcx
+-.LBB0_278:
+-	vmovups	-131(%rsi), %ymm0
+-	vmovups	%ymm0, -131(%r8)
+-	vmovups	-99(%rsi), %ymm0
+-	vmovups	%ymm0, -99(%r8)
+-	vmovups	-67(%rsi), %ymm0
+-	vmovups	%ymm0, -67(%r8)
+-	vmovups	-35(%rsi), %ymm0
+-	vmovups	%ymm0, -35(%r8)
+-.LBB0_279:
+-	movzwl	-3(%rsi), %ecx
+-	movw	%cx, -3(%r8)
+-	movb	-1(%rsi), %cl
+-	movb	%cl, -1(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_17:
+-	vmovups	-133(%rsi), %ymm0
+-	vmovups	%ymm0, -133(%rcx)
+-	vmovups	-101(%rsi), %ymm0
+-	vmovups	%ymm0, -101(%rcx)
+-	vmovups	-69(%rsi), %ymm0
+-	vmovups	%ymm0, -69(%rcx)
+-	vmovups	-37(%rsi), %ymm0
+-	vmovups	%ymm0, -37(%rcx)
+-.LBB0_18:
+-	movl	-5(%rsi), %edx
+-	movl	%edx, -5(%rcx)
+-	movb	-1(%rsi), %dl
+-	movb	%dl, -1(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_19:
+-	vmovups	-134(%rsi), %ymm0
+-	vmovups	%ymm0, -134(%rcx)
+-	vmovups	-102(%rsi), %ymm0
+-	vmovups	%ymm0, -102(%rcx)
+-	vmovups	-70(%rsi), %ymm0
+-	vmovups	%ymm0, -70(%rcx)
+-	vmovups	-38(%rsi), %ymm0
+-	vmovups	%ymm0, -38(%rcx)
+-.LBB0_20:
+-	movl	-6(%rsi), %edx
+-	movl	%edx, -6(%rcx)
+-	movzwl	-2(%rsi), %edx
+-	movw	%dx, -2(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_21:
+-	vmovups	-135(%rsi), %ymm0
+-	vmovups	%ymm0, -135(%rcx)
+-	vmovups	-103(%rsi), %ymm0
+-	vmovups	%ymm0, -103(%rcx)
+-	vmovups	-71(%rsi), %ymm0
+-	vmovups	%ymm0, -71(%rcx)
+-	vmovups	-39(%rsi), %ymm0
+-	vmovups	%ymm0, -39(%rcx)
+-.LBB0_22:
+-	movl	-7(%rsi), %edx
+-	movl	%edx, -7(%rcx)
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_27:
+-	vmovups	-137(%rsi), %ymm0
+-	vmovups	%ymm0, -137(%rcx)
+-	vmovups	-105(%rsi), %ymm0
+-	vmovups	%ymm0, -105(%rcx)
+-	vmovups	-73(%rsi), %ymm0
+-	vmovups	%ymm0, -73(%rcx)
+-	vmovups	-41(%rsi), %ymm0
+-	vmovups	%ymm0, -41(%rcx)
+-.LBB0_28:
+-	movq	-9(%rsi), %rdx
+-	movq	%rdx, -9(%rcx)
+-	movb	-1(%rsi), %dl
+-	movb	%dl, -1(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_29:
+-	vmovups	-138(%rsi), %ymm0
+-	vmovups	%ymm0, -138(%rcx)
+-	vmovups	-106(%rsi), %ymm0
+-	vmovups	%ymm0, -106(%rcx)
+-	vmovups	-74(%rsi), %ymm0
+-	vmovups	%ymm0, -74(%rcx)
+-	vmovups	-42(%rsi), %ymm0
+-	vmovups	%ymm0, -42(%rcx)
+-.LBB0_30:
+-	movq	-10(%rsi), %rdx
+-	movq	%rdx, -10(%rcx)
+-	movzwl	-2(%rsi), %edx
+-	movw	%dx, -2(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_31:
+-	vmovups	-139(%rsi), %ymm0
+-	vmovups	%ymm0, -139(%rcx)
+-	vmovups	-107(%rsi), %ymm0
+-	vmovups	%ymm0, -107(%rcx)
+-	vmovups	-75(%rsi), %ymm0
+-	vmovups	%ymm0, -75(%rcx)
+-	vmovups	-43(%rsi), %ymm0
+-	vmovups	%ymm0, -43(%rcx)
+-.LBB0_32:
+-	movq	-11(%rsi), %rdx
+-	movq	%rdx, -11(%rcx)
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_33:
+-	vmovups	-140(%rsi), %ymm0
+-	vmovups	%ymm0, -140(%rcx)
+-	vmovups	-108(%rsi), %ymm0
+-	vmovups	%ymm0, -108(%rcx)
+-	vmovups	-76(%rsi), %ymm0
+-	vmovups	%ymm0, -76(%rcx)
+-	vmovups	-44(%rsi), %ymm0
+-	vmovups	%ymm0, -44(%rcx)
+-.LBB0_34:
+-	movq	-12(%rsi), %rdx
+-	movq	%rdx, -12(%rcx)
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_35:
+-	vmovups	-141(%rsi), %ymm0
+-	vmovups	%ymm0, -141(%rcx)
+-	vmovups	-109(%rsi), %ymm0
+-	vmovups	%ymm0, -109(%rcx)
+-	vmovups	-77(%rsi), %ymm0
+-	vmovups	%ymm0, -77(%rcx)
+-	vmovups	-45(%rsi), %ymm0
+-	vmovups	%ymm0, -45(%rcx)
+-.LBB0_36:
+-	movq	-13(%rsi), %rdx
+-	movq	%rdx, -13(%rcx)
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_37:
+-	vmovups	-142(%rsi), %ymm0
+-	vmovups	%ymm0, -142(%rcx)
+-	vmovups	-110(%rsi), %ymm0
+-	vmovups	%ymm0, -110(%rcx)
+-	vmovups	-78(%rsi), %ymm0
+-	vmovups	%ymm0, -78(%rcx)
+-	vmovups	-46(%rsi), %ymm0
+-	vmovups	%ymm0, -46(%rcx)
+-.LBB0_38:
+-	movq	-14(%rsi), %rdx
+-	movq	%rdx, -14(%rcx)
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_39:
+-	vmovups	-143(%rsi), %ymm0
+-	vmovups	%ymm0, -143(%rcx)
+-	vmovups	-111(%rsi), %ymm0
+-	vmovups	%ymm0, -111(%rcx)
+-	vmovups	-79(%rsi), %ymm0
+-	vmovups	%ymm0, -79(%rcx)
+-	vmovups	-47(%rsi), %ymm0
+-	vmovups	%ymm0, -47(%rcx)
+-.LBB0_40:
+-	movq	-15(%rsi), %rdx
+-	movq	%rdx, -15(%rcx)
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_45:
+-	vmovups	-145(%rsi), %ymm0
+-	vmovups	%ymm0, -145(%rcx)
+-	vmovups	-113(%rsi), %ymm0
+-	vmovups	%ymm0, -113(%rcx)
+-	vmovups	-81(%rsi), %ymm0
+-	vmovups	%ymm0, -81(%rcx)
+-	vmovups	-49(%rsi), %ymm0
+-	vmovups	%ymm0, -49(%rcx)
+-.LBB0_46:
+-	vmovups	-17(%rsi), %xmm0
+-	vmovups	%xmm0, -17(%rcx)
+-	movb	-1(%rsi), %dl
+-	movb	%dl, -1(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_47:
+-	vmovups	-146(%rsi), %ymm0
+-	vmovups	%ymm0, -146(%rcx)
+-	vmovups	-114(%rsi), %ymm0
+-	vmovups	%ymm0, -114(%rcx)
+-	vmovups	-82(%rsi), %ymm0
+-	vmovups	%ymm0, -82(%rcx)
+-	vmovups	-50(%rsi), %ymm0
+-	vmovups	%ymm0, -50(%rcx)
+-.LBB0_48:
+-	vmovups	-18(%rsi), %xmm0
+-	vmovups	%xmm0, -18(%rcx)
+-	movzwl	-2(%rsi), %edx
+-	movw	%dx, -2(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_49:
+-	vmovups	-147(%rsi), %ymm0
+-	vmovups	%ymm0, -147(%rcx)
+-	vmovups	-115(%rsi), %ymm0
+-	vmovups	%ymm0, -115(%rcx)
+-	vmovups	-83(%rsi), %ymm0
+-	vmovups	%ymm0, -83(%rcx)
+-	vmovups	-51(%rsi), %ymm0
+-	vmovups	%ymm0, -51(%rcx)
+-.LBB0_50:
+-	vmovups	-19(%rsi), %xmm0
+-	vmovups	%xmm0, -19(%rcx)
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_51:
+-	vmovups	-148(%rsi), %ymm0
+-	vmovups	%ymm0, -148(%rcx)
+-	vmovups	-116(%rsi), %ymm0
+-	vmovups	%ymm0, -116(%rcx)
+-	vmovups	-84(%rsi), %ymm0
+-	vmovups	%ymm0, -84(%rcx)
+-	vmovups	-52(%rsi), %ymm0
+-	vmovups	%ymm0, -52(%rcx)
+-.LBB0_52:
+-	vmovups	-20(%rsi), %xmm0
+-	vmovups	%xmm0, -20(%rcx)
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_53:
+-	vmovups	-149(%rsi), %ymm0
+-	vmovups	%ymm0, -149(%rcx)
+-	vmovups	-117(%rsi), %ymm0
+-	vmovups	%ymm0, -117(%rcx)
+-	vmovups	-85(%rsi), %ymm0
+-	vmovups	%ymm0, -85(%rcx)
+-	vmovups	-53(%rsi), %ymm0
+-	vmovups	%ymm0, -53(%rcx)
+-.LBB0_54:
+-	vmovups	-21(%rsi), %xmm0
+-	vmovups	%xmm0, -21(%rcx)
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_55:
+-	vmovups	-150(%rsi), %ymm0
+-	vmovups	%ymm0, -150(%rcx)
+-	vmovups	-118(%rsi), %ymm0
+-	vmovups	%ymm0, -118(%rcx)
+-	vmovups	-86(%rsi), %ymm0
+-	vmovups	%ymm0, -86(%rcx)
+-	vmovups	-54(%rsi), %ymm0
+-	vmovups	%ymm0, -54(%rcx)
+-.LBB0_56:
+-	vmovups	-22(%rsi), %xmm0
+-	vmovups	%xmm0, -22(%rcx)
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_57:
+-	vmovups	-151(%rsi), %ymm0
+-	vmovups	%ymm0, -151(%rcx)
+-	vmovups	-119(%rsi), %ymm0
+-	vmovups	%ymm0, -119(%rcx)
+-	vmovups	-87(%rsi), %ymm0
+-	vmovups	%ymm0, -87(%rcx)
+-	vmovups	-55(%rsi), %ymm0
+-	vmovups	%ymm0, -55(%rcx)
+-.LBB0_58:
+-	vmovups	-23(%rsi), %xmm0
+-	vmovups	%xmm0, -23(%rcx)
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_59:
+-	vmovups	-152(%rsi), %ymm0
+-	vmovups	%ymm0, -152(%rcx)
+-	vmovups	-120(%rsi), %ymm0
+-	vmovups	%ymm0, -120(%rcx)
+-	vmovups	-88(%rsi), %ymm0
+-	vmovups	%ymm0, -88(%rcx)
+-	vmovups	-56(%rsi), %ymm0
+-	vmovups	%ymm0, -56(%rcx)
+-.LBB0_60:
+-	vmovups	-24(%rsi), %xmm0
+-	vmovups	%xmm0, -24(%rcx)
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_61:
+-	vmovups	-153(%rsi), %ymm0
+-	vmovups	%ymm0, -153(%rcx)
+-	vmovups	-121(%rsi), %ymm0
+-	vmovups	%ymm0, -121(%rcx)
+-	vmovups	-89(%rsi), %ymm0
+-	vmovups	%ymm0, -89(%rcx)
+-	vmovups	-57(%rsi), %ymm0
+-	vmovups	%ymm0, -57(%rcx)
+-.LBB0_62:
+-	vmovups	-25(%rsi), %xmm0
+-	vmovups	%xmm0, -25(%rcx)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_63:
+-	vmovups	-154(%rsi), %ymm0
+-	vmovups	%ymm0, -154(%rcx)
+-	vmovups	-122(%rsi), %ymm0
+-	vmovups	%ymm0, -122(%rcx)
+-	vmovups	-90(%rsi), %ymm0
+-	vmovups	%ymm0, -90(%rcx)
+-	vmovups	-58(%rsi), %ymm0
+-	vmovups	%ymm0, -58(%rcx)
+-.LBB0_64:
+-	vmovups	-26(%rsi), %xmm0
+-	vmovups	%xmm0, -26(%rcx)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_65:
+-	vmovups	-155(%rsi), %ymm0
+-	vmovups	%ymm0, -155(%rcx)
+-	vmovups	-123(%rsi), %ymm0
+-	vmovups	%ymm0, -123(%rcx)
+-	vmovups	-91(%rsi), %ymm0
+-	vmovups	%ymm0, -91(%rcx)
+-	vmovups	-59(%rsi), %ymm0
+-	vmovups	%ymm0, -59(%rcx)
+-.LBB0_66:
+-	vmovups	-27(%rsi), %xmm0
+-	vmovups	%xmm0, -27(%rcx)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_67:
+-	vmovups	-156(%rsi), %ymm0
+-	vmovups	%ymm0, -156(%rcx)
+-	vmovups	-124(%rsi), %ymm0
+-	vmovups	%ymm0, -124(%rcx)
+-	vmovups	-92(%rsi), %ymm0
+-	vmovups	%ymm0, -92(%rcx)
+-	vmovups	-60(%rsi), %ymm0
+-	vmovups	%ymm0, -60(%rcx)
+-.LBB0_68:
+-	vmovups	-28(%rsi), %xmm0
+-	vmovups	%xmm0, -28(%rcx)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_69:
+-	vmovups	-157(%rsi), %ymm0
+-	vmovups	%ymm0, -157(%rcx)
+-	vmovups	-125(%rsi), %ymm0
+-	vmovups	%ymm0, -125(%rcx)
+-	vmovups	-93(%rsi), %ymm0
+-	vmovups	%ymm0, -93(%rcx)
+-	vmovups	-61(%rsi), %ymm0
+-	vmovups	%ymm0, -61(%rcx)
+-.LBB0_70:
+-	vmovups	-29(%rsi), %xmm0
+-	vmovups	%xmm0, -29(%rcx)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_71:
+-	vmovups	-158(%rsi), %ymm0
+-	vmovups	%ymm0, -158(%rcx)
+-	vmovups	-126(%rsi), %ymm0
+-	vmovups	%ymm0, -126(%rcx)
+-	vmovups	-94(%rsi), %ymm0
+-	vmovups	%ymm0, -94(%rcx)
+-	vmovups	-62(%rsi), %ymm0
+-	vmovups	%ymm0, -62(%rcx)
+-.LBB0_72:
+-	vmovups	-30(%rsi), %xmm0
+-	vmovups	%xmm0, -30(%rcx)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_73:
+-	vmovups	-159(%rsi), %ymm0
+-	vmovups	%ymm0, -159(%rcx)
+-	vmovups	-127(%rsi), %ymm0
+-	vmovups	%ymm0, -127(%rcx)
+-	vmovups	-95(%rsi), %ymm0
+-	vmovups	%ymm0, -95(%rcx)
+-	vmovups	-63(%rsi), %ymm0
+-	vmovups	%ymm0, -63(%rcx)
+-.LBB0_74:
+-	vmovups	-31(%rsi), %xmm0
+-	vmovups	%xmm0, -31(%rcx)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_75:
+-	vmovups	-193(%rsi), %ymm0
+-	vmovups	%ymm0, -193(%rcx)
+-.LBB0_76:
+-	vmovups	-161(%rsi), %ymm0
+-	vmovups	%ymm0, -161(%rcx)
+-.LBB0_3:
+-	vmovups	-129(%rsi), %ymm0
+-	vmovups	%ymm0, -129(%rcx)
+-	vmovups	-97(%rsi), %ymm0
+-	vmovups	%ymm0, -97(%rcx)
+-.LBB0_4:
+-	vmovups	-65(%rsi), %ymm0
+-	vmovups	%ymm0, -65(%rcx)
+-.LBB0_5:
+-	vmovups	-33(%rsi), %ymm0
+-	vmovups	%ymm0, -33(%rcx)
+-.LBB0_6:
+-	movb	-1(%rsi), %dl
+-	movb	%dl, -1(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_77:
+-	vmovups	-194(%rsi), %ymm0
+-	vmovups	%ymm0, -194(%rcx)
+-.LBB0_78:
+-	vmovups	-162(%rsi), %ymm0
+-	vmovups	%ymm0, -162(%rcx)
+-.LBB0_7:
+-	vmovups	-130(%rsi), %ymm0
+-	vmovups	%ymm0, -130(%rcx)
+-	vmovups	-98(%rsi), %ymm0
+-	vmovups	%ymm0, -98(%rcx)
+-.LBB0_8:
+-	vmovups	-66(%rsi), %ymm0
+-	vmovups	%ymm0, -66(%rcx)
+-.LBB0_9:
+-	vmovups	-34(%rsi), %ymm0
+-	vmovups	%ymm0, -34(%rcx)
+-.LBB0_10:
+-	movzwl	-2(%rsi), %edx
+-	movw	%dx, -2(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_79:
+-	vmovups	-195(%rsi), %ymm0
+-	vmovups	%ymm0, -195(%rcx)
+-.LBB0_80:
+-	vmovups	-163(%rsi), %ymm0
+-	vmovups	%ymm0, -163(%rcx)
+-	vmovups	-131(%rsi), %ymm0
+-	vmovups	%ymm0, -131(%rcx)
+-	vmovups	-99(%rsi), %ymm0
+-	vmovups	%ymm0, -99(%rcx)
+-.LBB0_81:
+-	vmovups	-67(%rsi), %ymm0
+-	vmovups	%ymm0, -67(%rcx)
+-.LBB0_82:
+-	vmovups	-35(%rsi), %ymm0
+-	vmovups	%ymm0, -35(%rcx)
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_83:
+-	vmovups	-196(%rsi), %ymm0
+-	vmovups	%ymm0, -196(%rcx)
+-.LBB0_84:
+-	vmovups	-164(%rsi), %ymm0
+-	vmovups	%ymm0, -164(%rcx)
+-.LBB0_13:
+-	vmovups	-132(%rsi), %ymm0
+-	vmovups	%ymm0, -132(%rcx)
+-	vmovups	-100(%rsi), %ymm0
+-	vmovups	%ymm0, -100(%rcx)
+-.LBB0_14:
+-	vmovups	-68(%rsi), %ymm0
+-	vmovups	%ymm0, -68(%rcx)
+-.LBB0_15:
+-	vmovups	-36(%rsi), %ymm0
+-	vmovups	%ymm0, -36(%rcx)
+-.LBB0_16:
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_85:
+-	vmovups	-197(%rsi), %ymm0
+-	vmovups	%ymm0, -197(%rcx)
+-.LBB0_86:
+-	vmovups	-165(%rsi), %ymm0
+-	vmovups	%ymm0, -165(%rcx)
+-	vmovups	-133(%rsi), %ymm0
+-	vmovups	%ymm0, -133(%rcx)
+-	vmovups	-101(%rsi), %ymm0
+-	vmovups	%ymm0, -101(%rcx)
+-.LBB0_87:
+-	vmovups	-69(%rsi), %ymm0
+-	vmovups	%ymm0, -69(%rcx)
+-.LBB0_88:
+-	vmovups	-37(%rsi), %ymm0
+-	vmovups	%ymm0, -37(%rcx)
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_89:
+-	vmovups	-198(%rsi), %ymm0
+-	vmovups	%ymm0, -198(%rcx)
+-.LBB0_90:
+-	vmovups	-166(%rsi), %ymm0
+-	vmovups	%ymm0, -166(%rcx)
+-	vmovups	-134(%rsi), %ymm0
+-	vmovups	%ymm0, -134(%rcx)
+-	vmovups	-102(%rsi), %ymm0
+-	vmovups	%ymm0, -102(%rcx)
+-.LBB0_91:
+-	vmovups	-70(%rsi), %ymm0
+-	vmovups	%ymm0, -70(%rcx)
+-.LBB0_92:
+-	vmovups	-38(%rsi), %ymm0
+-	vmovups	%ymm0, -38(%rcx)
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_93:
+-	vmovups	-199(%rsi), %ymm0
+-	vmovups	%ymm0, -199(%rcx)
+-.LBB0_94:
+-	vmovups	-167(%rsi), %ymm0
+-	vmovups	%ymm0, -167(%rcx)
+-	vmovups	-135(%rsi), %ymm0
+-	vmovups	%ymm0, -135(%rcx)
+-	vmovups	-103(%rsi), %ymm0
+-	vmovups	%ymm0, -103(%rcx)
+-.LBB0_95:
+-	vmovups	-71(%rsi), %ymm0
+-	vmovups	%ymm0, -71(%rcx)
+-.LBB0_96:
+-	vmovups	-39(%rsi), %ymm0
+-	vmovups	%ymm0, -39(%rcx)
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_97:
+-	vmovups	-200(%rsi), %ymm0
+-	vmovups	%ymm0, -200(%rcx)
+-.LBB0_98:
+-	vmovups	-168(%rsi), %ymm0
+-	vmovups	%ymm0, -168(%rcx)
+-.LBB0_23:
+-	vmovups	-136(%rsi), %ymm0
+-	vmovups	%ymm0, -136(%rcx)
+-	vmovups	-104(%rsi), %ymm0
+-	vmovups	%ymm0, -104(%rcx)
+-.LBB0_24:
+-	vmovups	-72(%rsi), %ymm0
+-	vmovups	%ymm0, -72(%rcx)
+-.LBB0_25:
+-	vmovups	-40(%rsi), %ymm0
+-	vmovups	%ymm0, -40(%rcx)
+-.LBB0_26:
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_99:
+-	vmovups	-201(%rsi), %ymm0
+-	vmovups	%ymm0, -201(%rcx)
+-.LBB0_100:
+-	vmovups	-169(%rsi), %ymm0
+-	vmovups	%ymm0, -169(%rcx)
+-	vmovups	-137(%rsi), %ymm0
+-	vmovups	%ymm0, -137(%rcx)
+-	vmovups	-105(%rsi), %ymm0
+-	vmovups	%ymm0, -105(%rcx)
+-.LBB0_101:
+-	vmovups	-73(%rsi), %ymm0
+-	vmovups	%ymm0, -73(%rcx)
+-.LBB0_102:
+-	vmovups	-41(%rsi), %ymm0
+-	vmovups	%ymm0, -41(%rcx)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_103:
+-	vmovups	-202(%rsi), %ymm0
+-	vmovups	%ymm0, -202(%rcx)
+-.LBB0_104:
+-	vmovups	-170(%rsi), %ymm0
+-	vmovups	%ymm0, -170(%rcx)
+-	vmovups	-138(%rsi), %ymm0
+-	vmovups	%ymm0, -138(%rcx)
+-	vmovups	-106(%rsi), %ymm0
+-	vmovups	%ymm0, -106(%rcx)
+-.LBB0_105:
+-	vmovups	-74(%rsi), %ymm0
+-	vmovups	%ymm0, -74(%rcx)
+-.LBB0_106:
+-	vmovups	-42(%rsi), %ymm0
+-	vmovups	%ymm0, -42(%rcx)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_107:
+-	vmovups	-203(%rsi), %ymm0
+-	vmovups	%ymm0, -203(%rcx)
+-.LBB0_108:
+-	vmovups	-171(%rsi), %ymm0
+-	vmovups	%ymm0, -171(%rcx)
+-	vmovups	-139(%rsi), %ymm0
+-	vmovups	%ymm0, -139(%rcx)
+-	vmovups	-107(%rsi), %ymm0
+-	vmovups	%ymm0, -107(%rcx)
+-.LBB0_109:
+-	vmovups	-75(%rsi), %ymm0
+-	vmovups	%ymm0, -75(%rcx)
+-.LBB0_110:
+-	vmovups	-43(%rsi), %ymm0
+-	vmovups	%ymm0, -43(%rcx)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_111:
+-	vmovups	-204(%rsi), %ymm0
+-	vmovups	%ymm0, -204(%rcx)
+-.LBB0_112:
+-	vmovups	-172(%rsi), %ymm0
+-	vmovups	%ymm0, -172(%rcx)
+-	vmovups	-140(%rsi), %ymm0
+-	vmovups	%ymm0, -140(%rcx)
+-	vmovups	-108(%rsi), %ymm0
+-	vmovups	%ymm0, -108(%rcx)
+-.LBB0_113:
+-	vmovups	-76(%rsi), %ymm0
+-	vmovups	%ymm0, -76(%rcx)
+-.LBB0_114:
+-	vmovups	-44(%rsi), %ymm0
+-	vmovups	%ymm0, -44(%rcx)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_115:
+-	vmovups	-205(%rsi), %ymm0
+-	vmovups	%ymm0, -205(%rcx)
+-.LBB0_116:
+-	vmovups	-173(%rsi), %ymm0
+-	vmovups	%ymm0, -173(%rcx)
+-	vmovups	-141(%rsi), %ymm0
+-	vmovups	%ymm0, -141(%rcx)
+-	vmovups	-109(%rsi), %ymm0
+-	vmovups	%ymm0, -109(%rcx)
+-.LBB0_117:
+-	vmovups	-77(%rsi), %ymm0
+-	vmovups	%ymm0, -77(%rcx)
+-.LBB0_118:
+-	vmovups	-45(%rsi), %ymm0
+-	vmovups	%ymm0, -45(%rcx)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_119:
+-	vmovups	-206(%rsi), %ymm0
+-	vmovups	%ymm0, -206(%rcx)
+-.LBB0_120:
+-	vmovups	-174(%rsi), %ymm0
+-	vmovups	%ymm0, -174(%rcx)
+-	vmovups	-142(%rsi), %ymm0
+-	vmovups	%ymm0, -142(%rcx)
+-	vmovups	-110(%rsi), %ymm0
+-	vmovups	%ymm0, -110(%rcx)
+-.LBB0_121:
+-	vmovups	-78(%rsi), %ymm0
+-	vmovups	%ymm0, -78(%rcx)
+-.LBB0_122:
+-	vmovups	-46(%rsi), %ymm0
+-	vmovups	%ymm0, -46(%rcx)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_123:
+-	vmovups	-207(%rsi), %ymm0
+-	vmovups	%ymm0, -207(%rcx)
+-.LBB0_124:
+-	vmovups	-175(%rsi), %ymm0
+-	vmovups	%ymm0, -175(%rcx)
+-	vmovups	-143(%rsi), %ymm0
+-	vmovups	%ymm0, -143(%rcx)
+-	vmovups	-111(%rsi), %ymm0
+-	vmovups	%ymm0, -111(%rcx)
+-.LBB0_125:
+-	vmovups	-79(%rsi), %ymm0
+-	vmovups	%ymm0, -79(%rcx)
+-.LBB0_126:
+-	vmovups	-47(%rsi), %ymm0
+-	vmovups	%ymm0, -47(%rcx)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_127:
+-	vmovups	-208(%rsi), %ymm0
+-	vmovups	%ymm0, -208(%rcx)
+-.LBB0_128:
+-	vmovups	-176(%rsi), %ymm0
+-	vmovups	%ymm0, -176(%rcx)
+-.LBB0_41:
+-	vmovups	-144(%rsi), %ymm0
+-	vmovups	%ymm0, -144(%rcx)
+-	vmovups	-112(%rsi), %ymm0
+-	vmovups	%ymm0, -112(%rcx)
+-.LBB0_42:
+-	vmovups	-80(%rsi), %ymm0
+-	vmovups	%ymm0, -80(%rcx)
+-.LBB0_43:
+-	vmovups	-48(%rsi), %ymm0
+-	vmovups	%ymm0, -48(%rcx)
+-.LBB0_44:
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_129:
+-	vmovups	-209(%rsi), %ymm0
+-	vmovups	%ymm0, -209(%rcx)
+-.LBB0_130:
+-	vmovups	-177(%rsi), %ymm0
+-	vmovups	%ymm0, -177(%rcx)
+-	vmovups	-145(%rsi), %ymm0
+-	vmovups	%ymm0, -145(%rcx)
+-	vmovups	-113(%rsi), %ymm0
+-	vmovups	%ymm0, -113(%rcx)
+-.LBB0_131:
+-	vmovups	-81(%rsi), %ymm0
+-	vmovups	%ymm0, -81(%rcx)
+-.LBB0_132:
+-	vmovups	-49(%rsi), %ymm0
+-	vmovups	%ymm0, -49(%rcx)
+-	vmovups	-32(%rsi), %ymm0
+-	vmovups	%ymm0, -32(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_133:
+-	vmovups	-210(%rsi), %ymm0
+-	vmovups	%ymm0, -210(%rcx)
+-.LBB0_134:
+-	vmovups	-178(%rsi), %ymm0
+-	vmovups	%ymm0, -178(%rcx)
+-	vmovups	-146(%rsi), %ymm0
+-	vmovups	%ymm0, -146(%rcx)
+-	vmovups	-114(%rsi), %ymm0
+-	vmovups	%ymm0, -114(%rcx)
+-.LBB0_135:
+-	vmovups	-82(%rsi), %ymm0
+-	vmovups	%ymm0, -82(%rcx)
+-.LBB0_136:
+-	vmovups	-50(%rsi), %ymm0
+-	vmovups	%ymm0, -50(%rcx)
+-	vmovups	-32(%rsi), %ymm0
+-	vmovups	%ymm0, -32(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_137:
+-	vmovups	-211(%rsi), %ymm0
+-	vmovups	%ymm0, -211(%rcx)
+-.LBB0_138:
+-	vmovups	-179(%rsi), %ymm0
+-	vmovups	%ymm0, -179(%rcx)
+-	vmovups	-147(%rsi), %ymm0
+-	vmovups	%ymm0, -147(%rcx)
+-	vmovups	-115(%rsi), %ymm0
+-	vmovups	%ymm0, -115(%rcx)
+-.LBB0_139:
+-	vmovups	-83(%rsi), %ymm0
+-	vmovups	%ymm0, -83(%rcx)
+-.LBB0_140:
+-	vmovups	-51(%rsi), %ymm0
+-	vmovups	%ymm0, -51(%rcx)
+-	vmovups	-32(%rsi), %ymm0
+-	vmovups	%ymm0, -32(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_141:
+-	vmovups	-212(%rsi), %ymm0
+-	vmovups	%ymm0, -212(%rcx)
+-.LBB0_142:
+-	vmovups	-180(%rsi), %ymm0
+-	vmovups	%ymm0, -180(%rcx)
+-	vmovups	-148(%rsi), %ymm0
+-	vmovups	%ymm0, -148(%rcx)
+-	vmovups	-116(%rsi), %ymm0
+-	vmovups	%ymm0, -116(%rcx)
+-.LBB0_143:
+-	vmovups	-84(%rsi), %ymm0
+-	vmovups	%ymm0, -84(%rcx)
+-.LBB0_144:
+-	vmovups	-52(%rsi), %ymm0
+-	vmovups	%ymm0, -52(%rcx)
+-	vmovups	-32(%rsi), %ymm0
+-	vmovups	%ymm0, -32(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_145:
+-	vmovups	-213(%rsi), %ymm0
+-	vmovups	%ymm0, -213(%rcx)
+-.LBB0_146:
+-	vmovups	-181(%rsi), %ymm0
+-	vmovups	%ymm0, -181(%rcx)
+-	vmovups	-149(%rsi), %ymm0
+-	vmovups	%ymm0, -149(%rcx)
+-	vmovups	-117(%rsi), %ymm0
+-	vmovups	%ymm0, -117(%rcx)
+-.LBB0_147:
+-	vmovups	-85(%rsi), %ymm0
+-	vmovups	%ymm0, -85(%rcx)
+-.LBB0_148:
+-	vmovups	-53(%rsi), %ymm0
+-	vmovups	%ymm0, -53(%rcx)
+-	vmovups	-32(%rsi), %ymm0
+-	vmovups	%ymm0, -32(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_149:
+-	vmovups	-214(%rsi), %ymm0
+-	vmovups	%ymm0, -214(%rcx)
+-.LBB0_150:
+-	vmovups	-182(%rsi), %ymm0
+-	vmovups	%ymm0, -182(%rcx)
+-	vmovups	-150(%rsi), %ymm0
+-	vmovups	%ymm0, -150(%rcx)
+-	vmovups	-118(%rsi), %ymm0
+-	vmovups	%ymm0, -118(%rcx)
+-.LBB0_151:
+-	vmovups	-86(%rsi), %ymm0
+-	vmovups	%ymm0, -86(%rcx)
+-.LBB0_152:
+-	vmovups	-54(%rsi), %ymm0
+-	vmovups	%ymm0, -54(%rcx)
+-	vmovups	-32(%rsi), %ymm0
+-	vmovups	%ymm0, -32(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_153:
+-	vmovups	-215(%rsi), %ymm0
+-	vmovups	%ymm0, -215(%rcx)
+-.LBB0_154:
+-	vmovups	-183(%rsi), %ymm0
+-	vmovups	%ymm0, -183(%rcx)
+-	vmovups	-151(%rsi), %ymm0
+-	vmovups	%ymm0, -151(%rcx)
+-	vmovups	-119(%rsi), %ymm0
+-	vmovups	%ymm0, -119(%rcx)
+-.LBB0_155:
+-	vmovups	-87(%rsi), %ymm0
+-	vmovups	%ymm0, -87(%rcx)
+-.LBB0_156:
+-	vmovups	-55(%rsi), %ymm0
+-	vmovups	%ymm0, -55(%rcx)
+-	vmovups	-32(%rsi), %ymm0
+-	vmovups	%ymm0, -32(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_157:
+-	vmovups	-216(%rsi), %ymm0
+-	vmovups	%ymm0, -216(%rcx)
+-.LBB0_158:
+-	vmovups	-184(%rsi), %ymm0
+-	vmovups	%ymm0, -184(%rcx)
+-	vmovups	-152(%rsi), %ymm0
+-	vmovups	%ymm0, -152(%rcx)
+-	vmovups	-120(%rsi), %ymm0
+-	vmovups	%ymm0, -120(%rcx)
+-.LBB0_159:
+-	vmovups	-88(%rsi), %ymm0
+-	vmovups	%ymm0, -88(%rcx)
+-.LBB0_160:
+-	vmovups	-56(%rsi), %ymm0
+-	vmovups	%ymm0, -56(%rcx)
+-	vmovups	-32(%rsi), %ymm0
+-	vmovups	%ymm0, -32(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_161:
+-	vmovups	-217(%rsi), %ymm0
+-	vmovups	%ymm0, -217(%rcx)
+-.LBB0_162:
+-	vmovups	-185(%rsi), %ymm0
+-	vmovups	%ymm0, -185(%rcx)
+-	vmovups	-153(%rsi), %ymm0
+-	vmovups	%ymm0, -153(%rcx)
+-	vmovups	-121(%rsi), %ymm0
+-	vmovups	%ymm0, -121(%rcx)
+-.LBB0_163:
+-	vmovups	-89(%rsi), %ymm0
+-	vmovups	%ymm0, -89(%rcx)
+-.LBB0_164:
+-	vmovups	-57(%rsi), %ymm0
+-	vmovups	%ymm0, -57(%rcx)
+-	vmovups	-32(%rsi), %ymm0
+-	vmovups	%ymm0, -32(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_165:
+-	vmovups	-218(%rsi), %ymm0
+-	vmovups	%ymm0, -218(%rcx)
+-.LBB0_166:
+-	vmovups	-186(%rsi), %ymm0
+-	vmovups	%ymm0, -186(%rcx)
+-	vmovups	-154(%rsi), %ymm0
+-	vmovups	%ymm0, -154(%rcx)
+-	vmovups	-122(%rsi), %ymm0
+-	vmovups	%ymm0, -122(%rcx)
+-.LBB0_167:
+-	vmovups	-90(%rsi), %ymm0
+-	vmovups	%ymm0, -90(%rcx)
+-.LBB0_168:
+-	vmovups	-58(%rsi), %ymm0
+-	vmovups	%ymm0, -58(%rcx)
+-	vmovups	-32(%rsi), %ymm0
+-	vmovups	%ymm0, -32(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_169:
+-	vmovups	-219(%rsi), %ymm0
+-	vmovups	%ymm0, -219(%rcx)
+-.LBB0_170:
+-	vmovups	-187(%rsi), %ymm0
+-	vmovups	%ymm0, -187(%rcx)
+-	vmovups	-155(%rsi), %ymm0
+-	vmovups	%ymm0, -155(%rcx)
+-	vmovups	-123(%rsi), %ymm0
+-	vmovups	%ymm0, -123(%rcx)
+-.LBB0_171:
+-	vmovups	-91(%rsi), %ymm0
+-	vmovups	%ymm0, -91(%rcx)
+-.LBB0_172:
+-	vmovups	-59(%rsi), %ymm0
+-	vmovups	%ymm0, -59(%rcx)
+-	vmovups	-32(%rsi), %ymm0
+-	vmovups	%ymm0, -32(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_173:
+-	vmovups	-220(%rsi), %ymm0
+-	vmovups	%ymm0, -220(%rcx)
+-.LBB0_174:
+-	vmovups	-188(%rsi), %ymm0
+-	vmovups	%ymm0, -188(%rcx)
+-	vmovups	-156(%rsi), %ymm0
+-	vmovups	%ymm0, -156(%rcx)
+-	vmovups	-124(%rsi), %ymm0
+-	vmovups	%ymm0, -124(%rcx)
+-.LBB0_175:
+-	vmovups	-92(%rsi), %ymm0
+-	vmovups	%ymm0, -92(%rcx)
+-.LBB0_176:
+-	vmovups	-60(%rsi), %ymm0
+-	vmovups	%ymm0, -60(%rcx)
+-	vmovups	-32(%rsi), %ymm0
+-	vmovups	%ymm0, -32(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_177:
+-	vmovups	-221(%rsi), %ymm0
+-	vmovups	%ymm0, -221(%rcx)
+-.LBB0_178:
+-	vmovups	-189(%rsi), %ymm0
+-	vmovups	%ymm0, -189(%rcx)
+-	vmovups	-157(%rsi), %ymm0
+-	vmovups	%ymm0, -157(%rcx)
+-	vmovups	-125(%rsi), %ymm0
+-	vmovups	%ymm0, -125(%rcx)
+-.LBB0_179:
+-	vmovups	-93(%rsi), %ymm0
+-	vmovups	%ymm0, -93(%rcx)
+-.LBB0_180:
+-	vmovups	-61(%rsi), %ymm0
+-	vmovups	%ymm0, -61(%rcx)
+-	vmovups	-32(%rsi), %ymm0
+-	vmovups	%ymm0, -32(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_181:
+-	vmovups	-222(%rsi), %ymm0
+-	vmovups	%ymm0, -222(%rcx)
+-.LBB0_182:
+-	vmovups	-190(%rsi), %ymm0
+-	vmovups	%ymm0, -190(%rcx)
+-	vmovups	-158(%rsi), %ymm0
+-	vmovups	%ymm0, -158(%rcx)
+-	vmovups	-126(%rsi), %ymm0
+-	vmovups	%ymm0, -126(%rcx)
+-.LBB0_183:
+-	vmovups	-94(%rsi), %ymm0
+-	vmovups	%ymm0, -94(%rcx)
+-.LBB0_184:
+-	vmovups	-62(%rsi), %ymm0
+-	vmovups	%ymm0, -62(%rcx)
+-	vmovups	-32(%rsi), %ymm0
+-	vmovups	%ymm0, -32(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_185:
+-	vmovups	-223(%rsi), %ymm0
+-	vmovups	%ymm0, -223(%rcx)
+-.LBB0_186:
+-	vmovups	-191(%rsi), %ymm0
+-	vmovups	%ymm0, -191(%rcx)
+-	vmovups	-159(%rsi), %ymm0
+-	vmovups	%ymm0, -159(%rcx)
+-	vmovups	-127(%rsi), %ymm0
+-	vmovups	%ymm0, -127(%rcx)
+-.LBB0_187:
+-	vmovups	-95(%rsi), %ymm0
+-	vmovups	%ymm0, -95(%rcx)
+-.LBB0_188:
+-	vmovups	-63(%rsi), %ymm0
+-	vmovups	%ymm0, -63(%rcx)
+-	vmovups	-32(%rsi), %ymm0
+-	vmovups	%ymm0, -32(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_189:
+-	vmovups	-225(%rsi), %ymm0
+-	vmovups	%ymm0, -225(%rcx)
+-	vmovups	-193(%rsi), %ymm0
+-	vmovups	%ymm0, -193(%rcx)
+-	vmovups	-161(%rsi), %ymm0
+-	vmovups	%ymm0, -161(%rcx)
+-	vmovups	-129(%rsi), %ymm0
+-	vmovups	%ymm0, -129(%rcx)
+-.LBB0_190:
+-	vmovups	-97(%rsi), %ymm0
+-	vmovups	%ymm0, -97(%rcx)
+-	vmovups	-65(%rsi), %ymm0
+-	vmovups	%ymm0, -65(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_191:
+-	vmovups	-226(%rsi), %ymm0
+-	vmovups	%ymm0, -226(%rcx)
+-	vmovups	-194(%rsi), %ymm0
+-	vmovups	%ymm0, -194(%rcx)
+-	vmovups	-162(%rsi), %ymm0
+-	vmovups	%ymm0, -162(%rcx)
+-	vmovups	-130(%rsi), %ymm0
+-	vmovups	%ymm0, -130(%rcx)
+-.LBB0_192:
+-	vmovups	-98(%rsi), %ymm0
+-	vmovups	%ymm0, -98(%rcx)
+-	vmovups	-66(%rsi), %ymm0
+-	vmovups	%ymm0, -66(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_193:
+-	vmovups	-227(%rsi), %ymm0
+-	vmovups	%ymm0, -227(%rcx)
+-	vmovups	-195(%rsi), %ymm0
+-	vmovups	%ymm0, -195(%rcx)
+-	vmovups	-163(%rsi), %ymm0
+-	vmovups	%ymm0, -163(%rcx)
+-	vmovups	-131(%rsi), %ymm0
+-	vmovups	%ymm0, -131(%rcx)
+-.LBB0_194:
+-	vmovups	-99(%rsi), %ymm0
+-	vmovups	%ymm0, -99(%rcx)
+-	vmovups	-67(%rsi), %ymm0
+-	vmovups	%ymm0, -67(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_195:
+-	vmovups	-228(%rsi), %ymm0
+-	vmovups	%ymm0, -228(%rcx)
+-	vmovups	-196(%rsi), %ymm0
+-	vmovups	%ymm0, -196(%rcx)
+-	vmovups	-164(%rsi), %ymm0
+-	vmovups	%ymm0, -164(%rcx)
+-	vmovups	-132(%rsi), %ymm0
+-	vmovups	%ymm0, -132(%rcx)
+-.LBB0_196:
+-	vmovups	-100(%rsi), %ymm0
+-	vmovups	%ymm0, -100(%rcx)
+-	vmovups	-68(%rsi), %ymm0
+-	vmovups	%ymm0, -68(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_197:
+-	vmovups	-229(%rsi), %ymm0
+-	vmovups	%ymm0, -229(%rcx)
+-	vmovups	-197(%rsi), %ymm0
+-	vmovups	%ymm0, -197(%rcx)
+-	vmovups	-165(%rsi), %ymm0
+-	vmovups	%ymm0, -165(%rcx)
+-	vmovups	-133(%rsi), %ymm0
+-	vmovups	%ymm0, -133(%rcx)
+-.LBB0_198:
+-	vmovups	-101(%rsi), %ymm0
+-	vmovups	%ymm0, -101(%rcx)
+-	vmovups	-69(%rsi), %ymm0
+-	vmovups	%ymm0, -69(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_199:
+-	vmovups	-230(%rsi), %ymm0
+-	vmovups	%ymm0, -230(%rcx)
+-	vmovups	-198(%rsi), %ymm0
+-	vmovups	%ymm0, -198(%rcx)
+-	vmovups	-166(%rsi), %ymm0
+-	vmovups	%ymm0, -166(%rcx)
+-	vmovups	-134(%rsi), %ymm0
+-	vmovups	%ymm0, -134(%rcx)
+-.LBB0_200:
+-	vmovups	-102(%rsi), %ymm0
+-	vmovups	%ymm0, -102(%rcx)
+-	vmovups	-70(%rsi), %ymm0
+-	vmovups	%ymm0, -70(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_201:
+-	vmovups	-231(%rsi), %ymm0
+-	vmovups	%ymm0, -231(%rcx)
+-	vmovups	-199(%rsi), %ymm0
+-	vmovups	%ymm0, -199(%rcx)
+-	vmovups	-167(%rsi), %ymm0
+-	vmovups	%ymm0, -167(%rcx)
+-	vmovups	-135(%rsi), %ymm0
+-	vmovups	%ymm0, -135(%rcx)
+-.LBB0_202:
+-	vmovups	-103(%rsi), %ymm0
+-	vmovups	%ymm0, -103(%rcx)
+-	vmovups	-71(%rsi), %ymm0
+-	vmovups	%ymm0, -71(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_203:
+-	vmovups	-232(%rsi), %ymm0
+-	vmovups	%ymm0, -232(%rcx)
+-	vmovups	-200(%rsi), %ymm0
+-	vmovups	%ymm0, -200(%rcx)
+-	vmovups	-168(%rsi), %ymm0
+-	vmovups	%ymm0, -168(%rcx)
+-	vmovups	-136(%rsi), %ymm0
+-	vmovups	%ymm0, -136(%rcx)
+-.LBB0_204:
+-	vmovups	-104(%rsi), %ymm0
+-	vmovups	%ymm0, -104(%rcx)
+-	vmovups	-72(%rsi), %ymm0
+-	vmovups	%ymm0, -72(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_205:
+-	vmovups	-233(%rsi), %ymm0
+-	vmovups	%ymm0, -233(%rcx)
+-	vmovups	-201(%rsi), %ymm0
+-	vmovups	%ymm0, -201(%rcx)
+-	vmovups	-169(%rsi), %ymm0
+-	vmovups	%ymm0, -169(%rcx)
+-	vmovups	-137(%rsi), %ymm0
+-	vmovups	%ymm0, -137(%rcx)
+-.LBB0_206:
+-	vmovups	-105(%rsi), %ymm0
+-	vmovups	%ymm0, -105(%rcx)
+-	vmovups	-73(%rsi), %ymm0
+-	vmovups	%ymm0, -73(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_207:
+-	vmovups	-234(%rsi), %ymm0
+-	vmovups	%ymm0, -234(%rcx)
+-	vmovups	-202(%rsi), %ymm0
+-	vmovups	%ymm0, -202(%rcx)
+-	vmovups	-170(%rsi), %ymm0
+-	vmovups	%ymm0, -170(%rcx)
+-	vmovups	-138(%rsi), %ymm0
+-	vmovups	%ymm0, -138(%rcx)
+-.LBB0_208:
+-	vmovups	-106(%rsi), %ymm0
+-	vmovups	%ymm0, -106(%rcx)
+-	vmovups	-74(%rsi), %ymm0
+-	vmovups	%ymm0, -74(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_209:
+-	vmovups	-235(%rsi), %ymm0
+-	vmovups	%ymm0, -235(%rcx)
+-	vmovups	-203(%rsi), %ymm0
+-	vmovups	%ymm0, -203(%rcx)
+-	vmovups	-171(%rsi), %ymm0
+-	vmovups	%ymm0, -171(%rcx)
+-	vmovups	-139(%rsi), %ymm0
+-	vmovups	%ymm0, -139(%rcx)
+-.LBB0_210:
+-	vmovups	-107(%rsi), %ymm0
+-	vmovups	%ymm0, -107(%rcx)
+-	vmovups	-75(%rsi), %ymm0
+-	vmovups	%ymm0, -75(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_211:
+-	vmovups	-236(%rsi), %ymm0
+-	vmovups	%ymm0, -236(%rcx)
+-	vmovups	-204(%rsi), %ymm0
+-	vmovups	%ymm0, -204(%rcx)
+-	vmovups	-172(%rsi), %ymm0
+-	vmovups	%ymm0, -172(%rcx)
+-	vmovups	-140(%rsi), %ymm0
+-	vmovups	%ymm0, -140(%rcx)
+-.LBB0_212:
+-	vmovups	-108(%rsi), %ymm0
+-	vmovups	%ymm0, -108(%rcx)
+-	vmovups	-76(%rsi), %ymm0
+-	vmovups	%ymm0, -76(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_213:
+-	vmovups	-237(%rsi), %ymm0
+-	vmovups	%ymm0, -237(%rcx)
+-	vmovups	-205(%rsi), %ymm0
+-	vmovups	%ymm0, -205(%rcx)
+-	vmovups	-173(%rsi), %ymm0
+-	vmovups	%ymm0, -173(%rcx)
+-	vmovups	-141(%rsi), %ymm0
+-	vmovups	%ymm0, -141(%rcx)
+-.LBB0_214:
+-	vmovups	-109(%rsi), %ymm0
+-	vmovups	%ymm0, -109(%rcx)
+-	vmovups	-77(%rsi), %ymm0
+-	vmovups	%ymm0, -77(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_215:
+-	vmovups	-238(%rsi), %ymm0
+-	vmovups	%ymm0, -238(%rcx)
+-	vmovups	-206(%rsi), %ymm0
+-	vmovups	%ymm0, -206(%rcx)
+-	vmovups	-174(%rsi), %ymm0
+-	vmovups	%ymm0, -174(%rcx)
+-	vmovups	-142(%rsi), %ymm0
+-	vmovups	%ymm0, -142(%rcx)
+-.LBB0_216:
+-	vmovups	-110(%rsi), %ymm0
+-	vmovups	%ymm0, -110(%rcx)
+-	vmovups	-78(%rsi), %ymm0
+-	vmovups	%ymm0, -78(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_217:
+-	vmovups	-239(%rsi), %ymm0
+-	vmovups	%ymm0, -239(%rcx)
+-	vmovups	-207(%rsi), %ymm0
+-	vmovups	%ymm0, -207(%rcx)
+-	vmovups	-175(%rsi), %ymm0
+-	vmovups	%ymm0, -175(%rcx)
+-	vmovups	-143(%rsi), %ymm0
+-	vmovups	%ymm0, -143(%rcx)
+-.LBB0_218:
+-	vmovups	-111(%rsi), %ymm0
+-	vmovups	%ymm0, -111(%rcx)
+-	vmovups	-79(%rsi), %ymm0
+-	vmovups	%ymm0, -79(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_219:
+-	vmovups	-240(%rsi), %ymm0
+-	vmovups	%ymm0, -240(%rcx)
+-	vmovups	-208(%rsi), %ymm0
+-	vmovups	%ymm0, -208(%rcx)
+-	vmovups	-176(%rsi), %ymm0
+-	vmovups	%ymm0, -176(%rcx)
+-	vmovups	-144(%rsi), %ymm0
+-	vmovups	%ymm0, -144(%rcx)
+-.LBB0_220:
+-	vmovups	-112(%rsi), %ymm0
+-	vmovups	%ymm0, -112(%rcx)
+-	vmovups	-80(%rsi), %ymm0
+-	vmovups	%ymm0, -80(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_221:
+-	vmovups	-241(%rsi), %ymm0
+-	vmovups	%ymm0, -241(%rcx)
+-	vmovups	-209(%rsi), %ymm0
+-	vmovups	%ymm0, -209(%rcx)
+-	vmovups	-177(%rsi), %ymm0
+-	vmovups	%ymm0, -177(%rcx)
+-	vmovups	-145(%rsi), %ymm0
+-	vmovups	%ymm0, -145(%rcx)
+-.LBB0_222:
+-	vmovups	-113(%rsi), %ymm0
+-	vmovups	%ymm0, -113(%rcx)
+-	vmovups	-81(%rsi), %ymm0
+-	vmovups	%ymm0, -81(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_223:
+-	vmovups	-242(%rsi), %ymm0
+-	vmovups	%ymm0, -242(%rcx)
+-	vmovups	-210(%rsi), %ymm0
+-	vmovups	%ymm0, -210(%rcx)
+-	vmovups	-178(%rsi), %ymm0
+-	vmovups	%ymm0, -178(%rcx)
+-	vmovups	-146(%rsi), %ymm0
+-	vmovups	%ymm0, -146(%rcx)
+-.LBB0_224:
+-	vmovups	-114(%rsi), %ymm0
+-	vmovups	%ymm0, -114(%rcx)
+-	vmovups	-82(%rsi), %ymm0
+-	vmovups	%ymm0, -82(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_225:
+-	vmovups	-243(%rsi), %ymm0
+-	vmovups	%ymm0, -243(%rcx)
+-	vmovups	-211(%rsi), %ymm0
+-	vmovups	%ymm0, -211(%rcx)
+-	vmovups	-179(%rsi), %ymm0
+-	vmovups	%ymm0, -179(%rcx)
+-	vmovups	-147(%rsi), %ymm0
+-	vmovups	%ymm0, -147(%rcx)
+-.LBB0_226:
+-	vmovups	-115(%rsi), %ymm0
+-	vmovups	%ymm0, -115(%rcx)
+-	vmovups	-83(%rsi), %ymm0
+-	vmovups	%ymm0, -83(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_227:
+-	vmovups	-244(%rsi), %ymm0
+-	vmovups	%ymm0, -244(%rcx)
+-	vmovups	-212(%rsi), %ymm0
+-	vmovups	%ymm0, -212(%rcx)
+-	vmovups	-180(%rsi), %ymm0
+-	vmovups	%ymm0, -180(%rcx)
+-	vmovups	-148(%rsi), %ymm0
+-	vmovups	%ymm0, -148(%rcx)
+-.LBB0_228:
+-	vmovups	-116(%rsi), %ymm0
+-	vmovups	%ymm0, -116(%rcx)
+-	vmovups	-84(%rsi), %ymm0
+-	vmovups	%ymm0, -84(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_229:
+-	vmovups	-245(%rsi), %ymm0
+-	vmovups	%ymm0, -245(%rcx)
+-	vmovups	-213(%rsi), %ymm0
+-	vmovups	%ymm0, -213(%rcx)
+-	vmovups	-181(%rsi), %ymm0
+-	vmovups	%ymm0, -181(%rcx)
+-	vmovups	-149(%rsi), %ymm0
+-	vmovups	%ymm0, -149(%rcx)
+-.LBB0_230:
+-	vmovups	-117(%rsi), %ymm0
+-	vmovups	%ymm0, -117(%rcx)
+-	vmovups	-85(%rsi), %ymm0
+-	vmovups	%ymm0, -85(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_231:
+-	vmovups	-246(%rsi), %ymm0
+-	vmovups	%ymm0, -246(%rcx)
+-	vmovups	-214(%rsi), %ymm0
+-	vmovups	%ymm0, -214(%rcx)
+-	vmovups	-182(%rsi), %ymm0
+-	vmovups	%ymm0, -182(%rcx)
+-	vmovups	-150(%rsi), %ymm0
+-	vmovups	%ymm0, -150(%rcx)
+-.LBB0_232:
+-	vmovups	-118(%rsi), %ymm0
+-	vmovups	%ymm0, -118(%rcx)
+-	vmovups	-86(%rsi), %ymm0
+-	vmovups	%ymm0, -86(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_233:
+-	vmovups	-247(%rsi), %ymm0
+-	vmovups	%ymm0, -247(%rcx)
+-	vmovups	-215(%rsi), %ymm0
+-	vmovups	%ymm0, -215(%rcx)
+-	vmovups	-183(%rsi), %ymm0
+-	vmovups	%ymm0, -183(%rcx)
+-	vmovups	-151(%rsi), %ymm0
+-	vmovups	%ymm0, -151(%rcx)
+-.LBB0_234:
+-	vmovups	-119(%rsi), %ymm0
+-	vmovups	%ymm0, -119(%rcx)
+-	vmovups	-87(%rsi), %ymm0
+-	vmovups	%ymm0, -87(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_235:
+-	vmovups	-248(%rsi), %ymm0
+-	vmovups	%ymm0, -248(%rcx)
+-	vmovups	-216(%rsi), %ymm0
+-	vmovups	%ymm0, -216(%rcx)
+-	vmovups	-184(%rsi), %ymm0
+-	vmovups	%ymm0, -184(%rcx)
+-	vmovups	-152(%rsi), %ymm0
+-	vmovups	%ymm0, -152(%rcx)
+-.LBB0_236:
+-	vmovups	-120(%rsi), %ymm0
+-	vmovups	%ymm0, -120(%rcx)
+-	vmovups	-88(%rsi), %ymm0
+-	vmovups	%ymm0, -88(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_237:
+-	vmovups	-249(%rsi), %ymm0
+-	vmovups	%ymm0, -249(%rcx)
+-	vmovups	-217(%rsi), %ymm0
+-	vmovups	%ymm0, -217(%rcx)
+-	vmovups	-185(%rsi), %ymm0
+-	vmovups	%ymm0, -185(%rcx)
+-	vmovups	-153(%rsi), %ymm0
+-	vmovups	%ymm0, -153(%rcx)
+-.LBB0_238:
+-	vmovups	-121(%rsi), %ymm0
+-	vmovups	%ymm0, -121(%rcx)
+-	vmovups	-89(%rsi), %ymm0
+-	vmovups	%ymm0, -89(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_239:
+-	vmovups	-250(%rsi), %ymm0
+-	vmovups	%ymm0, -250(%rcx)
+-	vmovups	-218(%rsi), %ymm0
+-	vmovups	%ymm0, -218(%rcx)
+-	vmovups	-186(%rsi), %ymm0
+-	vmovups	%ymm0, -186(%rcx)
+-	vmovups	-154(%rsi), %ymm0
+-	vmovups	%ymm0, -154(%rcx)
+-.LBB0_240:
+-	vmovups	-122(%rsi), %ymm0
+-	vmovups	%ymm0, -122(%rcx)
+-	vmovups	-90(%rsi), %ymm0
+-	vmovups	%ymm0, -90(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_241:
+-	vmovups	-251(%rsi), %ymm0
+-	vmovups	%ymm0, -251(%rcx)
+-	vmovups	-219(%rsi), %ymm0
+-	vmovups	%ymm0, -219(%rcx)
+-	vmovups	-187(%rsi), %ymm0
+-	vmovups	%ymm0, -187(%rcx)
+-	vmovups	-155(%rsi), %ymm0
+-	vmovups	%ymm0, -155(%rcx)
+-.LBB0_242:
+-	vmovups	-123(%rsi), %ymm0
+-	vmovups	%ymm0, -123(%rcx)
+-	vmovups	-91(%rsi), %ymm0
+-	vmovups	%ymm0, -91(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_243:
+-	vmovups	-252(%rsi), %ymm0
+-	vmovups	%ymm0, -252(%rcx)
+-	vmovups	-220(%rsi), %ymm0
+-	vmovups	%ymm0, -220(%rcx)
+-	vmovups	-188(%rsi), %ymm0
+-	vmovups	%ymm0, -188(%rcx)
+-	vmovups	-156(%rsi), %ymm0
+-	vmovups	%ymm0, -156(%rcx)
+-.LBB0_244:
+-	vmovups	-124(%rsi), %ymm0
+-	vmovups	%ymm0, -124(%rcx)
+-	vmovups	-92(%rsi), %ymm0
+-	vmovups	%ymm0, -92(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_245:
+-	vmovups	-253(%rsi), %ymm0
+-	vmovups	%ymm0, -253(%rcx)
+-	vmovups	-221(%rsi), %ymm0
+-	vmovups	%ymm0, -221(%rcx)
+-	vmovups	-189(%rsi), %ymm0
+-	vmovups	%ymm0, -189(%rcx)
+-	vmovups	-157(%rsi), %ymm0
+-	vmovups	%ymm0, -157(%rcx)
+-.LBB0_246:
+-	vmovups	-125(%rsi), %ymm0
+-	vmovups	%ymm0, -125(%rcx)
+-	vmovups	-93(%rsi), %ymm0
+-	vmovups	%ymm0, -93(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_247:
+-	vmovups	-254(%rsi), %ymm0
+-	vmovups	%ymm0, -254(%rcx)
+-	vmovups	-222(%rsi), %ymm0
+-	vmovups	%ymm0, -222(%rcx)
+-	vmovups	-190(%rsi), %ymm0
+-	vmovups	%ymm0, -190(%rcx)
+-	vmovups	-158(%rsi), %ymm0
+-	vmovups	%ymm0, -158(%rcx)
+-.LBB0_248:
+-	vmovups	-126(%rsi), %ymm0
+-	vmovups	%ymm0, -126(%rcx)
+-	vmovups	-94(%rsi), %ymm0
+-	vmovups	%ymm0, -94(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_249:
+-	vmovups	-255(%rsi), %ymm0
+-	vmovups	%ymm0, -255(%rcx)
+-	vmovups	-223(%rsi), %ymm0
+-	vmovups	%ymm0, -223(%rcx)
+-	vmovups	-191(%rsi), %ymm0
+-	vmovups	%ymm0, -191(%rcx)
+-	vmovups	-159(%rsi), %ymm0
+-	vmovups	%ymm0, -159(%rcx)
+-.LBB0_250:
+-	vmovups	-127(%rsi), %ymm0
+-	vmovups	%ymm0, -127(%rcx)
+-	vmovups	-95(%rsi), %ymm0
+-	vmovups	%ymm0, -95(%rcx)
+-	jmp	.LBB0_257
+-.LBB0_251:
+-	vmovups	-256(%rsi), %ymm0
+-	vmovups	%ymm0, -256(%rcx)
+-.LBB0_252:
+-	vmovups	-224(%rsi), %ymm0
+-	vmovups	%ymm0, -224(%rcx)
+-.LBB0_253:
+-	vmovups	-192(%rsi), %ymm0
+-	vmovups	%ymm0, -192(%rcx)
+-.LBB0_254:
+-	vmovups	-160(%rsi), %ymm0
+-	vmovups	%ymm0, -160(%rcx)
+-.LBB0_255:
+-	vmovups	-128(%rsi), %ymm0
+-	vmovups	%ymm0, -128(%rcx)
+-.LBB0_256:
+-	vmovups	-96(%rsi), %ymm0
+-	vmovups	%ymm0, -96(%rcx)
+-.LBB0_257:
+-	vmovups	-64(%rsi), %ymm0
+-	vmovups	%ymm0, -64(%rcx)
+-.LBB0_258:
+-	vmovups	-32(%rsi), %ymm0
+-	vmovups	%ymm0, -32(%rcx)
+-	vzeroupper
+-	retq
+-.LBB0_284:
+-	vmovups	-133(%rsi), %ymm0
+-	vmovups	%ymm0, -133(%r8)
+-	vmovups	-101(%rsi), %ymm0
+-	vmovups	%ymm0, -101(%r8)
+-	vmovups	-69(%rsi), %ymm0
+-	vmovups	%ymm0, -69(%r8)
+-	vmovups	-37(%rsi), %ymm0
+-	vmovups	%ymm0, -37(%r8)
+-.LBB0_285:
+-	movl	-5(%rsi), %ecx
+-	movl	%ecx, -5(%r8)
+-	movb	-1(%rsi), %cl
+-	movb	%cl, -1(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_286:
+-	vmovups	-134(%rsi), %ymm0
+-	vmovups	%ymm0, -134(%r8)
+-	vmovups	-102(%rsi), %ymm0
+-	vmovups	%ymm0, -102(%r8)
+-	vmovups	-70(%rsi), %ymm0
+-	vmovups	%ymm0, -70(%r8)
+-	vmovups	-38(%rsi), %ymm0
+-	vmovups	%ymm0, -38(%r8)
+-.LBB0_287:
+-	movl	-6(%rsi), %ecx
+-	movl	%ecx, -6(%r8)
+-	movzwl	-2(%rsi), %ecx
+-	movw	%cx, -2(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_288:
+-	vmovups	-135(%rsi), %ymm0
+-	vmovups	%ymm0, -135(%r8)
+-	vmovups	-103(%rsi), %ymm0
+-	vmovups	%ymm0, -103(%r8)
+-	vmovups	-71(%rsi), %ymm0
+-	vmovups	%ymm0, -71(%r8)
+-	vmovups	-39(%rsi), %ymm0
+-	vmovups	%ymm0, -39(%r8)
+-.LBB0_289:
+-	movl	-7(%rsi), %ecx
+-	movl	%ecx, -7(%r8)
+-	movl	-4(%rsi), %ecx
+-	movl	%ecx, -4(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_294:
+-	vmovups	-137(%rsi), %ymm0
+-	vmovups	%ymm0, -137(%r8)
+-	vmovups	-105(%rsi), %ymm0
+-	vmovups	%ymm0, -105(%r8)
+-	vmovups	-73(%rsi), %ymm0
+-	vmovups	%ymm0, -73(%r8)
+-	vmovups	-41(%rsi), %ymm0
+-	vmovups	%ymm0, -41(%r8)
+-.LBB0_295:
+-	movq	-9(%rsi), %rcx
+-	movq	%rcx, -9(%r8)
+-	movb	-1(%rsi), %cl
+-	movb	%cl, -1(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_296:
+-	vmovups	-138(%rsi), %ymm0
+-	vmovups	%ymm0, -138(%r8)
+-	vmovups	-106(%rsi), %ymm0
+-	vmovups	%ymm0, -106(%r8)
+-	vmovups	-74(%rsi), %ymm0
+-	vmovups	%ymm0, -74(%r8)
+-	vmovups	-42(%rsi), %ymm0
+-	vmovups	%ymm0, -42(%r8)
+-.LBB0_297:
+-	movq	-10(%rsi), %rcx
+-	movq	%rcx, -10(%r8)
+-	movzwl	-2(%rsi), %ecx
+-	movw	%cx, -2(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_298:
+-	vmovups	-139(%rsi), %ymm0
+-	vmovups	%ymm0, -139(%r8)
+-	vmovups	-107(%rsi), %ymm0
+-	vmovups	%ymm0, -107(%r8)
+-	vmovups	-75(%rsi), %ymm0
+-	vmovups	%ymm0, -75(%r8)
+-	vmovups	-43(%rsi), %ymm0
+-	vmovups	%ymm0, -43(%r8)
+-.LBB0_299:
+-	movq	-11(%rsi), %rcx
+-	movq	%rcx, -11(%r8)
+-	movl	-4(%rsi), %ecx
+-	movl	%ecx, -4(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_300:
+-	vmovups	-140(%rsi), %ymm0
+-	vmovups	%ymm0, -140(%r8)
+-	vmovups	-108(%rsi), %ymm0
+-	vmovups	%ymm0, -108(%r8)
+-	vmovups	-76(%rsi), %ymm0
+-	vmovups	%ymm0, -76(%r8)
+-	vmovups	-44(%rsi), %ymm0
+-	vmovups	%ymm0, -44(%r8)
+-.LBB0_301:
+-	movq	-12(%rsi), %rcx
+-	movq	%rcx, -12(%r8)
+-	movl	-4(%rsi), %ecx
+-	movl	%ecx, -4(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_302:
+-	vmovups	-141(%rsi), %ymm0
+-	vmovups	%ymm0, -141(%r8)
+-	vmovups	-109(%rsi), %ymm0
+-	vmovups	%ymm0, -109(%r8)
+-	vmovups	-77(%rsi), %ymm0
+-	vmovups	%ymm0, -77(%r8)
+-	vmovups	-45(%rsi), %ymm0
+-	vmovups	%ymm0, -45(%r8)
+-.LBB0_303:
+-	movq	-13(%rsi), %rcx
+-	movq	%rcx, -13(%r8)
+-	movq	-8(%rsi), %rcx
+-	movq	%rcx, -8(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_304:
+-	vmovups	-142(%rsi), %ymm0
+-	vmovups	%ymm0, -142(%r8)
+-	vmovups	-110(%rsi), %ymm0
+-	vmovups	%ymm0, -110(%r8)
+-	vmovups	-78(%rsi), %ymm0
+-	vmovups	%ymm0, -78(%r8)
+-	vmovups	-46(%rsi), %ymm0
+-	vmovups	%ymm0, -46(%r8)
+-.LBB0_305:
+-	movq	-14(%rsi), %rcx
+-	movq	%rcx, -14(%r8)
+-	movq	-8(%rsi), %rcx
+-	movq	%rcx, -8(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_306:
+-	vmovups	-143(%rsi), %ymm0
+-	vmovups	%ymm0, -143(%r8)
+-	vmovups	-111(%rsi), %ymm0
+-	vmovups	%ymm0, -111(%r8)
+-	vmovups	-79(%rsi), %ymm0
+-	vmovups	%ymm0, -79(%r8)
+-	vmovups	-47(%rsi), %ymm0
+-	vmovups	%ymm0, -47(%r8)
+-.LBB0_307:
+-	movq	-15(%rsi), %rcx
+-	movq	%rcx, -15(%r8)
+-	movq	-8(%rsi), %rcx
+-	movq	%rcx, -8(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_312:
+-	vmovups	-145(%rsi), %ymm0
+-	vmovups	%ymm0, -145(%r8)
+-	vmovups	-113(%rsi), %ymm0
+-	vmovups	%ymm0, -113(%r8)
+-	vmovups	-81(%rsi), %ymm0
+-	vmovups	%ymm0, -81(%r8)
+-	vmovups	-49(%rsi), %ymm0
+-	vmovups	%ymm0, -49(%r8)
+-.LBB0_313:
+-	vmovups	-17(%rsi), %xmm0
+-	vmovups	%xmm0, -17(%r8)
+-	movb	-1(%rsi), %cl
+-	movb	%cl, -1(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_314:
+-	vmovups	-146(%rsi), %ymm0
+-	vmovups	%ymm0, -146(%r8)
+-	vmovups	-114(%rsi), %ymm0
+-	vmovups	%ymm0, -114(%r8)
+-	vmovups	-82(%rsi), %ymm0
+-	vmovups	%ymm0, -82(%r8)
+-	vmovups	-50(%rsi), %ymm0
+-	vmovups	%ymm0, -50(%r8)
+-.LBB0_315:
+-	vmovups	-18(%rsi), %xmm0
+-	vmovups	%xmm0, -18(%r8)
+-	movzwl	-2(%rsi), %ecx
+-	movw	%cx, -2(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_316:
+-	vmovups	-147(%rsi), %ymm0
+-	vmovups	%ymm0, -147(%r8)
+-	vmovups	-115(%rsi), %ymm0
+-	vmovups	%ymm0, -115(%r8)
+-	vmovups	-83(%rsi), %ymm0
+-	vmovups	%ymm0, -83(%r8)
+-	vmovups	-51(%rsi), %ymm0
+-	vmovups	%ymm0, -51(%r8)
+-.LBB0_317:
+-	vmovups	-19(%rsi), %xmm0
+-	vmovups	%xmm0, -19(%r8)
+-	movl	-4(%rsi), %ecx
+-	movl	%ecx, -4(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_318:
+-	vmovups	-148(%rsi), %ymm0
+-	vmovups	%ymm0, -148(%r8)
+-	vmovups	-116(%rsi), %ymm0
+-	vmovups	%ymm0, -116(%r8)
+-	vmovups	-84(%rsi), %ymm0
+-	vmovups	%ymm0, -84(%r8)
+-	vmovups	-52(%rsi), %ymm0
+-	vmovups	%ymm0, -52(%r8)
+-.LBB0_319:
+-	vmovups	-20(%rsi), %xmm0
+-	vmovups	%xmm0, -20(%r8)
+-	movl	-4(%rsi), %ecx
+-	movl	%ecx, -4(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_320:
+-	vmovups	-149(%rsi), %ymm0
+-	vmovups	%ymm0, -149(%r8)
+-	vmovups	-117(%rsi), %ymm0
+-	vmovups	%ymm0, -117(%r8)
+-	vmovups	-85(%rsi), %ymm0
+-	vmovups	%ymm0, -85(%r8)
+-	vmovups	-53(%rsi), %ymm0
+-	vmovups	%ymm0, -53(%r8)
+-.LBB0_321:
+-	vmovups	-21(%rsi), %xmm0
+-	vmovups	%xmm0, -21(%r8)
+-	movq	-8(%rsi), %rcx
+-	movq	%rcx, -8(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_322:
+-	vmovups	-150(%rsi), %ymm0
+-	vmovups	%ymm0, -150(%r8)
+-	vmovups	-118(%rsi), %ymm0
+-	vmovups	%ymm0, -118(%r8)
+-	vmovups	-86(%rsi), %ymm0
+-	vmovups	%ymm0, -86(%r8)
+-	vmovups	-54(%rsi), %ymm0
+-	vmovups	%ymm0, -54(%r8)
+-.LBB0_323:
+-	vmovups	-22(%rsi), %xmm0
+-	vmovups	%xmm0, -22(%r8)
+-	movq	-8(%rsi), %rcx
+-	movq	%rcx, -8(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_324:
+-	vmovups	-151(%rsi), %ymm0
+-	vmovups	%ymm0, -151(%r8)
+-	vmovups	-119(%rsi), %ymm0
+-	vmovups	%ymm0, -119(%r8)
+-	vmovups	-87(%rsi), %ymm0
+-	vmovups	%ymm0, -87(%r8)
+-	vmovups	-55(%rsi), %ymm0
+-	vmovups	%ymm0, -55(%r8)
+-.LBB0_325:
+-	vmovups	-23(%rsi), %xmm0
+-	vmovups	%xmm0, -23(%r8)
+-	movq	-8(%rsi), %rcx
+-	movq	%rcx, -8(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_326:
+-	vmovups	-152(%rsi), %ymm0
+-	vmovups	%ymm0, -152(%r8)
+-	vmovups	-120(%rsi), %ymm0
+-	vmovups	%ymm0, -120(%r8)
+-	vmovups	-88(%rsi), %ymm0
+-	vmovups	%ymm0, -88(%r8)
+-	vmovups	-56(%rsi), %ymm0
+-	vmovups	%ymm0, -56(%r8)
+-.LBB0_327:
+-	vmovups	-24(%rsi), %xmm0
+-	vmovups	%xmm0, -24(%r8)
+-	movq	-8(%rsi), %rcx
+-	movq	%rcx, -8(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_328:
+-	vmovups	-153(%rsi), %ymm0
+-	vmovups	%ymm0, -153(%r8)
+-	vmovups	-121(%rsi), %ymm0
+-	vmovups	%ymm0, -121(%r8)
+-	vmovups	-89(%rsi), %ymm0
+-	vmovups	%ymm0, -89(%r8)
+-	vmovups	-57(%rsi), %ymm0
+-	vmovups	%ymm0, -57(%r8)
+-.LBB0_329:
+-	vmovups	-25(%rsi), %xmm0
+-	vmovups	%xmm0, -25(%r8)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_330:
+-	vmovups	-154(%rsi), %ymm0
+-	vmovups	%ymm0, -154(%r8)
+-	vmovups	-122(%rsi), %ymm0
+-	vmovups	%ymm0, -122(%r8)
+-	vmovups	-90(%rsi), %ymm0
+-	vmovups	%ymm0, -90(%r8)
+-	vmovups	-58(%rsi), %ymm0
+-	vmovups	%ymm0, -58(%r8)
+-.LBB0_331:
+-	vmovups	-26(%rsi), %xmm0
+-	vmovups	%xmm0, -26(%r8)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_332:
+-	vmovups	-155(%rsi), %ymm0
+-	vmovups	%ymm0, -155(%r8)
+-	vmovups	-123(%rsi), %ymm0
+-	vmovups	%ymm0, -123(%r8)
+-	vmovups	-91(%rsi), %ymm0
+-	vmovups	%ymm0, -91(%r8)
+-	vmovups	-59(%rsi), %ymm0
+-	vmovups	%ymm0, -59(%r8)
+-.LBB0_333:
+-	vmovups	-27(%rsi), %xmm0
+-	vmovups	%xmm0, -27(%r8)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_334:
+-	vmovups	-156(%rsi), %ymm0
+-	vmovups	%ymm0, -156(%r8)
+-	vmovups	-124(%rsi), %ymm0
+-	vmovups	%ymm0, -124(%r8)
+-	vmovups	-92(%rsi), %ymm0
+-	vmovups	%ymm0, -92(%r8)
+-	vmovups	-60(%rsi), %ymm0
+-	vmovups	%ymm0, -60(%r8)
+-.LBB0_335:
+-	vmovups	-28(%rsi), %xmm0
+-	vmovups	%xmm0, -28(%r8)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_336:
+-	vmovups	-157(%rsi), %ymm0
+-	vmovups	%ymm0, -157(%r8)
+-	vmovups	-125(%rsi), %ymm0
+-	vmovups	%ymm0, -125(%r8)
+-	vmovups	-93(%rsi), %ymm0
+-	vmovups	%ymm0, -93(%r8)
+-	vmovups	-61(%rsi), %ymm0
+-	vmovups	%ymm0, -61(%r8)
+-.LBB0_337:
+-	vmovups	-29(%rsi), %xmm0
+-	vmovups	%xmm0, -29(%r8)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_338:
+-	vmovups	-158(%rsi), %ymm0
+-	vmovups	%ymm0, -158(%r8)
+-	vmovups	-126(%rsi), %ymm0
+-	vmovups	%ymm0, -126(%r8)
+-	vmovups	-94(%rsi), %ymm0
+-	vmovups	%ymm0, -94(%r8)
+-	vmovups	-62(%rsi), %ymm0
+-	vmovups	%ymm0, -62(%r8)
+-.LBB0_339:
+-	vmovups	-30(%rsi), %xmm0
+-	vmovups	%xmm0, -30(%r8)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_340:
+-	vmovups	-159(%rsi), %ymm0
+-	vmovups	%ymm0, -159(%r8)
+-	vmovups	-127(%rsi), %ymm0
+-	vmovups	%ymm0, -127(%r8)
+-	vmovups	-95(%rsi), %ymm0
+-	vmovups	%ymm0, -95(%r8)
+-	vmovups	-63(%rsi), %ymm0
+-	vmovups	%ymm0, -63(%r8)
+-.LBB0_341:
+-	vmovups	-31(%rsi), %xmm0
+-	vmovups	%xmm0, -31(%r8)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_342:
+-	vmovups	-193(%rsi), %ymm0
+-	vmovups	%ymm0, -193(%r8)
+-.LBB0_343:
+-	vmovups	-161(%rsi), %ymm0
+-	vmovups	%ymm0, -161(%r8)
+-.LBB0_270:
+-	vmovups	-129(%rsi), %ymm0
+-	vmovups	%ymm0, -129(%r8)
+-	vmovups	-97(%rsi), %ymm0
+-	vmovups	%ymm0, -97(%r8)
+-.LBB0_271:
+-	vmovups	-65(%rsi), %ymm0
+-	vmovups	%ymm0, -65(%r8)
+-.LBB0_272:
+-	vmovups	-33(%rsi), %ymm0
+-	vmovups	%ymm0, -33(%r8)
+-.LBB0_273:
+-	movb	-1(%rsi), %cl
+-	movb	%cl, -1(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_344:
+-	vmovups	-194(%rsi), %ymm0
+-	vmovups	%ymm0, -194(%r8)
+-.LBB0_345:
+-	vmovups	-162(%rsi), %ymm0
+-	vmovups	%ymm0, -162(%r8)
+-.LBB0_274:
+-	vmovups	-130(%rsi), %ymm0
+-	vmovups	%ymm0, -130(%r8)
+-	vmovups	-98(%rsi), %ymm0
+-	vmovups	%ymm0, -98(%r8)
+-.LBB0_275:
+-	vmovups	-66(%rsi), %ymm0
+-	vmovups	%ymm0, -66(%r8)
+-.LBB0_276:
+-	vmovups	-34(%rsi), %ymm0
+-	vmovups	%ymm0, -34(%r8)
+-.LBB0_277:
+-	movzwl	-2(%rsi), %ecx
+-	movw	%cx, -2(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_346:
+-	vmovups	-195(%rsi), %ymm0
+-	vmovups	%ymm0, -195(%r8)
+-.LBB0_347:
+-	vmovups	-163(%rsi), %ymm0
+-	vmovups	%ymm0, -163(%r8)
+-	vmovups	-131(%rsi), %ymm0
+-	vmovups	%ymm0, -131(%r8)
+-	vmovups	-99(%rsi), %ymm0
+-	vmovups	%ymm0, -99(%r8)
+-.LBB0_348:
+-	vmovups	-67(%rsi), %ymm0
+-	vmovups	%ymm0, -67(%r8)
+-.LBB0_349:
+-	vmovups	-35(%rsi), %ymm0
+-	vmovups	%ymm0, -35(%r8)
+-	movl	-4(%rsi), %ecx
+-	movl	%ecx, -4(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_350:
+-	vmovups	-196(%rsi), %ymm0
+-	vmovups	%ymm0, -196(%r8)
+-.LBB0_351:
+-	vmovups	-164(%rsi), %ymm0
+-	vmovups	%ymm0, -164(%r8)
+-.LBB0_280:
+-	vmovups	-132(%rsi), %ymm0
+-	vmovups	%ymm0, -132(%r8)
+-	vmovups	-100(%rsi), %ymm0
+-	vmovups	%ymm0, -100(%r8)
+-.LBB0_281:
+-	vmovups	-68(%rsi), %ymm0
+-	vmovups	%ymm0, -68(%r8)
+-.LBB0_282:
+-	vmovups	-36(%rsi), %ymm0
+-	vmovups	%ymm0, -36(%r8)
+-.LBB0_283:
+-	movl	-4(%rsi), %ecx
+-	movl	%ecx, -4(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_352:
+-	vmovups	-197(%rsi), %ymm0
+-	vmovups	%ymm0, -197(%r8)
+-.LBB0_353:
+-	vmovups	-165(%rsi), %ymm0
+-	vmovups	%ymm0, -165(%r8)
+-	vmovups	-133(%rsi), %ymm0
+-	vmovups	%ymm0, -133(%r8)
+-	vmovups	-101(%rsi), %ymm0
+-	vmovups	%ymm0, -101(%r8)
+-.LBB0_354:
+-	vmovups	-69(%rsi), %ymm0
+-	vmovups	%ymm0, -69(%r8)
+-.LBB0_355:
+-	vmovups	-37(%rsi), %ymm0
+-	vmovups	%ymm0, -37(%r8)
+-	movq	-8(%rsi), %rcx
+-	movq	%rcx, -8(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_356:
+-	vmovups	-198(%rsi), %ymm0
+-	vmovups	%ymm0, -198(%r8)
+-.LBB0_357:
+-	vmovups	-166(%rsi), %ymm0
+-	vmovups	%ymm0, -166(%r8)
+-	vmovups	-134(%rsi), %ymm0
+-	vmovups	%ymm0, -134(%r8)
+-	vmovups	-102(%rsi), %ymm0
+-	vmovups	%ymm0, -102(%r8)
+-.LBB0_358:
+-	vmovups	-70(%rsi), %ymm0
+-	vmovups	%ymm0, -70(%r8)
+-.LBB0_359:
+-	vmovups	-38(%rsi), %ymm0
+-	vmovups	%ymm0, -38(%r8)
+-	movq	-8(%rsi), %rcx
+-	movq	%rcx, -8(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_360:
+-	vmovups	-199(%rsi), %ymm0
+-	vmovups	%ymm0, -199(%r8)
+-.LBB0_361:
+-	vmovups	-167(%rsi), %ymm0
+-	vmovups	%ymm0, -167(%r8)
+-	vmovups	-135(%rsi), %ymm0
+-	vmovups	%ymm0, -135(%r8)
+-	vmovups	-103(%rsi), %ymm0
+-	vmovups	%ymm0, -103(%r8)
+-.LBB0_362:
+-	vmovups	-71(%rsi), %ymm0
+-	vmovups	%ymm0, -71(%r8)
+-.LBB0_363:
+-	vmovups	-39(%rsi), %ymm0
+-	vmovups	%ymm0, -39(%r8)
+-	movq	-8(%rsi), %rcx
+-	movq	%rcx, -8(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_364:
+-	vmovups	-200(%rsi), %ymm0
+-	vmovups	%ymm0, -200(%r8)
+-.LBB0_365:
+-	vmovups	-168(%rsi), %ymm0
+-	vmovups	%ymm0, -168(%r8)
+-.LBB0_290:
+-	vmovups	-136(%rsi), %ymm0
+-	vmovups	%ymm0, -136(%r8)
+-	vmovups	-104(%rsi), %ymm0
+-	vmovups	%ymm0, -104(%r8)
+-.LBB0_291:
+-	vmovups	-72(%rsi), %ymm0
+-	vmovups	%ymm0, -72(%r8)
+-.LBB0_292:
+-	vmovups	-40(%rsi), %ymm0
+-	vmovups	%ymm0, -40(%r8)
+-.LBB0_293:
+-	movq	-8(%rsi), %rcx
+-	movq	%rcx, -8(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_366:
+-	vmovups	-201(%rsi), %ymm0
+-	vmovups	%ymm0, -201(%r8)
+-.LBB0_367:
+-	vmovups	-169(%rsi), %ymm0
+-	vmovups	%ymm0, -169(%r8)
+-	vmovups	-137(%rsi), %ymm0
+-	vmovups	%ymm0, -137(%r8)
+-	vmovups	-105(%rsi), %ymm0
+-	vmovups	%ymm0, -105(%r8)
+-.LBB0_368:
+-	vmovups	-73(%rsi), %ymm0
+-	vmovups	%ymm0, -73(%r8)
+-.LBB0_369:
+-	vmovups	-41(%rsi), %ymm0
+-	vmovups	%ymm0, -41(%r8)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_370:
+-	vmovups	-202(%rsi), %ymm0
+-	vmovups	%ymm0, -202(%r8)
+-.LBB0_371:
+-	vmovups	-170(%rsi), %ymm0
+-	vmovups	%ymm0, -170(%r8)
+-	vmovups	-138(%rsi), %ymm0
+-	vmovups	%ymm0, -138(%r8)
+-	vmovups	-106(%rsi), %ymm0
+-	vmovups	%ymm0, -106(%r8)
+-.LBB0_372:
+-	vmovups	-74(%rsi), %ymm0
+-	vmovups	%ymm0, -74(%r8)
+-.LBB0_373:
+-	vmovups	-42(%rsi), %ymm0
+-	vmovups	%ymm0, -42(%r8)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_374:
+-	vmovups	-203(%rsi), %ymm0
+-	vmovups	%ymm0, -203(%r8)
+-.LBB0_375:
+-	vmovups	-171(%rsi), %ymm0
+-	vmovups	%ymm0, -171(%r8)
+-	vmovups	-139(%rsi), %ymm0
+-	vmovups	%ymm0, -139(%r8)
+-	vmovups	-107(%rsi), %ymm0
+-	vmovups	%ymm0, -107(%r8)
+-.LBB0_376:
+-	vmovups	-75(%rsi), %ymm0
+-	vmovups	%ymm0, -75(%r8)
+-.LBB0_377:
+-	vmovups	-43(%rsi), %ymm0
+-	vmovups	%ymm0, -43(%r8)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_378:
+-	vmovups	-204(%rsi), %ymm0
+-	vmovups	%ymm0, -204(%r8)
+-.LBB0_379:
+-	vmovups	-172(%rsi), %ymm0
+-	vmovups	%ymm0, -172(%r8)
+-	vmovups	-140(%rsi), %ymm0
+-	vmovups	%ymm0, -140(%r8)
+-	vmovups	-108(%rsi), %ymm0
+-	vmovups	%ymm0, -108(%r8)
+-.LBB0_380:
+-	vmovups	-76(%rsi), %ymm0
+-	vmovups	%ymm0, -76(%r8)
+-.LBB0_381:
+-	vmovups	-44(%rsi), %ymm0
+-	vmovups	%ymm0, -44(%r8)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_382:
+-	vmovups	-205(%rsi), %ymm0
+-	vmovups	%ymm0, -205(%r8)
+-.LBB0_383:
+-	vmovups	-173(%rsi), %ymm0
+-	vmovups	%ymm0, -173(%r8)
+-	vmovups	-141(%rsi), %ymm0
+-	vmovups	%ymm0, -141(%r8)
+-	vmovups	-109(%rsi), %ymm0
+-	vmovups	%ymm0, -109(%r8)
+-.LBB0_384:
+-	vmovups	-77(%rsi), %ymm0
+-	vmovups	%ymm0, -77(%r8)
+-.LBB0_385:
+-	vmovups	-45(%rsi), %ymm0
+-	vmovups	%ymm0, -45(%r8)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_386:
+-	vmovups	-206(%rsi), %ymm0
+-	vmovups	%ymm0, -206(%r8)
+-.LBB0_387:
+-	vmovups	-174(%rsi), %ymm0
+-	vmovups	%ymm0, -174(%r8)
+-	vmovups	-142(%rsi), %ymm0
+-	vmovups	%ymm0, -142(%r8)
+-	vmovups	-110(%rsi), %ymm0
+-	vmovups	%ymm0, -110(%r8)
+-.LBB0_388:
+-	vmovups	-78(%rsi), %ymm0
+-	vmovups	%ymm0, -78(%r8)
+-.LBB0_389:
+-	vmovups	-46(%rsi), %ymm0
+-	vmovups	%ymm0, -46(%r8)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_390:
+-	vmovups	-207(%rsi), %ymm0
+-	vmovups	%ymm0, -207(%r8)
+-.LBB0_391:
+-	vmovups	-175(%rsi), %ymm0
+-	vmovups	%ymm0, -175(%r8)
+-	vmovups	-143(%rsi), %ymm0
+-	vmovups	%ymm0, -143(%r8)
+-	vmovups	-111(%rsi), %ymm0
+-	vmovups	%ymm0, -111(%r8)
+-.LBB0_392:
+-	vmovups	-79(%rsi), %ymm0
+-	vmovups	%ymm0, -79(%r8)
+-.LBB0_393:
+-	vmovups	-47(%rsi), %ymm0
+-	vmovups	%ymm0, -47(%r8)
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_394:
+-	vmovups	-208(%rsi), %ymm0
+-	vmovups	%ymm0, -208(%r8)
+-.LBB0_395:
+-	vmovups	-176(%rsi), %ymm0
+-	vmovups	%ymm0, -176(%r8)
+-.LBB0_308:
+-	vmovups	-144(%rsi), %ymm0
+-	vmovups	%ymm0, -144(%r8)
+-	vmovups	-112(%rsi), %ymm0
+-	vmovups	%ymm0, -112(%r8)
+-.LBB0_309:
+-	vmovups	-80(%rsi), %ymm0
+-	vmovups	%ymm0, -80(%r8)
+-.LBB0_310:
+-	vmovups	-48(%rsi), %ymm0
+-	vmovups	%ymm0, -48(%r8)
+-.LBB0_311:
+-	vmovups	-16(%rsi), %xmm0
+-	vmovups	%xmm0, -16(%r8)
+-	vzeroupper
+-	retq
+-.LBB0_396:
+-	vmovups	-209(%rsi), %ymm0
+-	vmovups	%ymm0, -209(%r8)
+-.LBB0_397:
+-	vmovups	-177(%rsi), %ymm0
+-	vmovups	%ymm0, -177(%r8)
+-	vmovups	-145(%rsi), %ymm0
+-	vmovups	%ymm0, -145(%r8)
+-	vmovups	-113(%rsi), %ymm0
+-	vmovups	%ymm0, -113(%r8)
+-.LBB0_398:
+-	vmovups	-81(%rsi), %ymm0
+-	vmovups	%ymm0, -81(%r8)
+-.LBB0_399:
+-	vmovups	-49(%rsi), %ymm0
+-	vmovups	%ymm0, -49(%r8)
+-	jmp	.LBB0_525
+-.LBB0_400:
+-	vmovups	-210(%rsi), %ymm0
+-	vmovups	%ymm0, -210(%r8)
+-.LBB0_401:
+-	vmovups	-178(%rsi), %ymm0
+-	vmovups	%ymm0, -178(%r8)
+-	vmovups	-146(%rsi), %ymm0
+-	vmovups	%ymm0, -146(%r8)
+-	vmovups	-114(%rsi), %ymm0
+-	vmovups	%ymm0, -114(%r8)
+-.LBB0_402:
+-	vmovups	-82(%rsi), %ymm0
+-	vmovups	%ymm0, -82(%r8)
+-.LBB0_403:
+-	vmovups	-50(%rsi), %ymm0
+-	vmovups	%ymm0, -50(%r8)
+-	jmp	.LBB0_525
+-.LBB0_404:
+-	vmovups	-211(%rsi), %ymm0
+-	vmovups	%ymm0, -211(%r8)
+-.LBB0_405:
+-	vmovups	-179(%rsi), %ymm0
+-	vmovups	%ymm0, -179(%r8)
+-	vmovups	-147(%rsi), %ymm0
+-	vmovups	%ymm0, -147(%r8)
+-	vmovups	-115(%rsi), %ymm0
+-	vmovups	%ymm0, -115(%r8)
+-.LBB0_406:
+-	vmovups	-83(%rsi), %ymm0
+-	vmovups	%ymm0, -83(%r8)
+-.LBB0_407:
+-	vmovups	-51(%rsi), %ymm0
+-	vmovups	%ymm0, -51(%r8)
+-	jmp	.LBB0_525
+-.LBB0_408:
+-	vmovups	-212(%rsi), %ymm0
+-	vmovups	%ymm0, -212(%r8)
+-.LBB0_409:
+-	vmovups	-180(%rsi), %ymm0
+-	vmovups	%ymm0, -180(%r8)
+-	vmovups	-148(%rsi), %ymm0
+-	vmovups	%ymm0, -148(%r8)
+-	vmovups	-116(%rsi), %ymm0
+-	vmovups	%ymm0, -116(%r8)
+-.LBB0_410:
+-	vmovups	-84(%rsi), %ymm0
+-	vmovups	%ymm0, -84(%r8)
+-.LBB0_411:
+-	vmovups	-52(%rsi), %ymm0
+-	vmovups	%ymm0, -52(%r8)
+-	jmp	.LBB0_525
+-.LBB0_412:
+-	vmovups	-213(%rsi), %ymm0
+-	vmovups	%ymm0, -213(%r8)
+-.LBB0_413:
+-	vmovups	-181(%rsi), %ymm0
+-	vmovups	%ymm0, -181(%r8)
+-	vmovups	-149(%rsi), %ymm0
+-	vmovups	%ymm0, -149(%r8)
+-	vmovups	-117(%rsi), %ymm0
+-	vmovups	%ymm0, -117(%r8)
+-.LBB0_414:
+-	vmovups	-85(%rsi), %ymm0
+-	vmovups	%ymm0, -85(%r8)
+-.LBB0_415:
+-	vmovups	-53(%rsi), %ymm0
+-	vmovups	%ymm0, -53(%r8)
+-	jmp	.LBB0_525
+-.LBB0_416:
+-	vmovups	-214(%rsi), %ymm0
+-	vmovups	%ymm0, -214(%r8)
+-.LBB0_417:
+-	vmovups	-182(%rsi), %ymm0
+-	vmovups	%ymm0, -182(%r8)
+-	vmovups	-150(%rsi), %ymm0
+-	vmovups	%ymm0, -150(%r8)
+-	vmovups	-118(%rsi), %ymm0
+-	vmovups	%ymm0, -118(%r8)
+-.LBB0_418:
+-	vmovups	-86(%rsi), %ymm0
+-	vmovups	%ymm0, -86(%r8)
+-.LBB0_419:
+-	vmovups	-54(%rsi), %ymm0
+-	vmovups	%ymm0, -54(%r8)
+-	jmp	.LBB0_525
+-.LBB0_420:
+-	vmovups	-215(%rsi), %ymm0
+-	vmovups	%ymm0, -215(%r8)
+-.LBB0_421:
+-	vmovups	-183(%rsi), %ymm0
+-	vmovups	%ymm0, -183(%r8)
+-	vmovups	-151(%rsi), %ymm0
+-	vmovups	%ymm0, -151(%r8)
+-	vmovups	-119(%rsi), %ymm0
+-	vmovups	%ymm0, -119(%r8)
+-.LBB0_422:
+-	vmovups	-87(%rsi), %ymm0
+-	vmovups	%ymm0, -87(%r8)
+-.LBB0_423:
+-	vmovups	-55(%rsi), %ymm0
+-	vmovups	%ymm0, -55(%r8)
+-	jmp	.LBB0_525
+-.LBB0_424:
+-	vmovups	-216(%rsi), %ymm0
+-	vmovups	%ymm0, -216(%r8)
+-.LBB0_425:
+-	vmovups	-184(%rsi), %ymm0
+-	vmovups	%ymm0, -184(%r8)
+-	vmovups	-152(%rsi), %ymm0
+-	vmovups	%ymm0, -152(%r8)
+-	vmovups	-120(%rsi), %ymm0
+-	vmovups	%ymm0, -120(%r8)
+-.LBB0_426:
+-	vmovups	-88(%rsi), %ymm0
+-	vmovups	%ymm0, -88(%r8)
+-.LBB0_427:
+-	vmovups	-56(%rsi), %ymm0
+-	vmovups	%ymm0, -56(%r8)
+-	jmp	.LBB0_525
+-.LBB0_428:
+-	vmovups	-217(%rsi), %ymm0
+-	vmovups	%ymm0, -217(%r8)
+-.LBB0_429:
+-	vmovups	-185(%rsi), %ymm0
+-	vmovups	%ymm0, -185(%r8)
+-	vmovups	-153(%rsi), %ymm0
+-	vmovups	%ymm0, -153(%r8)
+-	vmovups	-121(%rsi), %ymm0
+-	vmovups	%ymm0, -121(%r8)
+-.LBB0_430:
+-	vmovups	-89(%rsi), %ymm0
+-	vmovups	%ymm0, -89(%r8)
+-.LBB0_431:
+-	vmovups	-57(%rsi), %ymm0
+-	vmovups	%ymm0, -57(%r8)
+-	jmp	.LBB0_525
+-.LBB0_432:
+-	vmovups	-218(%rsi), %ymm0
+-	vmovups	%ymm0, -218(%r8)
+-.LBB0_433:
+-	vmovups	-186(%rsi), %ymm0
+-	vmovups	%ymm0, -186(%r8)
+-	vmovups	-154(%rsi), %ymm0
+-	vmovups	%ymm0, -154(%r8)
+-	vmovups	-122(%rsi), %ymm0
+-	vmovups	%ymm0, -122(%r8)
+-.LBB0_434:
+-	vmovups	-90(%rsi), %ymm0
+-	vmovups	%ymm0, -90(%r8)
+-.LBB0_435:
+-	vmovups	-58(%rsi), %ymm0
+-	vmovups	%ymm0, -58(%r8)
+-	jmp	.LBB0_525
+-.LBB0_436:
+-	vmovups	-219(%rsi), %ymm0
+-	vmovups	%ymm0, -219(%r8)
+-.LBB0_437:
+-	vmovups	-187(%rsi), %ymm0
+-	vmovups	%ymm0, -187(%r8)
+-	vmovups	-155(%rsi), %ymm0
+-	vmovups	%ymm0, -155(%r8)
+-	vmovups	-123(%rsi), %ymm0
+-	vmovups	%ymm0, -123(%r8)
+-.LBB0_438:
+-	vmovups	-91(%rsi), %ymm0
+-	vmovups	%ymm0, -91(%r8)
+-.LBB0_439:
+-	vmovups	-59(%rsi), %ymm0
+-	vmovups	%ymm0, -59(%r8)
+-	jmp	.LBB0_525
+-.LBB0_440:
+-	vmovups	-220(%rsi), %ymm0
+-	vmovups	%ymm0, -220(%r8)
+-.LBB0_441:
+-	vmovups	-188(%rsi), %ymm0
+-	vmovups	%ymm0, -188(%r8)
+-	vmovups	-156(%rsi), %ymm0
+-	vmovups	%ymm0, -156(%r8)
+-	vmovups	-124(%rsi), %ymm0
+-	vmovups	%ymm0, -124(%r8)
+-.LBB0_442:
+-	vmovups	-92(%rsi), %ymm0
+-	vmovups	%ymm0, -92(%r8)
+-.LBB0_443:
+-	vmovups	-60(%rsi), %ymm0
+-	vmovups	%ymm0, -60(%r8)
+-	jmp	.LBB0_525
+-.LBB0_444:
+-	vmovups	-221(%rsi), %ymm0
+-	vmovups	%ymm0, -221(%r8)
+-.LBB0_445:
+-	vmovups	-189(%rsi), %ymm0
+-	vmovups	%ymm0, -189(%r8)
+-	vmovups	-157(%rsi), %ymm0
+-	vmovups	%ymm0, -157(%r8)
+-	vmovups	-125(%rsi), %ymm0
+-	vmovups	%ymm0, -125(%r8)
+-.LBB0_446:
+-	vmovups	-93(%rsi), %ymm0
+-	vmovups	%ymm0, -93(%r8)
+-.LBB0_447:
+-	vmovups	-61(%rsi), %ymm0
+-	vmovups	%ymm0, -61(%r8)
+-	jmp	.LBB0_525
+-.LBB0_448:
+-	vmovups	-222(%rsi), %ymm0
+-	vmovups	%ymm0, -222(%r8)
+-.LBB0_449:
+-	vmovups	-190(%rsi), %ymm0
+-	vmovups	%ymm0, -190(%r8)
+-	vmovups	-158(%rsi), %ymm0
+-	vmovups	%ymm0, -158(%r8)
+-	vmovups	-126(%rsi), %ymm0
+-	vmovups	%ymm0, -126(%r8)
+-.LBB0_450:
+-	vmovups	-94(%rsi), %ymm0
+-	vmovups	%ymm0, -94(%r8)
+-.LBB0_451:
+-	vmovups	-62(%rsi), %ymm0
+-	vmovups	%ymm0, -62(%r8)
+-	jmp	.LBB0_525
+-.LBB0_452:
+-	vmovups	-223(%rsi), %ymm0
+-	vmovups	%ymm0, -223(%r8)
+-.LBB0_453:
+-	vmovups	-191(%rsi), %ymm0
+-	vmovups	%ymm0, -191(%r8)
+-	vmovups	-159(%rsi), %ymm0
+-	vmovups	%ymm0, -159(%r8)
+-	vmovups	-127(%rsi), %ymm0
+-	vmovups	%ymm0, -127(%r8)
+-.LBB0_454:
+-	vmovups	-95(%rsi), %ymm0
+-	vmovups	%ymm0, -95(%r8)
+-.LBB0_455:
+-	vmovups	-63(%rsi), %ymm0
+-	vmovups	%ymm0, -63(%r8)
+-	jmp	.LBB0_525
+-.LBB0_456:
+-	vmovups	-225(%rsi), %ymm0
+-	vmovups	%ymm0, -225(%r8)
+-	vmovups	-193(%rsi), %ymm0
+-	vmovups	%ymm0, -193(%r8)
+-	vmovups	-161(%rsi), %ymm0
+-	vmovups	%ymm0, -161(%r8)
+-	vmovups	-129(%rsi), %ymm0
+-	vmovups	%ymm0, -129(%r8)
+-.LBB0_457:
+-	vmovups	-97(%rsi), %ymm0
+-	vmovups	%ymm0, -97(%r8)
+-	vmovups	-65(%rsi), %ymm0
+-	vmovups	%ymm0, -65(%r8)
+-	jmp	.LBB0_524
+-.LBB0_458:
+-	vmovups	-226(%rsi), %ymm0
+-	vmovups	%ymm0, -226(%r8)
+-	vmovups	-194(%rsi), %ymm0
+-	vmovups	%ymm0, -194(%r8)
+-	vmovups	-162(%rsi), %ymm0
+-	vmovups	%ymm0, -162(%r8)
+-	vmovups	-130(%rsi), %ymm0
+-	vmovups	%ymm0, -130(%r8)
+-.LBB0_459:
+-	vmovups	-98(%rsi), %ymm0
+-	vmovups	%ymm0, -98(%r8)
+-	vmovups	-66(%rsi), %ymm0
+-	vmovups	%ymm0, -66(%r8)
+-	jmp	.LBB0_524
+-.LBB0_460:
+-	vmovups	-227(%rsi), %ymm0
+-	vmovups	%ymm0, -227(%r8)
+-	vmovups	-195(%rsi), %ymm0
+-	vmovups	%ymm0, -195(%r8)
+-	vmovups	-163(%rsi), %ymm0
+-	vmovups	%ymm0, -163(%r8)
+-	vmovups	-131(%rsi), %ymm0
+-	vmovups	%ymm0, -131(%r8)
+-.LBB0_461:
+-	vmovups	-99(%rsi), %ymm0
+-	vmovups	%ymm0, -99(%r8)
+-	vmovups	-67(%rsi), %ymm0
+-	vmovups	%ymm0, -67(%r8)
+-	jmp	.LBB0_524
+-.LBB0_462:
+-	vmovups	-228(%rsi), %ymm0
+-	vmovups	%ymm0, -228(%r8)
+-	vmovups	-196(%rsi), %ymm0
+-	vmovups	%ymm0, -196(%r8)
+-	vmovups	-164(%rsi), %ymm0
+-	vmovups	%ymm0, -164(%r8)
+-	vmovups	-132(%rsi), %ymm0
+-	vmovups	%ymm0, -132(%r8)
+-.LBB0_463:
+-	vmovups	-100(%rsi), %ymm0
+-	vmovups	%ymm0, -100(%r8)
+-	vmovups	-68(%rsi), %ymm0
+-	vmovups	%ymm0, -68(%r8)
+-	jmp	.LBB0_524
+-.LBB0_464:
+-	vmovups	-229(%rsi), %ymm0
+-	vmovups	%ymm0, -229(%r8)
+-	vmovups	-197(%rsi), %ymm0
+-	vmovups	%ymm0, -197(%r8)
+-	vmovups	-165(%rsi), %ymm0
+-	vmovups	%ymm0, -165(%r8)
+-	vmovups	-133(%rsi), %ymm0
+-	vmovups	%ymm0, -133(%r8)
+-.LBB0_465:
+-	vmovups	-101(%rsi), %ymm0
+-	vmovups	%ymm0, -101(%r8)
+-	vmovups	-69(%rsi), %ymm0
+-	vmovups	%ymm0, -69(%r8)
+-	jmp	.LBB0_524
+-.LBB0_466:
+-	vmovups	-230(%rsi), %ymm0
+-	vmovups	%ymm0, -230(%r8)
+-	vmovups	-198(%rsi), %ymm0
+-	vmovups	%ymm0, -198(%r8)
+-	vmovups	-166(%rsi), %ymm0
+-	vmovups	%ymm0, -166(%r8)
+-	vmovups	-134(%rsi), %ymm0
+-	vmovups	%ymm0, -134(%r8)
+-.LBB0_467:
+-	vmovups	-102(%rsi), %ymm0
+-	vmovups	%ymm0, -102(%r8)
+-	vmovups	-70(%rsi), %ymm0
+-	vmovups	%ymm0, -70(%r8)
+-	jmp	.LBB0_524
+-.LBB0_468:
+-	vmovups	-231(%rsi), %ymm0
+-	vmovups	%ymm0, -231(%r8)
+-	vmovups	-199(%rsi), %ymm0
+-	vmovups	%ymm0, -199(%r8)
+-	vmovups	-167(%rsi), %ymm0
+-	vmovups	%ymm0, -167(%r8)
+-	vmovups	-135(%rsi), %ymm0
+-	vmovups	%ymm0, -135(%r8)
+-.LBB0_469:
+-	vmovups	-103(%rsi), %ymm0
+-	vmovups	%ymm0, -103(%r8)
+-	vmovups	-71(%rsi), %ymm0
+-	vmovups	%ymm0, -71(%r8)
+-	jmp	.LBB0_524
+-.LBB0_470:
+-	vmovups	-232(%rsi), %ymm0
+-	vmovups	%ymm0, -232(%r8)
+-	vmovups	-200(%rsi), %ymm0
+-	vmovups	%ymm0, -200(%r8)
+-	vmovups	-168(%rsi), %ymm0
+-	vmovups	%ymm0, -168(%r8)
+-	vmovups	-136(%rsi), %ymm0
+-	vmovups	%ymm0, -136(%r8)
+-.LBB0_471:
+-	vmovups	-104(%rsi), %ymm0
+-	vmovups	%ymm0, -104(%r8)
+-	vmovups	-72(%rsi), %ymm0
+-	vmovups	%ymm0, -72(%r8)
+-	jmp	.LBB0_524
+-.LBB0_472:
+-	vmovups	-233(%rsi), %ymm0
+-	vmovups	%ymm0, -233(%r8)
+-	vmovups	-201(%rsi), %ymm0
+-	vmovups	%ymm0, -201(%r8)
+-	vmovups	-169(%rsi), %ymm0
+-	vmovups	%ymm0, -169(%r8)
+-	vmovups	-137(%rsi), %ymm0
+-	vmovups	%ymm0, -137(%r8)
+-.LBB0_473:
+-	vmovups	-105(%rsi), %ymm0
+-	vmovups	%ymm0, -105(%r8)
+-	vmovups	-73(%rsi), %ymm0
+-	vmovups	%ymm0, -73(%r8)
+-	jmp	.LBB0_524
+-.LBB0_474:
+-	vmovups	-234(%rsi), %ymm0
+-	vmovups	%ymm0, -234(%r8)
+-	vmovups	-202(%rsi), %ymm0
+-	vmovups	%ymm0, -202(%r8)
+-	vmovups	-170(%rsi), %ymm0
+-	vmovups	%ymm0, -170(%r8)
+-	vmovups	-138(%rsi), %ymm0
+-	vmovups	%ymm0, -138(%r8)
+-.LBB0_475:
+-	vmovups	-106(%rsi), %ymm0
+-	vmovups	%ymm0, -106(%r8)
+-	vmovups	-74(%rsi), %ymm0
+-	vmovups	%ymm0, -74(%r8)
+-	jmp	.LBB0_524
+-.LBB0_476:
+-	vmovups	-235(%rsi), %ymm0
+-	vmovups	%ymm0, -235(%r8)
+-	vmovups	-203(%rsi), %ymm0
+-	vmovups	%ymm0, -203(%r8)
+-	vmovups	-171(%rsi), %ymm0
+-	vmovups	%ymm0, -171(%r8)
+-	vmovups	-139(%rsi), %ymm0
+-	vmovups	%ymm0, -139(%r8)
+-.LBB0_477:
+-	vmovups	-107(%rsi), %ymm0
+-	vmovups	%ymm0, -107(%r8)
+-	vmovups	-75(%rsi), %ymm0
+-	vmovups	%ymm0, -75(%r8)
+-	jmp	.LBB0_524
+-.LBB0_478:
+-	vmovups	-236(%rsi), %ymm0
+-	vmovups	%ymm0, -236(%r8)
+-	vmovups	-204(%rsi), %ymm0
+-	vmovups	%ymm0, -204(%r8)
+-	vmovups	-172(%rsi), %ymm0
+-	vmovups	%ymm0, -172(%r8)
+-	vmovups	-140(%rsi), %ymm0
+-	vmovups	%ymm0, -140(%r8)
+-.LBB0_479:
+-	vmovups	-108(%rsi), %ymm0
+-	vmovups	%ymm0, -108(%r8)
+-	vmovups	-76(%rsi), %ymm0
+-	vmovups	%ymm0, -76(%r8)
+-	jmp	.LBB0_524
+-.LBB0_480:
+-	vmovups	-237(%rsi), %ymm0
+-	vmovups	%ymm0, -237(%r8)
+-	vmovups	-205(%rsi), %ymm0
+-	vmovups	%ymm0, -205(%r8)
+-	vmovups	-173(%rsi), %ymm0
+-	vmovups	%ymm0, -173(%r8)
+-	vmovups	-141(%rsi), %ymm0
+-	vmovups	%ymm0, -141(%r8)
+-.LBB0_481:
+-	vmovups	-109(%rsi), %ymm0
+-	vmovups	%ymm0, -109(%r8)
+-	vmovups	-77(%rsi), %ymm0
+-	vmovups	%ymm0, -77(%r8)
+-	jmp	.LBB0_524
+-.LBB0_482:
+-	vmovups	-238(%rsi), %ymm0
+-	vmovups	%ymm0, -238(%r8)
+-	vmovups	-206(%rsi), %ymm0
+-	vmovups	%ymm0, -206(%r8)
+-	vmovups	-174(%rsi), %ymm0
+-	vmovups	%ymm0, -174(%r8)
+-	vmovups	-142(%rsi), %ymm0
+-	vmovups	%ymm0, -142(%r8)
+-.LBB0_483:
+-	vmovups	-110(%rsi), %ymm0
+-	vmovups	%ymm0, -110(%r8)
+-	vmovups	-78(%rsi), %ymm0
+-	vmovups	%ymm0, -78(%r8)
+-	jmp	.LBB0_524
+-.LBB0_484:
+-	vmovups	-239(%rsi), %ymm0
+-	vmovups	%ymm0, -239(%r8)
+-	vmovups	-207(%rsi), %ymm0
+-	vmovups	%ymm0, -207(%r8)
+-	vmovups	-175(%rsi), %ymm0
+-	vmovups	%ymm0, -175(%r8)
+-	vmovups	-143(%rsi), %ymm0
+-	vmovups	%ymm0, -143(%r8)
+-.LBB0_485:
+-	vmovups	-111(%rsi), %ymm0
+-	vmovups	%ymm0, -111(%r8)
+-	vmovups	-79(%rsi), %ymm0
+-	vmovups	%ymm0, -79(%r8)
+-	jmp	.LBB0_524
+-.LBB0_486:
+-	vmovups	-240(%rsi), %ymm0
+-	vmovups	%ymm0, -240(%r8)
+-	vmovups	-208(%rsi), %ymm0
+-	vmovups	%ymm0, -208(%r8)
+-	vmovups	-176(%rsi), %ymm0
+-	vmovups	%ymm0, -176(%r8)
+-	vmovups	-144(%rsi), %ymm0
+-	vmovups	%ymm0, -144(%r8)
+-.LBB0_487:
+-	vmovups	-112(%rsi), %ymm0
+-	vmovups	%ymm0, -112(%r8)
+-	vmovups	-80(%rsi), %ymm0
+-	vmovups	%ymm0, -80(%r8)
+-	jmp	.LBB0_524
+-.LBB0_488:
+-	vmovups	-241(%rsi), %ymm0
+-	vmovups	%ymm0, -241(%r8)
+-	vmovups	-209(%rsi), %ymm0
+-	vmovups	%ymm0, -209(%r8)
+-	vmovups	-177(%rsi), %ymm0
+-	vmovups	%ymm0, -177(%r8)
+-	vmovups	-145(%rsi), %ymm0
+-	vmovups	%ymm0, -145(%r8)
+-.LBB0_489:
+-	vmovups	-113(%rsi), %ymm0
+-	vmovups	%ymm0, -113(%r8)
+-	vmovups	-81(%rsi), %ymm0
+-	vmovups	%ymm0, -81(%r8)
+-	jmp	.LBB0_524
+-.LBB0_490:
+-	vmovups	-242(%rsi), %ymm0
+-	vmovups	%ymm0, -242(%r8)
+-	vmovups	-210(%rsi), %ymm0
+-	vmovups	%ymm0, -210(%r8)
+-	vmovups	-178(%rsi), %ymm0
+-	vmovups	%ymm0, -178(%r8)
+-	vmovups	-146(%rsi), %ymm0
+-	vmovups	%ymm0, -146(%r8)
+-.LBB0_491:
+-	vmovups	-114(%rsi), %ymm0
+-	vmovups	%ymm0, -114(%r8)
+-	vmovups	-82(%rsi), %ymm0
+-	vmovups	%ymm0, -82(%r8)
+-	jmp	.LBB0_524
+-.LBB0_492:
+-	vmovups	-243(%rsi), %ymm0
+-	vmovups	%ymm0, -243(%r8)
+-	vmovups	-211(%rsi), %ymm0
+-	vmovups	%ymm0, -211(%r8)
+-	vmovups	-179(%rsi), %ymm0
+-	vmovups	%ymm0, -179(%r8)
+-	vmovups	-147(%rsi), %ymm0
+-	vmovups	%ymm0, -147(%r8)
+-.LBB0_493:
+-	vmovups	-115(%rsi), %ymm0
+-	vmovups	%ymm0, -115(%r8)
+-	vmovups	-83(%rsi), %ymm0
+-	vmovups	%ymm0, -83(%r8)
+-	jmp	.LBB0_524
+-.LBB0_494:
+-	vmovups	-244(%rsi), %ymm0
+-	vmovups	%ymm0, -244(%r8)
+-	vmovups	-212(%rsi), %ymm0
+-	vmovups	%ymm0, -212(%r8)
+-	vmovups	-180(%rsi), %ymm0
+-	vmovups	%ymm0, -180(%r8)
+-	vmovups	-148(%rsi), %ymm0
+-	vmovups	%ymm0, -148(%r8)
+-.LBB0_495:
+-	vmovups	-116(%rsi), %ymm0
+-	vmovups	%ymm0, -116(%r8)
+-	vmovups	-84(%rsi), %ymm0
+-	vmovups	%ymm0, -84(%r8)
+-	jmp	.LBB0_524
+-.LBB0_496:
+-	vmovups	-245(%rsi), %ymm0
+-	vmovups	%ymm0, -245(%r8)
+-	vmovups	-213(%rsi), %ymm0
+-	vmovups	%ymm0, -213(%r8)
+-	vmovups	-181(%rsi), %ymm0
+-	vmovups	%ymm0, -181(%r8)
+-	vmovups	-149(%rsi), %ymm0
+-	vmovups	%ymm0, -149(%r8)
+-.LBB0_497:
+-	vmovups	-117(%rsi), %ymm0
+-	vmovups	%ymm0, -117(%r8)
+-	vmovups	-85(%rsi), %ymm0
+-	vmovups	%ymm0, -85(%r8)
+-	jmp	.LBB0_524
+-.LBB0_498:
+-	vmovups	-246(%rsi), %ymm0
+-	vmovups	%ymm0, -246(%r8)
+-	vmovups	-214(%rsi), %ymm0
+-	vmovups	%ymm0, -214(%r8)
+-	vmovups	-182(%rsi), %ymm0
+-	vmovups	%ymm0, -182(%r8)
+-	vmovups	-150(%rsi), %ymm0
+-	vmovups	%ymm0, -150(%r8)
+-.LBB0_499:
+-	vmovups	-118(%rsi), %ymm0
+-	vmovups	%ymm0, -118(%r8)
+-	vmovups	-86(%rsi), %ymm0
+-	vmovups	%ymm0, -86(%r8)
+-	jmp	.LBB0_524
+-.LBB0_500:
+-	vmovups	-247(%rsi), %ymm0
+-	vmovups	%ymm0, -247(%r8)
+-	vmovups	-215(%rsi), %ymm0
+-	vmovups	%ymm0, -215(%r8)
+-	vmovups	-183(%rsi), %ymm0
+-	vmovups	%ymm0, -183(%r8)
+-	vmovups	-151(%rsi), %ymm0
+-	vmovups	%ymm0, -151(%r8)
+-.LBB0_501:
+-	vmovups	-119(%rsi), %ymm0
+-	vmovups	%ymm0, -119(%r8)
+-	vmovups	-87(%rsi), %ymm0
+-	vmovups	%ymm0, -87(%r8)
+-	jmp	.LBB0_524
+-.LBB0_502:
+-	vmovups	-248(%rsi), %ymm0
+-	vmovups	%ymm0, -248(%r8)
+-	vmovups	-216(%rsi), %ymm0
+-	vmovups	%ymm0, -216(%r8)
+-	vmovups	-184(%rsi), %ymm0
+-	vmovups	%ymm0, -184(%r8)
+-	vmovups	-152(%rsi), %ymm0
+-	vmovups	%ymm0, -152(%r8)
+-.LBB0_503:
+-	vmovups	-120(%rsi), %ymm0
+-	vmovups	%ymm0, -120(%r8)
+-	vmovups	-88(%rsi), %ymm0
+-	vmovups	%ymm0, -88(%r8)
+-	jmp	.LBB0_524
+-.LBB0_504:
+-	vmovups	-249(%rsi), %ymm0
+-	vmovups	%ymm0, -249(%r8)
+-	vmovups	-217(%rsi), %ymm0
+-	vmovups	%ymm0, -217(%r8)
+-	vmovups	-185(%rsi), %ymm0
+-	vmovups	%ymm0, -185(%r8)
+-	vmovups	-153(%rsi), %ymm0
+-	vmovups	%ymm0, -153(%r8)
+-.LBB0_505:
+-	vmovups	-121(%rsi), %ymm0
+-	vmovups	%ymm0, -121(%r8)
+-	vmovups	-89(%rsi), %ymm0
+-	vmovups	%ymm0, -89(%r8)
+-	jmp	.LBB0_524
+-.LBB0_506:
+-	vmovups	-250(%rsi), %ymm0
+-	vmovups	%ymm0, -250(%r8)
+-	vmovups	-218(%rsi), %ymm0
+-	vmovups	%ymm0, -218(%r8)
+-	vmovups	-186(%rsi), %ymm0
+-	vmovups	%ymm0, -186(%r8)
+-	vmovups	-154(%rsi), %ymm0
+-	vmovups	%ymm0, -154(%r8)
+-.LBB0_507:
+-	vmovups	-122(%rsi), %ymm0
+-	vmovups	%ymm0, -122(%r8)
+-	vmovups	-90(%rsi), %ymm0
+-	vmovups	%ymm0, -90(%r8)
+-	jmp	.LBB0_524
+-.LBB0_508:
+-	vmovups	-251(%rsi), %ymm0
+-	vmovups	%ymm0, -251(%r8)
+-	vmovups	-219(%rsi), %ymm0
+-	vmovups	%ymm0, -219(%r8)
+-	vmovups	-187(%rsi), %ymm0
+-	vmovups	%ymm0, -187(%r8)
+-	vmovups	-155(%rsi), %ymm0
+-	vmovups	%ymm0, -155(%r8)
+-.LBB0_509:
+-	vmovups	-123(%rsi), %ymm0
+-	vmovups	%ymm0, -123(%r8)
+-	vmovups	-91(%rsi), %ymm0
+-	vmovups	%ymm0, -91(%r8)
+-	jmp	.LBB0_524
+-.LBB0_510:
+-	vmovups	-252(%rsi), %ymm0
+-	vmovups	%ymm0, -252(%r8)
+-	vmovups	-220(%rsi), %ymm0
+-	vmovups	%ymm0, -220(%r8)
+-	vmovups	-188(%rsi), %ymm0
+-	vmovups	%ymm0, -188(%r8)
+-	vmovups	-156(%rsi), %ymm0
+-	vmovups	%ymm0, -156(%r8)
+-.LBB0_511:
+-	vmovups	-124(%rsi), %ymm0
+-	vmovups	%ymm0, -124(%r8)
+-	vmovups	-92(%rsi), %ymm0
+-	vmovups	%ymm0, -92(%r8)
+-	jmp	.LBB0_524
+-.LBB0_512:
+-	vmovups	-253(%rsi), %ymm0
+-	vmovups	%ymm0, -253(%r8)
+-	vmovups	-221(%rsi), %ymm0
+-	vmovups	%ymm0, -221(%r8)
+-	vmovups	-189(%rsi), %ymm0
+-	vmovups	%ymm0, -189(%r8)
+-	vmovups	-157(%rsi), %ymm0
+-	vmovups	%ymm0, -157(%r8)
+-.LBB0_513:
+-	vmovups	-125(%rsi), %ymm0
+-	vmovups	%ymm0, -125(%r8)
+-	vmovups	-93(%rsi), %ymm0
+-	vmovups	%ymm0, -93(%r8)
+-	jmp	.LBB0_524
+-.LBB0_514:
+-	vmovups	-254(%rsi), %ymm0
+-	vmovups	%ymm0, -254(%r8)
+-	vmovups	-222(%rsi), %ymm0
+-	vmovups	%ymm0, -222(%r8)
+-	vmovups	-190(%rsi), %ymm0
+-	vmovups	%ymm0, -190(%r8)
+-	vmovups	-158(%rsi), %ymm0
+-	vmovups	%ymm0, -158(%r8)
+-.LBB0_515:
+-	vmovups	-126(%rsi), %ymm0
+-	vmovups	%ymm0, -126(%r8)
+-	vmovups	-94(%rsi), %ymm0
+-	vmovups	%ymm0, -94(%r8)
+-	jmp	.LBB0_524
+-.LBB0_516:
+-	vmovups	-255(%rsi), %ymm0
+-	vmovups	%ymm0, -255(%r8)
+-	vmovups	-223(%rsi), %ymm0
+-	vmovups	%ymm0, -223(%r8)
+-	vmovups	-191(%rsi), %ymm0
+-	vmovups	%ymm0, -191(%r8)
+-	vmovups	-159(%rsi), %ymm0
+-	vmovups	%ymm0, -159(%r8)
+-.LBB0_517:
+-	vmovups	-127(%rsi), %ymm0
+-	vmovups	%ymm0, -127(%r8)
+-	vmovups	-95(%rsi), %ymm0
+-	vmovups	%ymm0, -95(%r8)
+-	jmp	.LBB0_524
+-.LBB0_518:
+-	vmovups	-256(%rsi), %ymm0
+-	vmovups	%ymm0, -256(%r8)
+-.LBB0_519:
+-	vmovups	-224(%rsi), %ymm0
+-	vmovups	%ymm0, -224(%r8)
+-.LBB0_520:
+-	vmovups	-192(%rsi), %ymm0
+-	vmovups	%ymm0, -192(%r8)
+-.LBB0_521:
+-	vmovups	-160(%rsi), %ymm0
+-	vmovups	%ymm0, -160(%r8)
+-.LBB0_522:
+-	vmovups	-128(%rsi), %ymm0
+-	vmovups	%ymm0, -128(%r8)
+-.LBB0_523:
+-	vmovups	-96(%rsi), %ymm0
+-	vmovups	%ymm0, -96(%r8)
+-.LBB0_524:
+-	vmovups	-64(%rsi), %ymm0
+-	vmovups	%ymm0, -64(%r8)
+-.LBB0_525:
+-	vmovups	-32(%rsi), %ymm0
+-	vmovups	%ymm0, -32(%r8)
+-.LBB0_526:
+-	vzeroupper
+-	retq
+-.Lfunc_end0:
+-/*
+-	.size	memcpy, .Lfunc_end0-memcpy
+-	.cfi_endproc
+-	.section	.rodata,"a",@progbits
+-	.p2align	2
+-*/
+-	.cfi_endproc
+-END(memcpy_avx2)
+-
+-.LJTI0_0:
+-	.long	.LBB0_273-.LJTI0_0
+-	.long	.LBB0_277-.LJTI0_0
+-	.long	.LBB0_279-.LJTI0_0
+-	.long	.LBB0_283-.LJTI0_0
+-	.long	.LBB0_285-.LJTI0_0
+-	.long	.LBB0_287-.LJTI0_0
+-	.long	.LBB0_289-.LJTI0_0
+-	.long	.LBB0_293-.LJTI0_0
+-	.long	.LBB0_295-.LJTI0_0
+-	.long	.LBB0_297-.LJTI0_0
+-	.long	.LBB0_299-.LJTI0_0
+-	.long	.LBB0_301-.LJTI0_0
+-	.long	.LBB0_303-.LJTI0_0
+-	.long	.LBB0_305-.LJTI0_0
+-	.long	.LBB0_307-.LJTI0_0
+-	.long	.LBB0_311-.LJTI0_0
+-	.long	.LBB0_313-.LJTI0_0
+-	.long	.LBB0_315-.LJTI0_0
+-	.long	.LBB0_317-.LJTI0_0
+-	.long	.LBB0_319-.LJTI0_0
+-	.long	.LBB0_321-.LJTI0_0
+-	.long	.LBB0_323-.LJTI0_0
+-	.long	.LBB0_325-.LJTI0_0
+-	.long	.LBB0_327-.LJTI0_0
+-	.long	.LBB0_329-.LJTI0_0
+-	.long	.LBB0_331-.LJTI0_0
+-	.long	.LBB0_333-.LJTI0_0
+-	.long	.LBB0_335-.LJTI0_0
+-	.long	.LBB0_337-.LJTI0_0
+-	.long	.LBB0_339-.LJTI0_0
+-	.long	.LBB0_341-.LJTI0_0
+-	.long	.LBB0_525-.LJTI0_0
+-	.long	.LBB0_272-.LJTI0_0
+-	.long	.LBB0_276-.LJTI0_0
+-	.long	.LBB0_349-.LJTI0_0
+-	.long	.LBB0_282-.LJTI0_0
+-	.long	.LBB0_355-.LJTI0_0
+-	.long	.LBB0_359-.LJTI0_0
+-	.long	.LBB0_363-.LJTI0_0
+-	.long	.LBB0_292-.LJTI0_0
+-	.long	.LBB0_369-.LJTI0_0
+-	.long	.LBB0_373-.LJTI0_0
+-	.long	.LBB0_377-.LJTI0_0
+-	.long	.LBB0_381-.LJTI0_0
+-	.long	.LBB0_385-.LJTI0_0
+-	.long	.LBB0_389-.LJTI0_0
+-	.long	.LBB0_393-.LJTI0_0
+-	.long	.LBB0_310-.LJTI0_0
+-	.long	.LBB0_399-.LJTI0_0
+-	.long	.LBB0_403-.LJTI0_0
+-	.long	.LBB0_407-.LJTI0_0
+-	.long	.LBB0_411-.LJTI0_0
+-	.long	.LBB0_415-.LJTI0_0
+-	.long	.LBB0_419-.LJTI0_0
+-	.long	.LBB0_423-.LJTI0_0
+-	.long	.LBB0_427-.LJTI0_0
+-	.long	.LBB0_431-.LJTI0_0
+-	.long	.LBB0_435-.LJTI0_0
+-	.long	.LBB0_439-.LJTI0_0
+-	.long	.LBB0_443-.LJTI0_0
+-	.long	.LBB0_447-.LJTI0_0
+-	.long	.LBB0_451-.LJTI0_0
+-	.long	.LBB0_455-.LJTI0_0
+-	.long	.LBB0_524-.LJTI0_0
+-	.long	.LBB0_271-.LJTI0_0
+-	.long	.LBB0_275-.LJTI0_0
+-	.long	.LBB0_348-.LJTI0_0
+-	.long	.LBB0_281-.LJTI0_0
+-	.long	.LBB0_354-.LJTI0_0
+-	.long	.LBB0_358-.LJTI0_0
+-	.long	.LBB0_362-.LJTI0_0
+-	.long	.LBB0_291-.LJTI0_0
+-	.long	.LBB0_368-.LJTI0_0
+-	.long	.LBB0_372-.LJTI0_0
+-	.long	.LBB0_376-.LJTI0_0
+-	.long	.LBB0_380-.LJTI0_0
+-	.long	.LBB0_384-.LJTI0_0
+-	.long	.LBB0_388-.LJTI0_0
+-	.long	.LBB0_392-.LJTI0_0
+-	.long	.LBB0_309-.LJTI0_0
+-	.long	.LBB0_398-.LJTI0_0
+-	.long	.LBB0_402-.LJTI0_0
+-	.long	.LBB0_406-.LJTI0_0
+-	.long	.LBB0_410-.LJTI0_0
+-	.long	.LBB0_414-.LJTI0_0
+-	.long	.LBB0_418-.LJTI0_0
+-	.long	.LBB0_422-.LJTI0_0
+-	.long	.LBB0_426-.LJTI0_0
+-	.long	.LBB0_430-.LJTI0_0
+-	.long	.LBB0_434-.LJTI0_0
+-	.long	.LBB0_438-.LJTI0_0
+-	.long	.LBB0_442-.LJTI0_0
+-	.long	.LBB0_446-.LJTI0_0
+-	.long	.LBB0_450-.LJTI0_0
+-	.long	.LBB0_454-.LJTI0_0
+-	.long	.LBB0_523-.LJTI0_0
+-	.long	.LBB0_457-.LJTI0_0
+-	.long	.LBB0_459-.LJTI0_0
+-	.long	.LBB0_461-.LJTI0_0
+-	.long	.LBB0_463-.LJTI0_0
+-	.long	.LBB0_465-.LJTI0_0
+-	.long	.LBB0_467-.LJTI0_0
+-	.long	.LBB0_469-.LJTI0_0
+-	.long	.LBB0_471-.LJTI0_0
+-	.long	.LBB0_473-.LJTI0_0
+-	.long	.LBB0_475-.LJTI0_0
+-	.long	.LBB0_477-.LJTI0_0
+-	.long	.LBB0_479-.LJTI0_0
+-	.long	.LBB0_481-.LJTI0_0
+-	.long	.LBB0_483-.LJTI0_0
+-	.long	.LBB0_485-.LJTI0_0
+-	.long	.LBB0_487-.LJTI0_0
+-	.long	.LBB0_489-.LJTI0_0
+-	.long	.LBB0_491-.LJTI0_0
+-	.long	.LBB0_493-.LJTI0_0
+-	.long	.LBB0_495-.LJTI0_0
+-	.long	.LBB0_497-.LJTI0_0
+-	.long	.LBB0_499-.LJTI0_0
+-	.long	.LBB0_501-.LJTI0_0
+-	.long	.LBB0_503-.LJTI0_0
+-	.long	.LBB0_505-.LJTI0_0
+-	.long	.LBB0_507-.LJTI0_0
+-	.long	.LBB0_509-.LJTI0_0
+-	.long	.LBB0_511-.LJTI0_0
+-	.long	.LBB0_513-.LJTI0_0
+-	.long	.LBB0_515-.LJTI0_0
+-	.long	.LBB0_517-.LJTI0_0
+-	.long	.LBB0_522-.LJTI0_0
+-	.long	.LBB0_270-.LJTI0_0
+-	.long	.LBB0_274-.LJTI0_0
+-	.long	.LBB0_278-.LJTI0_0
+-	.long	.LBB0_280-.LJTI0_0
+-	.long	.LBB0_284-.LJTI0_0
+-	.long	.LBB0_286-.LJTI0_0
+-	.long	.LBB0_288-.LJTI0_0
+-	.long	.LBB0_290-.LJTI0_0
+-	.long	.LBB0_294-.LJTI0_0
+-	.long	.LBB0_296-.LJTI0_0
+-	.long	.LBB0_298-.LJTI0_0
+-	.long	.LBB0_300-.LJTI0_0
+-	.long	.LBB0_302-.LJTI0_0
+-	.long	.LBB0_304-.LJTI0_0
+-	.long	.LBB0_306-.LJTI0_0
+-	.long	.LBB0_308-.LJTI0_0
+-	.long	.LBB0_312-.LJTI0_0
+-	.long	.LBB0_314-.LJTI0_0
+-	.long	.LBB0_316-.LJTI0_0
+-	.long	.LBB0_318-.LJTI0_0
+-	.long	.LBB0_320-.LJTI0_0
+-	.long	.LBB0_322-.LJTI0_0
+-	.long	.LBB0_324-.LJTI0_0
+-	.long	.LBB0_326-.LJTI0_0
+-	.long	.LBB0_328-.LJTI0_0
+-	.long	.LBB0_330-.LJTI0_0
+-	.long	.LBB0_332-.LJTI0_0
+-	.long	.LBB0_334-.LJTI0_0
+-	.long	.LBB0_336-.LJTI0_0
+-	.long	.LBB0_338-.LJTI0_0
+-	.long	.LBB0_340-.LJTI0_0
+-	.long	.LBB0_521-.LJTI0_0
+-	.long	.LBB0_343-.LJTI0_0
+-	.long	.LBB0_345-.LJTI0_0
+-	.long	.LBB0_347-.LJTI0_0
+-	.long	.LBB0_351-.LJTI0_0
+-	.long	.LBB0_353-.LJTI0_0
+-	.long	.LBB0_357-.LJTI0_0
+-	.long	.LBB0_361-.LJTI0_0
+-	.long	.LBB0_365-.LJTI0_0
+-	.long	.LBB0_367-.LJTI0_0
+-	.long	.LBB0_371-.LJTI0_0
+-	.long	.LBB0_375-.LJTI0_0
+-	.long	.LBB0_379-.LJTI0_0
+-	.long	.LBB0_383-.LJTI0_0
+-	.long	.LBB0_387-.LJTI0_0
+-	.long	.LBB0_391-.LJTI0_0
+-	.long	.LBB0_395-.LJTI0_0
+-	.long	.LBB0_397-.LJTI0_0
+-	.long	.LBB0_401-.LJTI0_0
+-	.long	.LBB0_405-.LJTI0_0
+-	.long	.LBB0_409-.LJTI0_0
+-	.long	.LBB0_413-.LJTI0_0
+-	.long	.LBB0_417-.LJTI0_0
+-	.long	.LBB0_421-.LJTI0_0
+-	.long	.LBB0_425-.LJTI0_0
+-	.long	.LBB0_429-.LJTI0_0
+-	.long	.LBB0_433-.LJTI0_0
+-	.long	.LBB0_437-.LJTI0_0
+-	.long	.LBB0_441-.LJTI0_0
+-	.long	.LBB0_445-.LJTI0_0
+-	.long	.LBB0_449-.LJTI0_0
+-	.long	.LBB0_453-.LJTI0_0
+-	.long	.LBB0_520-.LJTI0_0
+-	.long	.LBB0_342-.LJTI0_0
+-	.long	.LBB0_344-.LJTI0_0
+-	.long	.LBB0_346-.LJTI0_0
+-	.long	.LBB0_350-.LJTI0_0
+-	.long	.LBB0_352-.LJTI0_0
+-	.long	.LBB0_356-.LJTI0_0
+-	.long	.LBB0_360-.LJTI0_0
+-	.long	.LBB0_364-.LJTI0_0
+-	.long	.LBB0_366-.LJTI0_0
+-	.long	.LBB0_370-.LJTI0_0
+-	.long	.LBB0_374-.LJTI0_0
+-	.long	.LBB0_378-.LJTI0_0
+-	.long	.LBB0_382-.LJTI0_0
+-	.long	.LBB0_386-.LJTI0_0
+-	.long	.LBB0_390-.LJTI0_0
+-	.long	.LBB0_394-.LJTI0_0
+-	.long	.LBB0_396-.LJTI0_0
+-	.long	.LBB0_400-.LJTI0_0
+-	.long	.LBB0_404-.LJTI0_0
+-	.long	.LBB0_408-.LJTI0_0
+-	.long	.LBB0_412-.LJTI0_0
+-	.long	.LBB0_416-.LJTI0_0
+-	.long	.LBB0_420-.LJTI0_0
+-	.long	.LBB0_424-.LJTI0_0
+-	.long	.LBB0_428-.LJTI0_0
+-	.long	.LBB0_432-.LJTI0_0
+-	.long	.LBB0_436-.LJTI0_0
+-	.long	.LBB0_440-.LJTI0_0
+-	.long	.LBB0_444-.LJTI0_0
+-	.long	.LBB0_448-.LJTI0_0
+-	.long	.LBB0_452-.LJTI0_0
+-	.long	.LBB0_519-.LJTI0_0
+-	.long	.LBB0_456-.LJTI0_0
+-	.long	.LBB0_458-.LJTI0_0
+-	.long	.LBB0_460-.LJTI0_0
+-	.long	.LBB0_462-.LJTI0_0
+-	.long	.LBB0_464-.LJTI0_0
+-	.long	.LBB0_466-.LJTI0_0
+-	.long	.LBB0_468-.LJTI0_0
+-	.long	.LBB0_470-.LJTI0_0
+-	.long	.LBB0_472-.LJTI0_0
+-	.long	.LBB0_474-.LJTI0_0
+-	.long	.LBB0_476-.LJTI0_0
+-	.long	.LBB0_478-.LJTI0_0
+-	.long	.LBB0_480-.LJTI0_0
+-	.long	.LBB0_482-.LJTI0_0
+-	.long	.LBB0_484-.LJTI0_0
+-	.long	.LBB0_486-.LJTI0_0
+-	.long	.LBB0_488-.LJTI0_0
+-	.long	.LBB0_490-.LJTI0_0
+-	.long	.LBB0_492-.LJTI0_0
+-	.long	.LBB0_494-.LJTI0_0
+-	.long	.LBB0_496-.LJTI0_0
+-	.long	.LBB0_498-.LJTI0_0
+-	.long	.LBB0_500-.LJTI0_0
+-	.long	.LBB0_502-.LJTI0_0
+-	.long	.LBB0_504-.LJTI0_0
+-	.long	.LBB0_506-.LJTI0_0
+-	.long	.LBB0_508-.LJTI0_0
+-	.long	.LBB0_510-.LJTI0_0
+-	.long	.LBB0_512-.LJTI0_0
+-	.long	.LBB0_514-.LJTI0_0
+-	.long	.LBB0_516-.LJTI0_0
+-	.long	.LBB0_518-.LJTI0_0
+-.LJTI0_1:
+-	.long	.LBB0_6-.LJTI0_1
+-	.long	.LBB0_10-.LJTI0_1
+-	.long	.LBB0_12-.LJTI0_1
+-	.long	.LBB0_16-.LJTI0_1
+-	.long	.LBB0_18-.LJTI0_1
+-	.long	.LBB0_20-.LJTI0_1
+-	.long	.LBB0_22-.LJTI0_1
+-	.long	.LBB0_26-.LJTI0_1
+-	.long	.LBB0_28-.LJTI0_1
+-	.long	.LBB0_30-.LJTI0_1
+-	.long	.LBB0_32-.LJTI0_1
+-	.long	.LBB0_34-.LJTI0_1
+-	.long	.LBB0_36-.LJTI0_1
+-	.long	.LBB0_38-.LJTI0_1
+-	.long	.LBB0_40-.LJTI0_1
+-	.long	.LBB0_44-.LJTI0_1
+-	.long	.LBB0_46-.LJTI0_1
+-	.long	.LBB0_48-.LJTI0_1
+-	.long	.LBB0_50-.LJTI0_1
+-	.long	.LBB0_52-.LJTI0_1
+-	.long	.LBB0_54-.LJTI0_1
+-	.long	.LBB0_56-.LJTI0_1
+-	.long	.LBB0_58-.LJTI0_1
+-	.long	.LBB0_60-.LJTI0_1
+-	.long	.LBB0_62-.LJTI0_1
+-	.long	.LBB0_64-.LJTI0_1
+-	.long	.LBB0_66-.LJTI0_1
+-	.long	.LBB0_68-.LJTI0_1
+-	.long	.LBB0_70-.LJTI0_1
+-	.long	.LBB0_72-.LJTI0_1
+-	.long	.LBB0_74-.LJTI0_1
+-	.long	.LBB0_258-.LJTI0_1
+-	.long	.LBB0_5-.LJTI0_1
+-	.long	.LBB0_9-.LJTI0_1
+-	.long	.LBB0_82-.LJTI0_1
+-	.long	.LBB0_15-.LJTI0_1
+-	.long	.LBB0_88-.LJTI0_1
+-	.long	.LBB0_92-.LJTI0_1
+-	.long	.LBB0_96-.LJTI0_1
+-	.long	.LBB0_25-.LJTI0_1
+-	.long	.LBB0_102-.LJTI0_1
+-	.long	.LBB0_106-.LJTI0_1
+-	.long	.LBB0_110-.LJTI0_1
+-	.long	.LBB0_114-.LJTI0_1
+-	.long	.LBB0_118-.LJTI0_1
+-	.long	.LBB0_122-.LJTI0_1
+-	.long	.LBB0_126-.LJTI0_1
+-	.long	.LBB0_43-.LJTI0_1
+-	.long	.LBB0_132-.LJTI0_1
+-	.long	.LBB0_136-.LJTI0_1
+-	.long	.LBB0_140-.LJTI0_1
+-	.long	.LBB0_144-.LJTI0_1
+-	.long	.LBB0_148-.LJTI0_1
+-	.long	.LBB0_152-.LJTI0_1
+-	.long	.LBB0_156-.LJTI0_1
+-	.long	.LBB0_160-.LJTI0_1
+-	.long	.LBB0_164-.LJTI0_1
+-	.long	.LBB0_168-.LJTI0_1
+-	.long	.LBB0_172-.LJTI0_1
+-	.long	.LBB0_176-.LJTI0_1
+-	.long	.LBB0_180-.LJTI0_1
+-	.long	.LBB0_184-.LJTI0_1
+-	.long	.LBB0_188-.LJTI0_1
+-	.long	.LBB0_257-.LJTI0_1
+-	.long	.LBB0_4-.LJTI0_1
+-	.long	.LBB0_8-.LJTI0_1
+-	.long	.LBB0_81-.LJTI0_1
+-	.long	.LBB0_14-.LJTI0_1
+-	.long	.LBB0_87-.LJTI0_1
+-	.long	.LBB0_91-.LJTI0_1
+-	.long	.LBB0_95-.LJTI0_1
+-	.long	.LBB0_24-.LJTI0_1
+-	.long	.LBB0_101-.LJTI0_1
+-	.long	.LBB0_105-.LJTI0_1
+-	.long	.LBB0_109-.LJTI0_1
+-	.long	.LBB0_113-.LJTI0_1
+-	.long	.LBB0_117-.LJTI0_1
+-	.long	.LBB0_121-.LJTI0_1
+-	.long	.LBB0_125-.LJTI0_1
+-	.long	.LBB0_42-.LJTI0_1
+-	.long	.LBB0_131-.LJTI0_1
+-	.long	.LBB0_135-.LJTI0_1
+-	.long	.LBB0_139-.LJTI0_1
+-	.long	.LBB0_143-.LJTI0_1
+-	.long	.LBB0_147-.LJTI0_1
+-	.long	.LBB0_151-.LJTI0_1
+-	.long	.LBB0_155-.LJTI0_1
+-	.long	.LBB0_159-.LJTI0_1
+-	.long	.LBB0_163-.LJTI0_1
+-	.long	.LBB0_167-.LJTI0_1
+-	.long	.LBB0_171-.LJTI0_1
+-	.long	.LBB0_175-.LJTI0_1
+-	.long	.LBB0_179-.LJTI0_1
+-	.long	.LBB0_183-.LJTI0_1
+-	.long	.LBB0_187-.LJTI0_1
+-	.long	.LBB0_256-.LJTI0_1
+-	.long	.LBB0_190-.LJTI0_1
+-	.long	.LBB0_192-.LJTI0_1
+-	.long	.LBB0_194-.LJTI0_1
+-	.long	.LBB0_196-.LJTI0_1
+-	.long	.LBB0_198-.LJTI0_1
+-	.long	.LBB0_200-.LJTI0_1
+-	.long	.LBB0_202-.LJTI0_1
+-	.long	.LBB0_204-.LJTI0_1
+-	.long	.LBB0_206-.LJTI0_1
+-	.long	.LBB0_208-.LJTI0_1
+-	.long	.LBB0_210-.LJTI0_1
+-	.long	.LBB0_212-.LJTI0_1
+-	.long	.LBB0_214-.LJTI0_1
+-	.long	.LBB0_216-.LJTI0_1
+-	.long	.LBB0_218-.LJTI0_1
+-	.long	.LBB0_220-.LJTI0_1
+-	.long	.LBB0_222-.LJTI0_1
+-	.long	.LBB0_224-.LJTI0_1
+-	.long	.LBB0_226-.LJTI0_1
+-	.long	.LBB0_228-.LJTI0_1
+-	.long	.LBB0_230-.LJTI0_1
+-	.long	.LBB0_232-.LJTI0_1
+-	.long	.LBB0_234-.LJTI0_1
+-	.long	.LBB0_236-.LJTI0_1
+-	.long	.LBB0_238-.LJTI0_1
+-	.long	.LBB0_240-.LJTI0_1
+-	.long	.LBB0_242-.LJTI0_1
+-	.long	.LBB0_244-.LJTI0_1
+-	.long	.LBB0_246-.LJTI0_1
+-	.long	.LBB0_248-.LJTI0_1
+-	.long	.LBB0_250-.LJTI0_1
+-	.long	.LBB0_255-.LJTI0_1
+-	.long	.LBB0_3-.LJTI0_1
+-	.long	.LBB0_7-.LJTI0_1
+-	.long	.LBB0_11-.LJTI0_1
+-	.long	.LBB0_13-.LJTI0_1
+-	.long	.LBB0_17-.LJTI0_1
+-	.long	.LBB0_19-.LJTI0_1
+-	.long	.LBB0_21-.LJTI0_1
+-	.long	.LBB0_23-.LJTI0_1
+-	.long	.LBB0_27-.LJTI0_1
+-	.long	.LBB0_29-.LJTI0_1
+-	.long	.LBB0_31-.LJTI0_1
+-	.long	.LBB0_33-.LJTI0_1
+-	.long	.LBB0_35-.LJTI0_1
+-	.long	.LBB0_37-.LJTI0_1
+-	.long	.LBB0_39-.LJTI0_1
+-	.long	.LBB0_41-.LJTI0_1
+-	.long	.LBB0_45-.LJTI0_1
+-	.long	.LBB0_47-.LJTI0_1
+-	.long	.LBB0_49-.LJTI0_1
+-	.long	.LBB0_51-.LJTI0_1
+-	.long	.LBB0_53-.LJTI0_1
+-	.long	.LBB0_55-.LJTI0_1
+-	.long	.LBB0_57-.LJTI0_1
+-	.long	.LBB0_59-.LJTI0_1
+-	.long	.LBB0_61-.LJTI0_1
+-	.long	.LBB0_63-.LJTI0_1
+-	.long	.LBB0_65-.LJTI0_1
+-	.long	.LBB0_67-.LJTI0_1
+-	.long	.LBB0_69-.LJTI0_1
+-	.long	.LBB0_71-.LJTI0_1
+-	.long	.LBB0_73-.LJTI0_1
+-	.long	.LBB0_254-.LJTI0_1
+-	.long	.LBB0_76-.LJTI0_1
+-	.long	.LBB0_78-.LJTI0_1
+-	.long	.LBB0_80-.LJTI0_1
+-	.long	.LBB0_84-.LJTI0_1
+-	.long	.LBB0_86-.LJTI0_1
+-	.long	.LBB0_90-.LJTI0_1
+-	.long	.LBB0_94-.LJTI0_1
+-	.long	.LBB0_98-.LJTI0_1
+-	.long	.LBB0_100-.LJTI0_1
+-	.long	.LBB0_104-.LJTI0_1
+-	.long	.LBB0_108-.LJTI0_1
+-	.long	.LBB0_112-.LJTI0_1
+-	.long	.LBB0_116-.LJTI0_1
+-	.long	.LBB0_120-.LJTI0_1
+-	.long	.LBB0_124-.LJTI0_1
+-	.long	.LBB0_128-.LJTI0_1
+-	.long	.LBB0_130-.LJTI0_1
+-	.long	.LBB0_134-.LJTI0_1
+-	.long	.LBB0_138-.LJTI0_1
+-	.long	.LBB0_142-.LJTI0_1
+-	.long	.LBB0_146-.LJTI0_1
+-	.long	.LBB0_150-.LJTI0_1
+-	.long	.LBB0_154-.LJTI0_1
+-	.long	.LBB0_158-.LJTI0_1
+-	.long	.LBB0_162-.LJTI0_1
+-	.long	.LBB0_166-.LJTI0_1
+-	.long	.LBB0_170-.LJTI0_1
+-	.long	.LBB0_174-.LJTI0_1
+-	.long	.LBB0_178-.LJTI0_1
+-	.long	.LBB0_182-.LJTI0_1
+-	.long	.LBB0_186-.LJTI0_1
+-	.long	.LBB0_253-.LJTI0_1
+-	.long	.LBB0_75-.LJTI0_1
+-	.long	.LBB0_77-.LJTI0_1
+-	.long	.LBB0_79-.LJTI0_1
+-	.long	.LBB0_83-.LJTI0_1
+-	.long	.LBB0_85-.LJTI0_1
+-	.long	.LBB0_89-.LJTI0_1
+-	.long	.LBB0_93-.LJTI0_1
+-	.long	.LBB0_97-.LJTI0_1
+-	.long	.LBB0_99-.LJTI0_1
+-	.long	.LBB0_103-.LJTI0_1
+-	.long	.LBB0_107-.LJTI0_1
+-	.long	.LBB0_111-.LJTI0_1
+-	.long	.LBB0_115-.LJTI0_1
+-	.long	.LBB0_119-.LJTI0_1
+-	.long	.LBB0_123-.LJTI0_1
+-	.long	.LBB0_127-.LJTI0_1
+-	.long	.LBB0_129-.LJTI0_1
+-	.long	.LBB0_133-.LJTI0_1
+-	.long	.LBB0_137-.LJTI0_1
+-	.long	.LBB0_141-.LJTI0_1
+-	.long	.LBB0_145-.LJTI0_1
+-	.long	.LBB0_149-.LJTI0_1
+-	.long	.LBB0_153-.LJTI0_1
+-	.long	.LBB0_157-.LJTI0_1
+-	.long	.LBB0_161-.LJTI0_1
+-	.long	.LBB0_165-.LJTI0_1
+-	.long	.LBB0_169-.LJTI0_1
+-	.long	.LBB0_173-.LJTI0_1
+-	.long	.LBB0_177-.LJTI0_1
+-	.long	.LBB0_181-.LJTI0_1
+-	.long	.LBB0_185-.LJTI0_1
+-	.long	.LBB0_252-.LJTI0_1
+-	.long	.LBB0_189-.LJTI0_1
+-	.long	.LBB0_191-.LJTI0_1
+-	.long	.LBB0_193-.LJTI0_1
+-	.long	.LBB0_195-.LJTI0_1
+-	.long	.LBB0_197-.LJTI0_1
+-	.long	.LBB0_199-.LJTI0_1
+-	.long	.LBB0_201-.LJTI0_1
+-	.long	.LBB0_203-.LJTI0_1
+-	.long	.LBB0_205-.LJTI0_1
+-	.long	.LBB0_207-.LJTI0_1
+-	.long	.LBB0_209-.LJTI0_1
+-	.long	.LBB0_211-.LJTI0_1
+-	.long	.LBB0_213-.LJTI0_1
+-	.long	.LBB0_215-.LJTI0_1
+-	.long	.LBB0_217-.LJTI0_1
+-	.long	.LBB0_219-.LJTI0_1
+-	.long	.LBB0_221-.LJTI0_1
+-	.long	.LBB0_223-.LJTI0_1
+-	.long	.LBB0_225-.LJTI0_1
+-	.long	.LBB0_227-.LJTI0_1
+-	.long	.LBB0_229-.LJTI0_1
+-	.long	.LBB0_231-.LJTI0_1
+-	.long	.LBB0_233-.LJTI0_1
+-	.long	.LBB0_235-.LJTI0_1
+-	.long	.LBB0_237-.LJTI0_1
+-	.long	.LBB0_239-.LJTI0_1
+-	.long	.LBB0_241-.LJTI0_1
+-	.long	.LBB0_243-.LJTI0_1
+-	.long	.LBB0_245-.LJTI0_1
+-	.long	.LBB0_247-.LJTI0_1
+-	.long	.LBB0_249-.LJTI0_1
+-	.long	.LBB0_251-.LJTI0_1
+-                                        # -- End function
+-/*
+-	.ident	"Android (5484270 based on r353983c) clang version 9.0.3 (https://android.googlesource.com/toolchain/clang 745b335211bb9eadfa6aa6301f84715cee4b37c5) (https://android.googlesource.com/toolchain/llvm 60cf23e54e46c807513f7a36d0a7b777920b5881) (based on LLVM 9.0.3svn)"
+-	.section	".note.GNU-stack","",@progbits
+-	.addrsig*/
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-memmove-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-memmove-kbl.S
+deleted file mode 100644
+index 8730e789a..000000000
+--- a/libc/arch-x86_64/kabylake/string/avx2-memmove-kbl.S
++++ /dev/null
+@@ -1,409 +0,0 @@
+-/* memmove with AVX
+-   Copyright (C) 2014 Free Software Foundation, Inc.
+-   This file is part of the GNU C Library.
+-
+-   The GNU C Library is free software; you can redistribute it and/or
+-   modify it under the terms of the GNU Lesser General Public
+-   License as published by the Free Software Foundation; either
+-   version 2.1 of the License, or (at your option) any later version.
+-
+-   The GNU C Library is distributed in the hope that it will be useful,
+-   but WITHOUT ANY WARRANTY; without even the implied warranty of
+-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-   Lesser General Public License for more details.
+-
+-   You should have received a copy of the GNU Lesser General Public
+-   License along with the GNU C Library
+-   <http://www.gnu.org/licenses/>.  */
+-
+-#include "cache.h"
+-
+-#ifndef MEMMOVE
+-# define MEMMOVE  memmove_avx2
+-#endif
+-
+-#ifndef L
+-# define L(label)	.L##label
+-#endif
+-
+-#ifndef cfi_startproc
+-# define cfi_startproc	.cfi_startproc
+-#endif
+-
+-#ifndef cfi_endproc
+-# define cfi_endproc	.cfi_endproc
+-#endif
+-
+-#ifndef cfi_rel_offset
+-# define cfi_rel_offset(reg, off)	.cfi_rel_offset reg, off
+-#endif
+-
+-#ifndef cfi_restore
+-# define cfi_restore(reg)	.cfi_restore reg
+-#endif
+-
+-#ifndef cfi_adjust_cfa_offset
+-# define cfi_adjust_cfa_offset(off)	.cfi_adjust_cfa_offset off
+-#endif
+-
+-#ifndef ENTRY
+-# define ENTRY(name)		\
+-	.type name,  @function;		\
+-	.globl name;		\
+-	.p2align 4;		\
+-name:		\
+-	cfi_startproc
+-#endif
+-
+-#ifndef END
+-# define END(name)		\
+-	cfi_endproc;		\
+-	.size name, .-name
+-#endif
+-
+-#define CFI_PUSH(REG)		\
+-	cfi_adjust_cfa_offset (4);		\
+-	cfi_rel_offset (REG, 0)
+-
+-#define CFI_POP(REG)		\
+-	cfi_adjust_cfa_offset (-4);		\
+-	cfi_restore (REG)
+-
+-#define PUSH(REG)	push REG;
+-#define POP(REG)	pop REG;
+-
+-#define ENTRANCE	PUSH (%rbx);
+-#define RETURN_END	POP (%rbx); ret
+-#define RETURN		RETURN_END;if not, see
+-
+-
+-	.section .text.avx,"ax",@progbits
+-ENTRY (MEMMOVE)
+-	mov	%rdi, %rax
+-	cmp	$256, %rdx
+-	jae	L(256bytesormore)
+-	cmp	$16, %dl
+-	jb	L(less_16bytes)
+-	cmp	$128, %dl
+-	jb	L(less_128bytes)
+-	vmovdqu (%rsi), %xmm0
+-	lea	(%rsi, %rdx), %rcx
+-	vmovdqu 0x10(%rsi), %xmm1
+-	vmovdqu 0x20(%rsi), %xmm2
+-	vmovdqu 0x30(%rsi), %xmm3
+-	vmovdqu 0x40(%rsi), %xmm4
+-	vmovdqu 0x50(%rsi), %xmm5
+-	vmovdqu 0x60(%rsi), %xmm6
+-	vmovdqu 0x70(%rsi), %xmm7
+-	vmovdqu -0x80(%rcx), %xmm8
+-	vmovdqu -0x70(%rcx), %xmm9
+-	vmovdqu -0x60(%rcx), %xmm10
+-	vmovdqu -0x50(%rcx), %xmm11
+-	vmovdqu -0x40(%rcx), %xmm12
+-	vmovdqu -0x30(%rcx), %xmm13
+-	vmovdqu -0x20(%rcx), %xmm14
+-	vmovdqu -0x10(%rcx), %xmm15
+-	lea	(%rdi, %rdx), %rdx
+-	vmovdqu %xmm0, (%rdi)
+-	vmovdqu %xmm1, 0x10(%rdi)
+-	vmovdqu %xmm2, 0x20(%rdi)
+-	vmovdqu %xmm3, 0x30(%rdi)
+-	vmovdqu %xmm4, 0x40(%rdi)
+-	vmovdqu %xmm5, 0x50(%rdi)
+-	vmovdqu %xmm6, 0x60(%rdi)
+-	vmovdqu %xmm7, 0x70(%rdi)
+-	vmovdqu %xmm8, -0x80(%rdx)
+-	vmovdqu %xmm9, -0x70(%rdx)
+-	vmovdqu %xmm10, -0x60(%rdx)
+-	vmovdqu %xmm11, -0x50(%rdx)
+-	vmovdqu %xmm12, -0x40(%rdx)
+-	vmovdqu %xmm13, -0x30(%rdx)
+-	vmovdqu %xmm14, -0x20(%rdx)
+-	vmovdqu %xmm15, -0x10(%rdx)
+-	ret
+-	.p2align 4
+-L(less_128bytes):
+-	cmp	$64, %dl
+-	jb	L(less_64bytes)
+-	vmovdqu (%rsi), %xmm0
+-	lea	(%rsi, %rdx), %rcx
+-	vmovdqu 0x10(%rsi), %xmm1
+-	vmovdqu 0x20(%rsi), %xmm2
+-	lea	(%rdi, %rdx), %rdx
+-	vmovdqu 0x30(%rsi), %xmm3
+-	vmovdqu -0x40(%rcx), %xmm4
+-	vmovdqu -0x30(%rcx), %xmm5
+-	vmovdqu -0x20(%rcx), %xmm6
+-	vmovdqu -0x10(%rcx), %xmm7
+-	vmovdqu %xmm0, (%rdi)
+-	vmovdqu %xmm1, 0x10(%rdi)
+-	vmovdqu %xmm2, 0x20(%rdi)
+-	vmovdqu %xmm3, 0x30(%rdi)
+-	vmovdqu %xmm4, -0x40(%rdx)
+-	vmovdqu %xmm5, -0x30(%rdx)
+-	vmovdqu %xmm6, -0x20(%rdx)
+-	vmovdqu %xmm7, -0x10(%rdx)
+-	ret
+-
+-	.p2align 4
+-L(less_64bytes):
+-	cmp	$32, %dl
+-	jb	L(less_32bytes)
+-	vmovdqu (%rsi), %xmm0
+-	vmovdqu 0x10(%rsi), %xmm1
+-	vmovdqu -0x20(%rsi, %rdx), %xmm6
+-	vmovdqu -0x10(%rsi, %rdx), %xmm7
+-	vmovdqu %xmm0, (%rdi)
+-	vmovdqu %xmm1, 0x10(%rdi)
+-	vmovdqu %xmm6, -0x20(%rdi, %rdx)
+-	vmovdqu %xmm7, -0x10(%rdi, %rdx)
+-	ret
+-
+-	.p2align 4
+-L(less_32bytes):
+-	vmovdqu (%rsi), %xmm0
+-	vmovdqu -0x10(%rsi, %rdx), %xmm7
+-	vmovdqu %xmm0, (%rdi)
+-	vmovdqu %xmm7, -0x10(%rdi, %rdx)
+-	ret
+-
+-	.p2align 4
+-L(less_16bytes):
+-	cmp	$8, %dl
+-	jb	L(less_8bytes)
+-	movq -0x08(%rsi, %rdx),	%rcx
+-	movq (%rsi),	%rsi
+-	movq %rsi, (%rdi)
+-	movq %rcx, -0x08(%rdi, %rdx)
+-	ret
+-
+-	.p2align 4
+-L(less_8bytes):
+-	cmp	$4, %dl
+-	jb	L(less_4bytes)
+-	mov -0x04(%rsi, %rdx), %ecx
+-	mov (%rsi),	%esi
+-	mov %esi, (%rdi)
+-	mov %ecx, -0x04(%rdi, %rdx)
+-	ret
+-
+-L(less_4bytes):
+-	cmp	$1, %dl
+-	jbe	L(less_2bytes)
+-	mov -0x02(%rsi, %rdx),	%cx
+-	mov (%rsi),	%si
+-	mov %si, (%rdi)
+-	mov %cx, -0x02(%rdi, %rdx)
+-	ret
+-
+-L(less_2bytes):
+-	jb	L(less_0bytes)
+-	mov	(%rsi), %cl
+-	mov	%cl,	(%rdi)
+-L(less_0bytes):
+-	ret
+-
+-	.p2align 4
+-L(256bytesormore):
+-	mov	%rdi, %rcx
+-	sub	%rsi, %rcx
+-	cmp	%rdx, %rcx
+-	jc	L(copy_backward)
+-	cmp	$2048, %rdx
+-	jae	L(gobble_data_movsb)
+-	mov	%rax, %r8
+-	lea	(%rsi, %rdx), %rcx
+-	mov	%rdi, %r10
+-	vmovdqu -0x80(%rcx), %xmm5
+-	vmovdqu -0x70(%rcx), %xmm6
+-	mov	$0x80, %rax
+-	and	$-32, %rdi
+-	add	$32, %rdi
+-	vmovdqu -0x60(%rcx), %xmm7
+-	vmovdqu -0x50(%rcx), %xmm8
+-	mov	%rdi, %r11
+-	sub	%r10, %r11
+-	vmovdqu -0x40(%rcx), %xmm9
+-	vmovdqu -0x30(%rcx), %xmm10
+-	sub	%r11, %rdx
+-	vmovdqu -0x20(%rcx), %xmm11
+-	vmovdqu -0x10(%rcx), %xmm12
+-	vmovdqu	(%rsi), %ymm4
+-	add	%r11, %rsi
+-	sub	%eax, %edx
+-L(goble_128_loop):
+-	vmovdqu (%rsi), %ymm0
+-	vmovdqu 0x20(%rsi), %ymm1
+-	vmovdqu 0x40(%rsi), %ymm2
+-	vmovdqu 0x60(%rsi), %ymm3
+-	add	%rax, %rsi
+-	vmovdqa %ymm0, (%rdi)
+-	vmovdqa %ymm1, 0x20(%rdi)
+-	vmovdqa %ymm2, 0x40(%rdi)
+-	vmovdqa %ymm3, 0x60(%rdi)
+-	add	%rax, %rdi
+-	sub	%eax, %edx
+-	jae	L(goble_128_loop)
+-	add	%eax, %edx
+-	add	%rdi, %rdx
+-	vmovdqu	%ymm4, (%r10)
+-	vzeroupper
+-	vmovdqu %xmm5, -0x80(%rdx)
+-	vmovdqu %xmm6, -0x70(%rdx)
+-	vmovdqu %xmm7, -0x60(%rdx)
+-	vmovdqu %xmm8, -0x50(%rdx)
+-	vmovdqu %xmm9, -0x40(%rdx)
+-	vmovdqu %xmm10, -0x30(%rdx)
+-	vmovdqu %xmm11, -0x20(%rdx)
+-	vmovdqu %xmm12, -0x10(%rdx)
+-	mov	%r8, %rax
+-	ret
+-
+-	.p2align 4
+-L(gobble_data_movsb):
+-#ifdef SHARED_CACHE_SIZE_HALF
+-	mov	$SHARED_CACHE_SIZE_HALF, %rcx
+-#else
+-	mov	__x86_shared_cache_size_half(%rip), %rcx
+-#endif
+-	shl	$3, %rcx
+-	cmp	%rcx, %rdx
+-	jae	L(gobble_big_data_fwd)
+-	mov	%rdx, %rcx
+-	mov	%rdx, %rcx
+-	rep	movsb
+-	ret
+-
+-	.p2align 4
+-L(gobble_big_data_fwd):
+-	lea	(%rsi, %rdx), %rcx
+-	vmovdqu	(%rsi), %ymm4
+-	vmovdqu -0x80(%rsi,%rdx), %xmm5
+-	vmovdqu -0x70(%rcx), %xmm6
+-	vmovdqu -0x60(%rcx), %xmm7
+-	vmovdqu -0x50(%rcx), %xmm8
+-	vmovdqu -0x40(%rcx), %xmm9
+-	vmovdqu -0x30(%rcx), %xmm10
+-	vmovdqu -0x20(%rcx), %xmm11
+-	vmovdqu -0x10(%rcx), %xmm12
+-	mov	%rdi, %r8
+-	and	$-32, %rdi
+-	add	$32, %rdi
+-	mov	%rdi, %r10
+-	sub	%r8, %r10
+-	sub	%r10, %rdx
+-	add	%r10, %rsi
+-	lea	(%rdi, %rdx), %rcx
+-	add	$-0x80, %rdx
+-L(gobble_mem_fwd_loop):
+-	prefetchnta 0x1c0(%rsi)
+-	prefetchnta 0x280(%rsi)
+-	vmovdqu	(%rsi), %ymm0
+-	vmovdqu	0x20(%rsi), %ymm1
+-	vmovdqu	0x40(%rsi), %ymm2
+-	vmovdqu	0x60(%rsi), %ymm3
+-	sub	$-0x80, %rsi
+-	vmovntdq	%ymm0, (%rdi)
+-	vmovntdq	%ymm1, 0x20(%rdi)
+-	vmovntdq	%ymm2, 0x40(%rdi)
+-	vmovntdq	%ymm3, 0x60(%rdi)
+-	sub	$-0x80, %rdi
+-	add	$-0x80, %rdx
+-	jb	L(gobble_mem_fwd_loop)
+-	sfence
+-	vmovdqu	%ymm4, (%r8)
+-	vzeroupper
+-	vmovdqu %xmm5, -0x80(%rcx)
+-	vmovdqu %xmm6, -0x70(%rcx)
+-	vmovdqu %xmm7, -0x60(%rcx)
+-	vmovdqu %xmm8, -0x50(%rcx)
+-	vmovdqu %xmm9, -0x40(%rcx)
+-	vmovdqu %xmm10, -0x30(%rcx)
+-	vmovdqu %xmm11, -0x20(%rcx)
+-	vmovdqu %xmm12, -0x10(%rcx)
+-	ret
+-
+-	.p2align 4
+-L(copy_backward):
+-#ifdef SHARED_CACHE_SIZE_HALF
+-	mov	$SHARED_CACHE_SIZE_HALF, %rcx
+-#else
+-	mov	__x86_shared_cache_size_half(%rip), %rcx
+-#endif
+-	shl	$3, %rcx
+-	vmovdqu (%rsi), %xmm5
+-	vmovdqu 0x10(%rsi), %xmm6
+-	add	%rdx, %rdi
+-	vmovdqu 0x20(%rsi), %xmm7
+-	vmovdqu 0x30(%rsi), %xmm8
+-	lea	-0x20(%rdi), %r10
+-	mov %rdi, %r11
+-	vmovdqu 0x40(%rsi), %xmm9
+-	vmovdqu 0x50(%rsi), %xmm10
+-	and	$0x1f, %r11
+-	vmovdqu 0x60(%rsi), %xmm11
+-	vmovdqu 0x70(%rsi), %xmm12
+-	xor	%r11, %rdi
+-	add	%rdx, %rsi
+-	vmovdqu	-0x20(%rsi), %ymm4
+-	sub	%r11, %rsi
+-	sub	%r11, %rdx
+-	cmp	%rcx, %rdx
+-	ja	L(gobble_big_data_bwd)
+-	add	$-0x80, %rdx
+-L(gobble_mem_bwd_llc):
+-	vmovdqu	-0x20(%rsi), %ymm0
+-	vmovdqu	-0x40(%rsi), %ymm1
+-	vmovdqu	-0x60(%rsi), %ymm2
+-	vmovdqu	-0x80(%rsi), %ymm3
+-	lea	-0x80(%rsi), %rsi
+-	vmovdqa	%ymm0, -0x20(%rdi)
+-	vmovdqa	%ymm1, -0x40(%rdi)
+-	vmovdqa	%ymm2, -0x60(%rdi)
+-	vmovdqa	%ymm3, -0x80(%rdi)
+-	lea	-0x80(%rdi), %rdi
+-	add	$-0x80, %rdx
+-	jb	L(gobble_mem_bwd_llc)
+-	vmovdqu	%ymm4, (%r10)
+-	vzeroupper
+-	vmovdqu %xmm5, (%rax)
+-	vmovdqu %xmm6, 0x10(%rax)
+-	vmovdqu %xmm7, 0x20(%rax)
+-	vmovdqu %xmm8, 0x30(%rax)
+-	vmovdqu %xmm9, 0x40(%rax)
+-	vmovdqu %xmm10, 0x50(%rax)
+-	vmovdqu %xmm11, 0x60(%rax)
+-	vmovdqu %xmm12, 0x70(%rax)
+-	ret
+-
+-	.p2align 4
+-L(gobble_big_data_bwd):
+-	add	$-0x80, %rdx
+-L(gobble_mem_bwd_loop):
+-	prefetchnta -0x1c0(%rsi)
+-	prefetchnta -0x280(%rsi)
+-	vmovdqu	-0x20(%rsi), %ymm0
+-	vmovdqu	-0x40(%rsi), %ymm1
+-	vmovdqu	-0x60(%rsi), %ymm2
+-	vmovdqu	-0x80(%rsi), %ymm3
+-	lea	-0x80(%rsi), %rsi
+-	vmovntdq	%ymm0, -0x20(%rdi)
+-	vmovntdq	%ymm1, -0x40(%rdi)
+-	vmovntdq	%ymm2, -0x60(%rdi)
+-	vmovntdq	%ymm3, -0x80(%rdi)
+-	lea	-0x80(%rdi), %rdi
+-	add	$-0x80, %rdx
+-	jb	L(gobble_mem_bwd_loop)
+-	sfence
+-	vmovdqu	%ymm4, (%r10)
+-	vzeroupper
+-	vmovdqu %xmm5, (%rax)
+-	vmovdqu %xmm6, 0x10(%rax)
+-	vmovdqu %xmm7, 0x20(%rax)
+-	vmovdqu %xmm8, 0x30(%rax)
+-	vmovdqu %xmm9, 0x40(%rax)
+-	vmovdqu %xmm10, 0x50(%rax)
+-	vmovdqu %xmm11, 0x60(%rax)
+-	vmovdqu %xmm12, 0x70(%rax)
+-	ret
+-END (MEMMOVE)
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-memcpy-slm.s b/libc/arch-x86_64/silvermont/string/sse2-memcpy-slm.s
+deleted file mode 100644
+index 2f0638ed4..000000000
+--- a/libc/arch-x86_64/silvermont/string/sse2-memcpy-slm.s
++++ /dev/null
+@@ -1,1374 +0,0 @@
+-	.text
+-	.file	"FastMemcpy_avx_sse2.c"
+-	.globl	memcpy_generic                  # -- Begin function memcpy
+-	.p2align	4, 0x90
+-	.type	memcpy_generic,@function
+-
+-
+-
+-memcpy_generic:                                 # @memcpy
+-	.cfi_startproc
+-
+-# %bb.0:
+-	movq	%rdi, %rax
+-	cmpq	$128, %rdx
+-	ja	.LBB0_129
+-# %bb.1:
+-	leaq	-1(%rdx), %rdi
+-	cmpq	$127, %rdi
+-	ja	.LBB0_145
+-# %bb.2:
+-	leaq	.LJTI0_1(%rip), %r8
+-	leaq	(%rax,%rdx), %rcx
+-	addq	%rdx, %rsi
+-	movslq	(%r8,%rdi,4), %rdi
+-	addq	%r8, %rdi
+-	jmpq	*%rdi
+-.LBB0_129:
+-	movl	%eax, %edi
+-	negl	%edi
+-	andq	$15, %rdi
+-	je	.LBB0_130
+-# %bb.131:
+-	movups	(%rsi), %xmm0
+-	leaq	(%rax,%rdi), %rcx
+-	addq	%rdi, %rsi
+-	subq	%rdi, %rdx
+-	movups	%xmm0, (%rax)
+-	cmpq	$2097152, %rdx          # imm = 0x200000
+-	ja	.LBB0_137
+-.LBB0_133:
+-	cmpq	$128, %rdx
+-	jb	.LBB0_141
+-# %bb.134:
+-	movq	%rdx, %rdi
+-	.p2align	4, 0x90
+-.LBB0_135:                              # =>This Inner Loop Header: Depth=1
+-	movups	(%rsi), %xmm0
+-	movups	16(%rsi), %xmm1
+-	movups	32(%rsi), %xmm2
+-	movups	48(%rsi), %xmm3
+-	movups	64(%rsi), %xmm4
+-	movups	80(%rsi), %xmm5
+-	movups	96(%rsi), %xmm6
+-	movups	112(%rsi), %xmm7
+-	prefetchnta	256(%rsi)
+-	addq	$-128, %rdi
+-	subq	$-128, %rsi
+-	movaps	%xmm0, (%rcx)
+-	movaps	%xmm1, 16(%rcx)
+-	movaps	%xmm2, 32(%rcx)
+-	movaps	%xmm3, 48(%rcx)
+-	movaps	%xmm4, 64(%rcx)
+-	movaps	%xmm5, 80(%rcx)
+-	movaps	%xmm6, 96(%rcx)
+-	movaps	%xmm7, 112(%rcx)
+-	subq	$-128, %rcx
+-	cmpq	$127, %rdi
+-	ja	.LBB0_135
+-# %bb.136:
+-	andl	$127, %edx
+-	leaq	-1(%rdx), %rdi
+-	cmpq	$127, %rdi
+-	jbe	.LBB0_142
+-	jmp	.LBB0_145
+-.LBB0_130:
+-	movq	%rax, %rcx
+-	cmpq	$2097152, %rdx          # imm = 0x200000
+-	jbe	.LBB0_133
+-.LBB0_137:
+-	prefetchnta	(%rsi)
+-	movq	%rdx, %rdi
+-	testb	$15, %sil
+-	je	.LBB0_139
+-	.p2align	4, 0x90
+-.LBB0_138:                              # =>This Inner Loop Header: Depth=1
+-	movups	(%rsi), %xmm0
+-	movups	16(%rsi), %xmm1
+-	movups	32(%rsi), %xmm2
+-	movups	48(%rsi), %xmm3
+-	movups	64(%rsi), %xmm4
+-	movups	80(%rsi), %xmm5
+-	movups	96(%rsi), %xmm6
+-	movups	112(%rsi), %xmm7
+-	prefetchnta	256(%rsi)
+-	addq	$-128, %rdi
+-	subq	$-128, %rsi
+-	movntps	%xmm0, (%rcx)
+-	movntps	%xmm1, 16(%rcx)
+-	movntps	%xmm2, 32(%rcx)
+-	movntps	%xmm3, 48(%rcx)
+-	movntps	%xmm4, 64(%rcx)
+-	movntps	%xmm5, 80(%rcx)
+-	movntps	%xmm6, 96(%rcx)
+-	movntps	%xmm7, 112(%rcx)
+-	subq	$-128, %rcx
+-	cmpq	$127, %rdi
+-	ja	.LBB0_138
+-	jmp	.LBB0_140
+-	.p2align	4, 0x90
+-.LBB0_139:                              # =>This Inner Loop Header: Depth=1
+-	movaps	(%rsi), %xmm0
+-	movaps	16(%rsi), %xmm1
+-	movaps	32(%rsi), %xmm2
+-	movaps	48(%rsi), %xmm3
+-	movaps	64(%rsi), %xmm4
+-	movaps	80(%rsi), %xmm5
+-	movaps	96(%rsi), %xmm6
+-	movaps	112(%rsi), %xmm7
+-	prefetchnta	256(%rsi)
+-	addq	$-128, %rdi
+-	subq	$-128, %rsi
+-	movntps	%xmm0, (%rcx)
+-	movntps	%xmm1, 16(%rcx)
+-	movntps	%xmm2, 32(%rcx)
+-	movntps	%xmm3, 48(%rcx)
+-	movntps	%xmm4, 64(%rcx)
+-	movntps	%xmm5, 80(%rcx)
+-	movntps	%xmm6, 96(%rcx)
+-	movntps	%xmm7, 112(%rcx)
+-	subq	$-128, %rcx
+-	cmpq	$127, %rdi
+-	ja	.LBB0_139
+-.LBB0_140:
+-	andl	$127, %edx
+-	sfence
+-.LBB0_141:
+-	leaq	-1(%rdx), %rdi
+-	cmpq	$127, %rdi
+-	ja	.LBB0_145
+-.LBB0_142:
+-	leaq	.LJTI0_0(%rip), %r8
+-	addq	%rdx, %rcx
+-	addq	%rdx, %rsi
+-	movslq	(%r8,%rdi,4), %rdi
+-	addq	%r8, %rdi
+-	jmpq	*%rdi
+-.LBB0_143:
+-	movups	-64(%rsi), %xmm0
+-	movups	-48(%rsi), %xmm1
+-	movups	-32(%rsi), %xmm2
+-	movups	-16(%rsi), %xmm3
+-	movups	%xmm0, -64(%rcx)
+-	movups	%xmm1, -48(%rcx)
+-	movups	%xmm2, -32(%rcx)
+-	movups	%xmm3, -16(%rcx)
+-	retq
+-.LBB0_3:
+-	movups	-65(%rsi), %xmm0
+-	movups	-49(%rsi), %xmm1
+-	movups	-33(%rsi), %xmm2
+-	movups	-17(%rsi), %xmm3
+-	movups	%xmm0, -65(%rcx)
+-	movups	%xmm1, -49(%rcx)
+-	movups	%xmm2, -33(%rcx)
+-	movups	%xmm3, -17(%rcx)
+-	movb	-1(%rsi), %dl
+-	movb	%dl, -1(%rcx)
+-	retq
+-.LBB0_5:
+-	movups	-66(%rsi), %xmm0
+-	movups	-50(%rsi), %xmm1
+-	movups	-34(%rsi), %xmm2
+-	movups	-18(%rsi), %xmm3
+-	movups	%xmm0, -66(%rcx)
+-	movups	%xmm1, -50(%rcx)
+-	movups	%xmm2, -34(%rcx)
+-	movups	%xmm3, -18(%rcx)
+-	movzwl	-2(%rsi), %edx
+-	movw	%dx, -2(%rcx)
+-	retq
+-.LBB0_7:
+-	movups	-67(%rsi), %xmm0
+-	movups	-51(%rsi), %xmm1
+-	movups	-35(%rsi), %xmm2
+-	movups	-19(%rsi), %xmm3
+-	movups	%xmm0, -67(%rcx)
+-	movups	%xmm1, -51(%rcx)
+-	movups	%xmm2, -35(%rcx)
+-	movups	%xmm3, -19(%rcx)
+-	jmp	.LBB0_8
+-.LBB0_9:
+-	movups	-68(%rsi), %xmm0
+-	movups	-52(%rsi), %xmm1
+-	movups	-36(%rsi), %xmm2
+-	movups	-20(%rsi), %xmm3
+-	movups	%xmm0, -68(%rcx)
+-	movups	%xmm1, -52(%rcx)
+-	movups	%xmm2, -36(%rcx)
+-	movups	%xmm3, -20(%rcx)
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	retq
+-.LBB0_11:
+-	movups	-69(%rsi), %xmm0
+-	movups	-53(%rsi), %xmm1
+-	movups	-37(%rsi), %xmm2
+-	movups	-21(%rsi), %xmm3
+-	movups	%xmm0, -69(%rcx)
+-	movups	%xmm1, -53(%rcx)
+-	movups	%xmm2, -37(%rcx)
+-	movups	%xmm3, -21(%rcx)
+-	jmp	.LBB0_12
+-.LBB0_13:
+-	movups	-70(%rsi), %xmm0
+-	movups	-54(%rsi), %xmm1
+-	movups	-38(%rsi), %xmm2
+-	movups	-22(%rsi), %xmm3
+-	movups	%xmm0, -70(%rcx)
+-	movups	%xmm1, -54(%rcx)
+-	movups	%xmm2, -38(%rcx)
+-	movups	%xmm3, -22(%rcx)
+-	jmp	.LBB0_14
+-.LBB0_15:
+-	movups	-71(%rsi), %xmm0
+-	movups	-55(%rsi), %xmm1
+-	movups	-39(%rsi), %xmm2
+-	movups	-23(%rsi), %xmm3
+-	movups	%xmm0, -71(%rcx)
+-	movups	%xmm1, -55(%rcx)
+-	movups	%xmm2, -39(%rcx)
+-	movups	%xmm3, -23(%rcx)
+-	jmp	.LBB0_16
+-.LBB0_17:
+-	movups	-72(%rsi), %xmm0
+-	movups	-56(%rsi), %xmm1
+-	movups	-40(%rsi), %xmm2
+-	movups	-24(%rsi), %xmm3
+-	movups	%xmm0, -72(%rcx)
+-	movups	%xmm1, -56(%rcx)
+-	movups	%xmm2, -40(%rcx)
+-	movups	%xmm3, -24(%rcx)
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	retq
+-.LBB0_19:
+-	movups	-73(%rsi), %xmm0
+-	movups	-57(%rsi), %xmm1
+-	movups	-41(%rsi), %xmm2
+-	movups	-25(%rsi), %xmm3
+-	movups	%xmm0, -73(%rcx)
+-	movups	%xmm1, -57(%rcx)
+-	movups	%xmm2, -41(%rcx)
+-	movups	%xmm3, -25(%rcx)
+-	jmp	.LBB0_20
+-.LBB0_21:
+-	movups	-74(%rsi), %xmm0
+-	movups	-58(%rsi), %xmm1
+-	movups	-42(%rsi), %xmm2
+-	movups	-26(%rsi), %xmm3
+-	movups	%xmm0, -74(%rcx)
+-	movups	%xmm1, -58(%rcx)
+-	movups	%xmm2, -42(%rcx)
+-	movups	%xmm3, -26(%rcx)
+-	jmp	.LBB0_22
+-.LBB0_23:
+-	movups	-75(%rsi), %xmm0
+-	movups	-59(%rsi), %xmm1
+-	movups	-43(%rsi), %xmm2
+-	movups	-27(%rsi), %xmm3
+-	movups	%xmm0, -75(%rcx)
+-	movups	%xmm1, -59(%rcx)
+-	movups	%xmm2, -43(%rcx)
+-	movups	%xmm3, -27(%rcx)
+-	jmp	.LBB0_24
+-.LBB0_25:
+-	movups	-76(%rsi), %xmm0
+-	movups	-60(%rsi), %xmm1
+-	movups	-44(%rsi), %xmm2
+-	movups	-28(%rsi), %xmm3
+-	movups	%xmm0, -76(%rcx)
+-	movups	%xmm1, -60(%rcx)
+-	movups	%xmm2, -44(%rcx)
+-	movups	%xmm3, -28(%rcx)
+-	jmp	.LBB0_26
+-.LBB0_27:
+-	movups	-77(%rsi), %xmm0
+-	movups	-61(%rsi), %xmm1
+-	movups	-45(%rsi), %xmm2
+-	movups	-29(%rsi), %xmm3
+-	movups	%xmm0, -77(%rcx)
+-	movups	%xmm1, -61(%rcx)
+-	movups	%xmm2, -45(%rcx)
+-	movups	%xmm3, -29(%rcx)
+-	jmp	.LBB0_28
+-.LBB0_29:
+-	movups	-78(%rsi), %xmm0
+-	movups	-62(%rsi), %xmm1
+-	movups	-46(%rsi), %xmm2
+-	movups	-30(%rsi), %xmm3
+-	movups	%xmm0, -78(%rcx)
+-	movups	%xmm1, -62(%rcx)
+-	movups	%xmm2, -46(%rcx)
+-	movups	%xmm3, -30(%rcx)
+-	jmp	.LBB0_30
+-.LBB0_31:
+-	movups	-79(%rsi), %xmm0
+-	movups	-63(%rsi), %xmm1
+-	movups	-47(%rsi), %xmm2
+-	movups	-31(%rsi), %xmm3
+-	movups	%xmm0, -79(%rcx)
+-	movups	%xmm1, -63(%rcx)
+-	movups	%xmm2, -47(%rcx)
+-	movups	%xmm3, -31(%rcx)
+-	jmp	.LBB0_32
+-.LBB0_33:
+-	movups	-80(%rsi), %xmm0
+-	movups	-64(%rsi), %xmm1
+-	movups	-48(%rsi), %xmm2
+-	movups	-32(%rsi), %xmm3
+-	movups	%xmm0, -80(%rcx)
+-	movups	%xmm1, -64(%rcx)
+-	movups	%xmm2, -48(%rcx)
+-	movups	%xmm3, -32(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_35:
+-	movups	-81(%rsi), %xmm0
+-	movups	-65(%rsi), %xmm1
+-	movups	-49(%rsi), %xmm2
+-	movups	-33(%rsi), %xmm3
+-	movups	%xmm0, -81(%rcx)
+-	movups	%xmm1, -65(%rcx)
+-	movups	%xmm2, -49(%rcx)
+-	movups	%xmm3, -33(%rcx)
+-	jmp	.LBB0_36
+-.LBB0_37:
+-	movups	-82(%rsi), %xmm0
+-	movups	-66(%rsi), %xmm1
+-	movups	-50(%rsi), %xmm2
+-	movups	-34(%rsi), %xmm3
+-	movups	%xmm0, -82(%rcx)
+-	movups	%xmm1, -66(%rcx)
+-	movups	%xmm2, -50(%rcx)
+-	movups	%xmm3, -34(%rcx)
+-	jmp	.LBB0_38
+-.LBB0_39:
+-	movups	-83(%rsi), %xmm0
+-	movups	-67(%rsi), %xmm1
+-	movups	-51(%rsi), %xmm2
+-	movups	-35(%rsi), %xmm3
+-	movups	%xmm0, -83(%rcx)
+-	movups	%xmm1, -67(%rcx)
+-	movups	%xmm2, -51(%rcx)
+-	movups	%xmm3, -35(%rcx)
+-	jmp	.LBB0_40
+-.LBB0_41:
+-	movups	-84(%rsi), %xmm0
+-	movups	-68(%rsi), %xmm1
+-	movups	-52(%rsi), %xmm2
+-	movups	-36(%rsi), %xmm3
+-	movups	%xmm0, -84(%rcx)
+-	movups	%xmm1, -68(%rcx)
+-	movups	%xmm2, -52(%rcx)
+-	movups	%xmm3, -36(%rcx)
+-	jmp	.LBB0_42
+-.LBB0_43:
+-	movups	-85(%rsi), %xmm0
+-	movups	-69(%rsi), %xmm1
+-	movups	-53(%rsi), %xmm2
+-	movups	-37(%rsi), %xmm3
+-	movups	%xmm0, -85(%rcx)
+-	movups	%xmm1, -69(%rcx)
+-	movups	%xmm2, -53(%rcx)
+-	movups	%xmm3, -37(%rcx)
+-	jmp	.LBB0_44
+-.LBB0_45:
+-	movups	-86(%rsi), %xmm0
+-	movups	-70(%rsi), %xmm1
+-	movups	-54(%rsi), %xmm2
+-	movups	-38(%rsi), %xmm3
+-	movups	%xmm0, -86(%rcx)
+-	movups	%xmm1, -70(%rcx)
+-	movups	%xmm2, -54(%rcx)
+-	movups	%xmm3, -38(%rcx)
+-	jmp	.LBB0_46
+-.LBB0_47:
+-	movups	-87(%rsi), %xmm0
+-	movups	-71(%rsi), %xmm1
+-	movups	-55(%rsi), %xmm2
+-	movups	-39(%rsi), %xmm3
+-	movups	%xmm0, -87(%rcx)
+-	movups	%xmm1, -71(%rcx)
+-	movups	%xmm2, -55(%rcx)
+-	movups	%xmm3, -39(%rcx)
+-	jmp	.LBB0_48
+-.LBB0_49:
+-	movups	-88(%rsi), %xmm0
+-	movups	-72(%rsi), %xmm1
+-	movups	-56(%rsi), %xmm2
+-	movups	-40(%rsi), %xmm3
+-	movups	%xmm0, -88(%rcx)
+-	movups	%xmm1, -72(%rcx)
+-	movups	%xmm2, -56(%rcx)
+-	movups	%xmm3, -40(%rcx)
+-	jmp	.LBB0_50
+-.LBB0_51:
+-	movups	-89(%rsi), %xmm0
+-	movups	-73(%rsi), %xmm1
+-	movups	-57(%rsi), %xmm2
+-	movups	-41(%rsi), %xmm3
+-	movups	%xmm0, -89(%rcx)
+-	movups	%xmm1, -73(%rcx)
+-	movups	%xmm2, -57(%rcx)
+-	movups	%xmm3, -41(%rcx)
+-	jmp	.LBB0_52
+-.LBB0_53:
+-	movups	-90(%rsi), %xmm0
+-	movups	-74(%rsi), %xmm1
+-	movups	-58(%rsi), %xmm2
+-	movups	-42(%rsi), %xmm3
+-	movups	%xmm0, -90(%rcx)
+-	movups	%xmm1, -74(%rcx)
+-	movups	%xmm2, -58(%rcx)
+-	movups	%xmm3, -42(%rcx)
+-	jmp	.LBB0_54
+-.LBB0_55:
+-	movups	-91(%rsi), %xmm0
+-	movups	-75(%rsi), %xmm1
+-	movups	-59(%rsi), %xmm2
+-	movups	-43(%rsi), %xmm3
+-	movups	%xmm0, -91(%rcx)
+-	movups	%xmm1, -75(%rcx)
+-	movups	%xmm2, -59(%rcx)
+-	movups	%xmm3, -43(%rcx)
+-	jmp	.LBB0_56
+-.LBB0_57:
+-	movups	-92(%rsi), %xmm0
+-	movups	-76(%rsi), %xmm1
+-	movups	-60(%rsi), %xmm2
+-	movups	-44(%rsi), %xmm3
+-	movups	%xmm0, -92(%rcx)
+-	movups	%xmm1, -76(%rcx)
+-	movups	%xmm2, -60(%rcx)
+-	movups	%xmm3, -44(%rcx)
+-	jmp	.LBB0_58
+-.LBB0_59:
+-	movups	-93(%rsi), %xmm0
+-	movups	-77(%rsi), %xmm1
+-	movups	-61(%rsi), %xmm2
+-	movups	-45(%rsi), %xmm3
+-	movups	%xmm0, -93(%rcx)
+-	movups	%xmm1, -77(%rcx)
+-	movups	%xmm2, -61(%rcx)
+-	movups	%xmm3, -45(%rcx)
+-	jmp	.LBB0_60
+-.LBB0_61:
+-	movups	-94(%rsi), %xmm0
+-	movups	-78(%rsi), %xmm1
+-	movups	-62(%rsi), %xmm2
+-	movups	-46(%rsi), %xmm3
+-	movups	%xmm0, -94(%rcx)
+-	movups	%xmm1, -78(%rcx)
+-	movups	%xmm2, -62(%rcx)
+-	movups	%xmm3, -46(%rcx)
+-	jmp	.LBB0_62
+-.LBB0_63:
+-	movups	-95(%rsi), %xmm0
+-	movups	-79(%rsi), %xmm1
+-	movups	-63(%rsi), %xmm2
+-	movups	-47(%rsi), %xmm3
+-	movups	%xmm0, -95(%rcx)
+-	movups	%xmm1, -79(%rcx)
+-	movups	%xmm2, -63(%rcx)
+-	movups	%xmm3, -47(%rcx)
+-	jmp	.LBB0_64
+-.LBB0_65:
+-	movups	-96(%rsi), %xmm0
+-	movups	-80(%rsi), %xmm1
+-	movups	-64(%rsi), %xmm2
+-	movups	-48(%rsi), %xmm3
+-	movups	%xmm0, -96(%rcx)
+-	movups	%xmm1, -80(%rcx)
+-	movups	%xmm2, -64(%rcx)
+-	movups	%xmm3, -48(%rcx)
+-.LBB0_66:
+-	movups	-32(%rsi), %xmm0
+-	movups	-16(%rsi), %xmm1
+-	movups	%xmm0, -32(%rcx)
+-	movups	%xmm1, -16(%rcx)
+-	retq
+-.LBB0_67:
+-	movups	-97(%rsi), %xmm0
+-	movups	-81(%rsi), %xmm1
+-	movups	-65(%rsi), %xmm2
+-	movups	-49(%rsi), %xmm3
+-	movups	%xmm0, -97(%rcx)
+-	movups	%xmm1, -81(%rcx)
+-	movups	%xmm2, -65(%rcx)
+-	movups	%xmm3, -49(%rcx)
+-.LBB0_68:
+-	movups	-33(%rsi), %xmm0
+-	movups	-17(%rsi), %xmm1
+-	movups	%xmm0, -33(%rcx)
+-	movups	%xmm1, -17(%rcx)
+-	movb	-1(%rsi), %dl
+-	movb	%dl, -1(%rcx)
+-	retq
+-.LBB0_69:
+-	movups	-98(%rsi), %xmm0
+-	movups	-82(%rsi), %xmm1
+-	movups	-66(%rsi), %xmm2
+-	movups	-50(%rsi), %xmm3
+-	movups	%xmm0, -98(%rcx)
+-	movups	%xmm1, -82(%rcx)
+-	movups	%xmm2, -66(%rcx)
+-	movups	%xmm3, -50(%rcx)
+-.LBB0_70:
+-	movups	-34(%rsi), %xmm0
+-	movups	-18(%rsi), %xmm1
+-	movups	%xmm0, -34(%rcx)
+-	movups	%xmm1, -18(%rcx)
+-	movzwl	-2(%rsi), %edx
+-	movw	%dx, -2(%rcx)
+-	retq
+-.LBB0_71:
+-	movups	-99(%rsi), %xmm0
+-	movups	-83(%rsi), %xmm1
+-	movups	-67(%rsi), %xmm2
+-	movups	-51(%rsi), %xmm3
+-	movups	%xmm0, -99(%rcx)
+-	movups	%xmm1, -83(%rcx)
+-	movups	%xmm2, -67(%rcx)
+-	movups	%xmm3, -51(%rcx)
+-.LBB0_72:
+-	movups	-35(%rsi), %xmm0
+-	movups	-19(%rsi), %xmm1
+-	movups	%xmm0, -35(%rcx)
+-	movups	%xmm1, -19(%rcx)
+-	jmp	.LBB0_8
+-.LBB0_73:
+-	movups	-100(%rsi), %xmm0
+-	movups	-84(%rsi), %xmm1
+-	movups	-68(%rsi), %xmm2
+-	movups	-52(%rsi), %xmm3
+-	movups	%xmm0, -100(%rcx)
+-	movups	%xmm1, -84(%rcx)
+-	movups	%xmm2, -68(%rcx)
+-	movups	%xmm3, -52(%rcx)
+-.LBB0_74:
+-	movups	-36(%rsi), %xmm0
+-	movups	-20(%rsi), %xmm1
+-	movups	%xmm0, -36(%rcx)
+-	movups	%xmm1, -20(%rcx)
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	retq
+-.LBB0_75:
+-	movups	-101(%rsi), %xmm0
+-	movups	-85(%rsi), %xmm1
+-	movups	-69(%rsi), %xmm2
+-	movups	-53(%rsi), %xmm3
+-	movups	%xmm0, -101(%rcx)
+-	movups	%xmm1, -85(%rcx)
+-	movups	%xmm2, -69(%rcx)
+-	movups	%xmm3, -53(%rcx)
+-.LBB0_76:
+-	movups	-37(%rsi), %xmm0
+-	movups	-21(%rsi), %xmm1
+-	movups	%xmm0, -37(%rcx)
+-	movups	%xmm1, -21(%rcx)
+-	jmp	.LBB0_12
+-.LBB0_77:
+-	movups	-102(%rsi), %xmm0
+-	movups	-86(%rsi), %xmm1
+-	movups	-70(%rsi), %xmm2
+-	movups	-54(%rsi), %xmm3
+-	movups	%xmm0, -102(%rcx)
+-	movups	%xmm1, -86(%rcx)
+-	movups	%xmm2, -70(%rcx)
+-	movups	%xmm3, -54(%rcx)
+-.LBB0_78:
+-	movups	-38(%rsi), %xmm0
+-	movups	-22(%rsi), %xmm1
+-	movups	%xmm0, -38(%rcx)
+-	movups	%xmm1, -22(%rcx)
+-	jmp	.LBB0_14
+-.LBB0_79:
+-	movups	-103(%rsi), %xmm0
+-	movups	-87(%rsi), %xmm1
+-	movups	-71(%rsi), %xmm2
+-	movups	-55(%rsi), %xmm3
+-	movups	%xmm0, -103(%rcx)
+-	movups	%xmm1, -87(%rcx)
+-	movups	%xmm2, -71(%rcx)
+-	movups	%xmm3, -55(%rcx)
+-.LBB0_80:
+-	movups	-39(%rsi), %xmm0
+-	movups	-23(%rsi), %xmm1
+-	movups	%xmm0, -39(%rcx)
+-	movups	%xmm1, -23(%rcx)
+-	jmp	.LBB0_16
+-.LBB0_81:
+-	movups	-104(%rsi), %xmm0
+-	movups	-88(%rsi), %xmm1
+-	movups	-72(%rsi), %xmm2
+-	movups	-56(%rsi), %xmm3
+-	movups	%xmm0, -104(%rcx)
+-	movups	%xmm1, -88(%rcx)
+-	movups	%xmm2, -72(%rcx)
+-	movups	%xmm3, -56(%rcx)
+-.LBB0_82:
+-	movups	-40(%rsi), %xmm0
+-	movups	-24(%rsi), %xmm1
+-	movups	%xmm0, -40(%rcx)
+-	movups	%xmm1, -24(%rcx)
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	retq
+-.LBB0_83:
+-	movups	-105(%rsi), %xmm0
+-	movups	-89(%rsi), %xmm1
+-	movups	-73(%rsi), %xmm2
+-	movups	-57(%rsi), %xmm3
+-	movups	%xmm0, -105(%rcx)
+-	movups	%xmm1, -89(%rcx)
+-	movups	%xmm2, -73(%rcx)
+-	movups	%xmm3, -57(%rcx)
+-.LBB0_84:
+-	movups	-41(%rsi), %xmm0
+-	movups	-25(%rsi), %xmm1
+-	movups	%xmm0, -41(%rcx)
+-	movups	%xmm1, -25(%rcx)
+-.LBB0_20:
+-	movq	-9(%rsi), %rdx
+-	movq	%rdx, -9(%rcx)
+-.LBB0_4:
+-	movb	-1(%rsi), %dl
+-	movb	%dl, -1(%rcx)
+-	retq
+-.LBB0_85:
+-	movups	-106(%rsi), %xmm0
+-	movups	-90(%rsi), %xmm1
+-	movups	-74(%rsi), %xmm2
+-	movups	-58(%rsi), %xmm3
+-	movups	%xmm0, -106(%rcx)
+-	movups	%xmm1, -90(%rcx)
+-	movups	%xmm2, -74(%rcx)
+-	movups	%xmm3, -58(%rcx)
+-.LBB0_86:
+-	movups	-42(%rsi), %xmm0
+-	movups	-26(%rsi), %xmm1
+-	movups	%xmm0, -42(%rcx)
+-	movups	%xmm1, -26(%rcx)
+-.LBB0_22:
+-	movq	-10(%rsi), %rdx
+-	movq	%rdx, -10(%rcx)
+-.LBB0_6:
+-	movzwl	-2(%rsi), %edx
+-	movw	%dx, -2(%rcx)
+-	retq
+-.LBB0_87:
+-	movups	-107(%rsi), %xmm0
+-	movups	-91(%rsi), %xmm1
+-	movups	-75(%rsi), %xmm2
+-	movups	-59(%rsi), %xmm3
+-	movups	%xmm0, -107(%rcx)
+-	movups	%xmm1, -91(%rcx)
+-	movups	%xmm2, -75(%rcx)
+-	movups	%xmm3, -59(%rcx)
+-.LBB0_88:
+-	movups	-43(%rsi), %xmm0
+-	movups	-27(%rsi), %xmm1
+-	movups	%xmm0, -43(%rcx)
+-	movups	%xmm1, -27(%rcx)
+-.LBB0_24:
+-	movq	-11(%rsi), %rdx
+-	movq	%rdx, -11(%rcx)
+-.LBB0_10:
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	retq
+-.LBB0_89:
+-	movups	-108(%rsi), %xmm0
+-	movups	-92(%rsi), %xmm1
+-	movups	-76(%rsi), %xmm2
+-	movups	-60(%rsi), %xmm3
+-	movups	%xmm0, -108(%rcx)
+-	movups	%xmm1, -92(%rcx)
+-	movups	%xmm2, -76(%rcx)
+-	movups	%xmm3, -60(%rcx)
+-.LBB0_90:
+-	movups	-44(%rsi), %xmm0
+-	movups	-28(%rsi), %xmm1
+-	movups	%xmm0, -44(%rcx)
+-	movups	%xmm1, -28(%rcx)
+-.LBB0_26:
+-	movq	-12(%rsi), %rdx
+-	movq	%rdx, -12(%rcx)
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	retq
+-.LBB0_91:
+-	movups	-109(%rsi), %xmm0
+-	movups	-93(%rsi), %xmm1
+-	movups	-77(%rsi), %xmm2
+-	movups	-61(%rsi), %xmm3
+-	movups	%xmm0, -109(%rcx)
+-	movups	%xmm1, -93(%rcx)
+-	movups	%xmm2, -77(%rcx)
+-	movups	%xmm3, -61(%rcx)
+-.LBB0_92:
+-	movups	-45(%rsi), %xmm0
+-	movups	-29(%rsi), %xmm1
+-	movups	%xmm0, -45(%rcx)
+-	movups	%xmm1, -29(%rcx)
+-.LBB0_28:
+-	movq	-13(%rsi), %rdx
+-	movq	%rdx, -13(%rcx)
+-	jmp	.LBB0_12
+-.LBB0_93:
+-	movups	-110(%rsi), %xmm0
+-	movups	-94(%rsi), %xmm1
+-	movups	-78(%rsi), %xmm2
+-	movups	-62(%rsi), %xmm3
+-	movups	%xmm0, -110(%rcx)
+-	movups	%xmm1, -94(%rcx)
+-	movups	%xmm2, -78(%rcx)
+-	movups	%xmm3, -62(%rcx)
+-.LBB0_94:
+-	movups	-46(%rsi), %xmm0
+-	movups	-30(%rsi), %xmm1
+-	movups	%xmm0, -46(%rcx)
+-	movups	%xmm1, -30(%rcx)
+-.LBB0_30:
+-	movq	-14(%rsi), %rdx
+-	movq	%rdx, -14(%rcx)
+-.LBB0_18:
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	retq
+-.LBB0_95:
+-	movups	-111(%rsi), %xmm0
+-	movups	-95(%rsi), %xmm1
+-	movups	-79(%rsi), %xmm2
+-	movups	-63(%rsi), %xmm3
+-	movups	%xmm0, -111(%rcx)
+-	movups	%xmm1, -95(%rcx)
+-	movups	%xmm2, -79(%rcx)
+-	movups	%xmm3, -63(%rcx)
+-.LBB0_96:
+-	movups	-47(%rsi), %xmm0
+-	movups	-31(%rsi), %xmm1
+-	movups	%xmm0, -47(%rcx)
+-	movups	%xmm1, -31(%rcx)
+-.LBB0_32:
+-	movq	-15(%rsi), %rdx
+-	movq	%rdx, -15(%rcx)
+-	movq	-8(%rsi), %rdx
+-	movq	%rdx, -8(%rcx)
+-	retq
+-.LBB0_97:
+-	movups	-112(%rsi), %xmm0
+-	movups	-96(%rsi), %xmm1
+-	movups	-80(%rsi), %xmm2
+-	movups	-64(%rsi), %xmm3
+-	movups	%xmm0, -112(%rcx)
+-	movups	%xmm1, -96(%rcx)
+-	movups	%xmm2, -80(%rcx)
+-	movups	%xmm3, -64(%rcx)
+-.LBB0_98:
+-	movups	-48(%rsi), %xmm0
+-	movups	-32(%rsi), %xmm1
+-	movups	%xmm0, -48(%rcx)
+-	movups	%xmm1, -32(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_99:
+-	movups	-113(%rsi), %xmm0
+-	movups	-97(%rsi), %xmm1
+-	movups	-81(%rsi), %xmm2
+-	movups	-65(%rsi), %xmm3
+-	movups	%xmm0, -113(%rcx)
+-	movups	%xmm1, -97(%rcx)
+-	movups	%xmm2, -81(%rcx)
+-	movups	%xmm3, -65(%rcx)
+-.LBB0_100:
+-	movups	-49(%rsi), %xmm0
+-	movups	-33(%rsi), %xmm1
+-	movups	%xmm0, -49(%rcx)
+-	movups	%xmm1, -33(%rcx)
+-.LBB0_36:
+-	movups	-17(%rsi), %xmm0
+-	movups	%xmm0, -17(%rcx)
+-	movb	-1(%rsi), %dl
+-	movb	%dl, -1(%rcx)
+-	retq
+-.LBB0_101:
+-	movups	-114(%rsi), %xmm0
+-	movups	-98(%rsi), %xmm1
+-	movups	-82(%rsi), %xmm2
+-	movups	-66(%rsi), %xmm3
+-	movups	%xmm0, -114(%rcx)
+-	movups	%xmm1, -98(%rcx)
+-	movups	%xmm2, -82(%rcx)
+-	movups	%xmm3, -66(%rcx)
+-.LBB0_102:
+-	movups	-50(%rsi), %xmm0
+-	movups	-34(%rsi), %xmm1
+-	movups	%xmm0, -50(%rcx)
+-	movups	%xmm1, -34(%rcx)
+-.LBB0_38:
+-	movups	-18(%rsi), %xmm0
+-	movups	%xmm0, -18(%rcx)
+-	movzwl	-2(%rsi), %edx
+-	movw	%dx, -2(%rcx)
+-	retq
+-.LBB0_103:
+-	movups	-115(%rsi), %xmm0
+-	movups	-99(%rsi), %xmm1
+-	movups	-83(%rsi), %xmm2
+-	movups	-67(%rsi), %xmm3
+-	movups	%xmm0, -115(%rcx)
+-	movups	%xmm1, -99(%rcx)
+-	movups	%xmm2, -83(%rcx)
+-	movups	%xmm3, -67(%rcx)
+-.LBB0_104:
+-	movups	-51(%rsi), %xmm0
+-	movups	-35(%rsi), %xmm1
+-	movups	%xmm0, -51(%rcx)
+-	movups	%xmm1, -35(%rcx)
+-.LBB0_40:
+-	movups	-19(%rsi), %xmm0
+-	movups	%xmm0, -19(%rcx)
+-.LBB0_8:
+-	movzwl	-3(%rsi), %edx
+-	movw	%dx, -3(%rcx)
+-	movb	-1(%rsi), %dl
+-	movb	%dl, -1(%rcx)
+-	retq
+-.LBB0_105:
+-	movups	-116(%rsi), %xmm0
+-	movups	-100(%rsi), %xmm1
+-	movups	-84(%rsi), %xmm2
+-	movups	-68(%rsi), %xmm3
+-	movups	%xmm0, -116(%rcx)
+-	movups	%xmm1, -100(%rcx)
+-	movups	%xmm2, -84(%rcx)
+-	movups	%xmm3, -68(%rcx)
+-.LBB0_106:
+-	movups	-52(%rsi), %xmm0
+-	movups	-36(%rsi), %xmm1
+-	movups	%xmm0, -52(%rcx)
+-	movups	%xmm1, -36(%rcx)
+-.LBB0_42:
+-	movups	-20(%rsi), %xmm0
+-	movups	%xmm0, -20(%rcx)
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	retq
+-.LBB0_107:
+-	movups	-117(%rsi), %xmm0
+-	movups	-101(%rsi), %xmm1
+-	movups	-85(%rsi), %xmm2
+-	movups	-69(%rsi), %xmm3
+-	movups	%xmm0, -117(%rcx)
+-	movups	%xmm1, -101(%rcx)
+-	movups	%xmm2, -85(%rcx)
+-	movups	%xmm3, -69(%rcx)
+-.LBB0_108:
+-	movups	-53(%rsi), %xmm0
+-	movups	-37(%rsi), %xmm1
+-	movups	%xmm0, -53(%rcx)
+-	movups	%xmm1, -37(%rcx)
+-.LBB0_44:
+-	movups	-21(%rsi), %xmm0
+-	movups	%xmm0, -21(%rcx)
+-.LBB0_12:
+-	movl	-5(%rsi), %edx
+-	movl	%edx, -5(%rcx)
+-	movb	-1(%rsi), %dl
+-	movb	%dl, -1(%rcx)
+-	retq
+-.LBB0_109:
+-	movups	-118(%rsi), %xmm0
+-	movups	-102(%rsi), %xmm1
+-	movups	-86(%rsi), %xmm2
+-	movups	-70(%rsi), %xmm3
+-	movups	%xmm0, -118(%rcx)
+-	movups	%xmm1, -102(%rcx)
+-	movups	%xmm2, -86(%rcx)
+-	movups	%xmm3, -70(%rcx)
+-.LBB0_110:
+-	movups	-54(%rsi), %xmm0
+-	movups	-38(%rsi), %xmm1
+-	movups	%xmm0, -54(%rcx)
+-	movups	%xmm1, -38(%rcx)
+-.LBB0_46:
+-	movups	-22(%rsi), %xmm0
+-	movups	%xmm0, -22(%rcx)
+-.LBB0_14:
+-	movl	-6(%rsi), %edx
+-	movl	%edx, -6(%rcx)
+-	movzwl	-2(%rsi), %edx
+-	movw	%dx, -2(%rcx)
+-	retq
+-.LBB0_111:
+-	movups	-119(%rsi), %xmm0
+-	movups	-103(%rsi), %xmm1
+-	movups	-87(%rsi), %xmm2
+-	movups	-71(%rsi), %xmm3
+-	movups	%xmm0, -119(%rcx)
+-	movups	%xmm1, -103(%rcx)
+-	movups	%xmm2, -87(%rcx)
+-	movups	%xmm3, -71(%rcx)
+-.LBB0_112:
+-	movups	-55(%rsi), %xmm0
+-	movups	-39(%rsi), %xmm1
+-	movups	%xmm0, -55(%rcx)
+-	movups	%xmm1, -39(%rcx)
+-.LBB0_48:
+-	movups	-23(%rsi), %xmm0
+-	movups	%xmm0, -23(%rcx)
+-.LBB0_16:
+-	movl	-7(%rsi), %edx
+-	movl	%edx, -7(%rcx)
+-	movl	-4(%rsi), %edx
+-	movl	%edx, -4(%rcx)
+-	retq
+-.LBB0_113:
+-	movups	-120(%rsi), %xmm0
+-	movups	-104(%rsi), %xmm1
+-	movups	-88(%rsi), %xmm2
+-	movups	-72(%rsi), %xmm3
+-	movups	%xmm0, -120(%rcx)
+-	movups	%xmm1, -104(%rcx)
+-	movups	%xmm2, -88(%rcx)
+-	movups	%xmm3, -72(%rcx)
+-.LBB0_114:
+-	movups	-56(%rsi), %xmm0
+-	movups	-40(%rsi), %xmm1
+-	movups	%xmm0, -56(%rcx)
+-	movups	%xmm1, -40(%rcx)
+-.LBB0_50:
+-	movups	-24(%rsi), %xmm0
+-	movups	%xmm0, -24(%rcx)
+-.LBB0_34:
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_115:
+-	movups	-121(%rsi), %xmm0
+-	movups	-105(%rsi), %xmm1
+-	movups	-89(%rsi), %xmm2
+-	movups	-73(%rsi), %xmm3
+-	movups	%xmm0, -121(%rcx)
+-	movups	%xmm1, -105(%rcx)
+-	movups	%xmm2, -89(%rcx)
+-	movups	%xmm3, -73(%rcx)
+-.LBB0_116:
+-	movups	-57(%rsi), %xmm0
+-	movups	-41(%rsi), %xmm1
+-	movups	%xmm0, -57(%rcx)
+-	movups	%xmm1, -41(%rcx)
+-.LBB0_52:
+-	movups	-25(%rsi), %xmm0
+-	movups	%xmm0, -25(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_117:
+-	movups	-122(%rsi), %xmm0
+-	movups	-106(%rsi), %xmm1
+-	movups	-90(%rsi), %xmm2
+-	movups	-74(%rsi), %xmm3
+-	movups	%xmm0, -122(%rcx)
+-	movups	%xmm1, -106(%rcx)
+-	movups	%xmm2, -90(%rcx)
+-	movups	%xmm3, -74(%rcx)
+-.LBB0_118:
+-	movups	-58(%rsi), %xmm0
+-	movups	-42(%rsi), %xmm1
+-	movups	%xmm0, -58(%rcx)
+-	movups	%xmm1, -42(%rcx)
+-.LBB0_54:
+-	movups	-26(%rsi), %xmm0
+-	movups	%xmm0, -26(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_119:
+-	movups	-123(%rsi), %xmm0
+-	movups	-107(%rsi), %xmm1
+-	movups	-91(%rsi), %xmm2
+-	movups	-75(%rsi), %xmm3
+-	movups	%xmm0, -123(%rcx)
+-	movups	%xmm1, -107(%rcx)
+-	movups	%xmm2, -91(%rcx)
+-	movups	%xmm3, -75(%rcx)
+-.LBB0_120:
+-	movups	-59(%rsi), %xmm0
+-	movups	-43(%rsi), %xmm1
+-	movups	%xmm0, -59(%rcx)
+-	movups	%xmm1, -43(%rcx)
+-.LBB0_56:
+-	movups	-27(%rsi), %xmm0
+-	movups	%xmm0, -27(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_121:
+-	movups	-124(%rsi), %xmm0
+-	movups	-108(%rsi), %xmm1
+-	movups	-92(%rsi), %xmm2
+-	movups	-76(%rsi), %xmm3
+-	movups	%xmm0, -124(%rcx)
+-	movups	%xmm1, -108(%rcx)
+-	movups	%xmm2, -92(%rcx)
+-	movups	%xmm3, -76(%rcx)
+-.LBB0_122:
+-	movups	-60(%rsi), %xmm0
+-	movups	-44(%rsi), %xmm1
+-	movups	%xmm0, -60(%rcx)
+-	movups	%xmm1, -44(%rcx)
+-.LBB0_58:
+-	movups	-28(%rsi), %xmm0
+-	movups	%xmm0, -28(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_123:
+-	movups	-125(%rsi), %xmm0
+-	movups	-109(%rsi), %xmm1
+-	movups	-93(%rsi), %xmm2
+-	movups	-77(%rsi), %xmm3
+-	movups	%xmm0, -125(%rcx)
+-	movups	%xmm1, -109(%rcx)
+-	movups	%xmm2, -93(%rcx)
+-	movups	%xmm3, -77(%rcx)
+-.LBB0_124:
+-	movups	-61(%rsi), %xmm0
+-	movups	-45(%rsi), %xmm1
+-	movups	%xmm0, -61(%rcx)
+-	movups	%xmm1, -45(%rcx)
+-.LBB0_60:
+-	movups	-29(%rsi), %xmm0
+-	movups	%xmm0, -29(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_125:
+-	movups	-126(%rsi), %xmm0
+-	movups	-110(%rsi), %xmm1
+-	movups	-94(%rsi), %xmm2
+-	movups	-78(%rsi), %xmm3
+-	movups	%xmm0, -126(%rcx)
+-	movups	%xmm1, -110(%rcx)
+-	movups	%xmm2, -94(%rcx)
+-	movups	%xmm3, -78(%rcx)
+-.LBB0_126:
+-	movups	-62(%rsi), %xmm0
+-	movups	-46(%rsi), %xmm1
+-	movups	%xmm0, -62(%rcx)
+-	movups	%xmm1, -46(%rcx)
+-.LBB0_62:
+-	movups	-30(%rsi), %xmm0
+-	movups	%xmm0, -30(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_127:
+-	movups	-127(%rsi), %xmm0
+-	movups	-111(%rsi), %xmm1
+-	movups	-95(%rsi), %xmm2
+-	movups	-79(%rsi), %xmm3
+-	movups	%xmm0, -127(%rcx)
+-	movups	%xmm1, -111(%rcx)
+-	movups	%xmm2, -95(%rcx)
+-	movups	%xmm3, -79(%rcx)
+-.LBB0_128:
+-	movups	-63(%rsi), %xmm0
+-	movups	-47(%rsi), %xmm1
+-	movups	%xmm0, -63(%rcx)
+-	movups	%xmm1, -47(%rcx)
+-.LBB0_64:
+-	movups	-31(%rsi), %xmm0
+-	movups	%xmm0, -31(%rcx)
+-	movups	-16(%rsi), %xmm0
+-	movups	%xmm0, -16(%rcx)
+-	retq
+-.LBB0_144:
+-	movups	-128(%rsi), %xmm0
+-	movups	-112(%rsi), %xmm1
+-	movups	-96(%rsi), %xmm2
+-	movups	-80(%rsi), %xmm3
+-	movups	-64(%rsi), %xmm4
+-	movups	-48(%rsi), %xmm5
+-	movups	-32(%rsi), %xmm6
+-	movups	-16(%rsi), %xmm7
+-	movups	%xmm0, -128(%rcx)
+-	movups	%xmm1, -112(%rcx)
+-	movups	%xmm2, -96(%rcx)
+-	movups	%xmm3, -80(%rcx)
+-	movups	%xmm4, -64(%rcx)
+-	movups	%xmm5, -48(%rcx)
+-	movups	%xmm6, -32(%rcx)
+-	movups	%xmm7, -16(%rcx)
+-.LBB0_145:
+-	retq
+-.Lfunc_end0:
+-	.size	memcpy, .Lfunc_end0-memcpy
+-	.cfi_endproc
+-	.section	.rodata,"a",@progbits
+-	.p2align	2
+-.LJTI0_0:
+-	.long	.LBB0_4-.LJTI0_0
+-	.long	.LBB0_6-.LJTI0_0
+-	.long	.LBB0_8-.LJTI0_0
+-	.long	.LBB0_10-.LJTI0_0
+-	.long	.LBB0_12-.LJTI0_0
+-	.long	.LBB0_14-.LJTI0_0
+-	.long	.LBB0_16-.LJTI0_0
+-	.long	.LBB0_18-.LJTI0_0
+-	.long	.LBB0_20-.LJTI0_0
+-	.long	.LBB0_22-.LJTI0_0
+-	.long	.LBB0_24-.LJTI0_0
+-	.long	.LBB0_26-.LJTI0_0
+-	.long	.LBB0_28-.LJTI0_0
+-	.long	.LBB0_30-.LJTI0_0
+-	.long	.LBB0_32-.LJTI0_0
+-	.long	.LBB0_34-.LJTI0_0
+-	.long	.LBB0_36-.LJTI0_0
+-	.long	.LBB0_38-.LJTI0_0
+-	.long	.LBB0_40-.LJTI0_0
+-	.long	.LBB0_42-.LJTI0_0
+-	.long	.LBB0_44-.LJTI0_0
+-	.long	.LBB0_46-.LJTI0_0
+-	.long	.LBB0_48-.LJTI0_0
+-	.long	.LBB0_50-.LJTI0_0
+-	.long	.LBB0_52-.LJTI0_0
+-	.long	.LBB0_54-.LJTI0_0
+-	.long	.LBB0_56-.LJTI0_0
+-	.long	.LBB0_58-.LJTI0_0
+-	.long	.LBB0_60-.LJTI0_0
+-	.long	.LBB0_62-.LJTI0_0
+-	.long	.LBB0_64-.LJTI0_0
+-	.long	.LBB0_66-.LJTI0_0
+-	.long	.LBB0_68-.LJTI0_0
+-	.long	.LBB0_70-.LJTI0_0
+-	.long	.LBB0_72-.LJTI0_0
+-	.long	.LBB0_74-.LJTI0_0
+-	.long	.LBB0_76-.LJTI0_0
+-	.long	.LBB0_78-.LJTI0_0
+-	.long	.LBB0_80-.LJTI0_0
+-	.long	.LBB0_82-.LJTI0_0
+-	.long	.LBB0_84-.LJTI0_0
+-	.long	.LBB0_86-.LJTI0_0
+-	.long	.LBB0_88-.LJTI0_0
+-	.long	.LBB0_90-.LJTI0_0
+-	.long	.LBB0_92-.LJTI0_0
+-	.long	.LBB0_94-.LJTI0_0
+-	.long	.LBB0_96-.LJTI0_0
+-	.long	.LBB0_98-.LJTI0_0
+-	.long	.LBB0_100-.LJTI0_0
+-	.long	.LBB0_102-.LJTI0_0
+-	.long	.LBB0_104-.LJTI0_0
+-	.long	.LBB0_106-.LJTI0_0
+-	.long	.LBB0_108-.LJTI0_0
+-	.long	.LBB0_110-.LJTI0_0
+-	.long	.LBB0_112-.LJTI0_0
+-	.long	.LBB0_114-.LJTI0_0
+-	.long	.LBB0_116-.LJTI0_0
+-	.long	.LBB0_118-.LJTI0_0
+-	.long	.LBB0_120-.LJTI0_0
+-	.long	.LBB0_122-.LJTI0_0
+-	.long	.LBB0_124-.LJTI0_0
+-	.long	.LBB0_126-.LJTI0_0
+-	.long	.LBB0_128-.LJTI0_0
+-	.long	.LBB0_143-.LJTI0_0
+-	.long	.LBB0_3-.LJTI0_0
+-	.long	.LBB0_5-.LJTI0_0
+-	.long	.LBB0_7-.LJTI0_0
+-	.long	.LBB0_9-.LJTI0_0
+-	.long	.LBB0_11-.LJTI0_0
+-	.long	.LBB0_13-.LJTI0_0
+-	.long	.LBB0_15-.LJTI0_0
+-	.long	.LBB0_17-.LJTI0_0
+-	.long	.LBB0_19-.LJTI0_0
+-	.long	.LBB0_21-.LJTI0_0
+-	.long	.LBB0_23-.LJTI0_0
+-	.long	.LBB0_25-.LJTI0_0
+-	.long	.LBB0_27-.LJTI0_0
+-	.long	.LBB0_29-.LJTI0_0
+-	.long	.LBB0_31-.LJTI0_0
+-	.long	.LBB0_33-.LJTI0_0
+-	.long	.LBB0_35-.LJTI0_0
+-	.long	.LBB0_37-.LJTI0_0
+-	.long	.LBB0_39-.LJTI0_0
+-	.long	.LBB0_41-.LJTI0_0
+-	.long	.LBB0_43-.LJTI0_0
+-	.long	.LBB0_45-.LJTI0_0
+-	.long	.LBB0_47-.LJTI0_0
+-	.long	.LBB0_49-.LJTI0_0
+-	.long	.LBB0_51-.LJTI0_0
+-	.long	.LBB0_53-.LJTI0_0
+-	.long	.LBB0_55-.LJTI0_0
+-	.long	.LBB0_57-.LJTI0_0
+-	.long	.LBB0_59-.LJTI0_0
+-	.long	.LBB0_61-.LJTI0_0
+-	.long	.LBB0_63-.LJTI0_0
+-	.long	.LBB0_65-.LJTI0_0
+-	.long	.LBB0_67-.LJTI0_0
+-	.long	.LBB0_69-.LJTI0_0
+-	.long	.LBB0_71-.LJTI0_0
+-	.long	.LBB0_73-.LJTI0_0
+-	.long	.LBB0_75-.LJTI0_0
+-	.long	.LBB0_77-.LJTI0_0
+-	.long	.LBB0_79-.LJTI0_0
+-	.long	.LBB0_81-.LJTI0_0
+-	.long	.LBB0_83-.LJTI0_0
+-	.long	.LBB0_85-.LJTI0_0
+-	.long	.LBB0_87-.LJTI0_0
+-	.long	.LBB0_89-.LJTI0_0
+-	.long	.LBB0_91-.LJTI0_0
+-	.long	.LBB0_93-.LJTI0_0
+-	.long	.LBB0_95-.LJTI0_0
+-	.long	.LBB0_97-.LJTI0_0
+-	.long	.LBB0_99-.LJTI0_0
+-	.long	.LBB0_101-.LJTI0_0
+-	.long	.LBB0_103-.LJTI0_0
+-	.long	.LBB0_105-.LJTI0_0
+-	.long	.LBB0_107-.LJTI0_0
+-	.long	.LBB0_109-.LJTI0_0
+-	.long	.LBB0_111-.LJTI0_0
+-	.long	.LBB0_113-.LJTI0_0
+-	.long	.LBB0_115-.LJTI0_0
+-	.long	.LBB0_117-.LJTI0_0
+-	.long	.LBB0_119-.LJTI0_0
+-	.long	.LBB0_121-.LJTI0_0
+-	.long	.LBB0_123-.LJTI0_0
+-	.long	.LBB0_125-.LJTI0_0
+-	.long	.LBB0_127-.LJTI0_0
+-	.long	.LBB0_144-.LJTI0_0
+-.LJTI0_1:
+-	.long	.LBB0_4-.LJTI0_1
+-	.long	.LBB0_6-.LJTI0_1
+-	.long	.LBB0_8-.LJTI0_1
+-	.long	.LBB0_10-.LJTI0_1
+-	.long	.LBB0_12-.LJTI0_1
+-	.long	.LBB0_14-.LJTI0_1
+-	.long	.LBB0_16-.LJTI0_1
+-	.long	.LBB0_18-.LJTI0_1
+-	.long	.LBB0_20-.LJTI0_1
+-	.long	.LBB0_22-.LJTI0_1
+-	.long	.LBB0_24-.LJTI0_1
+-	.long	.LBB0_26-.LJTI0_1
+-	.long	.LBB0_28-.LJTI0_1
+-	.long	.LBB0_30-.LJTI0_1
+-	.long	.LBB0_32-.LJTI0_1
+-	.long	.LBB0_34-.LJTI0_1
+-	.long	.LBB0_36-.LJTI0_1
+-	.long	.LBB0_38-.LJTI0_1
+-	.long	.LBB0_40-.LJTI0_1
+-	.long	.LBB0_42-.LJTI0_1
+-	.long	.LBB0_44-.LJTI0_1
+-	.long	.LBB0_46-.LJTI0_1
+-	.long	.LBB0_48-.LJTI0_1
+-	.long	.LBB0_50-.LJTI0_1
+-	.long	.LBB0_52-.LJTI0_1
+-	.long	.LBB0_54-.LJTI0_1
+-	.long	.LBB0_56-.LJTI0_1
+-	.long	.LBB0_58-.LJTI0_1
+-	.long	.LBB0_60-.LJTI0_1
+-	.long	.LBB0_62-.LJTI0_1
+-	.long	.LBB0_64-.LJTI0_1
+-	.long	.LBB0_66-.LJTI0_1
+-	.long	.LBB0_68-.LJTI0_1
+-	.long	.LBB0_70-.LJTI0_1
+-	.long	.LBB0_72-.LJTI0_1
+-	.long	.LBB0_74-.LJTI0_1
+-	.long	.LBB0_76-.LJTI0_1
+-	.long	.LBB0_78-.LJTI0_1
+-	.long	.LBB0_80-.LJTI0_1
+-	.long	.LBB0_82-.LJTI0_1
+-	.long	.LBB0_84-.LJTI0_1
+-	.long	.LBB0_86-.LJTI0_1
+-	.long	.LBB0_88-.LJTI0_1
+-	.long	.LBB0_90-.LJTI0_1
+-	.long	.LBB0_92-.LJTI0_1
+-	.long	.LBB0_94-.LJTI0_1
+-	.long	.LBB0_96-.LJTI0_1
+-	.long	.LBB0_98-.LJTI0_1
+-	.long	.LBB0_100-.LJTI0_1
+-	.long	.LBB0_102-.LJTI0_1
+-	.long	.LBB0_104-.LJTI0_1
+-	.long	.LBB0_106-.LJTI0_1
+-	.long	.LBB0_108-.LJTI0_1
+-	.long	.LBB0_110-.LJTI0_1
+-	.long	.LBB0_112-.LJTI0_1
+-	.long	.LBB0_114-.LJTI0_1
+-	.long	.LBB0_116-.LJTI0_1
+-	.long	.LBB0_118-.LJTI0_1
+-	.long	.LBB0_120-.LJTI0_1
+-	.long	.LBB0_122-.LJTI0_1
+-	.long	.LBB0_124-.LJTI0_1
+-	.long	.LBB0_126-.LJTI0_1
+-	.long	.LBB0_128-.LJTI0_1
+-	.long	.LBB0_143-.LJTI0_1
+-	.long	.LBB0_3-.LJTI0_1
+-	.long	.LBB0_5-.LJTI0_1
+-	.long	.LBB0_7-.LJTI0_1
+-	.long	.LBB0_9-.LJTI0_1
+-	.long	.LBB0_11-.LJTI0_1
+-	.long	.LBB0_13-.LJTI0_1
+-	.long	.LBB0_15-.LJTI0_1
+-	.long	.LBB0_17-.LJTI0_1
+-	.long	.LBB0_19-.LJTI0_1
+-	.long	.LBB0_21-.LJTI0_1
+-	.long	.LBB0_23-.LJTI0_1
+-	.long	.LBB0_25-.LJTI0_1
+-	.long	.LBB0_27-.LJTI0_1
+-	.long	.LBB0_29-.LJTI0_1
+-	.long	.LBB0_31-.LJTI0_1
+-	.long	.LBB0_33-.LJTI0_1
+-	.long	.LBB0_35-.LJTI0_1
+-	.long	.LBB0_37-.LJTI0_1
+-	.long	.LBB0_39-.LJTI0_1
+-	.long	.LBB0_41-.LJTI0_1
+-	.long	.LBB0_43-.LJTI0_1
+-	.long	.LBB0_45-.LJTI0_1
+-	.long	.LBB0_47-.LJTI0_1
+-	.long	.LBB0_49-.LJTI0_1
+-	.long	.LBB0_51-.LJTI0_1
+-	.long	.LBB0_53-.LJTI0_1
+-	.long	.LBB0_55-.LJTI0_1
+-	.long	.LBB0_57-.LJTI0_1
+-	.long	.LBB0_59-.LJTI0_1
+-	.long	.LBB0_61-.LJTI0_1
+-	.long	.LBB0_63-.LJTI0_1
+-	.long	.LBB0_65-.LJTI0_1
+-	.long	.LBB0_67-.LJTI0_1
+-	.long	.LBB0_69-.LJTI0_1
+-	.long	.LBB0_71-.LJTI0_1
+-	.long	.LBB0_73-.LJTI0_1
+-	.long	.LBB0_75-.LJTI0_1
+-	.long	.LBB0_77-.LJTI0_1
+-	.long	.LBB0_79-.LJTI0_1
+-	.long	.LBB0_81-.LJTI0_1
+-	.long	.LBB0_83-.LJTI0_1
+-	.long	.LBB0_85-.LJTI0_1
+-	.long	.LBB0_87-.LJTI0_1
+-	.long	.LBB0_89-.LJTI0_1
+-	.long	.LBB0_91-.LJTI0_1
+-	.long	.LBB0_93-.LJTI0_1
+-	.long	.LBB0_95-.LJTI0_1
+-	.long	.LBB0_97-.LJTI0_1
+-	.long	.LBB0_99-.LJTI0_1
+-	.long	.LBB0_101-.LJTI0_1
+-	.long	.LBB0_103-.LJTI0_1
+-	.long	.LBB0_105-.LJTI0_1
+-	.long	.LBB0_107-.LJTI0_1
+-	.long	.LBB0_109-.LJTI0_1
+-	.long	.LBB0_111-.LJTI0_1
+-	.long	.LBB0_113-.LJTI0_1
+-	.long	.LBB0_115-.LJTI0_1
+-	.long	.LBB0_117-.LJTI0_1
+-	.long	.LBB0_119-.LJTI0_1
+-	.long	.LBB0_121-.LJTI0_1
+-	.long	.LBB0_123-.LJTI0_1
+-	.long	.LBB0_125-.LJTI0_1
+-	.long	.LBB0_127-.LJTI0_1
+-	.long	.LBB0_144-.LJTI0_1
+-                                        # -- End function
+-- 
+2.17.1
+


### PR DESCRIPTION
Optimization was targeted seperately for memmove
and memcpy. But this means no support for
overlapping copy when using memcpy. So modify
sse2/avx2 version of memcpy and memmove to
point to AOSP's memmove

Signed-off-by: ahs <amrita.h.s@intel.com>