### PR TITLE
Revert "Kernel_v5.10.118: Update build script with latest CVE fixes"

### DIFF
--- a/host/kernel/lts2020-chromium/build_weekly.sh
+++ b/host/kernel/lts2020-chromium/build_weekly.sh
@@ -3,9 +3,9 @@
 rm -rf host_kernel
 mkdir -p host_kernel
 cd host_kernel
-git clone -b lts-v5.10.118-20221103-r1 https://github.com/projectceladon/linux-intel-lts2020-chromium.git
+git clone https://github.com/projectceladon/linux-intel-lts2020-chromium.git
 cd linux-intel-lts2020-chromium
-
+git checkout 1ce1f718381768bc6da9bbe59c5f8a05188ad066
 cp ../../x86_64_defconfig .config
 patch_list=`find ../../ -iname "*.patch" | sort -u`
 for i in $patch_list


### PR DESCRIPTION
    Updating new tag: lts-v5.10.118-20221103-r1
    Contains following CVE fixes:

    CVE-2022-21123 - Applied
    CVE-2022-21125 - Applied
    CVE-2022-21166 - Applied
    CVE-2022-1972/CVE-2022-2078 - Applied
    CVE-2022-3028 - Applied
    CVE-2022-1184 - Applied
    CVE-2022-2959 - Applied
    CVE-2022-2503 - Applied
    CVE-2022-36123 - Applied
    CVE-2022-36879 - Applied
    CVE-2021-33655 - Applied
    CVE-2022-3577 - Applied
    CVE-2022-3594 - Applied
    CVE-2022-20422 - Applied
    CVE-2022-20421 - Applied

    Tracked-On: OAM-104461

This reverts commit 838e740138ce790a727e56284aae8a7c95665788.