### PR TITLE
Fix i915 driver crash while system resume

### DIFF
--- a/bsp_diff/common/kernel/lts2019-chromium/72-0072-drm-i915-Factor-out-i915_ggtt_suspend_vm-i915_ggtt_r.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/72-0072-drm-i915-Factor-out-i915_ggtt_suspend_vm-i915_ggtt_r.patch
@@ -1,0 +1,143 @@
+From 360d423dea5670bb418631e9e460face2e8b80b3 Mon Sep 17 00:00:00 2001
+From: Imre Deak <imre.deak@intel.com>
+Date: Mon, 1 Nov 2021 20:35:50 +0200
+Subject: [PATCH] drm/i915: Factor out
+ i915_ggtt_suspend_vm/i915_ggtt_resume_vm()
+
+Factor out functions that are needed by the next patch to suspend/resume
+the memory mappings for DPT FBs.
+
+No functional change, except reordering during suspend the
+ggtt->invalidate(ggtt) call wrt. atomic_set(&ggtt->vm.open, open) and
+mutex_unlock(&ggtt->vm.mutex). This shouldn't matter due to the i915
+suspend sequence being single threaded.
+
+Cc: Chris Wilson <chris@chris-wilson.co.uk>
+Cc: Ville Syrjälä <ville.syrjala@linux.intel.com>
+Signed-off-by: Imre Deak <imre.deak@intel.com>
+Reviewed-by: Chris Wilson <chris@chris-wilson.co.uk>
+Reviewed-by: Ville Syrjälä <ville.syrjala@linux.intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20211101183551.3580546-1-imre.deak@intel.com
+---
+ drivers/gpu/drm/i915/gt/intel_ggtt.c | 58 ++++++++++++++++++++++------
+ drivers/gpu/drm/i915/gt/intel_gtt.h  |  2 +
+ 2 files changed, 49 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/gt/intel_ggtt.c b/drivers/gpu/drm/i915/gt/intel_ggtt.c
+index abc52d709757..5a35dca32f88 100644
+--- a/drivers/gpu/drm/i915/gt/intel_ggtt.c
++++ b/drivers/gpu/drm/i915/gt/intel_ggtt.c
+@@ -115,14 +115,28 @@ static bool needs_idle_maps(struct drm_i915_private *i915)
+ 	return false;
+ }
+
+-void i915_ggtt_suspend(struct i915_ggtt *ggtt)
++/**
++ * i915_ggtt_suspend_vm - Suspend the memory mappings for a GGTT or DPT VM
++ * @vm: The VM to suspend the mappings for
++ *
++ * Suspend the memory mappings for all objects mapped to HW via the GGTT or a
++ * DPT page table.
++ */
++void i915_ggtt_suspend_vm(struct i915_address_space *vm)
+ {
+ 	struct i915_vma *vma;
+
+-	list_for_each_entry(vma, &ggtt->vm.bound_list, vm_link)
++	drm_WARN_ON(&vm->i915->drm, !vm->is_ggtt);
++
++	list_for_each_entry(vma, &vm->bound_list, vm_link)
+ 		i915_vma_wait_for_bind(vma);
+
+-	ggtt->vm.clear_range(&ggtt->vm, 0, ggtt->vm.total);
++	vm->clear_range(vm, 0, vm->total);
++}
++
++void i915_ggtt_suspend(struct i915_ggtt *ggtt)
++{
++	i915_ggtt_suspend_vm(&ggtt->vm);
+ 	ggtt->invalidate(ggtt);
+
+ 	intel_gt_check_and_clear_faults(ggtt->vm.gt);
+@@ -1164,22 +1178,32 @@ void i915_ggtt_disable_guc(struct i915_ggtt *ggtt)
+ 	ggtt->invalidate(ggtt);
+ }
+
+-void i915_ggtt_resume(struct i915_ggtt *ggtt)
++/**
++ * i915_ggtt_resume_vm - Restore the memory mappings for a GGTT or DPT VM
++ * @vm: The VM to restore the mappings for
++ *
++ * Restore the memory mappings for all objects mapped to HW via the GGTT or a
++ * DPT page table.
++ *
++ * Returns %true if restoring the mapping for any object that was in a write
++ * domain before suspend.
++ */
++bool i915_ggtt_resume_vm(struct i915_address_space *vm)
+ {
+ 	struct i915_vma *vma;
+-	bool flush = false;
++	bool write_domain_objs = false;
+ 	int open;
+
+-	intel_gt_check_and_clear_faults(ggtt->vm.gt);
++	drm_WARN_ON(&vm->i915->drm, !vm->is_ggtt);
+
+ 	/* First fill our portion of the GTT with scratch pages */
+-	ggtt->vm.clear_range(&ggtt->vm, 0, ggtt->vm.total);
++	vm->clear_range(vm, 0, vm->total);
+
+ 	/* Skip rewriting PTE on VMA unbind. */
+-	open = atomic_xchg(&ggtt->vm.open, 0);
++	open = atomic_xchg(&vm->open, 0);
+
+ 	/* clflush objects bound into the GGTT and rebind them. */
+-	list_for_each_entry(vma, &ggtt->vm.bound_list, vm_link) {
++	list_for_each_entry(vma, &vm->bound_list, vm_link) {
+ 		struct drm_i915_gem_object *obj = vma->obj;
+
+ 		if (!i915_vma_is_bound(vma, I915_VMA_GLOBAL_BIND))
+@@ -1190,12 +1214,24 @@ void i915_ggtt_resume(struct i915_ggtt *ggtt)
+ 				      obj ? obj->cache_level : 0,
+ 				      PIN_GLOBAL, NULL));
+ 		if (obj) { /* only used during resume => exclusive access */
+-			flush |= fetch_and_zero(&obj->write_domain);
++			write_domain_objs |= fetch_and_zero(&obj->write_domain);
+ 			obj->read_domains |= I915_GEM_DOMAIN_GTT;
+ 		}
+ 	}
+
+-	atomic_set(&ggtt->vm.open, open);
++	atomic_set(&vm->open, open);
++
++	return write_domain_objs;
++}
++
++void i915_ggtt_resume(struct i915_ggtt *ggtt)
++{
++	bool flush;
++
++	intel_gt_check_and_clear_faults(ggtt->vm.gt);
++
++	flush = i915_ggtt_resume_vm(&ggtt->vm);
++
+ 	ggtt->invalidate(ggtt);
+
+ 	if (flush)
+diff --git a/drivers/gpu/drm/i915/gt/intel_gtt.h b/drivers/gpu/drm/i915/gt/intel_gtt.h
+index 9a185f4537e1..184820139aa6 100644
+--- a/drivers/gpu/drm/i915/gt/intel_gtt.h
++++ b/drivers/gpu/drm/i915/gt/intel_gtt.h
+@@ -512,6 +512,8 @@ int i915_ppgtt_init_hw(struct intel_gt *gt);
+
+ struct i915_ppgtt *i915_ppgtt_create(struct intel_gt *gt);
+
++void i915_ggtt_suspend_vm(struct i915_address_space *vm);
++bool i915_ggtt_resume_vm(struct i915_address_space *vm);
+ void i915_ggtt_suspend(struct i915_ggtt *gtt);
+ void i915_ggtt_resume(struct i915_ggtt *ggtt);
+
+--
+2.17.1
+

--- a/bsp_diff/common/kernel/lts2019-chromium/73-0073-drm-i915-Improve-on-suspend-resume-time-with-VT-d-en.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/73-0073-drm-i915-Improve-on-suspend-resume-time-with-VT-d-en.patch
@@ -1,0 +1,237 @@
+From c6e6dd3478460d67196dff584eaf027726307834 Mon Sep 17 00:00:00 2001
+From: Thomas HellstrÃ¶m <thomas.hellstrom@linux.intel.com>
+Date: Fri, 17 Jun 2022 17:28:55 +0200
+Subject: [PATCH] drm/i915: Improve on suspend / resume time with VT-d enabled
+
+When DMAR / VT-d is enabled, the display engine uses overfetching,
+presumably to deal with the increased latency. To avoid display engine
+errors and DMAR faults, as a workaround the GGTT is populated with scatch
+PTEs when VT-d is enabled. However starting with gen10, Write-combined
+writing of scratch PTES is no longer possible and as a result, populating
+the full GGTT with scratch PTEs like on resume becomes very slow as
+uncached access is needed.
+
+Therefore, on integrated GPUs utilize the fact that the PTEs are stored in
+stolen memory which retain content across S3 suspend. Don't clear the PTEs
+on suspend and resume. This improves on resume time with around 100 ms.
+While 100+ms might appear like a short time it's 10% to 20% of total resume
+time and important in some applications.
+
+One notable exception is Intel Rapid Start Technology which may cause
+stolen memory to be lost across what the OS percieves as S3 suspend.
+If IRST is enabled or if we can't detect whether IRST is enabled, retain
+the old workaround, clearing and re-instating PTEs.
+
+As an additional measure, if we detect that the last ggtt pte was lost
+during suspend, print a warning and re-populate the GGTT ptes
+
+On discrete GPUs, the display engine scans out from LMEM which isn't
+subject to DMAR, and presumably the workaround is therefore not needed,
+but that needs to be verified and disabling the workaround for dGPU,
+if possible, will be deferred to a follow-up patch.
+
+v2:
+- Rely on retained ptes to also speed up suspend and resume re-binding.
+- Re-build GGTT ptes if Intel rst is enabled.
+v3:
+- Re-build GGTT ptes also if we can't detect whether Intel rst is enabled,
+  and if the guard page PTE and end of GGTT was lost.
+v4:
+- Fix some kerneldoc issues (Matthew Auld), rebase.
+
+Signed-off-by: Thomas HellstrÃ¶m <thomas.hellstrom@linux.intel.com>
+Acked-by: Daniel Vetter <daniel.vetter@ffwll.ch>
+Reviewed-by: Matthew Auld <matthew.auld@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20220617152856.249295-1-thomas.hellstrom@linux.intel.com
+---
+ drivers/gpu/drm/i915/gt/intel_ggtt.c | 47 ++++++++++++++++++++++++++--
+ drivers/gpu/drm/i915/gt/intel_gtt.h  | 24 ++++++++++++++
+ drivers/gpu/drm/i915/i915_drv.c      | 16 ++++++++++
+ 3 files changed, 84 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/gt/intel_ggtt.c b/drivers/gpu/drm/i915/gt/intel_ggtt.c
+index 5a35dca32f88..83b998989949 100644
+--- a/drivers/gpu/drm/i915/gt/intel_ggtt.c
++++ b/drivers/gpu/drm/i915/gt/intel_ggtt.c
+@@ -20,6 +20,12 @@
+ static int
+ i915_get_ggtt_vma_pages(struct i915_vma *vma);
+
++static inline bool suspend_retains_ptes(struct i915_address_space *vm)
++{
++	return !HAS_LMEM(vm->i915) &&
++		vm->is_ggtt;
++}
++
+ static void i915_ggtt_color_adjust(const struct drm_mm_node *node,
+ 				   unsigned long color,
+ 				   u64 *start,
+@@ -115,6 +121,22 @@ static bool needs_idle_maps(struct drm_i915_private *i915)
+ 	return false;
+ }
+
++/*
++ * Return the value of the last GGTT pte cast to an u64, if
++ * the system is supposed to retain ptes across resume. 0 otherwise.
++ */
++static u64 read_last_pte(struct i915_address_space *vm)
++{
++	struct i915_ggtt *ggtt = i915_vm_to_ggtt(vm);
++	gen8_pte_t __iomem *ptep;
++
++	if (!suspend_retains_ptes(vm))
++		return 0;
++
++	ptep = (typeof(ptep))ggtt->gsm + (ggtt_total_entries(ggtt) - 1);
++	return readq(ptep);
++}
++
+ /**
+  * i915_ggtt_suspend_vm - Suspend the memory mappings for a GGTT or DPT VM
+  * @vm: The VM to suspend the mappings for
+@@ -131,7 +153,10 @@ void i915_ggtt_suspend_vm(struct i915_address_space *vm)
+ 	list_for_each_entry(vma, &vm->bound_list, vm_link)
+ 		i915_vma_wait_for_bind(vma);
+
+-	vm->clear_range(vm, 0, vm->total);
++	if (!suspend_retains_ptes(vm))
++		vm->clear_range(vm, 0, vm->total);
++	else
++		i915_vm_to_ggtt(vm)->probed_pte = read_last_pte(vm);
+ }
+
+ void i915_ggtt_suspend(struct i915_ggtt *ggtt)
+@@ -504,6 +529,8 @@ static int init_ggtt(struct i915_ggtt *ggtt)
+ 	struct drm_mm_node *entry;
+ 	int ret;
+
++	ggtt->pte_lost = true;
++
+ 	/*
+ 	 * GuC requires all resources that we're sharing with it to be placed in
+ 	 * non-WOPCM memory. If GuC is not present or not in use we still need a
+@@ -1193,11 +1220,20 @@ bool i915_ggtt_resume_vm(struct i915_address_space *vm)
+ 	struct i915_vma *vma;
+ 	bool write_domain_objs = false;
+ 	int open;
++	bool retained_ptes;
+
+ 	drm_WARN_ON(&vm->i915->drm, !vm->is_ggtt);
+
+-	/* First fill our portion of the GTT with scratch pages */
+-	vm->clear_range(vm, 0, vm->total);
++	/*
++	 * First fill our portion of the GTT with scratch pages if
++	 * they were not retained across suspend.
++	 */
++	retained_ptes = suspend_retains_ptes(vm) &&
++		!i915_vm_to_ggtt(vm)->pte_lost &&
++		!GEM_WARN_ON(i915_vm_to_ggtt(vm)->probed_pte != read_last_pte(vm));
++
++	if (!retained_ptes)
++		vm->clear_range(vm, 0, vm->total);
+
+ 	/* Skip rewriting PTE on VMA unbind. */
+ 	open = atomic_xchg(&vm->open, 0);
+@@ -1493,3 +1529,8 @@ i915_get_ggtt_vma_pages(struct i915_vma *vma)
+ 	}
+ 	return ret;
+ }
++
++void i915_ggtt_mark_pte_lost(struct drm_i915_private *i915, bool val)
++{
++	(&i915->gt)->ggtt->pte_lost = val;
++}
+diff --git a/drivers/gpu/drm/i915/gt/intel_gtt.h b/drivers/gpu/drm/i915/gt/intel_gtt.h
+index 184820139aa6..e9d6099d599e 100644
+--- a/drivers/gpu/drm/i915/gt/intel_gtt.h
++++ b/drivers/gpu/drm/i915/gt/intel_gtt.h
+@@ -323,6 +323,19 @@ struct i915_ggtt {
+
+ 	bool do_idle_maps;
+
++	/**
++	 * @pte_lost: Are ptes lost on resume?
++	 *
++	 * Whether the system was recently restored from hibernate and
++	 * thus may have lost pte content.
++	 */
++	bool pte_lost;
++
++	/**
++	 * @probed_pte: Probed pte value on suspend. Re-checked on resume.
++	 */
++	u64 probed_pte;
++
+ 	int mtrr;
+
+ 	/** Bit 6 swizzling required for X tiling */
+@@ -522,6 +535,17 @@ void cleanup_page_dma(struct i915_address_space *vm, struct i915_page_dma *p);
+
+ #define kmap_atomic_px(px) kmap_atomic(px_base(px)->page)
+
++/**
++ * i915_ggtt_mark_pte_lost - Mark ggtt ptes as lost or clear such a marking
++ * @i915 The device private.
++ * @val whether the ptes should be marked as lost.
++ *
++ * In some cases pte content is retained across suspend, but typically lost
++ * across hibernate. Typically they should be marked as lost on
++ * hibernation restore and such marking cleared on suspend.
++ */
++void i915_ggtt_mark_pte_lost(struct drm_i915_private *i915, bool val);
++
+ void
+ fill_page_dma(const struct i915_page_dma *p, const u64 val, unsigned int count);
+
+diff --git a/drivers/gpu/drm/i915/i915_drv.c b/drivers/gpu/drm/i915/i915_drv.c
+index e8685e99633f..7934bb459ded 100644
+--- a/drivers/gpu/drm/i915/i915_drv.c
++++ b/drivers/gpu/drm/i915/i915_drv.c
+@@ -84,6 +84,9 @@
+ #include "intel_memory_region.h"
+ #include "intel_pm.h"
+
++/* Intel Rapid Start Technology ACPI device name */
++static const char irst_name[] = "INT3392";
++
+ static struct drm_driver driver;
+
+ struct vlv_s0ix_state {
+@@ -2047,6 +2050,8 @@ static int i915_pm_suspend(struct device *kdev)
+ 		return -ENODEV;
+ 	}
+
++	i915_ggtt_mark_pte_lost(i915, false);
++
+ 	if (i915->drm.switch_power_state == DRM_SWITCH_POWER_OFF)
+ 		return 0;
+
+@@ -2099,6 +2104,14 @@ static int i915_pm_resume(struct device *kdev)
+ 	if (i915->drm.switch_power_state == DRM_SWITCH_POWER_OFF)
+ 		return 0;
+
++	/*
++	 * If IRST is enabled, or if we can't detect whether it's enabled,
++	 * then we must assume we lost the GGTT page table entries, since
++	 * they are not retained if IRST decided to enter S4.
++	 */
++	if (!IS_ENABLED(CONFIG_ACPI) || acpi_dev_present(irst_name, NULL, -1))
++		i915_ggtt_mark_pte_lost(i915, true);
++
+ 	return i915_drm_resume(&i915->drm);
+ }
+
+@@ -2158,6 +2171,9 @@ static int i915_pm_restore_early(struct device *kdev)
+
+ static int i915_pm_restore(struct device *kdev)
+ {
++	struct drm_i915_private *i915 = kdev_to_i915(kdev);
++
++	i915_ggtt_mark_pte_lost(i915, true);
+ 	return i915_pm_resume(kdev);
+ }
+
+--
+2.17.1
+


### PR DESCRIPTION
Cherry-pick 2 i915 patches from Patchwork Intel GFX

1.drm/i915: Factor out i915_ggtt_suspend_vm/i915_ggtt_resume_vm()
https://patchwork.freedesktop.org/patch/461948/

2.drm/i915: Improve on suspend / resume time with VT-d enabled
https://patchwork.freedesktop.org/series/102187/

Tracked-On: OAM-103652
Signed-off-by: Zhuo Peng <zhuo.peng@intel.com>