### PR TITLE
Fix a bug when getting a gzip header extra field with inflate().

### DIFF
--- a/aosp_diff/preliminary/external/zlib/0001-Fix-a-bug-when-getting-a-gzip-header-extra-field-wit.patch
+++ b/aosp_diff/preliminary/external/zlib/0001-Fix-a-bug-when-getting-a-gzip-header-extra-field-wit.patch
@@ -1,0 +1,36 @@
+From 6ab036ac519e7a1dbc3151203a0506b640501930 Mon Sep 17 00:00:00 2001
+From: jizhenlo <zhenlong.z.ji@intel.com>
+Date: Fri, 28 Oct 2022 11:38:14 +0800
+Subject: [PATCH] Fix a bug when getting a gzip header extra field with
+ inflate().
+
+If the extra field was larger than the space the user provided with
+inflateGetHeader(), and if multiple calls of inflate() delivered
+the extra header data, then there could be a buffer overflow of the
+provided space. This commit assures that provided space is not
+exceeded.
+
+Signed-off-by: jizhenlo <zhenlong.z.ji@intel.com>
+---
+ inflate.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/inflate.c b/inflate.c
+index 68902e8..9057a57 100644
+--- a/inflate.c
++++ b/inflate.c
+@@ -760,8 +760,9 @@ int flush;
+                 if (copy > have) copy = have;
+                 if (copy) {
+                     if (state->head != Z_NULL &&
+-                        state->head->extra != Z_NULL) {
+-                        len = state->head->extra_len - state->length;
++                        state->head->extra != Z_NULL &&
++                        (len = state->head->extra_len - state->length) <
++                            state->head->extra_max) {
+                         zmemcpy(state->head->extra + len, next,
+                                 len + copy > state->head->extra_max ?
+                                 state->head->extra_max - len : copy);
+-- 
+2.25.1
+


### PR DESCRIPTION
If the extra field was larger than the space the user provided with inflateGetHeader(), and if multiple calls of inflate() delivered the extra header data, then there could be a buffer overflow of the provided space. This commit assures that provided space is not exceeded.

Tracked-On: OAM-104413
Signed-off-by: jizhenlo <zhenlong.z.ji@intel.com>