### PR TITLE
CVE: Update build scripts with latest commit tag for v5.15.74

### DIFF
--- a/host/kernel/lts2021-chromium/build.sh
+++ b/host/kernel/lts2021-chromium/build.sh
@@ -5,7 +5,7 @@ mkdir -p host_kernel
 cd host_kernel
 git clone https://github.com/projectceladon/vendor-intel-utils
 
-tag="lts-v5.15.74-20221108-r1"
+tag="lts-v5.15.74-20221122-r3"
 git clone -b $tag https://github.com/projectceladon/linux-intel-lts2021-chromium.git
 cd linux-intel-lts2021-chromium
 

--- a/host/kernel/lts2021-chromium/build_weekly.sh
+++ b/host/kernel/lts2021-chromium/build_weekly.sh
@@ -9,7 +9,7 @@ cd vendor-intel-utils
 git checkout e4b94fc4f53b1ddb9bc7c3a0ef0e306a393bfd63
 cd ../
 
-tag="lts-v5.15.74-20221118-r2"
+tag="lts-v5.15.74-20221122-r3"
 git clone -b $tag https://github.com/projectceladon/linux-intel-lts2021-chromium.git
 cd linux-intel-lts2021-chromium
 


### PR DESCRIPTION
CVE-2022-3435 - Applied
CVE-2022-41850 - Applied
CVE-2022-3169 - Applied

Tracked-On: OAM-104926
Signed-off-by: tboppana <tej.kiran.boppana@intel.com>