### PR TITLE
Fix drawing delay issue in cases of resize and rotation for SRIOV

### DIFF
--- a/host/qemu/0008-Fix-drawing-delay-issue-in-cases-of-resize-and-rotat.patch
+++ b/host/qemu/0008-Fix-drawing-delay-issue-in-cases-of-resize-and-rotat.patch
@@ -1,0 +1,36 @@
+From 27337b953941c8cf4228da74135005b97358a62b Mon Sep 17 00:00:00 2001
+From: Lu Yang A <yang.a.lu@intel.com>
+Date: Thu, 22 Sep 2022 17:12:27 +0800
+Subject: [PATCH] Fix drawing delay issue in cases of resize and rotation for
+ SRIOV
+
+gd_egl_draw does not flush anything when draw_submitted=false, this
+includes the cases of resize and rotation, so add one time flush to
+fix it.
+
+Tracked-On: OAM-104047
+Signed-off-by: Lu Yang A <yang.a.lu@intel.com>
+---
+ ui/gtk-egl.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/ui/gtk-egl.c b/ui/gtk-egl.c
+index 3dce3b6aa9..7bc3f41bd9 100644
+--- a/ui/gtk-egl.c
++++ b/ui/gtk-egl.c
+@@ -80,6 +80,12 @@ void gd_egl_draw(VirtualConsole *vc)
+ #ifdef CONFIG_GBM
+         if (dmabuf) {
+             if (!dmabuf->draw_submitted) {
++                gd_egl_scanout_flush(&vc->gfx.dcl, 0, 0, vc->gfx.w, vc->gfx.h);
++
++                vc->gfx.scale_x = (double)ww / vc->gfx.w;
++                vc->gfx.scale_y = (double)wh / vc->gfx.h;
++
++                glFlush();
+                 return;
+             } else {
+                 dmabuf->draw_submitted = false;
+-- 
+2.25.1
+


### PR DESCRIPTION
gd_egl_draw does not flush anything when draw_submitted=false, this inludes the cases of resize and rotation, so add one time flush to fix it.

Tracked-On: OAM-104047
Signed-off-by: Lu Yang A <yang.a.lu@intel.com>