### PR TITLE
Fix for AOSP Camera Launch Issue from Task Bar.

### DIFF
--- a/aosp_diff/preliminary/packages/apps/Camera2/04_0004-Fix-for-can-not-open-AOSP-Camera-from-Android-home-T.patch
+++ b/aosp_diff/preliminary/packages/apps/Camera2/04_0004-Fix-for-can-not-open-AOSP-Camera-from-Android-home-T.patch
@@ -1,0 +1,31 @@
+From d74f64d611459dffbb0f11028f1c5e214a4a5033 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Tue, 29 Nov 2022 10:11:19 +0530
+Subject: [PATCH] Fix for can not open AOSP Camera from Android home Task Bar.
+
+When launching the app from  home task bar, then it try to
+match intent filter with the requested launch activity.
+Launcher category was missing from Camera2 manifest, so there
+was no exact match.
+
+Tracked-On: OAM-104947
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ AndroidManifest.xml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/AndroidManifest.xml b/AndroidManifest.xml
+index d2c35f2b9..9faab630d 100644
+--- a/AndroidManifest.xml
++++ b/AndroidManifest.xml
+@@ -65,6 +65,7 @@
+             </intent-filter>
+             <intent-filter>
+                 <action android:name="android.intent.action.MAIN" />
++                <category android:name="android.intent.category.LAUNCHER" />
+                 <category android:name="android.intent.category.DEFAULT" />
+             </intent-filter>
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
When launching the app from  home task bar, then it try to match intent filter with the requested launch activity. Launcher category was missing from Camera2 manifest, so there was no exact match.

Tracked-On: OAM-104947
Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>