### PR TITLE
remove support for nintendo-charge-grip

### DIFF
--- a/bsp_diff/common/kernel/lts2019-chromium/74-0074-Revert-BACKPORT-HID-nintendo-add-support-for-chargin.patch
+++ b/bsp_diff/common/kernel/lts2019-chromium/74-0074-Revert-BACKPORT-HID-nintendo-add-support-for-chargin.patch
@@ -1,0 +1,216 @@
+From c147c388794953a88780a2def8cd167ab56bade6 Mon Sep 17 00:00:00 2001
+From: rajucm <raju.mallikarjun.chegaraddi@intel.com>
+Date: Mon, 9 Jan 2023 19:12:39 +0530
+Subject: [PATCH] Revert "BACKPORT: HID: nintendo: add support for charging
+ grip"
+
+This reverts commit 33751237ead2ff98dfef304bd826e126e5003fda.
+---
+ drivers/hid/hid-ids.h      |  1 -
+ drivers/hid/hid-nintendo.c | 64 +++++++-------------------------------
+ 2 files changed, 12 insertions(+), 53 deletions(-)
+
+diff --git a/drivers/hid/hid-ids.h b/drivers/hid/hid-ids.h
+index eb4777a63b04..6ba837669d83 100644
+--- a/drivers/hid/hid-ids.h
++++ b/drivers/hid/hid-ids.h
+@@ -905,7 +905,6 @@
+ #define USB_DEVICE_ID_NINTENDO_JOYCONL	0x2006
+ #define USB_DEVICE_ID_NINTENDO_JOYCONR	0x2007
+ #define USB_DEVICE_ID_NINTENDO_PROCON	0x2009
+-#define USB_DEVICE_ID_NINTENDO_CHRGGRIP	0x200E
+ 
+ #define USB_VENDOR_ID_NOVATEK		0x0603
+ #define USB_DEVICE_ID_NOVATEK_PCT	0x0600
+diff --git a/drivers/hid/hid-nintendo.c b/drivers/hid/hid-nintendo.c
+index 2bb2ae94c348..f5918cde720e 100644
+--- a/drivers/hid/hid-nintendo.c
++++ b/drivers/hid/hid-nintendo.c
+@@ -237,13 +237,6 @@ enum joycon_ctlr_state {
+ 	JOYCON_CTLR_STATE_REMOVED,
+ };
+ 
+-/* Controller type received as part of device info */
+-enum joycon_ctlr_type {
+-	JOYCON_CTLR_TYPE_JCL = 0x01,
+-	JOYCON_CTLR_TYPE_JCR = 0x02,
+-	JOYCON_CTLR_TYPE_PRO = 0x03,
+-};
+-
+ struct joycon_stick_cal {
+ 	s32 max;
+ 	s32 min;
+@@ -334,7 +327,6 @@ struct joycon_ctlr {
+ 	spinlock_t lock;
+ 	u8 mac_addr[6];
+ 	char *mac_addr_str;
+-	enum joycon_ctlr_type ctlr_type;
+ 
+ 	/* The following members are used for synchronous sends/receives */
+ 	enum joycon_msg_type msg_type;
+@@ -375,26 +367,6 @@ struct joycon_ctlr {
+ 	unsigned short rumble_zero_countdown;
+ };
+ 
+-/* Helper macros for checking controller type */
+-#define jc_type_is_joycon(ctlr) \
+-	(ctlr->hdev->product == USB_DEVICE_ID_NINTENDO_JOYCONL || \
+-	 ctlr->hdev->product == USB_DEVICE_ID_NINTENDO_JOYCONR || \
+-	 ctlr->hdev->product == USB_DEVICE_ID_NINTENDO_CHRGGRIP)
+-#define jc_type_is_procon(ctlr) \
+-	(ctlr->hdev->product == USB_DEVICE_ID_NINTENDO_PROCON)
+-#define jc_type_is_chrggrip(ctlr) \
+-	(ctlr->hdev->product == USB_DEVICE_ID_NINTENDO_CHRGGRIP)
+-
+-/* Does this controller have inputs associated with left joycon? */
+-#define jc_type_has_left(ctlr) \
+-	(ctlr->ctlr_type == JOYCON_CTLR_TYPE_JCL || \
+-	 ctlr->ctlr_type == JOYCON_CTLR_TYPE_PRO)
+-
+-/* Does this controller have inputs associated with right joycon? */
+-#define jc_type_has_right(ctlr) \
+-	(ctlr->ctlr_type == JOYCON_CTLR_TYPE_JCR || \
+-	 ctlr->ctlr_type == JOYCON_CTLR_TYPE_PRO)
+-
+ static int __joycon_hid_send(struct hid_device *hdev, u8 *data, size_t len)
+ {
+ 	u8 *buf;
+@@ -703,6 +675,7 @@ static void joycon_parse_report(struct joycon_ctlr *ctlr,
+ 	unsigned long flags;
+ 	u8 tmp;
+ 	u32 btns;
++	u32 id = ctlr->hdev->product;
+ 	unsigned long msecs = jiffies_to_msecs(jiffies);
+ 
+ 	spin_lock_irqsave(&ctlr->lock, flags);
+@@ -752,7 +725,7 @@ static void joycon_parse_report(struct joycon_ctlr *ctlr,
+ 	/* Parse the buttons and sticks */
+ 	btns = hid_field_extract(ctlr->hdev, rep->button_status, 0, 24);
+ 
+-	if (jc_type_has_left(ctlr)) {
++	if (id != USB_DEVICE_ID_NINTENDO_JOYCONR) {
+ 		u16 raw_x;
+ 		u16 raw_y;
+ 		s32 x;
+@@ -776,7 +749,7 @@ static void joycon_parse_report(struct joycon_ctlr *ctlr,
+ 		input_report_key(dev, BTN_THUMBL, btns & JC_BTN_LSTICK);
+ 		input_report_key(dev, BTN_Z, btns & JC_BTN_CAP);
+ 
+-		if (jc_type_is_joycon(ctlr)) {
++		if (id != USB_DEVICE_ID_NINTENDO_PROCON) {
+ 			/* Report the S buttons as the non-existent triggers */
+ 			input_report_key(dev, BTN_TR, btns & JC_BTN_SL_L);
+ 			input_report_key(dev, BTN_TR2, btns & JC_BTN_SR_L);
+@@ -808,7 +781,7 @@ static void joycon_parse_report(struct joycon_ctlr *ctlr,
+ 			input_report_abs(dev, ABS_HAT0Y, haty);
+ 		}
+ 	}
+-	if (jc_type_has_right(ctlr)) {
++	if (id != USB_DEVICE_ID_NINTENDO_JOYCONL) {
+ 		u16 raw_x;
+ 		u16 raw_y;
+ 		s32 x;
+@@ -828,7 +801,7 @@ static void joycon_parse_report(struct joycon_ctlr *ctlr,
+ 		/* report buttons */
+ 		input_report_key(dev, BTN_TR, btns & JC_BTN_R);
+ 		input_report_key(dev, BTN_TR2, btns & JC_BTN_ZR);
+-		if (jc_type_is_joycon(ctlr)) {
++		if (id != USB_DEVICE_ID_NINTENDO_PROCON) {
+ 			/* Report the S buttons as the non-existent triggers */
+ 			input_report_key(dev, BTN_TL, btns & JC_BTN_SL_R);
+ 			input_report_key(dev, BTN_TL2, btns & JC_BTN_SR_R);
+@@ -1083,12 +1056,6 @@ static int joycon_input_create(struct joycon_ctlr *ctlr)
+ 	case USB_DEVICE_ID_NINTENDO_PROCON:
+ 		name = "Nintendo Switch Pro Controller";
+ 		break;
+-	case USB_DEVICE_ID_NINTENDO_CHRGGRIP:
+-		if (jc_type_has_left(ctlr))
+-			name = "Nintendo Switch Left Joy-Con (Grip)";
+-		else
+-			name = "Nintendo Switch Right Joy-Con (Grip)";
+-		break;
+ 	case USB_DEVICE_ID_NINTENDO_JOYCONL:
+ 		name = "Nintendo Switch Left Joy-Con";
+ 		break;
+@@ -1111,8 +1078,9 @@ static int joycon_input_create(struct joycon_ctlr *ctlr)
+ 	ctlr->input->name = name;
+ 	input_set_drvdata(ctlr->input, ctlr);
+ 
++
+ 	/* set up sticks and buttons */
+-	if (jc_type_has_left(ctlr)) {
++	if (hdev->product != USB_DEVICE_ID_NINTENDO_JOYCONR) {
+ 		input_set_abs_params(ctlr->input, ABS_X,
+ 				     -JC_MAX_STICK_MAG, JC_MAX_STICK_MAG,
+ 				     JC_STICK_FUZZ, JC_STICK_FLAT);
+@@ -1138,7 +1106,7 @@ static int joycon_input_create(struct joycon_ctlr *ctlr)
+ 					     JC_DPAD_FUZZ, JC_DPAD_FLAT);
+ 		}
+ 	}
+-	if (jc_type_has_right(ctlr)) {
++	if (hdev->product != USB_DEVICE_ID_NINTENDO_JOYCONL) {
+ 		input_set_abs_params(ctlr->input, ABS_RX,
+ 				     -JC_MAX_STICK_MAG, JC_MAX_STICK_MAG,
+ 				     JC_STICK_FUZZ, JC_STICK_FLAT);
+@@ -1264,7 +1232,7 @@ static int joycon_power_supply_create(struct joycon_ctlr *ctlr)
+ 	return power_supply_powers(ctlr->battery, &hdev->dev);
+ }
+ 
+-static int joycon_read_info(struct joycon_ctlr *ctlr)
++static int joycon_read_mac(struct joycon_ctlr *ctlr)
+ {
+ 	int ret;
+ 	int i;
+@@ -1296,8 +1264,6 @@ static int joycon_read_info(struct joycon_ctlr *ctlr)
+ 		return -ENOMEM;
+ 	hid_info(ctlr->hdev, "controller MAC = %s\n", ctlr->mac_addr_str);
+ 
+-	/* Retrieve the type so we can distinguish for charging grip */
+-	ctlr->ctlr_type = report->reply.data[2];
+ 	return 0;
+ }
+ 
+@@ -1436,7 +1402,7 @@ static int nintendo_hid_probe(struct hid_device *hdev,
+ 	/* Initialize the controller */
+ 	mutex_lock(&ctlr->output_mutex);
+ 	/* if handshake command fails, assume ble pro controller */
+-	if ((jc_type_is_procon(ctlr) || jc_type_is_chrggrip(ctlr)) &&
++	if (hdev->product == USB_DEVICE_ID_NINTENDO_PROCON &&
+ 	    !joycon_send_usb(ctlr, JC_USB_CMD_HANDSHAKE, HZ)) {
+ 		hid_dbg(hdev, "detected USB controller\n");
+ 		/* set baudrate for improved latency */
+@@ -1456,10 +1422,6 @@ static int nintendo_hid_probe(struct hid_device *hdev,
+ 		 * This doesn't send a response, so ignore the timeout.
+ 		 */
+ 		joycon_send_usb(ctlr, JC_USB_CMD_NO_TIMEOUT, HZ/10);
+-	} else if (jc_type_is_chrggrip(ctlr)) {
+-		hid_err(hdev, "Failed charging grip handshake\n");
+-		ret = -ETIMEDOUT;
+-		goto err_mutex;
+ 	}
+ 
+ 	/* get controller calibration data, and parse it */
+@@ -1486,9 +1448,9 @@ static int nintendo_hid_probe(struct hid_device *hdev,
+ 		goto err_mutex;
+ 	}
+ 
+-	ret = joycon_read_info(ctlr);
++	ret = joycon_read_mac(ctlr);
+ 	if (ret) {
+-		hid_err(hdev, "Failed to retrieve controller info; ret=%d\n",
++		hid_err(hdev, "Failed to retrieve controller MAC; ret=%d\n",
+ 			ret);
+ 		goto err_mutex;
+ 	}
+@@ -1549,8 +1511,6 @@ static const struct hid_device_id nintendo_hid_devices[] = {
+ 			 USB_DEVICE_ID_NINTENDO_PROCON) },
+ 	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_NINTENDO,
+ 			 USB_DEVICE_ID_NINTENDO_PROCON) },
+-	{ HID_USB_DEVICE(USB_VENDOR_ID_NINTENDO,
+-			 USB_DEVICE_ID_NINTENDO_CHRGGRIP) },
+ 	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_NINTENDO,
+ 			 USB_DEVICE_ID_NINTENDO_JOYCONL) },
+ 	{ HID_BLUETOOTH_DEVICE(USB_VENDOR_ID_NINTENDO,
+-- 
+2.39.0
+


### PR DESCRIPTION
Android-R CTS failed due to newly added nintendo charge-grip support hence, removed

Tracked-On: OAM-105465
Signed-off-by: rajucm <raju.mallikarjun.chegaraddi@intel.com>