### PR TITLE
kernel: Fix host kernel build issue

### DIFF
--- a/host/kernel/lts2021-chromium/build_weekly.sh
+++ b/host/kernel/lts2021-chromium/build_weekly.sh
@@ -5,7 +5,7 @@ mkdir -p host_kernel
 cd host_kernel
 git clone https://github.com/projectceladon/vendor-intel-utils.git
 cd vendor-intel-utils
-git checkout 7507c2fa8b6b548e3889b4c5fc32d5511a8af07e
+git checkout 7d246edc3370d823194d2306ca2a484568dea75e
 cd ../
 git clone https://github.com/projectceladon/linux-intel-lts2021-chromium.git
 cd linux-intel-lts2021-chromium


### PR DESCRIPTION
Host kernel build fails with implicit declaration of function ‘pcie_has_flr’ error.

Updated SHA ID in build script to point to vendor/intel/utils commit hash having the correct diff patch. Commit hash corresponds to "kernel: Fix patch conflict and build script issues" commit.

Tracked-On: OAM-103945
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>