### PR TITLE
kernel: Update build script with latest commit hash - ww39

### DIFF
--- a/host/kernel/lts2020-chromium/build_weekly.sh
+++ b/host/kernel/lts2020-chromium/build_weekly.sh
@@ -5,7 +5,7 @@ mkdir -p host_kernel
 cd host_kernel
 git clone https://github.com/projectceladon/linux-intel-lts2020-chromium.git
 cd linux-intel-lts2020-chromium
-git checkout 4d29e1cee847ff001c7e4439dd893c6df6164868
+git checkout 6493a9f834bd26f174792284f53baa5fcb0c5798
 cp ../../x86_64_defconfig .config
 patch_list=`find ../../ -iname "*.patch" | sort -u`
 for i in $patch_list


### PR DESCRIPTION
Updated SHA ID in build script to point to latest kernel cve fix
- vt: drop old FONT ioctls

Tracked-On: OAM-103477
Signed-off-by: rajucm <raju.mallikarjun.chegaraddi@intel.com>