### PR TITLE
Fix virtio2d color r/b reversed issue

### DIFF
--- a/host/qemu/0034-Fix-virtio2d-color-r-b-reversed-issue.patch
+++ b/host/qemu/0034-Fix-virtio2d-color-r-b-reversed-issue.patch
@@ -1,0 +1,41 @@
+From 31e615094fb866a06d78dfd2e00f6185237c1326 Mon Sep 17 00:00:00 2001
+From: chenyanxzhu <chenyanx.zhu@intel.com>
+Date: Thu, 10 Nov 2022 14:24:19 +0800
+Subject: [PATCH] Fix virtio2d color r/b reversed issue
+
+Add rgbx format support for virtio2d dumb.
+
+Tracked-On: OAM-103582
+Signed-off-by: chenyanxzhu <chenyanx.zhu@intel.com>
+---
+ ui/console-gl.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/ui/console-gl.c b/ui/console-gl.c
+index 7c9894a51d..b199eddd1b 100644
+--- a/ui/console-gl.c
++++ b/ui/console-gl.c
+@@ -36,6 +36,8 @@ bool console_gl_check_format(DisplayChangeListener *dcl,
+     switch (format) {
+     case PIXMAN_BE_b8g8r8x8:
+     case PIXMAN_BE_b8g8r8a8:
++    case PIXMAN_BE_r8g8b8x8:
++    case PIXMAN_BE_r8g8b8a8:
+     case PIXMAN_r5g6b5:
+         return true;
+     default:
+@@ -60,6 +62,11 @@ void surface_gl_create_texture(QemuGLShader *gls,
+         surface->glformat = GL_RGBA;
+         surface->gltype = GL_UNSIGNED_BYTE;
+         break;
++    case PIXMAN_BE_r8g8b8x8:
++    case PIXMAN_BE_r8g8b8a8:
++        surface->glformat = GL_RGBA;
++        surface->gltype = GL_UNSIGNED_BYTE;
++        break;
+     case PIXMAN_r5g6b5:
+         surface->glformat = GL_RGB;
+         surface->gltype = GL_UNSIGNED_SHORT_5_6_5;
+-- 
+2.38.1
+


### PR DESCRIPTION
Add rgbx format support for virtio2d dumb.

Tracked-On: OAM-103582
Signed-off-by: chenyanxzhu <chenyanx.zhu@intel.com>