### PR TITLE
Fix phone process crash when there is no modem

### DIFF
--- a/aosp_diff/preliminary/packages/services/Telephony/01_0001-Fix-phone-process-crash-when-there-is-no-modem.patch
+++ b/aosp_diff/preliminary/packages/services/Telephony/01_0001-Fix-phone-process-crash-when-there-is-no-modem.patch
@@ -1,0 +1,53 @@
+From c3b379595bb2c784f064c5ee7b235a099e9d6f28 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Mon, 12 Sep 2022 09:06:16 +0530
+Subject: [PATCH] Fix phone process crash when there is no modem
+
+Phone process keeps crashing with ArrayIndexOutOfBoundsException
+exception.
+
+When there is no modem, tm.getSupportedModemCount returns 0.
+mTelephonyCallbacks object array is created with 0 but index 1 is
+accessed resulting in ArrayIndexOutOfBoundsException exception.
+
+Fix the issue by allocating and accessing mTelephonyCallbacks only
+when tm.getSupportedModemCount is greater than 0.
+
+Tracked-On: OAM-103825
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ src/com/android/phone/PhoneGlobals.java | 18 ++++++++++--------
+ 1 file changed, 10 insertions(+), 8 deletions(-)
+
+diff --git a/src/com/android/phone/PhoneGlobals.java b/src/com/android/phone/PhoneGlobals.java
+index 99e73ff9f..5a5a686b7 100644
+--- a/src/com/android/phone/PhoneGlobals.java
++++ b/src/com/android/phone/PhoneGlobals.java
+@@ -548,14 +548,16 @@ public class PhoneGlobals extends ContextWrapper {
+             PhoneConfigurationManager.registerForMultiSimConfigChange(
+                     mHandler, EVENT_MULTI_SIM_CONFIG_CHANGED, null);
+ 
+-            mTelephonyCallbacks = new PhoneAppCallback[tm.getSupportedModemCount()];
+-
+-            for (Phone phone : PhoneFactory.getPhones()) {
+-                int subId = phone.getSubId();
+-                PhoneAppCallback callback = new PhoneAppCallback(subId);
+-                tm.createForSubscriptionId(subId).registerTelephonyCallback(
+-                        TelephonyManager.INCLUDE_LOCATION_DATA_NONE, mHandler::post, callback);
+-                mTelephonyCallbacks[phone.getPhoneId()] = callback;
++            if (tm.getSupportedModemCount() > 0) {
++                mTelephonyCallbacks = new PhoneAppCallback[tm.getSupportedModemCount()];
++
++                for (Phone phone : PhoneFactory.getPhones()) {
++                    int subId = phone.getSubId();
++                    PhoneAppCallback callback = new PhoneAppCallback(subId);
++                    tm.createForSubscriptionId(subId).registerTelephonyCallback(
++                            TelephonyManager.INCLUDE_LOCATION_DATA_NONE, mHandler::post, callback);
++                    mTelephonyCallbacks[phone.getPhoneId()] = callback;
++                }
+             }
+ 
+             mCarrierVvmPackageInstalledReceiver.register(this);
+-- 
+2.35.1
+


### PR DESCRIPTION
Phone process keeps crashing with ArrayIndexOutOfBoundsException exception.

When there is no modem, tm.getSupportedModemCount returns 0. mTelephonyCallbacks object array is created with 0 but index 1 is accessed resulting in ArrayIndexOutOfBoundsException exception.

Fix the issue by allocating and accessing mTelephonyCallbacks only when tm.getSupportedModemCount is greater than 0.

Tracked-On: OAM-103825
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>