### PR TITLE
kernel: Fix patch conflict and build script issues

### DIFF
--- a/host/kernel/lts2021-chromium/0005-Fix-device-hang-on-TGL-RVP.patch
+++ b/host/kernel/lts2021-chromium/0005-Fix-device-hang-on-TGL-RVP.patch
@@ -1,23 +1,25 @@
-From 986ba0ec0d1fb4a08d13e111b1572d8a7230ddc5 Mon Sep 17 00:00:00 2001
+From 7799d4b81e0e9bfd417a661f1a346ec126d12448 Mon Sep 17 00:00:00 2001
 From: renchenglei <chenglei.ren@intel.com>
 Date: Tue, 2 Mar 2021 21:25:21 +0800
 Subject: [PATCH] Fix device hang on TGL RVP
 
 This change is to help fix device hang on TGL
 RVP when launch GVT-d
+
+Signed-off-by: Ren, Chenglei <chenglei.ren@intel.com>
 ---
  drivers/pci/quirks.c | 45 ++++++++++++++++++++++++++++++++++++++++++++
  1 file changed, 45 insertions(+)
 
 diff --git a/drivers/pci/quirks.c b/drivers/pci/quirks.c
-index 0443c28bab4b..1cf482b66015 100644
+index 0443c28bab4b..73c2c400c470 100644
 --- a/drivers/pci/quirks.c
 +++ b/drivers/pci/quirks.c
 @@ -4048,6 +4048,50 @@ static int reset_hinic_vf_dev(struct pci_dev *pdev, bool probe)
  	return 0;
  }
  
-+static int set_gmbus_and_flr(struct pci_dev *dev, int probe)
++static int set_gmbus_and_flr(struct pci_dev *dev, bool probe)
 +{
 +	void __iomem *bar;
 +	const u32 PCH_GMBUS0 = 0xc5100;
@@ -26,7 +28,7 @@ index 0443c28bab4b..1cf482b66015 100644
 +	u32 gmbus_rd2;
 +	u16 cmd;
 +
-+	if (!pcie_has_flr(dev))
++	if (pcie_reset_flr(dev, PCI_RESET_PROBE))
 +		return -ENOTTY;
 +
 +	if (probe)
@@ -73,5 +75,5 @@ index 0443c28bab4b..1cf482b66015 100644
  	{ PCI_VENDOR_ID_INTEL, 0x0a54, delay_250ms_after_flr },
  	{ PCI_VENDOR_ID_CHELSIO, PCI_ANY_ID,
 -- 
-2.17.1
+2.35.1
 

--- a/host/kernel/lts2021-chromium/build_weekly.sh
+++ b/host/kernel/lts2021-chromium/build_weekly.sh
@@ -3,11 +3,15 @@
 rm -rf host_kernel
 mkdir -p host_kernel
 cd host_kernel
+git clone https://github.com/projectceladon/vendor-intel-utils.git
+cd vendor-intel-utils
+git checkout 7507c2fa8b6b548e3889b4c5fc32d5511a8af07e
+cd ../
 git clone https://github.com/projectceladon/linux-intel-lts2021-chromium.git
 cd linux-intel-lts2021-chromium
-git checkout 3c7852fc6d88bfff414f790113249b12030f30ce
-cp ../../x86_64_defconfig .config
-patch_list=`find ../../ -iname "*.patch" | sort -u`
+git checkout 94ca6268827aa5389b6e560dbed0b79f537b8f59
+cp ../vendor-intel-utils/host/kernel/lts2021-chromium/x86_64_defconfig .config
+patch_list=`find  ../vendor-intel-utils/host/kernel/lts2021-chromium -iname "*.patch" | sort -u`
 for i in $patch_list
 do
   a=`grep "Date: " $i`


### PR DESCRIPTION
With the latest 5.15 kernel + host kernel diff patches, build error is seen due to change in function prototype. Also, build script expects the user to clone vendor-intel-utils project for it to work.

Fix the build error and also modify the script so one can compile by downloading the build script alone.

Tracked-On: OAM-103824
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>