### PR TITLE
Fix for adb disconnecting during Monkey Test Run.

### DIFF
--- a/aosp_diff/preliminary/packages/apps/Settings/21_0021-Fix-for-adb-disconnecting-during-Monkey-Test-Run.patch
+++ b/aosp_diff/preliminary/packages/apps/Settings/21_0021-Fix-for-adb-disconnecting-during-Monkey-Test-Run.patch
@@ -1,0 +1,42 @@
+From 9877f5d41cac38ab0094a1363abbcb37a0f1f474 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Thu, 15 Dec 2022 12:21:25 +0530
+Subject: [PATCH] Fix for adb disconnecting during Monkey Test Run.
+
+When running the monkey test, its going in tethering page
+inside Settings app and enabling ethernet tethering.
+Due to get adb connection is getting lost.
+
+Guarding ethernet tethering option when monkey test is running,
+it will not display ethernet tethering option during monkey test.
+
+Tracked-On: OAM-103750
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../settings/network/EthernetTetherPreferenceController.java   | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/settings/network/EthernetTetherPreferenceController.java b/src/com/android/settings/network/EthernetTetherPreferenceController.java
+index 06cd6a7fee..807d5d1f03 100644
+--- a/src/com/android/settings/network/EthernetTetherPreferenceController.java
++++ b/src/com/android/settings/network/EthernetTetherPreferenceController.java
+@@ -27,6 +27,7 @@ import androidx.lifecycle.Lifecycle;
+ import androidx.lifecycle.OnLifecycleEvent;
+ 
+ import com.android.internal.annotations.VisibleForTesting;
++import com.android.settings.Utils;
+ 
+ /**
+  * This controller helps to manage the switch state and visibility of ethernet tether switch
+@@ -76,7 +77,7 @@ public final class EthernetTetherPreferenceController extends TetherBasePreferen
+ 
+     @Override
+     public boolean shouldShow() {
+-        return !TextUtils.isEmpty(mEthernetRegex);
++        return !TextUtils.isEmpty(mEthernetRegex) && !Utils.isMonkeyRunning();
+     }
+ 
+     @Override
+-- 
+2.17.1
+


### PR DESCRIPTION
When running the monkey test, its going in tethering page inside Settings app and enabling ethernet tethering. Due to get adb connection is getting lost.

Guarding ethernet tethering option when monkey test is running, it will not display ethernet tethering option during monkey test.

Tracked-On: OAM-103750
Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>