### PR TITLE
Fix gpu hang when run antutu9 on tgl

### DIFF
--- a/bsp_diff/common/kernel/lts2020-yocto/0043-Revert-drm-i915-Implement-Wa_1508744258.patch
+++ b/bsp_diff/common/kernel/lts2020-yocto/0043-Revert-drm-i915-Implement-Wa_1508744258.patch
@@ -1,0 +1,53 @@
+From a4d911fc77d319d884d602abe4e2978d7b0a4976 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jos=C3=A9=20Roberto=20de=20Souza?= <jose.souza@intel.com>
+Date: Fri, 19 Nov 2021 06:09:30 -0800
+Subject: [PATCH] Revert "drm/i915: Implement Wa_1508744258"
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+[ Upstream commit 72641d8d60401a5f1e1a0431ceaf928680d34418 ]
+
+This workarounds are causing hangs, because I missed the fact that it
+needs to be enabled for all cases and disabled when doing a resolve
+pass.
+
+So KMD only needs to whitelist it and UMD will be the one setting it
+on per case.
+
+This reverts commit 28ec02c9cbebf3feeaf21a59df9dfbc02bda3362.
+
+Closes: https://gitlab.freedesktop.org/drm/intel/-/issues/4145
+Signed-off-by: José Roberto de Souza <jose.souza@intel.com>
+Fixes: 28ec02c9cbeb ("drm/i915: Implement Wa_1508744258")
+Reviewed-by: Matt Atwood <matthew.s.atwood@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20211119140931.32791-1-jose.souza@intel.com
+(cherry picked from commit f3799ff16fcfacd44aee55db162830df461b631f)
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+Signed-off-by: chenyanxzhu <chenyanx.zhu@intel.com>
+---
+ drivers/gpu/drm/i915/gt/intel_workarounds.c | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/gt/intel_workarounds.c b/drivers/gpu/drm/i915/gt/intel_workarounds.c
+index 6ceb0a522474..9f05870298b4 100644
+--- a/drivers/gpu/drm/i915/gt/intel_workarounds.c
++++ b/drivers/gpu/drm/i915/gt/intel_workarounds.c
+@@ -621,13 +621,6 @@ static void gen12_ctx_workarounds_init(struct intel_engine_cs *engine,
+ 	       FF_MODE2_GS_TIMER_MASK,
+ 	       FF_MODE2_GS_TIMER_224,
+ 	       0, false);
+-
+-	/*
+-	 * Wa_14012131227:dg1
+-	 * Wa_1508744258:tgl,rkl,dg1,adl-s,adl-p
+-	 */
+-	wa_masked_en(wal, GEN7_COMMON_SLICE_CHICKEN1,
+-		     GEN9_RHWO_OPTIMIZATION_DISABLE);
+ }
+ 
+ static void dg1_ctx_workarounds_init(struct intel_engine_cs *engine,
+-- 
+2.38.1
+

--- a/host/kernel/lts2020-yocto/0002-Revert-drm-i915-Implement-Wa_1508744258.patch
+++ b/host/kernel/lts2020-yocto/0002-Revert-drm-i915-Implement-Wa_1508744258.patch
@@ -1,0 +1,53 @@
+From 113e05af6b37c684a2661d7090dbdbc70ed8abb6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jos=C3=A9=20Roberto=20de=20Souza?= <jose.souza@intel.com>
+Date: Fri, 19 Nov 2021 06:09:30 -0800
+Subject: [PATCH] Revert "drm/i915: Implement Wa_1508744258"
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+[ Upstream commit 72641d8d60401a5f1e1a0431ceaf928680d34418 ]
+
+This workarounds are causing hangs, because I missed the fact that it
+needs to be enabled for all cases and disabled when doing a resolve
+pass.
+
+So KMD only needs to whitelist it and UMD will be the one setting it
+on per case.
+
+This reverts commit 28ec02c9cbebf3feeaf21a59df9dfbc02bda3362.
+
+Closes: https://gitlab.freedesktop.org/drm/intel/-/issues/4145
+Signed-off-by: José Roberto de Souza <jose.souza@intel.com>
+Fixes: 28ec02c9cbeb ("drm/i915: Implement Wa_1508744258")
+Reviewed-by: Matt Atwood <matthew.s.atwood@intel.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20211119140931.32791-1-jose.souza@intel.com
+(cherry picked from commit f3799ff16fcfacd44aee55db162830df461b631f)
+Signed-off-by: Rodrigo Vivi <rodrigo.vivi@intel.com>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+Signed-off-by: chenyanxzhu <chenyanx.zhu@intel.com>
+---
+ drivers/gpu/drm/i915/gt/intel_workarounds.c | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/gt/intel_workarounds.c b/drivers/gpu/drm/i915/gt/intel_workarounds.c
+index 6ceb0a522474..9f05870298b4 100644
+--- a/drivers/gpu/drm/i915/gt/intel_workarounds.c
++++ b/drivers/gpu/drm/i915/gt/intel_workarounds.c
+@@ -621,13 +621,6 @@ static void gen12_ctx_workarounds_init(struct intel_engine_cs *engine,
+ 	       FF_MODE2_GS_TIMER_MASK,
+ 	       FF_MODE2_GS_TIMER_224,
+ 	       0, false);
+-
+-	/*
+-	 * Wa_14012131227:dg1
+-	 * Wa_1508744258:tgl,rkl,dg1,adl-s,adl-p
+-	 */
+-	wa_masked_en(wal, GEN7_COMMON_SLICE_CHICKEN1,
+-		     GEN9_RHWO_OPTIMIZATION_DISABLE);
+ }
+ 
+ static void dg1_ctx_workarounds_init(struct intel_engine_cs *engine,
+-- 
+2.38.1
+


### PR DESCRIPTION
In sriov mode, the gpu hang happens in host kernel. In gvt-d mode, the gpu hang happens in guest kernel.

Signed-off-by: chenyanxzhu <chenyanx.zhu@intel.com>