### PR TITLE
CVE: Update build_weekly.sh with latest commit tag for v5.15.74

### DIFF
--- a/host/kernel/lts2021-chromium/build_weekly.sh
+++ b/host/kernel/lts2021-chromium/build_weekly.sh
@@ -9,7 +9,7 @@ cd vendor-intel-utils
 git checkout e4b94fc4f53b1ddb9bc7c3a0ef0e306a393bfd63
 cd ../
 
-tag="lts-v5.15.74-20221125-r4"
+tag="lts-v5.15.74-20221128-r5"
 git clone -b $tag https://github.com/projectceladon/linux-intel-lts2021-chromium.git
 cd linux-intel-lts2021-chromium
 


### PR DESCRIPTION
CVE-2022-42895 - Fix Applied
CVE-2022-42896 - Fix Applied
New commit tag lts-v5.15.74-20221128-r5

Tracked-On: OAM-105039
Signed-off-by: tboppana <tej.kiran.boppana@intel.com>