### PR TITLE
CVE: Update build_weekly.sh with latest commit tag for v5.10.118

### DIFF
--- a/host/kernel/lts2020-chromium/build_weekly.sh
+++ b/host/kernel/lts2020-chromium/build_weekly.sh
@@ -3,7 +3,7 @@
 rm -rf host_kernel
 mkdir -p host_kernel
 cd host_kernel
-git clone -b lts-v5.10.118-20221103-r1 https://github.com/projectceladon/linux-intel-lts2020-chromium.git
+git clone -b lts-v5.10.118-20221118-r2 https://github.com/projectceladon/linux-intel-lts2020-chromium.git
 cd linux-intel-lts2020-chromium
 
 cp ../../x86_64_defconfig .config


### PR DESCRIPTION
CVE-2022-43750 - Applied
CVE-2022-3623 - Applied
CVE-2022-3625 - Applied
CVE-2022-3629 - Applied
CVE-2022-20409 - Applied

Tracked-On: OAM-104870
Signed-off-by: tboppana <tej.kiran.boppana@intel.com>