### PR TITLE
Change enhanced SCO setup data path to HCI

### DIFF
--- a/aosp_diff/preliminary/packages/modules/Bluetooth/0006-Change-enhanced-SCO-setup-data-path-to-HCI.patch
+++ b/aosp_diff/preliminary/packages/modules/Bluetooth/0006-Change-enhanced-SCO-setup-data-path-to-HCI.patch
@@ -1,0 +1,59 @@
+From c402213755fa0a115751803259e196a7938ccda9 Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Thu, 10 Nov 2022 17:49:36 +0530
+Subject: [PATCH] Change enhanced SCO setup data path to HCI
+
+Android T bt stack is setting enhanced sco data path over
+PCM(0x01), whereas Intel AX211 has Enhance SCO data path
+set over HCI(0x00). Hence Enhanced SCO create request was
+getting rejected with error Invalid command.
+
+Refer Bluetooth core spec section 7.1.45
+Enhanced Setup Synchronous Connection command:
+Input_Data_Path,
+Output_Data_Path.
+
+Changes made to set esco data path to 0x00 (HCI) which
+successfully creates the esco channel and routes audio packets
+over HCI.
+
+Tracked-On: OAM-104716
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ system/stack/btm/btm_sco.cc | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/system/stack/btm/btm_sco.cc b/system/stack/btm/btm_sco.cc
+index 9c5c41fb13..f35fe2adec 100644
+--- a/system/stack/btm/btm_sco.cc
++++ b/system/stack/btm/btm_sco.cc
+@@ -142,7 +142,7 @@ static void btm_esco_conn_rsp(uint16_t sco_inx, uint8_t hci_status,
+     if (controller_get_interface()
+             ->supports_enhanced_setup_synchronous_connection()) {
+       /* Use the saved SCO routing */
+-      p_setup->input_data_path = p_setup->output_data_path = ESCO_DATA_PATH;
++      p_setup->input_data_path = p_setup->output_data_path = ESCO_DATA_PATH_HCI;
+ 
+       BTM_TRACE_DEBUG(
+           "%s: txbw 0x%x, rxbw 0x%x, lat 0x%x, retrans 0x%02x, "
+@@ -345,7 +345,7 @@ static tBTM_STATUS btm_send_connect_request(uint16_t acl_handle,
+       LOG_INFO("Sending enhanced SCO connect request over handle:0x%04x",
+                acl_handle);
+       /* Use the saved SCO routing */
+-      p_setup->input_data_path = p_setup->output_data_path = ESCO_DATA_PATH;
++      p_setup->input_data_path = p_setup->output_data_path = ESCO_DATA_PATH_HCI;
+       LOG(INFO) << __func__ << std::hex << ": enhanced parameter list"
+                 << " txbw=0x" << unsigned(p_setup->transmit_bandwidth)
+                 << ", rxbw=0x" << unsigned(p_setup->receive_bandwidth)
+@@ -1176,7 +1176,7 @@ static tBTM_STATUS BTM_ChangeEScoLinkParms(uint16_t sco_inx,
+     if (controller_get_interface()
+             ->supports_enhanced_setup_synchronous_connection()) {
+       /* Use the saved SCO routing */
+-      p_setup->input_data_path = p_setup->output_data_path = ESCO_DATA_PATH;
++      p_setup->input_data_path = p_setup->output_data_path = ESCO_DATA_PATH_HCI;
+ 
+       btsnd_hcic_enhanced_set_up_synchronous_connection(p_sco->hci_handle,
+                                                         p_setup);
+-- 
+2.17.1
+


### PR DESCRIPTION
Intel BT chip is expecting SCO data path as 0x00 (HCI), But Android by default setting data path as 0x01 (PCM), which is not supported in Intel BT chip, so call audio is not routing to Bluetooth headset.

Refer Bluetooth core spec section 7.1.45
Enhanced Setup Synchronous Connection command:
Input_Data_Path,
Output_Data_Path.

After setting data path to 0x00 (HCI), now call audio packets are sent to BT chip via HCI and routed to BT headset.

Tracked-On: OAM-104716
Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>