### PR TITLE
Device going to offline during cts tests.

### DIFF
--- a/aosp_diff/preliminary/frameworks/opt/net/ethernet/0001-Device-going-to-offline-during-cts-tests.patch
+++ b/aosp_diff/preliminary/frameworks/opt/net/ethernet/0001-Device-going-to-offline-during-cts-tests.patch
@@ -1,0 +1,41 @@
+From 0fcd1e7ff691cbd74db6642d338df3d03773c1af Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Wed, 23 Nov 2022 20:53:20 +0530
+Subject: [PATCH] Device going to offline during cts tests.
+
+While it remove the user, then all services which had requested
+for ethernet network, request for release network. After that
+since there is no request pending, it stop ethernet.
+
+Here we need to take network reference count in consideration
+if ethernet start due to interface link state change.
+
+Tracked-On: OAM-102974
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../android/server/ethernet/EthernetNetworkFactory.java  | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/java/com/android/server/ethernet/EthernetNetworkFactory.java b/java/com/android/server/ethernet/EthernetNetworkFactory.java
+index 28b24f1..a6a2c2f 100644
+--- a/java/com/android/server/ethernet/EthernetNetworkFactory.java
++++ b/java/com/android/server/ethernet/EthernetNetworkFactory.java
+@@ -513,8 +513,13 @@ public class EthernetNetworkFactory extends NetworkFactory {
+             if (mLinkUp == up) return false;
+             mLinkUp = up;
+ 
+-            stop();
+-            if (up) {
++            // Maintaining network reference count here based on interface state
++            if(!up) {
++                --refCount;
++                stop();
++            }
++            else {
++                ++refCount;
+                 start();
+             }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
While it remove the user, then all services which had requested for ethernet network, request for release network. After that since there is no request pending, it stop ethernet.

Here we need to take network reference count in consideration if ethernet start due to interface link state change.

Tracked-On: OAM-102974
Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>