### PR TITLE
Update VIRTIO_ID_TRUSTY_IPC from 13 to 14

### DIFF
--- a/bsp_diff/common/kernel/lts2020-yocto/50_0050-Update-VIRTIO_ID_TRUSTY_IPC-from-13-to-14.patch
+++ b/bsp_diff/common/kernel/lts2020-yocto/50_0050-Update-VIRTIO_ID_TRUSTY_IPC-from-13-to-14.patch
@@ -1,0 +1,30 @@
+From a14bc95f6455ac1a922c7ca88baec0d553090c33 Mon Sep 17 00:00:00 2001
+From: HeYue <yue.he@intel.com>
+Date: Tue, 20 Sep 2022 13:42:08 +0800
+Subject: [PATCH] Update VIRTIO_ID_TRUSTY_IPC from 13 to 14
+
+VIRTIO ID 13 is assigned to MEMORY BALLON from kernel 5.15, in order
+to avoid conflict on VIRTIO ID assignment, update ID for TRUSTY_IPC
+device from 13 to 14.
+
+Signed-off-by: Zhong,Fangjian <fangjian.zhong@intel.com>
+---
+ include/uapi/linux/virtio_ids.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/uapi/linux/virtio_ids.h b/include/uapi/linux/virtio_ids.h
+index cf6b95d9a1ec..9b97df4d7743 100644
+--- a/include/uapi/linux/virtio_ids.h
++++ b/include/uapi/linux/virtio_ids.h
+@@ -39,7 +39,7 @@
+ #define VIRTIO_ID_9P		9 /* 9p virtio console */
+ #define VIRTIO_ID_RPROC_SERIAL 11 /* virtio remoteproc serial link */
+ #define VIRTIO_ID_CAIF	       12 /* Virtio caif */
+-#define VIRTIO_ID_TRUSTY_IPC   13 /* virtio trusty ipc */
++#define VIRTIO_ID_TRUSTY_IPC   14 /* virtio trusty ipc */
+ #define VIRTIO_ID_GPU          16 /* virtio GPU */
+ #define VIRTIO_ID_INPUT        18 /* virtio input */
+ #define VIRTIO_ID_VSOCK        19 /* virtio vsock transport */
+-- 
+2.17.1
+


### PR DESCRIPTION
VIRTIO ID 13 is assigned to MEMORY BALLON from kernel 5.15, in order to avoid conflict on VIRTIO ID assignment, update ID for TRUSTY_IPC device from 13 to 14.

Tracked-On: OAM-103995
Signed-off-by: HeYue <yue.he@intel.com>