### PR TITLE
[bsp_diff:kernel/ACPI]: add bsp diff patch

### DIFF
--- a/bsp_diff/common/kernel/lts2021-chromium/20_0020-ACPI-PM-Propagate-power-button-event-to-user-space-w.patch
+++ b/bsp_diff/common/kernel/lts2021-chromium/20_0020-ACPI-PM-Propagate-power-button-event-to-user-space-w.patch
@@ -1,0 +1,74 @@
+From 10df525cb1eff8d7c326f6a9283c01ecaeafc9a0 Mon Sep 17 00:00:00 2001
+From: Kaushlendra Kumar <kaushlendra.kumar@intel.com>
+Date: Fri, 22 Apr 2022 14:38:58 +0530
+Subject: [PATCH] ACPI/PM: Propagate power button event to user space when
+ device wakes up
+
+Sometimes power button does not wake up the systemm, we get suspends
+event
+right after that. here Android needs to see KEY_POWER at resume.
+Otherwise, its
+opportunistic suspend will kick in shortly.
+
+However, other OS such as Ubuntu doesn't like KEY_POWER at resume. So
+add a knob "/sys/module/button/parameters/key_power_at_resume" for users
+to select.
+
+Tracked-On: OAM-101964
+Signed-off-by: Kaushlendra Kumar <kaushlendra.kumar@intel.com>
+---
+ drivers/acpi/button.c | 6 +++++-
+ drivers/acpi/sleep.c  | 6 ++++++
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/acpi/button.c b/drivers/acpi/button.c
+index 0d93a5ef4d07..db849acbaabf 100644
+--- a/drivers/acpi/button.c
++++ b/drivers/acpi/button.c
+@@ -40,6 +40,10 @@
+ #define ACPI_BUTTON_DEVICE_NAME_LID	"Lid Switch"
+ #define ACPI_BUTTON_TYPE_LID		0x05
+ 
++/* does userspace want to see KEY_POWER at resume? */
++static bool __read_mostly key_power_at_resume = true;
++module_param(key_power_at_resume, bool, 0644);
++
+ enum {
+ 	ACPI_BUTTON_LID_INIT_IGNORE,
+ 	ACPI_BUTTON_LID_INIT_OPEN,
+@@ -417,7 +421,7 @@ static void acpi_button_notify(struct acpi_device *device, u32 event)
+ 			int keycode;
+ 
+ 			acpi_pm_wakeup_event(&device->dev);
+-			if (button->suspended)
++			if (button->suspended && !key_power_at_resume)
+ 				break;
+ 
+ 			keycode = test_bit(KEY_SLEEP, input->keybit) ?
+diff --git a/drivers/acpi/sleep.c b/drivers/acpi/sleep.c
+index aae35872d851..64ba310bf3f7 100644
+--- a/drivers/acpi/sleep.c
++++ b/drivers/acpi/sleep.c
+@@ -442,6 +442,11 @@ static int acpi_pm_prepare(void)
+ 	return error;
+ }
+ 
++static void pwr_btn_notify(struct acpi_device *device)
++{
++	device->driver->ops.notify(device, ACPI_FIXED_HARDWARE_EVENT);
++}
++
+ /**
+  *	acpi_pm_finish - Instruct the platform to leave a sleep state.
+  *
+@@ -485,6 +490,7 @@ static void acpi_pm_finish(void)
+ 						    NULL, -1);
+ 	if (pwr_btn_adev) {
+ 		pm_wakeup_event(&pwr_btn_adev->dev, 0);
++		pwr_btn_notify(pwr_btn_adev);
+ 		acpi_dev_put(pwr_btn_adev);
+ 	}
+ }
+-- 
+2.33.0
+


### PR DESCRIPTION
Add bsp_diff patch in kernel to propagate power button event to user space.

Tracked-On: OAM-103826
Signed-off-by: kaushlendra <kaushlendra.kumar@intel.com>