### PR TITLE
Fix volume up/down button issue with 3.5mm

### DIFF
--- a/bsp_diff/common/kernel/lts2020-chromium/43_0043-Fix-volume-up-down-button-issue-with-3.5mm.patch
+++ b/bsp_diff/common/kernel/lts2020-chromium/43_0043-Fix-volume-up-down-button-issue-with-3.5mm.patch
@@ -1,0 +1,38 @@
+From 4d356ada7e3b8802d29b118d95a29bf1b281ff2e Mon Sep 17 00:00:00 2001
+From: pmandri <padmashree.mandri@intel.com>
+Date: Wed, 7 Sep 2022 16:33:19 +0530
+Subject: [PATCH] Fix volume up/down button issue with 3.5mm
+
+This patches resolves volume up/down button
+not working issue, when no music is playing.
+
+Tracked-On: OAM-102723
+Signed-off-by: Pshou <pshou@realtek.com>
+Signed-off-by: pmandri <padmashree.mandri@intel.com>
+---
+ sound/pci/hda/patch_realtek.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/sound/pci/hda/patch_realtek.c b/sound/pci/hda/patch_realtek.c
+index 9c5827ad5b24..9467f1d166b8 100644
+--- a/sound/pci/hda/patch_realtek.c
++++ b/sound/pci/hda/patch_realtek.c
+@@ -8853,6 +8853,7 @@ static const struct snd_pci_quirk alc269_fixup_tbl[] = {
+ 	SND_PCI_QUIRK(0x10ec, 0x1230, "Intel Reference board", ALC295_FIXUP_CHROME_BOOK),
+ 	SND_PCI_QUIRK(0x10ec, 0x1252, "Intel Reference board", ALC295_FIXUP_CHROME_BOOK),
+ 	SND_PCI_QUIRK(0x10ec, 0x1254, "Intel Reference board", ALC295_FIXUP_CHROME_BOOK),
++	SND_PCI_QUIRK(0x10ec, 0x1274, "Intel Reference board", ALC295_FIXUP_CHROME_BOOK),
+ 	SND_PCI_QUIRK(0x10ec, 0x127e, "Intel Reference board", ALC295_FIXUP_CHROME_BOOK),
+ 	SND_PCI_QUIRK(0x10f7, 0x8338, "Panasonic CF-SZ6", ALC269_FIXUP_HEADSET_MODE),
+ 	SND_PCI_QUIRK(0x144d, 0xc109, "Samsung Ativ book 9 (NP900X3G)", ALC269_FIXUP_INV_DMIC),
+@@ -9870,6 +9871,7 @@ static int patch_alc269(struct hda_codec *codec)
+ 		spec->codec_variant = ALC269_TYPE_ALC700;
+ 		spec->gen.mixer_nid = 0; /* ALC700 does not have any loopback mixer path */
+ 		alc_update_coef_idx(codec, 0x4a, 1 << 15, 0); /* Combo jack auto trigger control */
++		alc_update_coef_idx(codec, 0x47, 1 << 2, 1 << 2);
+ 		spec->init_hook = alc294_init;
+ 		break;
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
This patches resolves volume up/down button
not working issue, when no music is playing.

Tracked-On: OAM-102723
Signed-off-by: Pshou <pshou@realtek.com>
Signed-off-by: pmandri <padmashree.mandri@intel.com>