### PR TITLE
CVE: Update build scripts with latest commit tag for v5.10.118

### DIFF
--- a/host/kernel/lts2020-chromium/build.sh
+++ b/host/kernel/lts2020-chromium/build.sh
@@ -4,7 +4,9 @@ rm -rf host_kernel
 mkdir -p host_kernel
 cd host_kernel
 git clone https://github.com/projectceladon/vendor-intel-utils
-git clone https://github.com/projectceladon/linux-intel-lts2020-chromium.git
+
+tag="lts-v5.10.118-20221123-r3"
+git clone -b $tag https://github.com/projectceladon/linux-intel-lts2020-chromium.git
 cd linux-intel-lts2020-chromium
 cp ../vendor-intel-utils/host/kernel/lts2020-chromium/x86_64_defconfig .config
 patch_list=`find ../vendor-intel-utils/host/kernel/lts2020-chromium -iname "*.patch" | sort -u`

--- a/host/kernel/lts2020-chromium/build_weekly.sh
+++ b/host/kernel/lts2020-chromium/build_weekly.sh
@@ -3,7 +3,7 @@
 rm -rf host_kernel
 mkdir -p host_kernel
 cd host_kernel
-git clone -b lts-v5.10.118-20221118-r2 https://github.com/projectceladon/linux-intel-lts2020-chromium.git
+git clone -b lts-v5.10.118-20221123-r3 https://github.com/projectceladon/linux-intel-lts2020-chromium.git
 cd linux-intel-lts2020-chromium
 
 cp ../../x86_64_defconfig .config


### PR DESCRIPTION
CVE-2022-3435 - Applied
CVE-2022-3169 - Applied
CVE-2022-2978 - Applied
CVE-2022-3619 - Applied
CVE-2022-3564 - Applied

Tracked-On: OAM-104942
Signed-off-by: tboppana <tej.kiran.boppana@intel.com>