### PR TITLE
CVE: Update build_weekly.sh with latest commit tag for v5.10.118

### DIFF
--- a/host/kernel/lts2020-chromium/build.sh
+++ b/host/kernel/lts2020-chromium/build.sh
@@ -5,8 +5,8 @@ mkdir -p host_kernel
 cd host_kernel
 git clone https://github.com/projectceladon/vendor-intel-utils
 
-tag="lts-v5.10.118-20221123-r3"
-git clone -b $tag https://github.com/projectceladon/linux-intel-lts2020-chromium.git
+branch_name="celadon/s/mr0/stable"
+git clone -b $branch_name https://github.com/projectceladon/linux-intel-lts2020-chromium.git
 cd linux-intel-lts2020-chromium
 cp ../vendor-intel-utils/host/kernel/lts2020-chromium/x86_64_defconfig .config
 patch_list=`find ../vendor-intel-utils/host/kernel/lts2020-chromium -iname "*.patch" | sort -u`

--- a/host/kernel/lts2020-chromium/build_weekly.sh
+++ b/host/kernel/lts2020-chromium/build_weekly.sh
@@ -3,7 +3,9 @@
 rm -rf host_kernel
 mkdir -p host_kernel
 cd host_kernel
-git clone -b lts-v5.10.118-20221123-r3 https://github.com/projectceladon/linux-intel-lts2020-chromium.git
+
+tag="lts-v5.10.118-20221128-r4"
+git clone -b $tag https://github.com/projectceladon/linux-intel-lts2020-chromium.git
 cd linux-intel-lts2020-chromium
 
 cp ../../x86_64_defconfig .config


### PR DESCRIPTION
CVE-2022-42895 - Fix Applied
CVE-2022-42896 - Fix Applied
New commit tag lts-v5.10.118-20221128-r4

Tracked-On: OAM-105004
Signed-off-by: tboppana <tej.kiran.boppana@intel.com>