### PR TITLE
CVE: Update build script with latest commit hash for v5.10.118

### DIFF
--- a/host/kernel/lts2020-chromium/build_weekly.sh
+++ b/host/kernel/lts2020-chromium/build_weekly.sh
@@ -5,7 +5,7 @@ mkdir -p host_kernel
 cd host_kernel
 git clone https://github.com/projectceladon/linux-intel-lts2020-chromium.git
 cd linux-intel-lts2020-chromium
-git checkout 8b980c44db8347e1e954592f62f48af7213f3692
+git checkout 1ce1f718381768bc6da9bbe59c5f8a05188ad066
 cp ../../x86_64_defconfig .config
 patch_list=`find ../../ -iname "*.patch" | sort -u`
 for i in $patch_list


### PR DESCRIPTION
CVE-2022-2905 - Applied
CVE-2022-2663 - Applied
CVE-2022-36946 - Applied

CVE-2022-0480  - Applied
CVE-2022-39188 - Applied
CVE-2022-2327  - Applied
CVE-2022-3176  - Applied
CVE-2022-3303  - Applied
CVE-2022-42719 - Applied
CVE-2022-42721 - Applied
CVE-2022-42722 - Applied
CVE-2022-42720 - Applied
CVE-2022-41674 - Applied
CVE-2019-15794 - Applied

Tracked-On: OAM-104375
Signed-off-by: rajucm <raju.mallikarjun.chegaraddi@intel.com>
Signed-off-by: tboppana <tej.kiran.boppana@intel.com>