### PR TITLE
Fix vla-parameter error

### DIFF
--- a/host/ovmf/0002-Fix-vla-parameter-error.patch
+++ b/host/ovmf/0002-Fix-vla-parameter-error.patch
@@ -1,0 +1,52 @@
+From ce41b2d7f19c748358f3583fefc51b6321732ac8 Mon Sep 17 00:00:00 2001
+From: HeYue <yue.he@intel.com>
+Date: Mon, 30 Jan 2023 21:30:49 +0800
+Subject: [PATCH] Fix vla-parameter error
+
+Make vla buffer types consistent in declarations and definitions.
+Resolve build error when using -Werror due to "vla-parameter"
+
+Ref: https://git.ostc-eu.org/distro/oniro/-/merge_requests/237
+Signed-off-by: Adrian Herrera <adr.her.arc.95@gmail.com>
+Signed-off-by: Andrei Gherzan <andrei.gherzan@huawei.com>
+---
+ Source/C/BrotliCompress/brotli/c/dec/decode.c | 6 ++++--
+ Source/C/BrotliCompress/brotli/c/enc/encode.c | 5 +++--
+ 2 files changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/Source/C/BrotliCompress/brotli/c/dec/decode.c b/Source/C/BrotliCompress/brotli/c/dec/decode.c
+index 114c505..bb6f1ab 100644
+--- a/Source/C/BrotliCompress/brotli/c/dec/decode.c
++++ b/Source/C/BrotliCompress/brotli/c/dec/decode.c
+@@ -2030,8 +2030,10 @@ static BROTLI_NOINLINE BrotliDecoderErrorCode SafeProcessCommands(
+ }
+ 
+ BrotliDecoderResult BrotliDecoderDecompress(
+-    size_t encoded_size, const uint8_t* encoded_buffer, size_t* decoded_size,
+-    uint8_t* decoded_buffer) {
++    size_t encoded_size,
++    const uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(encoded_size)],
++    size_t* decoded_size,
++    uint8_t decoded_buffer[BROTLI_ARRAY_PARAM(*decoded_size)]) {
+   BrotliDecoderState s;
+   BrotliDecoderResult result;
+   size_t total_out = 0;
+diff --git a/Source/C/BrotliCompress/brotli/c/enc/encode.c b/Source/C/BrotliCompress/brotli/c/enc/encode.c
+index 68548ef..ab0a490 100644
+--- a/Source/C/BrotliCompress/brotli/c/enc/encode.c
++++ b/Source/C/BrotliCompress/brotli/c/enc/encode.c
+@@ -1470,8 +1470,9 @@ static size_t MakeUncompressedStream(
+ 
+ BROTLI_BOOL BrotliEncoderCompress(
+     int quality, int lgwin, BrotliEncoderMode mode, size_t input_size,
+-    const uint8_t* input_buffer, size_t* encoded_size,
+-    uint8_t* encoded_buffer) {
++    const uint8_t input_buffer[BROTLI_ARRAY_PARAM(input_size)],
++    size_t* encoded_size,
++    uint8_t encoded_buffer[BROTLI_ARRAY_PARAM(*encoded_size)]) {
+   BrotliEncoderState* s;
+   size_t out_size = *encoded_size;
+   const uint8_t* input_start = input_buffer;
+-- 
+2.34.1
+


### PR DESCRIPTION
Make vla buffer types consistent in declarations and definitions. 
Resolve build error when using -Werror due to "vla-parameter".

Tracked-On: OAM-105735
Signed-off-by: HeYue <yue.he@intel.com>