### PR TITLE
Fix compilation error due to dma-buf function prototype mismatch

### DIFF
--- a/bsp_diff/common/kernel/lts2020-chromium/23_0023-Fix-compilation-error-due-to-dma-buf-function-protot.patch
+++ b/bsp_diff/common/kernel/lts2020-chromium/23_0023-Fix-compilation-error-due-to-dma-buf-function-protot.patch
@@ -1,0 +1,73 @@
+From 31d6f53e8ef53c81f11a8f97c432c459fc2ccd53 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Mon, 7 Nov 2022 10:12:50 +0000
+Subject: [PATCH] Fix compilation error due to dma-buf function prototype
+ mismatch
+
+Build error is seen in dma-buf system_heap driver.
+
+dma-buf system_heap driver functions updated accordingly as per
+the interface change.
+
+Tracked-On: OAM-104594
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ drivers/dma-buf/heaps/system_heap.c | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/dma-buf/heaps/system_heap.c b/drivers/dma-buf/heaps/system_heap.c
+index 5e5f20071961..8b8e293e770c 100644
+--- a/drivers/dma-buf/heaps/system_heap.c
++++ b/drivers/dma-buf/heaps/system_heap.c
+@@ -269,31 +269,35 @@ static void *system_heap_do_vmap(struct system_heap_buffer *buffer)
+ 	return vaddr;
+ }
+ 
+-static void *system_heap_vmap(struct dma_buf *dmabuf)
++static int system_heap_vmap(struct dma_buf *dmabuf, struct dma_buf_map *map)
+ {
+ 	struct system_heap_buffer *buffer = dmabuf->priv;
+ 	void *vaddr;
++	int ret = 0;
+ 
+ 	mutex_lock(&buffer->lock);
+ 	if (buffer->vmap_cnt) {
+ 		buffer->vmap_cnt++;
+-		vaddr = buffer->vaddr;
++		dma_buf_map_set_vaddr(map, buffer->vaddr);
+ 		goto out;
+ 	}
+ 
+ 	vaddr = system_heap_do_vmap(buffer);
+-	if (IS_ERR(vaddr))
++	if (IS_ERR(vaddr)) {
++		ret = PTR_ERR(vaddr);
+ 		goto out;
++	}
+ 
+ 	buffer->vaddr = vaddr;
+ 	buffer->vmap_cnt++;
++	dma_buf_map_set_vaddr(map, buffer->vaddr);
+ out:
+ 	mutex_unlock(&buffer->lock);
+ 
+-	return vaddr;
++	return ret;
+ }
+ 
+-static void system_heap_vunmap(struct dma_buf *dmabuf, void *vaddr)
++static void system_heap_vunmap(struct dma_buf *dmabuf, struct dma_buf_map *map)
+ {
+ 	struct system_heap_buffer *buffer = dmabuf->priv;
+ 
+@@ -303,6 +307,7 @@ static void system_heap_vunmap(struct dma_buf *dmabuf, void *vaddr)
+ 		buffer->vaddr = NULL;
+ 	}
+ 	mutex_unlock(&buffer->lock);
++	dma_buf_map_clear(map);
+ }
+ 
+ static int system_heap_zero_buffer(struct system_heap_buffer *buffer)
+-- 
+2.38.1
+


### PR DESCRIPTION
Build error is seen in dma-buf system_heap driver.

dma-buf system_heap driver functions updated accordingly as per the interface change.

Tracked-On: OAM-104594
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>