### PR TITLE
Enable volume up/down functionality for ALC711 codec

### DIFF
--- a/bsp_diff/common/kernel/lts2020-chromium/43_0043-Enable-volume-up-down-functionality-for-ALC711-codec.patch
+++ b/bsp_diff/common/kernel/lts2020-chromium/43_0043-Enable-volume-up-down-functionality-for-ALC711-codec.patch
@@ -1,0 +1,63 @@
+From 5ceb474657bee8e44b03d8654fa5aa9ee87952f9 Mon Sep 17 00:00:00 2001
+From: pmandri <padmashree.mandri@intel.com>
+Date: Tue, 30 Aug 2022 17:38:30 +0530
+Subject: [PATCH] Enable volume up/down functionality for ALC711 codec
+
+This change enables volume up/down button functionality
+for 3.5mm headset, with ALC711 codec.
+
+Tracked-On: OAM-102723
+Signed-off-by: Pshou <pshou@realtek.com>
+Signed-off-by: pmandri <padmashree.mandri@intel.com>
+---
+ sound/pci/hda/patch_realtek.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/sound/pci/hda/patch_realtek.c b/sound/pci/hda/patch_realtek.c
+index ee253efb0ad2..5b306d5a0f34 100644
+--- a/sound/pci/hda/patch_realtek.c
++++ b/sound/pci/hda/patch_realtek.c
+@@ -3235,6 +3235,7 @@ static void alc_disable_headset_jack_key(struct hda_codec *codec)
+ 	case 0x10ec0295:
+ 	case 0x10ec0289:
+ 	case 0x10ec0299:
++	case 0x10ec0711:
+ 		alc_write_coef_idx(codec, 0x48, 0x0);
+ 		alc_update_coef_idx(codec, 0x49, 0x0045, 0x0);
+ 		alc_update_coef_idx(codec, 0x44, 0x0045 << 8, 0x0);
+@@ -3263,6 +3264,7 @@ static void alc_enable_headset_jack_key(struct hda_codec *codec)
+ 	case 0x10ec0295:
+ 	case 0x10ec0289:
+ 	case 0x10ec0299:
++	case 0x10ec0711:
+ 		alc_write_coef_idx(codec, 0x48, 0xd011);
+ 		alc_update_coef_idx(codec, 0x49, 0x007f, 0x0045);
+ 		alc_update_coef_idx(codec, 0x44, 0x007f << 8, 0x0045 << 8);
+@@ -6332,7 +6334,6 @@ static void alc295_fixup_chromebook(struct hda_codec *codec,
+ 				    const struct hda_fixup *fix, int action)
+ {
+ 	struct alc_spec *spec = codec->spec;
+-
+ 	switch (action) {
+ 	case HDA_FIXUP_ACT_PRE_PROBE:
+ 		spec->ultra_low_power = true;
+@@ -8851,6 +8852,8 @@ static const struct snd_pci_quirk alc269_fixup_tbl[] = {
+ 	SND_PCI_QUIRK(0x10ec, 0x1230, "Intel Reference board", ALC295_FIXUP_CHROME_BOOK),
+ 	SND_PCI_QUIRK(0x10ec, 0x1252, "Intel Reference board", ALC295_FIXUP_CHROME_BOOK),
+ 	SND_PCI_QUIRK(0x10ec, 0x1254, "Intel Reference board", ALC295_FIXUP_CHROME_BOOK),
++	SND_PCI_QUIRK(0x10ec, 0x1274, "Intel Reference board", ALC295_FIXUP_CHROME_BOOK),
++	SND_PCI_QUIRK(0x10ec, 0x127e, "Intel Reference board", ALC295_FIXUP_CHROME_BOOK),
+ 	SND_PCI_QUIRK(0x10f7, 0x8338, "Panasonic CF-SZ6", ALC269_FIXUP_HEADSET_MODE),
+ 	SND_PCI_QUIRK(0x144d, 0xc109, "Samsung Ativ book 9 (NP900X3G)", ALC269_FIXUP_INV_DMIC),
+ 	SND_PCI_QUIRK(0x144d, 0xc169, "Samsung Notebook 9 Pen (NP930SBE-K01US)", ALC298_FIXUP_SAMSUNG_HEADPHONE_VERY_QUIET),
+@@ -9867,6 +9870,7 @@ static int patch_alc269(struct hda_codec *codec)
+ 		spec->codec_variant = ALC269_TYPE_ALC700;
+ 		spec->gen.mixer_nid = 0; /* ALC700 does not have any loopback mixer path */
+ 		alc_update_coef_idx(codec, 0x4a, 1 << 15, 0); /* Combo jack auto trigger control */
++		alc_update_coef_idx(codec, 0x47, 1 << 2, 1 << 2);
+ 		spec->init_hook = alc294_init;
+ 		break;
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
This change enables volume up/down button functionality
for 3.5mm headset, with ALC711 codec.

Tracked-On: OAM-102723
Signed-off-by: Pshou <pshou@realtek.com>
Signed-off-by: pmandri <padmashree.mandri@intel.com>