### PR TITLE
Fix for commit id issue patch

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/101_0101-Add-safety-checks-on-KEY_INTENT-mismatch-.bulletin.patch
+++ b/aosp_diff/preliminary/frameworks/base/101_0101-Add-safety-checks-on-KEY_INTENT-mismatch-.bulletin.patch
@@ -1,6 +1,6 @@
-From 64e3c7f0e086d0eaee0c2a07514f8dd4fb0bcf80 Mon Sep 17 00:00:00 2001
-From: Hao Ke <haok@google.com>
-Date: Tue, 4 Oct 2022 19:43:58 +0000
+From bd6d2f1e4e4c5269ce4dfe2fe87fc140a11442e6 Mon Sep 17 00:00:00 2001
+From: Hao ke <haok@google.com>
+Date: Tue, 31 Jan 2023 16:22:28 +0530
 Subject: [PATCH] Add safety checks on KEY_INTENT mismatch.
 
 For many years, Parcel mismatch typed exploits has been using the
@@ -13,7 +13,6 @@ Bug: 250588548
 Bug: 240138294
 Test: atest CtsAccountManagerTestCases
 Test: local test, also see b/250588548
-Change-Id: I433e34f6e21ce15c89825044a15b1dec46bb25cc
 (cherry picked from commit eb9a0566a583fa13f8aff671c41f78a9e33eab82)
 Merged-In: I433e34f6e21ce15c89825044a15b1dec46bb25cc
 ---
@@ -21,7 +20,7 @@ Merged-In: I433e34f6e21ce15c89825044a15b1dec46bb25cc
  1 file changed, 30 insertions(+), 4 deletions(-)
 
 diff --git a/services/core/java/com/android/server/accounts/AccountManagerService.java b/services/core/java/com/android/server/accounts/AccountManagerService.java
-index 4c320e5bda2f..2e8dd9cd5881 100644
+index db3c25a7e43a..1a0baa8b67c6 100644
 --- a/services/core/java/com/android/server/accounts/AccountManagerService.java
 +++ b/services/core/java/com/android/server/accounts/AccountManagerService.java
 @@ -87,6 +87,7 @@ import android.os.SystemClock;
@@ -32,7 +31,7 @@ index 4c320e5bda2f..2e8dd9cd5881 100644
  import android.util.Log;
  import android.util.Pair;
  import android.util.Slog;
-@@ -3022,7 +3023,7 @@ public class AccountManagerService
+@@ -3005,7 +3006,7 @@ public class AccountManagerService
                               */
                              if (!checkKeyIntent(
                                      Binder.getCallingUid(),
@@ -41,7 +40,7 @@ index 4c320e5bda2f..2e8dd9cd5881 100644
                                  onError(AccountManager.ERROR_CODE_INVALID_RESPONSE,
                                          "invalid intent in bundle returned");
                                  return;
-@@ -3432,7 +3433,7 @@ public class AccountManagerService
+@@ -3416,7 +3417,7 @@ public class AccountManagerService
                      && (intent = result.getParcelable(AccountManager.KEY_INTENT)) != null) {
                  if (!checkKeyIntent(
                          Binder.getCallingUid(),
@@ -50,7 +49,7 @@ index 4c320e5bda2f..2e8dd9cd5881 100644
                      onError(AccountManager.ERROR_CODE_INVALID_RESPONSE,
                              "invalid intent in bundle returned");
                      return;
-@@ -4783,7 +4784,13 @@ public class AccountManagerService
+@@ -4767,7 +4768,13 @@ public class AccountManagerService
           * into launching arbitrary intents on the device via by tricking to click authenticator
           * supplied entries in the system Settings app.
           */
@@ -65,7 +64,7 @@ index 4c320e5bda2f..2e8dd9cd5881 100644
              // Explicitly set an empty ClipData to ensure that we don't offer to
              // promote any Uris contained inside for granting purposes
              if (intent.getClipData() == null) {
-@@ -4820,6 +4827,25 @@ public class AccountManagerService
+@@ -4804,6 +4811,25 @@ public class AccountManagerService
              }
          }
  
@@ -91,7 +90,7 @@ index 4c320e5bda2f..2e8dd9cd5881 100644
          private boolean isExportedSystemActivity(ActivityInfo activityInfo) {
              String className = activityInfo.name;
              return "android".equals(activityInfo.packageName) &&
-@@ -4966,7 +4992,7 @@ public class AccountManagerService
+@@ -4950,7 +4976,7 @@ public class AccountManagerService
                      && (intent = result.getParcelable(AccountManager.KEY_INTENT)) != null) {
                  if (!checkKeyIntent(
                          Binder.getCallingUid(),
@@ -101,5 +100,5 @@ index 4c320e5bda2f..2e8dd9cd5881 100644
                              "invalid intent in bundle returned");
                      return;
 -- 
-2.38.1.273.g43a17bfeac-goog
+2.17.1
 


### PR DESCRIPTION
Manual porting of the patch due to merge conflicts.

Ported from:
Add safety checks on KEY_INTENT mismatch.

For many years, Parcel mismatch typed exploits has been using the
AccoungManagerService's passing of KEY_INTENT workflow, as a foothold of
launching arbitrary intents. We are adding an extra check on the service
side to simulate the final deserialization of the KEY_INTENT value, to
make sure the client side won't get a mismatched KEY_INTENT value.

Bug: 250588548
Bug: 240138294
Test: atest CtsAccountManagerTestCases
Test: local test, also see b/250588548
(cherry picked from commit eb9a0566a583fa13f8aff671c41f78a9e33eab82)
Commit-id : I433e34f6e21ce15c89825044a15b1dec46bb25cc

Tracked-On: OAM-105691
Signed-off-by: Reddy, Alavala Srinivasa <alavala.srinivasa.reddy@intel.com>