### PR TITLE
lts2020-chromium: CFI vulnerability fix in gpu-i915

### DIFF
--- a/bsp_diff/common/kernel/lts2020-chromium/0001-fix-cfi-vulnerability-in-display-driver.patch
+++ b/bsp_diff/common/kernel/lts2020-chromium/0001-fix-cfi-vulnerability-in-display-driver.patch
@@ -1,0 +1,44 @@
+From b17f044d653493df7e530e229f96591392cd06e0 Mon Sep 17 00:00:00 2001
+From: rajucm <raju.mallikarjun.chegraddi@intel.com>
+Date: Tue, 16 Aug 2022 08:54:15 +0000
+Subject: [PATCH] fix cfi vulnerability in display-driver
+
+mismatch in pointer type, device_attribute & kobj_attribute
+
+Signed-off-by: rajucm <raju.mallikarjun.chegraddi@intel.com>
+---
+ drivers/gpu/drm/i915/i915_perf.c       | 4 ++--
+ drivers/gpu/drm/i915/i915_perf_types.h | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/i915_perf.c b/drivers/gpu/drm/i915/i915_perf.c
+index 9f94914958c3..9aebacc7c125 100644
+--- a/drivers/gpu/drm/i915/i915_perf.c
++++ b/drivers/gpu/drm/i915/i915_perf.c
+@@ -4000,8 +4000,8 @@ static struct i915_oa_reg *alloc_oa_regs(struct i915_perf *perf,
+ 	return ERR_PTR(err);
+ }
+ 
+-static ssize_t show_dynamic_id(struct device *dev,
+-			       struct device_attribute *attr,
++static ssize_t show_dynamic_id(struct kobject *kobj,
++			       struct kobj_attribute *attr,
+ 			       char *buf)
+ {
+ 	struct i915_oa_config *oa_config =
+diff --git a/drivers/gpu/drm/i915/i915_perf_types.h b/drivers/gpu/drm/i915/i915_perf_types.h
+index aa14354a5120..f682c7a6474d 100644
+--- a/drivers/gpu/drm/i915/i915_perf_types.h
++++ b/drivers/gpu/drm/i915/i915_perf_types.h
+@@ -55,7 +55,7 @@ struct i915_oa_config {
+ 
+ 	struct attribute_group sysfs_metric;
+ 	struct attribute *attrs[2];
+-	struct device_attribute sysfs_metric_id;
++	struct kobj_attribute sysfs_metric_id;
+ 
+ 	struct kref ref;
+ 	struct rcu_head rcu;
+-- 
+2.33.1
+


### PR DESCRIPTION
Tracked-On: OAM-103440
Signed-off-by: rajucm <raju.mallikarjun.chegraddi@intel.com>