### PR TITLE
Resolving the media-driver and gmmlib warnings

### DIFF
--- a/bsp_diff/common/hardware/intel/gmmlib/0001-Add-Android.mk-for-intel-gmmlib-22.3.0.patch
+++ b/bsp_diff/common/hardware/intel/gmmlib/0001-Add-Android.mk-for-intel-gmmlib-22.3.0.patch
@@ -1,4 +1,4 @@
-From ccc7ea6335464ebb7f1aee7c5836dd84b98bf2e5 Mon Sep 17 00:00:00 2001
+From f97ef01368048efd6d59689f7c91daa5d1bba9e5 Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Fri, 15 Jul 2022 22:02:24 +0530
 Subject: [PATCH] Add Android.mk for intel-gmmlib-22.3.0
@@ -8,16 +8,16 @@ Tracked-On: OAM-104571
 Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Signed-off-by: Yerriswamy <yerriswamy.kt@intel.com>
 ---
- Android.mk | 118 +++++++++++++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 118 insertions(+)
+ Android.mk | 126 +++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 126 insertions(+)
  create mode 100644 Android.mk
 
 diff --git a/Android.mk b/Android.mk
 new file mode 100644
-index 0000000..c90f8b3
+index 0000000..c388889
 --- /dev/null
 +++ b/Android.mk
-@@ -0,0 +1,118 @@
+@@ -0,0 +1,126 @@
 +# Copyright(c) 2018 Intel Corporation
 +
 +# Permission is hereby granted, free of charge, to any person obtaining a
@@ -87,6 +87,7 @@ index 0000000..c90f8b3
 +    Source/Common/AssertTracer/AssertTracer.cpp \
 +
 +LOCAL_CFLAGS := \
++    -Wno-logical-op-parentheses \
 +    -Wno-error \
 +    -Wno-unused-parameter \
 +    -msse2 \
@@ -111,6 +112,13 @@ index 0000000..c90f8b3
 +    -Digfx_gmmumd_dll_EXPORTS
 +
 +LOCAL_CPPFLAGS := \
++    -Wno-implicit-fallthrough \
++    -Wno-missing-braces \
++    -Wno-parentheses-equality \
++    -Wno-logical-not-parentheses \
++    -Wno-missing-field-initializers \
++    -Wno-unknown-pragmas \
++    -Wno-parentheses \
 +    -Wno-pragma-pack \
 +    -fexceptions \
 +    -std=c++11 \
@@ -137,5 +145,5 @@ index 0000000..c90f8b3
 +
 +include $(BUILD_STATIC_LIBRARY)
 -- 
-2.38.1
+2.39.0
 

--- a/bsp_diff/common/hardware/intel/media-driver/0001-Add-changes-to-build-latest-media-driver-in-Android.patch
+++ b/bsp_diff/common/hardware/intel/media-driver/0001-Add-changes-to-build-latest-media-driver-in-Android.patch
@@ -1,4 +1,4 @@
-From 4c2af9a2d5f66da675c1df09d732edbe9c943d10 Mon Sep 17 00:00:00 2001
+From 07e34fbc71a6f172af1b3210854c9d9e26c1fdb3 Mon Sep 17 00:00:00 2001
 From: Ratnesh Kumar Rai <ratnesh.kumar.rai@intel.com>
 Date: Fri, 30 Sep 2022 23:00:55 +0530
 Subject: [PATCH] Add changes to build latest media driver in Android
@@ -19,10 +19,10 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
 ---
  CMakeLists.txt                                |    4 +-
  .../Android/GenerateAndroidMk.py              |   25 +
- Tools/MediaDriverTools/Android/mk/cmrt.tpl    |    4 +
+ Tools/MediaDriverTools/Android/mk/cmrt.tpl    |    6 +
  Tools/MediaDriverTools/Android/mk/gmm.tpl     |   15 +-
- .../Android/mk/media_driver.tpl               |   14 +-
- cmrtlib/Android.mk                            |   84 +
+ .../Android/mk/media_driver.tpl               |   27 +-
+ cmrtlib/Android.mk                            |   86 +
  .../agnostic/common/cp/media_srcs.cmake       |    4 +-
  .../common/heap_manager/media_srcs.cmake      |    1 +
  .../agnostic/common/hw/media_srcs.cmake       |    6 +
@@ -38,7 +38,7 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  .../common/vp/kernel/media_srcs.cmake         |    4 +-
  .../linux/common/cp/os/media_srcs.cmake       |    1 +
  media_common/linux/common/os/media_srcs.cmake |    1 +
- media_driver/Android.mk                       | 1655 +++++++++++++++++
+ media_driver/Android.mk                       | 1667 +++++++++++++++++
  .../agnostic/Xe_M/Xe_HPM/hw/media_srcs.cmake  |    1 +
  .../Xe_M/Xe_HPM/hw/vdbox/media_srcs.cmake     |    1 +
  .../Xe_M/Xe_HPM/vp/hal/media_srcs.cmake       |    2 +
@@ -238,7 +238,7 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  .../common/os/osservice/media_srcs.cmake      |    1 +
  .../os/osservice/mos_utilities_specific.cpp   |    3 +-
  .../os/osservice/mos_utilities_specific.h     |    1 +
- 221 files changed, 2451 insertions(+), 145 deletions(-)
+ 221 files changed, 2480 insertions(+), 145 deletions(-)
  create mode 100644 cmrtlib/Android.mk
  create mode 100644 media_driver/Android.mk
  create mode 100644 media_driver/agnostic/gen12_tgllp/vp/kernel/swsb/media_srcs.cmake
@@ -314,13 +314,15 @@ index 84126a73e..2ffcbc269 100755
  
  class Main:
 diff --git a/Tools/MediaDriverTools/Android/mk/cmrt.tpl b/Tools/MediaDriverTools/Android/mk/cmrt.tpl
-index 470cc64b3..2ec860983 100644
+index 470cc64b3..6af93c859 100644
 --- a/Tools/MediaDriverTools/Android/mk/cmrt.tpl
 +++ b/Tools/MediaDriverTools/Android/mk/cmrt.tpl
-@@ -33,6 +33,10 @@ LOCAL_C_INCLUDES += \
+@@ -33,6 +33,12 @@ LOCAL_C_INCLUDES += \
  @LOCAL_C_INCLUDES
  
  LOCAL_CFLAGS += \
++    -Wno-implicit-fallthrough \
++    -Wno-reorder-ctor \
 +    -Wno-error \
 +    -Wno-unused-variable \
 +    -Wno-unused-parameter \
@@ -357,10 +359,10 @@ index 863be9d2e..a5339c0e1 100644
  LOCAL_C_INCLUDES = \
  @LOCAL_C_INCLUDES
 diff --git a/Tools/MediaDriverTools/Android/mk/media_driver.tpl b/Tools/MediaDriverTools/Android/mk/media_driver.tpl
-index f51b83d43..1409861d6 100644
+index f51b83d43..c494b46cd 100644
 --- a/Tools/MediaDriverTools/Android/mk/media_driver.tpl
 +++ b/Tools/MediaDriverTools/Android/mk/media_driver.tpl
-@@ -35,16 +35,26 @@ LOCAL_SHARED_LIBRARIES := \
+@@ -35,16 +35,39 @@ LOCAL_SHARED_LIBRARIES := \
      liblog \
  
  
@@ -370,6 +372,19 @@ index f51b83d43..1409861d6 100644
  
 -LOCAL_CPPFLAGS = \
 +LOCAL_CPPFLAGS := \
++    -Wno-delete-incomplete \
++    -Wno-implicit-fallthrough \
++    -Wno-overloaded-virtual \
++    -Wno-logical-op-parentheses \
++    -Wno-missing-braces \
++    -Wno-ignored-qualifiers \
++    -Wno-missing-field-initializers \
++    -Wno-deprecated-declarations \
++    -Wno-parentheses-equality \
++    -Wno-parentheses \
++    -Wno-reorder-ctor \
++    -Wno-comment \
++    -Wno-format \
 +    -Wno-error \
 +    -Wno-pragma-pack \
 +    -Wno-unused-parameter \
@@ -391,10 +406,10 @@ index f51b83d43..1409861d6 100644
  LOCAL_CONLYFLAGS = -x c++
 diff --git a/cmrtlib/Android.mk b/cmrtlib/Android.mk
 new file mode 100644
-index 000000000..4dee8b3e6
+index 000000000..69c511edf
 --- /dev/null
 +++ b/cmrtlib/Android.mk
-@@ -0,0 +1,84 @@
+@@ -0,0 +1,86 @@
 +# Copyright(c) 2018 Intel Corporation
 +
 +# Permission is hereby granted, free of charge, to any person obtaining a
@@ -448,6 +463,8 @@ index 000000000..4dee8b3e6
 +    $(LOCAL_PATH)/linux/hardware
 +
 +LOCAL_CFLAGS += \
++    -Wno-implicit-fallthrough \
++    -Wno-reorder-ctor \
 +    -Wno-error \
 +    -Wno-unused-variable \
 +    -Wno-unused-parameter \
@@ -673,10 +690,10 @@ index e117b5e8d..828fa2060 100644
  endif() # CMAKE_WDDM_LINUX
 diff --git a/media_driver/Android.mk b/media_driver/Android.mk
 new file mode 100644
-index 000000000..0a79f93d6
+index 000000000..e85b86e65
 --- /dev/null
 +++ b/media_driver/Android.mk
-@@ -0,0 +1,1655 @@
+@@ -0,0 +1,1667 @@
 +
 +# Copyright(c) 2018 Intel Corporation
 +
@@ -1897,6 +1914,19 @@ index 000000000..0a79f93d6
 +    libgmm_umd \
 +
 +LOCAL_CPPFLAGS := \
++    -Wno-delete-incomplete \
++    -Wno-implicit-fallthrough \
++    -Wno-overloaded-virtual \
++    -Wno-logical-op-parentheses \
++    -Wno-missing-braces \
++    -Wno-ignored-qualifiers \
++    -Wno-missing-field-initializers \
++    -Wno-deprecated-declarations \
++    -Wno-parentheses-equality \
++    -Wno-parentheses \
++    -Wno-reorder-ctor \
++    -Wno-comment \
++    -Wno-format \
 +    -Wno-error \
 +    -Wno-pragma-pack \
 +    -Wno-unused-parameter \
@@ -1947,7 +1977,7 @@ index 000000000..0a79f93d6
 +    -DIGFX_XE_HPG_CMFCPATCH_SUPPORTED \
 +    -DIGFX_XE_HPG_SUPPORTED \
 +    -DMEDIA_VERSION=\"22.6.1\" \
-+    -DMEDIA_VERSION_DETAILS=\"ef04e2e48\" \
++    -DMEDIA_VERSION_DETAILS=\"bfd8bdb38\" \
 +    -DVEBOX_AUTO_DENOISE_SUPPORTED=1 \
 +    -DX11_FOUND \
 +    -D_AV1_DECODE_SUPPORTED \
@@ -2323,7 +2353,6 @@ index 000000000..0a79f93d6
 +    $(LOCAL_PATH)/../media_softlet/linux/common/os/i915_production \
 +    $(LOCAL_PATH)/../media_softlet/linux/common/os \
 +    $(LOCAL_PATH)/../media_softlet/linux/common/cp \
-+    $(LOCAL_PATH)/../cmrtlib/linux/hardware
 +
 +
 +#LOCAL_CPP_FEATURES := rtti exceptions
@@ -4996,5 +5025,5 @@ index b6a986af3..af18e7382 100644
  #define USER_FEATURE_FILE                   "/etc/igfx_user_feature.txt"
  #define USER_FEATURE_FILE_NEXT              "/etc/igfx_user_feature_next.txt"
 -- 
-2.17.1
+2.39.0
 

--- a/bsp_diff/common/hardware/intel/media-driver/0002-Resolved-compilation-issue-for-media-driver.patch
+++ b/bsp_diff/common/hardware/intel/media-driver/0002-Resolved-compilation-issue-for-media-driver.patch
@@ -1,4 +1,4 @@
-From aaa99cf1fe62b5111c504be04865ea0efb9161d1 Mon Sep 17 00:00:00 2001
+From 7ad061ed5e42e631908071e702ee9534a213d860 Mon Sep 17 00:00:00 2001
 From: Ratnesh Kumar Rai <ratnesh.kumar.rai@intel.com>
 Date: Mon, 22 Aug 2022 11:08:25 +0530
 Subject: [PATCH] Resolved compilation issue for media driver
@@ -13,9 +13,10 @@ Signed-off-by: Ratnesh Kumar Rai <ratnesh.kumar.rai@intel.com>
 Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
 ---
  cmrtlib/linux/hardware/cm_device_os.cpp                     | 6 ++++--
+ media_driver/Android.mk                                     | 1 +
  media_softlet/agnostic/common/vp/kdll/hal_kerneldll_next.c  | 3 ++-
  .../linux/common/os/osservice/mos_utilities_specific.cpp    | 2 ++
- 3 files changed, 8 insertions(+), 3 deletions(-)
+ 4 files changed, 9 insertions(+), 3 deletions(-)
 
 diff --git a/cmrtlib/linux/hardware/cm_device_os.cpp b/cmrtlib/linux/hardware/cm_device_os.cpp
 index 36b98c13a..e21292283 100644
@@ -34,6 +35,18 @@ index 36b98c13a..e21292283 100644
  {
  
      // New Surface Manager
+diff --git a/media_driver/Android.mk b/media_driver/Android.mk
+index e85b86e65..775d1f48f 100644
+--- a/media_driver/Android.mk
++++ b/media_driver/Android.mk
+@@ -1657,6 +1657,7 @@ LOCAL_C_INCLUDES  = \
+     $(LOCAL_PATH)/../media_softlet/linux/common/os/i915_production \
+     $(LOCAL_PATH)/../media_softlet/linux/common/os \
+     $(LOCAL_PATH)/../media_softlet/linux/common/cp \
++    $(LOCAL_PATH)/../cmrtlib/linux/hardware
+ 
+ 
+ #LOCAL_CPP_FEATURES := rtti exceptions
 diff --git a/media_softlet/agnostic/common/vp/kdll/hal_kerneldll_next.c b/media_softlet/agnostic/common/vp/kdll/hal_kerneldll_next.c
 index 69572eb3d..64c9405b4 100644
 --- a/media_softlet/agnostic/common/vp/kdll/hal_kerneldll_next.c
@@ -76,5 +89,5 @@ index 4b799e3f6..566c63c7a 100644
      return;
  }
 -- 
-2.17.1
+2.39.0
 

--- a/bsp_diff/common/hardware/intel/media-driver/0003-Revert-Decode-Enhance-robustness-of-ddi-for-AV1.patch
+++ b/bsp_diff/common/hardware/intel/media-driver/0003-Revert-Decode-Enhance-robustness-of-ddi-for-AV1.patch
@@ -1,4 +1,4 @@
-From e68af858cd1a4055c884d7762e2d600d31460ce0 Mon Sep 17 00:00:00 2001
+From 98e1eb777717e331f2c7b831c14caef853ce9169 Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Thu, 10 Nov 2022 15:49:20 +0530
 Subject: [PATCH] Revert "[Decode] Enhance robustness of ddi for AV1"
@@ -31,5 +31,5 @@ index c15c74d15..b5fc343be 100755
                      if (mediaSurfaceHeapElmt != nullptr &&
                              mediaSurfaceHeapElmt->pSurface != nullptr &&
 -- 
-2.38.1
+2.39.0
 


### PR DESCRIPTION
Changes are done on top of below tag versions:
media-driver: tag: intel-media-22.6.1
gmmlib: tag: intel-gmmlib-22.3.0

Change-Id: Ia23cd16f49af380994e65358a9e958e67ecb5c11
Tracked-On: OAM-105094
Signed-off-by: Yerriswamy <yerriswamy.kt@intel.com>