### PR TITLE
kernel: Update build script with latest commit hash for 5.15.44

### DIFF
--- a/host/kernel/lts2021-chromium/build_weekly.sh
+++ b/host/kernel/lts2021-chromium/build_weekly.sh
@@ -5,7 +5,7 @@ mkdir -p host_kernel
 cd host_kernel
 git clone https://github.com/projectceladon/linux-intel-lts2021-chromium.git
 cd linux-intel-lts2021-chromium
-git checkout 6dda9a5b0c342d16e4cde6fab186a89595de5095
+git checkout 3c7852fc6d88bfff414f790113249b12030f30ce
 cp ../../x86_64_defconfig .config
 patch_list=`find ../../ -iname "*.patch" | sort -u`
 for i in $patch_list


### PR DESCRIPTION
Updated SHA ID in build script to point to 5.15.44 kernel commit.

Tracked-On: OAM-103751
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>