### PR TITLE
CVE-2021-0934 fix for ASB-December-2022  - android_cloud

### DIFF
--- a/aosp_diff/common/frameworks/base/0121-Prevent-apps-from-spamming-addAccountExplicitly-See-comment.bulletin.patch
+++ b/aosp_diff/common/frameworks/base/0121-Prevent-apps-from-spamming-addAccountExplicitly-See-comment.bulletin.patch
@@ -1,0 +1,66 @@
+From 1189db7ab87fff48129d9f9454b9f5cd408e4f01 Mon Sep 17 00:00:00 2001
+From: Aseem Kumar <aseemk@google.com>
+Date: Mon, 17 May 2021 09:25:03 +0000
+Subject: [PATCH] Prevent apps from spamming addAccountExplicitly. See comment
+ here for the discussion on solution
+ https://b.corp.google.com/issues/169762606#comment14
+
+Change-Id: If212df3a3b7be1de0fb26b8e88b2fcbb8077c253
+
+Bug: 169762606
+(cherry picked from commit 11053c17b397db67b20e96ce769508766cef7db9)
+
+Change-Id: I3ff7d8f4df086cb4c153e7ec873b85a093810722
+Merged-In: If212df3a3b7be1de0fb26b8e88b2fcbb8077c253
+(cherry picked from commit c65b81ba2728bfc3d296b8b3fbe0acacd67d1bd6)
+(cherry picked from commit 846b862aa83699c1e2f1bf80e20d86c540d8de53)
+Merged-In: I3ff7d8f4df086cb4c153e7ec873b85a093810722
+---
+ core/java/android/accounts/Account.java                    | 7 +++++++
+ .../com/android/server/accounts/AccountManagerService.java | 5 +++++
+ 2 files changed, 12 insertions(+)
+
+diff --git a/core/java/android/accounts/Account.java b/core/java/android/accounts/Account.java
+index 9a18880a353b..965b6e0a02cd 100644
+--- a/core/java/android/accounts/Account.java
++++ b/core/java/android/accounts/Account.java
+@@ -30,6 +30,7 @@ import android.util.Log;
+ 
+ import com.android.internal.annotations.GuardedBy;
+ 
++import java.util.Objects;
+ import java.util.Set;
+ 
+ /**
+@@ -85,6 +86,12 @@ public class Account implements Parcelable {
+         if (TextUtils.isEmpty(type)) {
+             throw new IllegalArgumentException("the type must not be empty: " + type);
+         }
++        if (name.length() > 200) {
++            throw new IllegalArgumentException("account name is longer than 200 characters");
++        }
++        if (type.length() > 200) {
++            throw new IllegalArgumentException("account type is longer than 200 characters");
++        }
+         this.name = name;
+         this.type = type;
+         this.accessId = accessId;
+diff --git a/services/core/java/com/android/server/accounts/AccountManagerService.java b/services/core/java/com/android/server/accounts/AccountManagerService.java
+index 066ceef789f5..4d3af6fac31f 100644
+--- a/services/core/java/com/android/server/accounts/AccountManagerService.java
++++ b/services/core/java/com/android/server/accounts/AccountManagerService.java
+@@ -1821,6 +1821,11 @@ public class AccountManagerService
+                                 + ", skipping since the account already exists");
+                         return false;
+                     }
++                    if (accounts.accountsDb.findAllDeAccounts().size() > 100) {
++                        Log.w(TAG, "insertAccountIntoDatabase: " + account.toSafeString()
++                                + ", skipping since more than 50 accounts on device exist");
++                        return false;
++                    }
+                     long accountId = accounts.accountsDb.insertCeAccount(account, password);
+                     if (accountId < 0) {
+                         Log.w(TAG, "insertAccountIntoDatabase: " + account.toSafeString()
+-- 
+2.39.0.rc1.256.g54fd8350bd-goog
+

--- a/aosp_diff/common/frameworks/base/0122-DO-NOT-MERGE-Move-accountname-and-typeName-length-check-from.bulletin.patch
+++ b/aosp_diff/common/frameworks/base/0122-DO-NOT-MERGE-Move-accountname-and-typeName-length-check-from.bulletin.patch
@@ -1,0 +1,125 @@
+From 8a04e7a8b5655776704fa23c5f5e94f018be01ae Mon Sep 17 00:00:00 2001
+From: Aseem Kumar <aseemk@google.com>
+Date: Mon, 21 Mar 2022 20:35:20 -0700
+Subject: [PATCH] DO NOT MERGE Move accountname and typeName length check from
+ Account.java to AccountManagerService.
+
+Bug: 169762606
+Test: atest AccountManagerServiceTest
+Change-Id: I80fabf3a64c55837db98ff316e7e5420129c001b
+(cherry picked from commit 0adcadb0b28310bac568def4da2cbaf16843bcea)
+Merged-In: I80fabf3a64c55837db98ff316e7e5420129c001b
+(cherry picked from commit aa58f99079ed8adac51b6b21faae24cb1c86262b)
+(cherry picked from commit 355de0a1e9c9e3549db36e11b7522fa0d646f53b)
+Merged-In: I80fabf3a64c55837db98ff316e7e5420129c001b
+---
+ core/java/android/accounts/Account.java       |  7 ------
+ .../accounts/AccountManagerService.java       | 12 ++++++++++
+ .../accounts/AccountManagerServiceTest.java   | 22 +++++++++++++++++++
+ 3 files changed, 34 insertions(+), 7 deletions(-)
+
+diff --git a/core/java/android/accounts/Account.java b/core/java/android/accounts/Account.java
+index 965b6e0a02cd..9a18880a353b 100644
+--- a/core/java/android/accounts/Account.java
++++ b/core/java/android/accounts/Account.java
+@@ -30,7 +30,6 @@ import android.util.Log;
+ 
+ import com.android.internal.annotations.GuardedBy;
+ 
+-import java.util.Objects;
+ import java.util.Set;
+ 
+ /**
+@@ -86,12 +85,6 @@ public class Account implements Parcelable {
+         if (TextUtils.isEmpty(type)) {
+             throw new IllegalArgumentException("the type must not be empty: " + type);
+         }
+-        if (name.length() > 200) {
+-            throw new IllegalArgumentException("account name is longer than 200 characters");
+-        }
+-        if (type.length() > 200) {
+-            throw new IllegalArgumentException("account type is longer than 200 characters");
+-        }
+         this.name = name;
+         this.type = type;
+         this.accessId = accessId;
+diff --git a/services/core/java/com/android/server/accounts/AccountManagerService.java b/services/core/java/com/android/server/accounts/AccountManagerService.java
+index 4d3af6fac31f..2e8dd9cd5881 100644
+--- a/services/core/java/com/android/server/accounts/AccountManagerService.java
++++ b/services/core/java/com/android/server/accounts/AccountManagerService.java
+@@ -1807,6 +1807,14 @@ public class AccountManagerService
+         if (account == null) {
+             return false;
+         }
++        if (account.name != null && account.name.length() > 200) {
++            Log.w(TAG, "Account cannot be added - Name longer than 200 chars");
++            return false;
++        }
++        if (account.type != null && account.type.length() > 200) {
++            Log.w(TAG, "Account cannot be added - Name longer than 200 chars");
++            return false;
++        }
+         if (!isLocalUnlockedUser(accounts.userId)) {
+             Log.w(TAG, "Account " + account.toSafeString() + " cannot be added - user "
+                     + accounts.userId + " is locked. callingUid=" + callingUid);
+@@ -2000,6 +2008,10 @@ public class AccountManagerService
+                 + ", pid " + Binder.getCallingPid());
+         }
+         if (accountToRename == null) throw new IllegalArgumentException("account is null");
++        if (newName != null && newName.length() > 200) {
++            Log.e(TAG, "renameAccount failed - account name longer than 200");
++            throw new IllegalArgumentException("account name longer than 200");
++        }
+         int userId = UserHandle.getCallingUserId();
+         if (!isAccountManagedByCaller(accountToRename.type, callingUid, userId)) {
+             String msg = String.format(
+diff --git a/services/tests/servicestests/src/com/android/server/accounts/AccountManagerServiceTest.java b/services/tests/servicestests/src/com/android/server/accounts/AccountManagerServiceTest.java
+index 39a3aae767ea..ac305a93bfb8 100644
+--- a/services/tests/servicestests/src/com/android/server/accounts/AccountManagerServiceTest.java
++++ b/services/tests/servicestests/src/com/android/server/accounts/AccountManagerServiceTest.java
+@@ -36,6 +36,7 @@ import android.accounts.CantAddAccountActivity;
+ import android.accounts.IAccountManagerResponse;
+ import android.app.AppOpsManager;
+ import android.app.INotificationManager;
++import android.app.PropertyInvalidatedCache;
+ import android.app.admin.DevicePolicyManager;
+ import android.app.admin.DevicePolicyManagerInternal;
+ import android.content.BroadcastReceiver;
+@@ -132,6 +133,8 @@ public class AccountManagerServiceTest extends AndroidTestCase {
+     protected void setUp() throws Exception {
+         MockitoAnnotations.initMocks(this);
+ 
++        PropertyInvalidatedCache.disableForTestMode();
++
+         when(mMockPackageManager.checkSignatures(anyInt(), anyInt()))
+                     .thenReturn(PackageManager.SIGNATURE_MATCH);
+         final UserInfo ui = new UserInfo(UserHandle.USER_SYSTEM, "user0", 0);
+@@ -241,6 +244,25 @@ public class AccountManagerServiceTest extends AndroidTestCase {
+         assertEquals(a31, accounts[1]);
+     }
+ 
++    @SmallTest
++    public void testCheckAddAccountLongName() throws Exception {
++        unlockSystemUser();
++        String longString = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++                + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++                + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
++                + "aaaaa";
++        Account a11 = new Account(longString, AccountManagerServiceTestFixtures.ACCOUNT_TYPE_1);
++
++        mAms.addAccountExplicitly(a11, /* password= */ "p11", /* extras= */ null);
++
++        String[] list = new String[]{AccountManagerServiceTestFixtures.CALLER_PACKAGE};
++        when(mMockPackageManager.getPackagesForUid(anyInt())).thenReturn(list);
++        Account[] accounts = mAms.getAccountsAsUser(null,
++                UserHandle.getCallingUserId(), mContext.getOpPackageName());
++        assertEquals(0, accounts.length);
++    }
++
++
+     @SmallTest
+     public void testPasswords() throws Exception {
+         unlockSystemUser();
+-- 
+2.39.0.rc1.256.g54fd8350bd-goog
+


### PR DESCRIPTION
Zip file correction for CVE-2021-0934 bulletin_2022_12_preview_v2.zip. Provided on Dec 7th, 2022 did not include the complete patch details for CVE-2021-0934. Android 11 partners, who did not apply the patch from the zip file. Must apply the CVE-2021-0934 patch from bulletin_2022_12_preview_v3.zip. to fully remediate this CVE. No other Android versions are impacted with these changes.

Patches details
1)Prevent-apps-from-spamming-addAccountExplicitly-See-comment.bulletin.patch 2)DO-NOT-MERGE-Move-accountname-and-typeName-length-check-from.bulletin.patch

Tracked-On: OAM-105319
Signed-off-by: Reddy, Alavala Srinivasa <alavala.srinivasa.reddy@intel.com>