### PR TITLE
kernel: Update build script with latest commit hash

### DIFF
--- a/host/kernel/lts2020-chromium/build_weekly.sh
+++ b/host/kernel/lts2020-chromium/build_weekly.sh
@@ -5,7 +5,7 @@ mkdir -p host_kernel
 cd host_kernel
 git clone https://github.com/projectceladon/linux-intel-lts2020-chromium.git
 cd linux-intel-lts2020-chromium
-git checkout 6493a9f834bd26f174792284f53baa5fcb0c5798
+git checkout 8b980c44db8347e1e954592f62f48af7213f3692
 cp ../../x86_64_defconfig .config
 patch_list=`find ../../ -iname "*.patch" | sort -u`
 for i in $patch_list


### PR DESCRIPTION
Updated SHA ID in build script to point to latest kernel fix
for CVE-2022-1012:
 - secure_seq: use the 64 bits of the siphash for port offset
   calculation

Tracked-On: OAM-103485
Signed-off-by: rajucm <raju.mallikarjun.chegaraddi@intel.com>