### PR TITLE
CVE: Update build_weekly.sh with latest commit tag for v5.15.78

### DIFF
--- a/host/kernel/lts2021-chromium/build_weekly.sh
+++ b/host/kernel/lts2021-chromium/build_weekly.sh
@@ -9,7 +9,7 @@ cd vendor-intel-utils
 git checkout e936af4e95a4cb52bd5808323f99dda832aa58b2
 cd ../
 
-tag="lts-v5.15.78-20230131-r8"
+tag="lts-v5.15.78-20230206-r9"
 git clone -b $tag https://github.com/projectceladon/linux-intel-lts2021-chromium.git
 cd linux-intel-lts2021-chromium
 


### PR DESCRIPTION
CVE-2022-4378 - Fix Applied
CVE-2022-47940 - Fix Applied
CVE-2023-23454 - Fix Applied
CVE-2023-23455 - Fix Applied
New commit tag lts-v5.15.78-20230206-r9

Tracked-On: OAM-105544
Signed-off-by: Boppana, Tej Kiran <tej.kiran.boppana@intel.com>