### PR TITLE
Enable dynamic cache config

### DIFF
--- a/aosp_diff/preliminary/build/soong/0010-Allow-build-commands-to-make-Celadon-as-ISO-format-i.patch
+++ b/aosp_diff/preliminary/build/soong/0010-Allow-build-commands-to-make-Celadon-as-ISO-format-i.patch
@@ -1,26 +1,29 @@
-From 0c110957ffbc563f1f7c5531695987af7e35bba2 Mon Sep 17 00:00:00 2001
+From 27c50bb7854aa9fbd714bb09d958b55e86671c1b Mon Sep 17 00:00:00 2001
 From: "Chen, Gang G" <gang.g.chen@intel.com>
 Date: Wed, 6 Jul 2022 18:15:36 +0800
-Subject: [PATCH] Allow sgdisk and mmd to make USB disk installer image
+Subject: [PATCH] Allow build commands to make Celadon as ISO format image
 
-Sgdisk command is used to make GPT bootable images
-
+Tracked-On: OAM-OAM-103806
 Signed-off-by: Chen, Gang G <gang.g.chen@intel.com>
 ---
- ui/build/paths/config.go | 3 +++
- 1 file changed, 3 insertions(+)
+ ui/build/paths/config.go | 7 +++++++
+ 1 file changed, 7 insertions(+)
 
 diff --git a/ui/build/paths/config.go b/ui/build/paths/config.go
-index 3ddd25ada..7aac20890 100644
+index 3ddd25ada..ae628199d 100644
 --- a/ui/build/paths/config.go
 +++ b/ui/build/paths/config.go
-@@ -99,6 +99,9 @@ var Configuration = map[string]PathConfig{
+@@ -99,6 +99,13 @@ var Configuration = map[string]PathConfig{
         "repo":    Allowed,
         "mkdosfs": Allowed,
         "mcopy":   Allowed,
 +       "mmd":     Allowed,
 +       "sgdisk":  Allowed,
 +       "split":   Allowed,
++       "mkisofs":   Allowed,
++       "isohybrid":   Allowed,
++       "xorriso":   Allowed,
++       "zcat":   Allowed,
         "x86_64-linux-androidkernel-as": Allowed,
         "x86_64-linux-androidkernel-ld": Allowed,
         "file":    Allowed,


### PR DESCRIPTION
This patch reads cache info from CPU.
Cache info is used in memory and string functions.

Signed-off-by: Vinay Prasad Kompella <vinay.kompella@intel.com>