### PR TITLE
CTS fix AudioManagerTest#GetAdditionalOutputDelay

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/55_0055-CTS-fix-AudioManagerTest-GetAdditionalOutputDelay.patch
+++ b/aosp_diff/preliminary/frameworks/base/55_0055-CTS-fix-AudioManagerTest-GetAdditionalOutputDelay.patch
@@ -1,0 +1,36 @@
+From a6013ebada7c001abb445b7102c4b762a39db8dc Mon Sep 17 00:00:00 2001
+From: celadon <celadon@intel.com>
+Date: Wed, 10 Aug 2022 12:18:43 +0000
+Subject: [PATCH] CTS fix for audio string parsing
+
+Use replaceAll Java method to get a numerical
+value from key:value pair string instead of using substring.
+---
+ services/core/java/com/android/server/audio/AudioService.java | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/services/core/java/com/android/server/audio/AudioService.java b/services/core/java/com/android/server/audio/AudioService.java
+index 8d596b62cbf7..a4bdae714bda 100644
+--- a/services/core/java/com/android/server/audio/AudioService.java
++++ b/services/core/java/com/android/server/audio/AudioService.java
+@@ -10379,7 +10379,7 @@ public class AudioService extends IAudioService.Stub
+                 key + "=" + device.getInternalType() + "," + device.getAddress());
+         long delayMillis;
+         try {
+-            delayMillis = Long.parseLong(reply.substring(key.length() + 1));
++	     delayMillis = Long.parseLong(reply.replaceAll("[^0-9]", ""));
+         } catch (NullPointerException e) {
+             delayMillis = 0;
+         }
+@@ -10406,7 +10406,7 @@ public class AudioService extends IAudioService.Stub
+                 key + "=" + device.getInternalType() + "," + device.getAddress());
+         long delayMillis;
+         try {
+-            delayMillis = Long.parseLong(reply.substring(key.length() + 1));
++            delayMillis = Long.parseLong(reply.replaceAll("[^0-9]", ""));
+         } catch (NullPointerException e) {
+             delayMillis = 0;
+         }
+-- 
+2.33.1
+


### PR DESCRIPTION
Use replaceAll Java method to get a numerical
value from key:value pair string instead of using substring.

Tracked-On: OAM-103498
Signed-off-by: Deepa G k<g.k.deepa@intel.com>
Signed-off-by: gollarx <ratnakumarix.golla@intel.com>