### PR TITLE
Bluetooth: btintel: Fix bdaddress with garbage

### DIFF
--- a/bsp_diff/common/kernel/lts2020-yocto/0043-Bluetooth-btintel-Fix-bdaddress-comparison-with-garb.patch
+++ b/bsp_diff/common/kernel/lts2020-yocto/0043-Bluetooth-btintel-Fix-bdaddress-comparison-with-garb.patch
@@ -1,0 +1,62 @@
+From 4e694320c993c1172cacce8add0735cc228d2231 Mon Sep 17 00:00:00 2001
+From: Kiran K <kiran.k@intel.com>
+Date: Wed, 13 Oct 2021 13:35:11 +0530
+Subject: [PATCH 2/3] Bluetooth: btintel: Fix bdaddress comparison with garbage
+ value
+
+Intel Read Verision(TLV) data is parsed into a local structure variable
+and it contains a field for bd address. Bd address is returned only in
+bootloader mode and hence bd address in TLV structure needs to be validated
+only if controller is present in boot loader mode.
+
+Signed-off-by: Kiran K <kiran.k@intel.com>
+Reviewed-by: Tedd Ho-Jeong An <tedd.an@intel.com>
+Signed-off-by: Marcel Holtmann <marcel@holtmann.org>
+(cherry picked from commit 893505319c74cf3faa45a5ed9d5338ff03b66949)
+---
+ drivers/bluetooth/btintel.c | 22 ++++++++++++++--------
+ 1 file changed, 14 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/bluetooth/btintel.c b/drivers/bluetooth/btintel.c
+index 851a0c9b8fae..1a4f8b227eac 100644
+--- a/drivers/bluetooth/btintel.c
++++ b/drivers/bluetooth/btintel.c
+@@ -2081,14 +2081,16 @@ static int btintel_prepare_fw_download_tlv(struct hci_dev *hdev,
+ 	if (ver->img_type == 0x03) {
+ 		btintel_clear_flag(hdev, INTEL_BOOTLOADER);
+ 		btintel_check_bdaddr(hdev);
+-	}
+-
+-	/* If the OTP has no valid Bluetooth device address, then there will
+-	 * also be no valid address for the operational firmware.
+-	 */
+-	if (!bacmp(&ver->otp_bd_addr, BDADDR_ANY)) {
+-		bt_dev_info(hdev, "No device address configured");
+-		set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
++	} else {
++		/*
++		 * Check for valid bd address in boot loader mode. Device
++		 * will be marked as unconfigured if empty bd address is
++		 * found.
++		 */
++		if (!bacmp(&ver->otp_bd_addr, BDADDR_ANY)) {
++			bt_dev_info(hdev, "No device address configured");
++			set_bit(HCI_QUIRK_INVALID_BDADDR, &hdev->quirks);
++		}
+ 	}
+ 
+ 	btintel_get_fw_name_tlv(ver, fwname, sizeof(fwname), "sfi");
+@@ -2467,6 +2469,10 @@ static int btintel_setup_combined(struct hci_dev *hdev)
+ 		goto exit_error;
+ 	}
+ 
++	/* memset ver_tlv to start with clean state as few fields are exclusive
++	 * to bootloader mode and are not populated in operational mode
++	 */
++	memset(&ver_tlv, 0, sizeof(ver_tlv));
+ 	/* For TLV type device, parse the tlv data */
+ 	err = btintel_parse_version_tlv(hdev, &ver_tlv, skb);
+ 	if (err) {
+-- 
+2.35.0
+

--- a/bsp_diff/common/vendor/linux/firmware/0004-WA-Delete-iwlwifi-ty-a0-gf-a0.pnvm-for-Intel-AX210.patch
+++ b/bsp_diff/common/vendor/linux/firmware/0004-WA-Delete-iwlwifi-ty-a0-gf-a0.pnvm-for-Intel-AX210.patch
@@ -1,0 +1,185 @@
+From acc55e680a792f4160b5a7723174cdcc1c50fd85 Mon Sep 17 00:00:00 2001
+From: "Suresh, Prashanth" <prashanth.suresh@intel.com>
+Date: Mon, 19 Dec 2022 18:07:05 +0530
+Subject: [PATCH] WA:Delete iwlwifi-ty-a0-gf-a0.pnvm for Intel AX210
+
+wlwifi-ty-a0-gf-a0.pnvm causes iwlwifi reporting "Timeout
+waiting for PNVM load!" error for AX210 at 5.11.+ kernel.
+Temporarily remove it.
+
+Tracked-On: OAM-102112
+Signed-off-by: Zhuo Peng <zhuo.peng@intel.com>
+---
+ iwlwifi-ty-a0-gf-a0.pnvm | Bin 41876 -> 0 bytes
+ 1 file changed, 0 insertions(+), 0 deletions(-)
+ delete mode 100644 iwlwifi-ty-a0-gf-a0.pnvm
+
+diff --git a/iwlwifi-ty-a0-gf-a0.pnvm b/iwlwifi-ty-a0-gf-a0.pnvm
+deleted file mode 100644
+index 1a65d3df4aa9150a494d05987c5abb811079714b..0000000000000000000000000000000000000000
+GIT binary patch
+literal 0
+HcmV?d00001
+
+literal 41876
+zcmeHQ33Ob=m3_TPwplD$w(%~>mTb$iEVrfB)@rp{y>Du@u_44U$tN};F_6tHVJ56f
+zAPbWOJ7lsj!(vDXA;e)1aVDI2!X!D)31^%z3`xuy!U2vUgcvZ3=iaLSTVJh~ZOrC@
+zUq0Pc|JAEkuU^%w|G!+fUsyzr!sp)VN_^`SKt@_bj&_+O38CP{XZZ>L`^TxsKMVFB
+z?t1MvY*oNV#I3$BzCfgM%7XeJ1k415a`>@Q1q$}QEc&75H}^b$@wZR=c+2*CKXLir
+zgJ=Hu<mWD#f7P_muP^w?rI(+-{@ib!u*v(0J##Lc`kA`?4R`$Ng%uyW@x=7qU#Pfc
+z_gRaUZ2bAOff<)Q*|W8O(rsU!wc)PE&i-s}--oXIa^E9``&KU7wfdZO|MZn@zuR!t
+zO?UkDq;+TPyZxl2|FPwlAN|FOQ)jO^?av?je(eWlez)tqyCdhHo1U~`)n9ks6)!v#
+z8NTh<UG5Vv$@kv%{S7mxKKEGj2cCNB`Hqb{Hf%ZdFUNmt@cHA<*tYTE$Qc7S-}Rs0
+zx%B=OryuILopvJ@;3A!X&$Y`%Ui-}tcU^(pNsa{^3%q+Rz<bbDroXSw6`Gp|kIzpe
+z(M%5?DZWV;dL-)^@1Mv?Rr=p$Rr;UR*2*n<F`sam`ZqAa{O1|)45&Ng)m3lvKhM>k
+zt5we)pGdc<a0_y;Ycjr1!)MKEk@Jf8Z<9sR7d56g$(r@3^H?-1*L54NEn7F-m_oa2
+zS67T}x5=Bv&410cZaIIJCCkb;d3lRd{f(*n<He`{@pjjm)!s6Ce$l&dKm9EnSLPg<
+z#=3fuv&M|Qanh#xw0i@`Fs3f8$G5&*ojC^DbIcf4Uew6`V6(Hv*b{acSI<peRLL5A
+z#_F=ktH#H97^9~t6S|z=LkaeTx=oF)HP=?k`Sa{_maVzP_=ZdCFg~_hjdmxFsry`J
+ze{=gav|Eq)8)Fx&LC)W5^mk#YOlu96*TovcSea;dnc3eMTbK6nPF`13i}-vGPpE`%
+z&Yan#QVY^b88e-)Tg_uXx&J1s4p6^3{Kj=C)!?|dK&I=mBiK#NF~T<n5w*Zv?wX0T
+z;j9{$xM~C!c(p(gkAEChg-mgIV0-a;Q6)!uS;LnQFL-N^i~3UE<TsO&Q6t<ptyF^+
+z_JsDhgv%Dm71JQR##=!`MFmPVGQ$lH<<@4?*}C@{>T0G*R>|unr`Af>SuI^MYvff-
+zRVf8g^3K4QGK&|A9HR|GmCU9UHCo;*s#AkjtV5d`RCu8!ZOQ&CXcrVfw2~=HUyhJ@
+zO-s$JnFx-ftp*eV`gCUFCdH&`+02WnVki96cwstfWpy+Ym#C<LQM{Nqq$+&W^kMUH
+zaU`RYzR^<(^{CPBo)nE_2_0QjRj>cc9E44#8i5wX4vm6sCB1(6Wm{m(^5F~keR!w!
+z4^29}6?C+Fms-FrAK7Yq*ngLf(ixUx0mlN41!#ej-h$^0zC^A2fAE}fvh$qbIKew&
+z0k@puJZHQkmUlXJEZ|t+?YDq?vq;zEA6>)0YFu^px#yhnYTJg#*S_?^qCd@Aw>5dq
+z8E4E)KU0f3cZ0ZGVi*R??c!EtT&n8^@f7PC@Lv+-LyfyZDs1#hTN!`9BZpytXCnIM
+z1^Fl0c#d$9N;#|KNc&%1KxU#IM`=2*RDV3cpf21EGTH2da;t28RNKl^Y-RkBQMD!i
+zR9ktPtvuaUKE_s_VJpv6{ZhZE%mTfb3{9IohPF!Pl+wV;@y)g9s%?YJ<FzWcORZH_
+zysKosXKrE0C=`sLf{{uZ!Cr_E_d3^t2kT;yXj?dB<Oeg|nY1yK&jqs?aOQe*Ic8nR
+zhVq$i5Rr8u8_cD;(kWvw8|zFbjYz!D9~v+^{L7ZF@ENTw^>xin)UQDriu1Ky8uz*S
+zLqRd(34A4zAu*DP0Wk(b0WqTC9x?j*P+HNlSd5mXwF3KWl!cz!LLo1OLIIy48O&uQ
+zos3FbJN}f;`bDGb3xio*-=^vxmBm$cg?v_W8A{0ID2v~^oI`o2kdtf<!;y3<)ZZ?F
+z-ZtMdX>D<PTunRoc{14qIv!DAXlPJ|hH{cl$CWY}<Wwk)k;D?cO0l-~R;jDSAE@2i
+zWyuRw*<4ZzXkv|_P{>LidgiieNugOh+AeL-w{AZEJ}mAn(%hd-CnXu@fOEM#)X!wJ
+zf`RTf>Gapt&Xzffcb#YH3$CHs*Q%x7D-$nBr6OIim{BOC^t`1aYWh+Ioek(Lh%A+k
+zcE;jZCn{w!soq3_?Rqpzzs}5dv5_lqc4<yshqaM21_uWUATkSwjaa<95FW5ZW6)Yy
+zA*7@fv=XXaO-*Ix<jLq(T~$|my+<8o?A`m+(|h+~?$^0m>e{QqZg)I}r2!UxCBz8z
+zbqS@5kxqw6D+szynI+mx^JTJ0lU7$Z)hx}MHwDW|+*4i4Ubv(t8H1z<7oHNAN@7{k
+z+FE8hgU&eBSn_$3wq(gXv$S~e95FDztv~m4cdRfaghPHYV&Q%<vY1;f#_w-3OKok7
+zxTZJD^6A4hii|-pZ)vHQ?(P<O_SwgZIr)4gd`;-H9N&r(zQ*~}%ks5>FC2!7=$AQd
+z6^nJtE3Z6T%-L^y317?d`NevRpL~As<#Lz<$Yai_C=_BcapEh*oO~T6d_93>#d?dM
+zzS7w>JbNG#f?q|H%zPoEWTw-7DxWrOqRQ8<EeOlv-YH!#4A*3H12T}o)&V_~gAXPp
+zpBzxUSdF9FTJ5^`RfPL7{k=ha4TSKO%V52z=^q@#qz}St4Yjz`RI8HvQR#8HT-EKO
+z{7p?BJLM#%QbBYSQ<F)WHBp_N&9Zy<BZ9Vp3(>aCY|9DgA2k^<)rM^?BS#{gvUl%p
+zao^(V{V)7a)~C(3G<GVL&4wkJG|QkQQ^{PfL{pSt7};DuD7uz<<#Ln?|5UYwAyBfK
+z&gq&sF`tiMo2jhaE0vYdHRw9?Q`n89$v(D*hUv0k!7-4o$H#F!`Q$Ej{X}j@?l0+I
+zr?G$a{m;>&78u8;7aA5DHcqyq7FHYVv7raStF_eHkJX!|$KIj!RwH5iC!f?5cZ1-_
+zMJNQj@_ra`vBwz3$?FD*7Vkd|5>s`M1A5#gjg9=TK$H_M{O@d|E+<_Q4Epc^J%#(H
+zVnR7><H@)*3-^&M*Fy{D1<lzq77Q9@f=;ne$f&KYsjaOwcI>$O{vA84I?QY=60xq_
+z!;*7_E5o9!!xq9S+!do(n5xA4!r<k@nn6)$$nvZLdHE~LvW^G@&k*Fzom<TwRBrZL
+zq)|@cAb3_D1kbVHX=<9Q`eJVNWzpEzssr+DmerRZ>9X&gmK@UPavTfyoZ}9PZ&;4M
+z+~ZP~L_6k|Jc~xX-giKrjdH@u3N%6QOt7*p=o0mLKh{!lozUp)XzSLk0>+}j!MDcF
+zXBo=kvy6qk@&k504&Lvl#M;_z+qTNKZIo&lny$-uR$A*Cn8IaRcCy{;<iyMHADC93
+zY*p-UvwV<s_I}3p0K2!#NuKItJdjES@Xa;*;qBFd?iQodZ@|foR0>&8XX+{(=`eyJ
+zOd0)fol6pl0L!any~h=$J##7eQ!EU7YMzr_(%fvmZ+yfh++9`MQ(VH`G8BTGkHR*J
+z3FVL3cs95+i@5*pI<?p33O3+a2AWHMf1AIz*XZx}>&)j<SH4zF>_lcJ?3jES%49+z
+z^%$hCF!2FAb|H)DEQHKV*aSk@1o$7>Uaw(pO_;yarVLaVI8hCq$;n$y49^bqX?4jB
+z&A>qslZG*Fm(y?CUfQ5gz^$^R6*nhMgZ)4LAojy{Q)r<OHA_nT2qSH{PChZ+BeQ2u
+zCJP=&7pa^}m35!oPu-{XQ}=1qEm|~N$x@v{HkTD;ZXCC6qnt7Q$f6EbJIlxU+<)eN
+z>xbp6=|x+q+cL*QIUF<XMZZ4#Ab37=Tm|OH;PgNQ6Qme4uVFwI-cPs4Ik*SN0&^{u
+zGa#m3(31Y}Pj=pNhAHwsD*tTf<%G1hQi{Rl2T##u?UQVU^`&an*giX@S|7opKK98h
+z%HJsG#&JlRI#>qg#1!kd$a$>S{qDa<cY|E$!V`(|-F0%2r#c+&gn5+J;4ZWvoPa()
+zZ1eHYsjb(vt+FWBVS{|$=HnOJ{Pz-@kAK1D<6pG#e5vT;+g)GA!y0{@=>k0e__6(T
+zcl&&PZbq?IwHd`akwL#s=*LGSO$_PGyux-?Qg`gJi9|kc)YeYH$8fu!$H#!~9@nLH
+zQ5;hVM<RHaph4IWFB!a49-c~tSyHbnsAz4i7h~D7Ix&_m#my0lVvYPuhbNrF3#o3Q
+zTzsTOXD9XqzaQSIc)xO`Hx@%TY9ld)L+-!;9`gqVu!nSYVK<=MsC>1;t^Au)x_9q0
+ziuScKw9CrSHi2d>mCDMORol&FXkQ17^0}m@Ou;<^{a!wXwo1NH;f9eqg+_rH1vUil
+zD*4y4^kMntag|&}GznHY6AZyS+#<7t{p4Fb`BjgxGFj`M14Z4p?REBnU?2F7z0SVg
+zIe;m+WrF95DdCl)<U#{^@x`a*fd}prma!-O+vo8tYsn_f>wQrkfBX?$zeWC?^>+E>
+zF$}!;N_F*f&+V4yp3@X}gIrzor!8{L_G&!ZV60e7W$vNTs2{g31KOe87Mp)vYx);k
+z=^ab+TxavI@7jFldp7^N-sWH5xAELi^siN}AN0fC4azElznl2{on1yCh^(7iqrY2a
+zK4gJNYinnSYm{z=v9w?;<~`JOB@CQN+4{yQE-V~TOIkUNdazR^vcT3`<cELolw~Mo
+z<-FWfrymWKz)}XR&mUoZTFXW25S6WEXg@APyBRe5lykk`QigUbXqI1CecV=tb~|X)
+z(;O}A5tTc}&{oNv)5&Jgm=MPVi(#Gr#J-m8gF@Y1_By-LSl>Uj*Nt7HkiAN_O$nnD
+zq)~FC^0Uu_HcH+)`47^{$q9qb^LzJJbB=Z5eS@?&f-lQJ0N>{*haW4k7kgh8{ZR9_
+z8ef*b=hm6$uaM(AesTRnEqm@e-E-VIub#R4V}Gju>vMm5Y3)B=PX0D?^vB;{m79FU
+z6Q9}i;BS91{ezo-x_)?R)Yt!wzpd&xZ`<6@-7}DS#`nRacU_hFXvd_l&3(0P?Io_v
+ztA9K0OZW7(ByT#@aXalsEP%aH;miJH;!S>!+)0iF91FaAEx^;I_nZD+4qx_+gD)c<
+zid*BTWMO+y=NVOj3k!o(w$8zqIry@Y1p{1~gD)$w2`?RdSsA0ePLhK!8!;H(pVU6?
+z;L9wV@b0gXWe&c~vdP<@JNUA<-{ww_w19&zbJl@l0mlOG9Sb=4viHthJ0m?@Ea2eF
+z4wsp5^l&WTSm3R<0M5M1>_y?9^AAqMmtFbV={3KroIbO#_tYJG)~r0?o>dp^aqwlL
+z4tTg5<nYCpMP+`)%t9U~w0OQZ5;k}qh1jx0qQ4Di-SdM<jV;R(KL$JxaY%q`5L<?<
+zn^`{FlOwh)69Bf%#2Q5-L4SV;r=NVweLkb5WpQ28IM}j29G;C6)RBzhL|iJ_FF0`9
+zD@K156@3JHEL~a;Y*}*y&k${vh12T_g+a04T^6*9*sLtTLn~G+!<xj|m_?pCq8Erm
+z7|IXfGpL|nxlCNzR<w}E<68XHIwD5WsRC+=HXFg24dn}x&E#`Kl1U8$RFqCc!T|{d
+z`+8SMPghGz6Ar{eMuV&A!F`@wI;Nl!g&|<h@)l@}IZ$B0n&kn2%j0ZdDjrcvX3|kf
+z#DP0o(W;cu=XH0=l6_S<uq(X*U!v|5naiYQXfOkP2wRItBDO*`tzV$95X7FPQwfR3
+zhJb_0W^ynCP$f`0mFVp7fwi$=rqtJQ%)p*KXv3amfIUkn?3tcW6ML34A!s)2Sq_*%
+zzz@xo&&7H(DPs)w4A2!4P3#%3a3rz|D+@#$_AEEpUr41D_AH%#<Jhy^8hdsNuxI;-
+zJ&O|2Rmf-Xl}q51Wj~e^5|N95FXjObggy#!R={NuGBiTtLI6vg&>~8~JQ!o~Xdc(H
+zJ1(h-#c)bg9a7U>#QV$!`Y`Aa`WY9B#`EF8q6K<z<Wsfo58z~Zn9#~pN*yId$2=>n
+zRp7}igFbMmShPh4iA9^=FjXDCE5)`QG8S!FIV{>O;_n)+NhQNVC=th>Hp^<^<BaKO
+zOxhOdn4z(2<Rd@Z_4JI7OG_lX;cu8m@@6#FZG2qXcImnU`p`Ggj%~OO4g!<b-wpQO
+zPJD#|_!?x7c|sra*bBHZn)7GFr0vw0Gz(Xz<`^9^=OIFZ3#kClJ#rF?c(k1oAa==W
+zN1PV<G+ygKShNYnb~GGT7>+d)3&Ao?8jtESB?81ThEC0R+}egnQ<O4TG><EI%Sw$!
+z^Z6I5arxVccWIJ#9D}AL<yGbw$HS!k8E0=fHliT_^f24)2a}d*!KRl=_DBq4>BYEm
+zxjuYr&DkTiBsDrs8H-6H)ByXWg-Hv)O_;PtC5vaNBGw361aT4{;2@&VCQNww{s|MH
+zw@TP+Y$!D7TEwBLU5J1p@|DA(jcilnvr-;#XysTP92%CdI*JVQ(oSz84h{BJv-_UM
+zp(PX!4Tv(F7Y7clXVe+`ymgdbov07PX2mn~`@y04IbA$w|K{M(wzy6OM#a})Vu!Fl
+z`QfX<u#czak@3_#h&(lKCTuo*B*M=5`XFb(5Ce1ODuX$LVBBp=;b!CF&7y>~;Mr%S
+z8TUCVBnIs4;LUii2LcCHrBP`d+J-*<`tW8^nivUE9K4y|Ph1*MBV4S8n|QNoz^eck
+z1+Kxwo1qq#H~8`y2`Fy{UkTnUkpP^OTyQItv@gFoc(ZneHzN*^=>k06l;F+a%OH-z
+zn<Wy^)<nSIw<(Ny^MDk65g&uU7jS8vrveWx5&R?qMujJNg#wF2!YpBlnQ$))DAwFu
+zFUFE3z>>ia4}c+CDn>^~vlv*HTVxyzSvcIm*AaYm@E0xwyrVH>uf9smR#fa5GK*%%
+zkXbZ4hHL`kv!JaVLuS$J7_zBT`8yAzF=U!H8biik_8{D<6hk&b-y+{U(ZY~L%te6Z
+zMEKZJgVr!h)N33p83%&8vRE=I4<8>FOGc%q;usNl%3{g(?R#Dxd1QPn8RhfY77BCD
+z#=(+Jow^&n@HZpy8!F&bzH<0u$)>t~&||}rS@*%9x(^;adJOlt8)uAQ$M~v)1&sG#
+z<u0YjFU-Z^f+HK2oByD3(!6I-QG3pbqz{b6l?}_SXlLQd%C{Sq+YW-~cJR<tv=rso
+zbKU>2+;KpjcLgpjjvYX!Hv^ZJ#bL_vacLucS$!UA{#N7C>RpBVjMW=f?Y!{CZJT>8
+zs(WI?mX^Qtzclyi_}$CSZp^x-KJlYZUi0<H<r8DGUpwoj2i||~?|<^ZiJJ!Qf8r}k
+z{3l1f(`N16wWIQelU9A<n(V#ryT0S8k9hCP_0&GL^Bd1UymjRj-~8F3j@xNBVgddi
+z3h%2AnK%{VRh;Blz_Gx)*8)75ZsAbN;nJRUaA^)Mtz`K-anDrDx8V}Ah!gj$)FN-}
+z+QFs0G5fK#gG(E+p@T~sv4t)<xU^D>yc5?BF72JLy3;5AD(J*LbC!W)0mlOG84EbL
+zwD-(ZI|DszEa2eM4x6cP6mcxzSl}(U0C8!%cR#_{UJ92MJ@eJ;+poLg_VriB|8dvE
+zqh{Q7>-ozaTpA7-8F&jl>~U#8m8ny+Mkq*q*AbT%iS)MOU@Z_-{zTl!W|Hm61h`V&
+zIFpylW!iPdLwpDg)R9UUKt^@OV@4toYX_dKKh*8(4H!OO%hHw>glcG*)7YqO(csc%
+z;Tc-QJnQY@Z?X3x2t%|VXOUu2V2FZ5qxAxYVDxmOV)0`9_<PeL9NjZ<X}MflpaVXL
+zPKH=g*=!2%F9ZckMrGNuC0LU<M+RIPV~8o94B=X7;Lixv8j#jyfRvfIv~(&8Ko^l;
+zsRU&b$&kZ0;9ZhTWKvn6z<^1UcqA0;lt6b+*D~p7Z)$2p@Egd`xU^Ip*cx`0g;JT6
+z>Xfjg957Fb_yC}734CG_8we>S6Y+kD40J(}W~I!`nfT)^;xz%6mIAvHmC@s)$W$UO
+z*>nQ>FdkY+B4NZ}L({pn(>M;|(&90w7{)Y#DFrjcqA4gHix7g>x~#r#n#`R;-V$6|
+zA{J_ogbkd$)Ds%hzwIA2f8xJS&2o%$4){=8EQ$rKQYIB9o(=6fG)u3}%$NY-k*icH
+z){cN5;LIr^%mQKQ-W&p~0V0%($BpoSKNsw?M8o`ASWZV4$Y~{1yUCN??jw$XFm-hl
+zj5cwiv1iYdPwd%aFb<T7OY0Bd%r$X&2#|sZAfa9?CnPMf2+oOSfb4^aEWZF7%3uNL
+z(g=+U0ki?sDk<cfGpEYrn>FibEJdy#;?lxl;*oelTz4^mh-peNMvhVz{bVthnznG^
+zEVI<mFoWw^;nF%gTFutIosbhGI1Ry4Oio5$(yd!t7ib?KE=`d!DCP`JLCDY3Pd`-5
+z=_`zpX6IXgPRsEzMw*>(UR_mLKH}2Ufp+xEoE9T&h(Gmj<?NR+((HUqhzw`dTRG3%
+z6PFf?2H|eN_CaRcEYp63Me)q4m2;gFmquRlk)P#`jwMB&5#H@8URosThreMO$&0v(
+zlpBxtsGNZXczwbNIRqH+Vm>u4Ek@r&JGS9E$VB@TA6Dt8cDl_@L9Dc1KiIq4@D=F9
+zSDHO$7@`6oU0lNX4YeZFoU0OiUBybX@MU)6a}ZW+A#1XDh>;j7v>Sy>vm2T1$WO&B
+zBXeECKg<|uBe*mg4l4|h$}oJDWtw!LUzaJtFvil^1CCW=!c`nE@MsFB$?MfoP~7f4
+z2v-5$DB{vueDl>J^(}8y`EuU^7!n&My$U^1XO8Xh#~)DFkEMQ<dN}^eIOe;LxHOJ2
+z7+fyBy<Bi?hv<Rk7_BzwPsK`0C7Q75#iAV&##p*Au2c#bH4}Ts9<lqV(P_=u{_)2(
+z#jRqc@pvcJg2JVtXQIP+-5}B8eXD`7(ohFEpvMtaqh9U9Dpnd1g^EAvQb$F*yTQX)
+zX^IJD#7ZmjWL)eHs79P;AB9T;xf>uCgc6uNd$!^6yzqOE$1oG-G&}-%L0_9ye6+ho
+z9gAffAt#XC2-s<?UAxx2ggqG}ZDgxbr4n}45Hb}utsJWos<^<z7-_tB@tV0QtVp9A
+z#z;F54`ZYqh=(!K7;lb!F}M1%XzYtI(yZ(9JUT|2-Q6rXq*?Amn=(e)f%!BxjV?jG
+zm|OBJ8uem~H0!!NkBX57dqWBntgH*VM14lZNVAN6<Bc~87>mXO->4XAmJuvI%Q)EU
+zM#V_OKwt6sp!zGbXWx0}jj!B!C#4#Aej{C%5i6t^BhBictIL`=w;3bN>XWUC{h2Y+
+zXi(J;%v9_F6kW!;Q!&z_Kwic=@y$IS*t8CR6Exw5WZ+REqcig=2%8}Snf5tg(|Al9
+za#V~oL|DW&#$Z%o<*lGAY#O6+s4`-tac5QKQ*@lfKma_9k*1hXMvSx~&juG=B0$XC
+zXlxpG1A@}JgDQ9nvgWpc0b*MqfT5{`4JVAv2h-mf4l@huEP%{Rfk0~j4WJJan}@mk
+zj9}A7{E@pC8{v)<z_UXmo<%8A3^c^tG8S41a}E(NVL?3qj5Oosqnp9bz@~AR)zyl-
+z93$oHSZK!_a|D?Yb_)+B$hizy$5?3N)iD;@cy)}0W`)mGgMv&hAIfAbwDNU27Mi7l
+z)sD-IzHG%p8^2!1LNjfpZZ8}Q<<K}ZDgBq&v;*-V78+Q1OYDaTCP=}`;~Io4U`<M5
+zp_MfRCmsrbcT_C2vV*sHOJbpMu+6~hU~%AWEC7$tW$k-tWVQnX$5xDmMtv+psmV0?
+z;P)yP8g;M?tR}{)H)Emce)r#_TVd1S+;CIOE3j$7U>kiK3!1(i3Uw-P1|P6#MPEiN
+zv`7SQOfL8ZO6VIrz@`;_8L`lcetL<`ml+Gq@@2$AEAo7)=*uP8G(6$>po-t$(xNt<
+zFnt-sHl<%1T^gaJBe+6T*hnU0;C%oesPsHOn7bl2EyN#~z+n0K7voC;o?4aXs^79u
+zG<CUX(OfYWE}SD=BgCfZR|opILX(bgwzVxr4Dc0;&<)oJuxW@TN6C0?FomK~Ft~y=
+zeDPOWz)E}!<C|Gi{L)L$DjKnAr8HvGN@>KVS<~<FyrS9?n^sCAHjT@G%cQD`&(s>5
+zHkzifY1Emc=i3xa2VNcDY%E=2(@ft2)K@J6g9+9!XbrQ(ah71y>;pmFC~TTtdHBI7
+zY?^&7b0Ae!kZr@JS#qI-y!`UBvTN6W3(N2o73a*7O&Sfx=UY{8V$<yMNjHqDswdG4
+zpVjd$t0-<2=Zwn-eXBTU*wSqG!Bnc7E@R#Y`}=((_rWbT-$9%+wFi+;??#l@AlKP^
+z2XW4de(^n<?=a4p<vWOTR^+*%=sP9YH0wU7gP3)On&~^3Iyw!sZ-PT%g9u<tGJOX_
+zWg5Yzar!Z_SmCOq{6jsKsS;Sl(Dq=AvvMqBm@y}aai++Mzmx%MlrhfiQ_6MA7-yw4
+z#yA^I)7Ug?x+$7#-^!^jWf7ZZ@o1XHrdfVr@msmYLu}fCc!*8oxM&}?x964|V$=4|
+zqp)dUQDJe>jEQzGiJ4{}JnBZpOtTLVzA`Fi+Sv6D*|wNzqvV<~(?-cNW2Tjp^MB9?
+B^QZs-
+
+-- 
+2.39.0
+


### PR DESCRIPTION
Move vertical changes to Horizontal.

Intel Read Verision(TLV) data is parsed into a local structure variable and it contains a field for bd address. Bd address is returned only in bootloader mode and hence bd address in TLV structure needs to be validated only if controller is present in boot loader mode.

Tracked-On: OAM-105473
Signed-off-by: Kothapeta, BikshapathiX <bikshapathix.kothapeta@intel.com>