### PR TITLE
Configure scudo to use exclusive TSD

### DIFF
--- a/aosp_diff/preliminary/external/scudo/0001-Configure-scudo-to-use-exclusive-TSD.patch
+++ b/aosp_diff/preliminary/external/scudo/0001-Configure-scudo-to-use-exclusive-TSD.patch
@@ -1,0 +1,48 @@
+From c011726863b4ae0ffb056fb5e74b436a1170f211 Mon Sep 17 00:00:00 2001
+From: Vinay Prasad Kompella <vinay.kompella@intel.com>
+Date: Tue, 2 Aug 2022 16:57:29 +0530
+Subject: [PATCH] Configure scudo to use exclusive TSD
+
+Exclusive TSD reduces thread contention for allocation
+and improves multicore performance on Geekbench.
+
+Signed-off-by: Vinay Prasad Kompella <vinay.kompella@intel.com>
+---
+ Android.bp                    | 1 +
+ standalone/allocator_config.h | 7 ++++++-
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/Android.bp b/Android.bp
+index 60cadc91263..378da61bdd5 100644
+--- a/Android.bp
++++ b/Android.bp
+@@ -148,6 +148,7 @@ cc_library_static {
+     defaults: ["libscudo_defaults"],
+     cflags: [
+       "-D_BIONIC=1",
++      "-DSCUDO_ANDROID_USE_EXCLUSIVETSD",
+       "-DSCUDO_HAS_PLATFORM_TLS_SLOT",
+     ],
+     visibility: [
+diff --git a/standalone/allocator_config.h b/standalone/allocator_config.h
+index 8e103f28b1a..77494491880 100644
+--- a/standalone/allocator_config.h
++++ b/standalone/allocator_config.h
+@@ -105,8 +105,13 @@ struct AndroidConfig {
+   static const s32 SecondaryCacheMinReleaseToOsIntervalMs = 0;
+   static const s32 SecondaryCacheMaxReleaseToOsIntervalMs = 1000;
+ 
++#ifdef SCUDO_ANDROID_USE_EXCLUSIVETSD
+   template <class A>
+-  using TSDRegistryT = TSDRegistrySharedT<A, 8U, 2U>; // Shared, max 8 TSDs.
++  using TSDRegistryT = TSDRegistryExT<A>; // Exclusive
++#else
++  template <class A>
++  using TSDRegistryT = TSDRegistrySharedT<A, 32U, 2U>; // Start with 2, max 32 TSDs
++#endif
+ };
+ 
+ struct AndroidSvelteConfig {
+-- 
+2.17.1
+


### PR DESCRIPTION
Exclusive TSD reduces thread contention for allocation and improves multicore performance on Geekbench.

Signed-off-by: Vinay Prasad Kompella <vinay.kompella@intel.com>