### PR TITLE
ALSA: hda/realtek: Add ALC256 Intel NUC 11

### DIFF
--- a/bsp_diff/common/kernel/lts2021-chromium/22_0022-ALSA-hda-realtek-Add-ALC256-Intel-NUC-11.patch
+++ b/bsp_diff/common/kernel/lts2021-chromium/22_0022-ALSA-hda-realtek-Add-ALC256-Intel-NUC-11.patch
@@ -1,0 +1,30 @@
+From 02b61b0262fb08bcffdfe0a480fa9d2298b52919 Mon Sep 17 00:00:00 2001
+From: gkdeepa <g.k.deepa@intel.com>
+Date: Fri, 4 Nov 2022 15:50:29 +0530
+Subject: [PATCH] ALSA: hda/realtek: Add ALC256 Intel NUC 11
+
+Fix "ALC256 codec issue with 3.5mm headset mode" problem.
+
+Tracked-On:
+Signed-off-by:PeiSen Hou<pshou@realtek.com>
+Signed-off-by:Deepa, G K <g.k.deepa@intel.com>
+---
+ sound/pci/hda/patch_realtek.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sound/pci/hda/patch_realtek.c b/sound/pci/hda/patch_realtek.c
+index 040825ea9a08..42c6e41356a6 100644
+--- a/sound/pci/hda/patch_realtek.c
++++ b/sound/pci/hda/patch_realtek.c
+@@ -9089,7 +9089,7 @@ static const struct snd_pci_quirk alc269_fixup_tbl[] = {
+ 	SND_PCI_QUIRK(0x8086, 0x2074, "Intel NUC 8", ALC233_FIXUP_INTEL_NUC8_DMIC),
+ 	SND_PCI_QUIRK(0x8086, 0x2080, "Intel NUC 8 Rugged", ALC256_FIXUP_INTEL_NUC8_RUGGED),
+ 	SND_PCI_QUIRK(0x8086, 0x2081, "Intel NUC 10", ALC256_FIXUP_INTEL_NUC10),
+-
++        SND_PCI_QUIRK(0x8086, 0x3004, "Intel NUC 11", ALC256_FIXUP_INTEL_NUC10),
+ #if 0
+ 	/* Below is a quirk table taken from the old code.
+ 	 * Basically the device should work as is without the fixup table.
+-- 
+2.17.1
+


### PR DESCRIPTION
Fix "ALC256 codec issue with 3.5mm headset mode" problem.

Tracked-On:
Signed-off-by:PeiSen Hou<pshou@realtek.com>
Signed-off-by:Deepa, G K <g.k.deepa@intel.com>