### PR TITLE
Add the RGBA/RGBX format support in Qemu

### DIFF
--- a/host/qemu/0009-Add-the-rgba-rgbx-support.patch
+++ b/host/qemu/0009-Add-the-rgba-rgbx-support.patch
@@ -1,0 +1,39 @@
+From f4f25805f9fb9596981c76ec9ad25472667cf47e Mon Sep 17 00:00:00 2001
+From: He Yue <yue.he@intel.com>
+Date: Mon, 12 Dec 2022 12:54:00 +0800
+Subject: [PATCH] Add the rgba/rgbx support
+
+Tracked-On: OAM-105230
+Signed-off-by: He Yue <yue.he@intel.com>
+---
+ ui/console-gl.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/ui/console-gl.c b/ui/console-gl.c
+index 8e3c9a3c8..78431bb16 100644
+--- a/ui/console-gl.c
++++ b/ui/console-gl.c
+@@ -36,6 +36,8 @@ bool console_gl_check_format(DisplayChangeListener *dcl,
+     switch (format) {
+     case PIXMAN_BE_b8g8r8x8:
+     case PIXMAN_BE_b8g8r8a8:
++    case PIXMAN_BE_r8g8b8x8:
++    case PIXMAN_BE_r8g8b8a8:
+     case PIXMAN_r5g6b5:
+         return true;
+     default:
+@@ -64,6 +66,11 @@ void surface_gl_create_texture(QemuGLShader *gls,
+         surface->glformat = GL_RGBA;
+         surface->gltype = GL_UNSIGNED_BYTE;
+         break;
++    case PIXMAN_BE_r8g8b8x8:
++    case PIXMAN_BE_r8g8b8a8:
++	surface->glformat = GL_RGBA;
++	surface->gltype = GL_UNSIGNED_BYTE;
++	break;
+     case PIXMAN_r5g6b5:
+         surface->glformat = GL_RGB;
+         surface->gltype = GL_UNSIGNED_SHORT_5_6_5;
+-- 
+2.25.1
+


### PR DESCRIPTION
Fix the SRIOV boot fail on 5.15 kernel.

Tracked-On: OAM-105230
Signed-off-by: HeYue <yue.he@intel.com>