### PR TITLE
Moving Thermal Diff patch from BSP to AOSP diff

### DIFF
--- a/aosp_diff/preliminary/hardware/interfaces/10_0010-Fix-for-VTS-issue-in-thermal.patch
+++ b/aosp_diff/preliminary/hardware/interfaces/10_0010-Fix-for-VTS-issue-in-thermal.patch
@@ -1,0 +1,27 @@
+From 90b93b6b58e6b6cfd293ecccd69c1119ff38634e Mon Sep 17 00:00:00 2001
+From: gkdeepa <g.k.deepa@intel.com>
+Date: Tue, 27 Jul 2021 09:31:51 +0530
+Subject: [PATCH] Fix for VTS issue in thermal
+
+Removing the thermal 1.0 HAL interface from 2.0
+service.
+
+Tracked-On: OAM-97800
+Signed-off-by: Deepa g.k.deepa@intel.com
+---
+ thermal/2.0/default/android.hardware.thermal@2.0-service.rc | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/thermal/2.0/default/android.hardware.thermal@2.0-service.rc b/thermal/2.0/default/android.hardware.thermal@2.0-service.rc
+index 4ff8bd69e..046c77176 100644
+--- a/thermal/2.0/default/android.hardware.thermal@2.0-service.rc
++++ b/thermal/2.0/default/android.hardware.thermal@2.0-service.rc
+@@ -1,5 +1,4 @@
+ service vendor.thermal-hal-2-0-mock /vendor/bin/hw/android.hardware.thermal@2.0-service.mock
+-    interface android.hardware.thermal@1.0::IThermal default
+     interface android.hardware.thermal@2.0::IThermal default
+     class hal
+     user system
+-- 
+2.17.1
+


### PR DESCRIPTION
To Keep the source directory cleaner and
more readable above mentioned movement
of diff patch is done.

Tracked-On: OAM-103812
Signed-off-by: Vilas R K <vilas.r.k@intel.com>