### PR TITLE
Disabling Input Devices

### DIFF
--- a/aosp_diff/celadon_ivi/frameworks/native/0001-Disabling-Input-Devices.patch
+++ b/aosp_diff/celadon_ivi/frameworks/native/0001-Disabling-Input-Devices.patch
@@ -1,0 +1,54 @@
+From 91fe2e75256abdbb717c9b53f43af0b1381f4c6c Mon Sep 17 00:00:00 2001
+From: Vilas R K <vilas.r.k@intel.com>
+Date: Tue, 8 Nov 2022 16:02:46 +0530
+Subject: [PATCH] Disabling Input Devices.
+
+Disable the Input Devices based on property
+set by the user.
+
+Ex:
+adb shell setprop persist.sys.disable.deviceid
+03f0:2a4a
+
+Signed-off-by: Vilas R K <vilas.r.k@intel.com>
+---
+ services/inputflinger/reader/EventHub.cpp | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/services/inputflinger/reader/EventHub.cpp b/services/inputflinger/reader/EventHub.cpp
+index b19b4195d1..e2630688a1 100644
+--- a/services/inputflinger/reader/EventHub.cpp
++++ b/services/inputflinger/reader/EventHub.cpp
+@@ -1978,6 +1978,11 @@ void EventHub::openDeviceLocked(const std::string& devicePath) {
+     device->readDeviceBitMask(EVIOCGBIT(EV_MSC, 0), device->mscBitmask);
+     device->readDeviceBitMask(EVIOCGPROP(0), device->propBitmask);
+ 
++    char value[PROPERTY_VALUE_MAX] = {0};
++    property_get("persist.sys.disable.deviceid", value, "invalid_device_id");
++
++    char deviceID[20];
++    sprintf(deviceID, "%x:%x", identifier.vendor,identifier.product);
+     // See if this is a keyboard.  Ignore everything in the button range except for
+     // joystick and gamepad buttons which are handled like keyboards for the most part.
+     bool haveKeyboardKeys =
+@@ -1985,13 +1990,15 @@ void EventHub::openDeviceLocked(const std::string& devicePath) {
+     bool haveGamepadButtons = device->keyBitmask.any(BTN_MISC, BTN_MOUSE) ||
+             device->keyBitmask.any(BTN_JOYSTICK, BTN_DIGI);
+     if (haveKeyboardKeys || haveGamepadButtons) {
+-        device->classes |= InputDeviceClass::KEYBOARD;
++        if (std::string(value).find(std::string(deviceID)) == std::string::npos )
++            device->classes |= InputDeviceClass::KEYBOARD;
+     }
+ 
+     // See if this is a cursor device such as a trackball or mouse.
+     if (device->keyBitmask.test(BTN_MOUSE) && device->relBitmask.test(REL_X) &&
+         device->relBitmask.test(REL_Y)) {
+-        device->classes |= InputDeviceClass::CURSOR;
++        if (std::string(value).find(std::string(deviceID)) == std::string::npos )
++            device->classes |= InputDeviceClass::CURSOR;
+     }
+ 
+     // See if this is a rotary encoder type device.
+-- 
+2.17.1
+


### PR DESCRIPTION
Disable the Input Devices based on property
set by the user.

Ex:
adb shell setprop persist.sys.disable.deviceid
03f0:2a4a

Signed-off-by: Vilas R K <vilas.r.k@intel.com>