### PR TITLE
Port "Add support for override_lib_name" to Android-13

### DIFF
--- a/aosp_diff/preliminary/build/soong/0007-Add-support-for-overide_lib_name-for-IA-perf-variant.patch
+++ b/aosp_diff/preliminary/build/soong/0007-Add-support-for-overide_lib_name-for-IA-perf-variant.patch
@@ -1,0 +1,94 @@
+From e72146e3ca0ebb37c0e78f8ea2bf4fb3da56455f Mon Sep 17 00:00:00 2001
+From: bodapati <shalini.salomi.bodapati@intel.com>
+Date: Mon, 26 Apr 2021 14:24:42 +0530
+Subject: [PATCH] Add support for overide_lib_name for IA perf variants of a
+ library
+
+Change-Id: If803bfd12181fc9c32585252b71a182326255549
+Tracked-On: OAM-95425
+Signed-off-by: bodapati <shalini.salomi.bodapati@intel.com>
+---
+ android/module.go | 5 +++++
+ cc/cc.go          | 5 +++++
+ cc/library.go     | 5 +++++
+ cc/vndk.go        | 2 ++
+ 4 files changed, 17 insertions(+)
+
+diff --git a/android/module.go b/android/module.go
+index 7285a2f21..bab47a252 100644
+--- a/android/module.go
++++ b/android/module.go
+@@ -678,6 +678,7 @@ func SortedUniqueNamedPaths(l NamedPaths) NamedPaths {
+ type nameProperties struct {
+ 	// The name of the module.  Must be unique across all modules.
+ 	Name *string
++	Override_lib_name *string
+ }
+ 
+ type commonProperties struct {
+@@ -1644,6 +1645,10 @@ func (m *ModuleBase) BaseModuleName() string {
+ 	return String(m.nameProperties.Name)
+ }
+ 
++func (m *ModuleBase) OverrideLibraryName() string {
++        return String(m.nameProperties.Override_lib_name)
++}
++
+ func (m *ModuleBase) base() *ModuleBase {
+ 	return m
+ }
+diff --git a/cc/cc.go b/cc/cc.go
+index 456b73628..74a8c3bc8 100644
+--- a/cc/cc.go
++++ b/cc/cc.go
+@@ -504,6 +504,7 @@ type ModuleContextIntf interface {
+ 	inRecovery() bool
+ 	selectedStl() string
+ 	baseModuleName() string
++	overrideLibraryName() string
+ 	getVndkExtendsModuleName() string
+ 	isAfdoCompile() bool
+ 	isPgoCompile() bool
+@@ -1598,6 +1599,10 @@ func (ctx *moduleContextImpl) baseModuleName() string {
+ 	return ctx.mod.ModuleBase.BaseModuleName()
+ }
+ 
++func (ctx *moduleContextImpl) overrideLibraryName() string {
++        return ctx.mod.ModuleBase.OverrideLibraryName()
++}
++
+ func (ctx *moduleContextImpl) getVndkExtendsModuleName() string {
+ 	return ctx.mod.getVndkExtendsModuleName()
+ }
+diff --git a/cc/library.go b/cc/library.go
+index f9bef6c5e..6d2f43935 100644
+--- a/cc/library.go
++++ b/cc/library.go
+@@ -1177,6 +1177,11 @@ func (library *libraryDecorator) getLibNameHelper(baseModuleName string, inVendo
+ // getLibName returns the actual canonical name of the library (the name which
+ // should be passed to the linker via linker flags).
+ func (library *libraryDecorator) getLibName(ctx BaseModuleContext) string {
++	// If an overrideLibraryName exists => this is a proxy library
++        // We must use the overrideLibraryName
++        if ctx.overrideLibraryName() != "" {
++               library.libName = ctx.overrideLibraryName()
++        }
+ 	name := library.getLibNameHelper(ctx.baseModuleName(), ctx.inVendor(), ctx.inProduct())
+ 
+ 	if ctx.IsVndkExt() {
+diff --git a/cc/vndk.go b/cc/vndk.go
+index bf6148b1c..ea3e2060c 100644
+--- a/cc/vndk.go
++++ b/cc/vndk.go
+@@ -698,6 +698,8 @@ func (c *vndkSnapshotSingleton) GenerateBuildActions(ctx android.SingletonContex
+ 		}
+ 
+ 		libPath := m.outputFile.Path()
++		qualifiedLibName := m.RelativeInstallPath()
++                qualifiedLibName = filepath.Join(qualifiedLibName, libPath.Base())
+ 		snapshotLibOut := filepath.Join(snapshotArchDir, targetArch, "shared", vndkType, libPath.Base())
+ 		ret = append(ret, snapshot.CopyFileRule(pctx, ctx, libPath, snapshotLibOut))
+ 
+-- 
+2.37.1
+


### PR DESCRIPTION
override_lib_name soong variable support is
required by IPP patch.

Tracked-On: OAM-103597
Signed-off-by: ahs <amrita.h.s@intel.com>