### PR TITLE
Correcting the patches numbering

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/99_0100--DO-NOT-MERGE-Fix-permanent-denial-of-service-via-setCompon.bulletin.patch
+++ b/aosp_diff/preliminary/frameworks/base/99_0100--DO-NOT-MERGE-Fix-permanent-denial-of-service-via-setCompon.bulletin.patch
@@ -1,0 +1,34 @@
+From 8e9e46f6ed93ea6d1ebb52b243bf79af19054543 Mon Sep 17 00:00:00 2001
+From: Rhed Jao <rhedjao@google.com>
+Date: Tue, 3 Jan 2023 10:49:58 +0530
+Subject: [PATCH] Fix permanent denial of service via
+ setComponentEnabledSetting
+
+Do not update invalid component enabled settings to prevent the
+malicious apps from exhausting system server memory.
+
+Bug: 240936919
+Test: atest android.security.cts.PackageManagerTest
+(cherry picked from commit 5e98f267592775a2b886ccaa752377d6967f9741)
+Merged-In: I08165337895e89f13a2b9fcce1201cba9ad13d7d
+---
+ .../core/java/com/android/server/pm/PackageManagerService.java | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/services/core/java/com/android/server/pm/PackageManagerService.java b/services/core/java/com/android/server/pm/PackageManagerService.java
+index cde249fe2a72..2922c56fb47c 100644
+--- a/services/core/java/com/android/server/pm/PackageManagerService.java
++++ b/services/core/java/com/android/server/pm/PackageManagerService.java
+@@ -21137,6 +21137,9 @@ public class PackageManagerService extends IPackageManager.Stub
+                     } else {
+                         Slog.w(TAG, "Failed setComponentEnabledSetting: component class "
+                                 + className + " does not exist in " + packageName);
++			// Safetynet logging for b/240936919
++			EventLog.writeEvent(0x534e4554, "240936919", callingUid);
++			return;
+                     }
+                 }
+                 switch (newState) {
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/frameworks/base/99_0101-Add-safety-checks-on-KEY_INTENT-mismatch-.bulletin.patch
+++ b/aosp_diff/preliminary/frameworks/base/99_0101-Add-safety-checks-on-KEY_INTENT-mismatch-.bulletin.patch
@@ -1,0 +1,104 @@
+From bd6d2f1e4e4c5269ce4dfe2fe87fc140a11442e6 Mon Sep 17 00:00:00 2001
+From: Hao ke <haok@google.com>
+Date: Tue, 31 Jan 2023 16:22:28 +0530
+Subject: [PATCH] Add safety checks on KEY_INTENT mismatch.
+
+For many years, Parcel mismatch typed exploits has been using the
+AccoungManagerService's passing of KEY_INTENT workflow, as a foothold of
+launching arbitrary intents. We are adding an extra check on the service
+side to simulate the final deserialization of the KEY_INTENT value, to
+make sure the client side won't get a mismatched KEY_INTENT value.
+
+Bug: 250588548
+Bug: 240138294
+Test: atest CtsAccountManagerTestCases
+Test: local test, also see b/250588548
+(cherry picked from commit eb9a0566a583fa13f8aff671c41f78a9e33eab82)
+Merged-In: I433e34f6e21ce15c89825044a15b1dec46bb25cc
+---
+ .../accounts/AccountManagerService.java       | 34 ++++++++++++++++---
+ 1 file changed, 30 insertions(+), 4 deletions(-)
+
+diff --git a/services/core/java/com/android/server/accounts/AccountManagerService.java b/services/core/java/com/android/server/accounts/AccountManagerService.java
+index db3c25a7e43a..1a0baa8b67c6 100644
+--- a/services/core/java/com/android/server/accounts/AccountManagerService.java
++++ b/services/core/java/com/android/server/accounts/AccountManagerService.java
+@@ -87,6 +87,7 @@ import android.os.SystemClock;
+ import android.os.UserHandle;
+ import android.os.UserManager;
+ import android.text.TextUtils;
++import android.util.EventLog;
+ import android.util.Log;
+ import android.util.Pair;
+ import android.util.Slog;
+@@ -3005,7 +3006,7 @@ public class AccountManagerService
+                              */
+                             if (!checkKeyIntent(
+                                     Binder.getCallingUid(),
+-                                    intent)) {
++                                    result)) {
+                                 onError(AccountManager.ERROR_CODE_INVALID_RESPONSE,
+                                         "invalid intent in bundle returned");
+                                 return;
+@@ -3416,7 +3417,7 @@ public class AccountManagerService
+                     && (intent = result.getParcelable(AccountManager.KEY_INTENT)) != null) {
+                 if (!checkKeyIntent(
+                         Binder.getCallingUid(),
+-                        intent)) {
++                        result)) {
+                     onError(AccountManager.ERROR_CODE_INVALID_RESPONSE,
+                             "invalid intent in bundle returned");
+                     return;
+@@ -4767,7 +4768,13 @@ public class AccountManagerService
+          * into launching arbitrary intents on the device via by tricking to click authenticator
+          * supplied entries in the system Settings app.
+          */
+-         protected boolean checkKeyIntent(int authUid, Intent intent) {
++        protected boolean checkKeyIntent(int authUid, Bundle bundle) {
++            if (!checkKeyIntentParceledCorrectly(bundle)) {
++            	EventLog.writeEvent(0x534e4554, "250588548", authUid, "");
++                return false;
++            }
++
++            Intent intent = bundle.getParcelable(AccountManager.KEY_INTENT);
+             // Explicitly set an empty ClipData to ensure that we don't offer to
+             // promote any Uris contained inside for granting purposes
+             if (intent.getClipData() == null) {
+@@ -4804,6 +4811,25 @@ public class AccountManagerService
+             }
+         }
+ 
++        /**
++         * Simulate the client side's deserialization of KEY_INTENT value, to make sure they don't
++         * violate our security policy.
++         *
++         * In particular we want to make sure the Authenticator doesn't trick users
++         * into launching arbitrary intents on the device via exploiting any other Parcel read/write
++         * mismatch problems.
++         */
++        private boolean checkKeyIntentParceledCorrectly(Bundle bundle) {
++            Parcel p = Parcel.obtain();
++            p.writeBundle(bundle);
++            p.setDataPosition(0);
++            Bundle simulateBundle = p.readBundle();
++            p.recycle();
++            Intent intent = bundle.getParcelable(AccountManager.KEY_INTENT);
++            Intent simulateIntent = simulateBundle.getParcelable(AccountManager.KEY_INTENT);
++            return (intent.filterEquals(simulateIntent));
++        }
++
+         private boolean isExportedSystemActivity(ActivityInfo activityInfo) {
+             String className = activityInfo.name;
+             return "android".equals(activityInfo.packageName) &&
+@@ -4950,7 +4976,7 @@ public class AccountManagerService
+                     && (intent = result.getParcelable(AccountManager.KEY_INTENT)) != null) {
+                 if (!checkKeyIntent(
+                         Binder.getCallingUid(),
+-                        intent)) {
++                        result)) {
+                     onError(AccountManager.ERROR_CODE_INVALID_RESPONSE,
+                             "invalid intent in bundle returned");
+                     return;
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/frameworks/base/99_0102-Validate-package-name-passed-to-setApplicationRestrictions-.bulletin.patch
+++ b/aosp_diff/preliminary/frameworks/base/99_0102-Validate-package-name-passed-to-setApplicationRestrictions-.bulletin.patch
@@ -1,0 +1,109 @@
+From 60b745a2f9a9647df8683d8e66a2462bf072043f Mon Sep 17 00:00:00 2001
+From: Oli Lan <olilan@google.com>
+Date: Fri, 19 Aug 2022 17:08:13 +0100
+Subject: [PATCH] Validate package name passed to setApplicationRestrictions.
+
+This adds validation that the package name passed to
+setApplicationRestrictions is in the correct format. This will avoid
+an issue where a path could be entered resulting in a file being
+written to an unexpected place.
+
+Bug: 239701237
+Test: atest UserManagerServiceTest
+Change-Id: I1ab2b7228470f10ec26fe3a608ae540cfc9e9a96
+(cherry picked from commit 31a582490d6e8952d24f267df47d669e3861cf67)
+(cherry picked from commit cfcfe6ca8c545f78603c05e23687f8638fd4b51d)
+(cherry picked from commit 527146512051626bbcbd6e3590c47ceca2e404ab)
+Merged-In: I1ab2b7228470f10ec26fe3a608ae540cfc9e9a96
+---
+ .../android/server/pm/UserManagerService.java | 41 +++++++++++++++++++
+ .../server/pm/UserManagerServiceTest.java     |  7 ++++
+ 2 files changed, 48 insertions(+)
+
+diff --git a/services/core/java/com/android/server/pm/UserManagerService.java b/services/core/java/com/android/server/pm/UserManagerService.java
+index 66fc608ead4a..0f321cdbbb05 100644
+--- a/services/core/java/com/android/server/pm/UserManagerService.java
++++ b/services/core/java/com/android/server/pm/UserManagerService.java
+@@ -88,6 +88,7 @@ import android.stats.devicepolicy.DevicePolicyEnums;
+ import android.util.ArrayMap;
+ import android.util.ArraySet;
+ import android.util.AtomicFile;
++import android.util.EventLog;
+ import android.util.IntArray;
+ import android.util.Slog;
+ import android.util.SparseArray;
+@@ -4089,6 +4090,13 @@ public class UserManagerService extends IUserManager.Stub {
+     public void setApplicationRestrictions(String packageName, Bundle restrictions,
+             @UserIdInt int userId) {
+         checkSystemOrRoot("set application restrictions");
++        String validationResult = validateName(packageName);
++        if (validationResult != null) {
++            if (packageName.contains("../")) {
++                EventLog.writeEvent(0x534e4554, "239701237", -1, "");
++            }
++            throw new IllegalArgumentException("Invalid package name: " + validationResult);
++        }
+         if (restrictions != null) {
+             restrictions.setDefusable(true);
+         }
+@@ -4115,6 +4123,39 @@ public class UserManagerService extends IUserManager.Stub {
+         mContext.sendBroadcastAsUser(changeIntent, UserHandle.of(userId));
+     }
+ 
++    /**
++     * Check if the given name is valid.
++     *
++     * Note: the logic is taken from FrameworkParsingPackageUtils in master, edited to remove
++     * unnecessary parts. Copied here for a security fix.
++     *
++     * @param name The name to check.
++     * @return null if it's valid, error message if not
++     */
++    @VisibleForTesting
++    static String validateName(String name) {
++        final int n = name.length();
++        boolean front = true;
++        for (int i = 0; i < n; i++) {
++            final char c = name.charAt(i);
++            if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
++                front = false;
++                continue;
++            }
++            if (!front) {
++                if ((c >= '0' && c <= '9') || c == '_') {
++                    continue;
++                }
++                if (c == '.') {
++                    front = true;
++                    continue;
++                }
++            }
++            return "bad character '" + c + "'";
++        }
++        return null;
++    }
++
+     private int getUidForPackage(String packageName) {
+         long ident = Binder.clearCallingIdentity();
+         try {
+diff --git a/services/tests/servicestests/src/com/android/server/pm/UserManagerServiceTest.java b/services/tests/servicestests/src/com/android/server/pm/UserManagerServiceTest.java
+index 6c1c019f504e..658f168b608b 100644
+--- a/services/tests/servicestests/src/com/android/server/pm/UserManagerServiceTest.java
++++ b/services/tests/servicestests/src/com/android/server/pm/UserManagerServiceTest.java
+@@ -86,6 +86,13 @@ public class UserManagerServiceTest extends AndroidTestCase {
+         }
+     }
+ 
++    public void testValidateName() {
++        assertNull(UserManagerService.validateName("android"));
++        assertNull(UserManagerService.validateName("com.company.myapp"));
++        assertNotNull(UserManagerService.validateName("/../../data"));
++        assertNotNull(UserManagerService.validateName("/dir"));
++    }
++
+     private Bundle createBundle() {
+         Bundle result = new Bundle();
+         // Tests for 6 allowed types: Integer, Boolean, String, String[], Bundle and Parcelable[]
+-- 
+2.38.1.273.g43a17bfeac-goog
+


### PR DESCRIPTION
Below patches numbering is not proper,
so patch application sequence is incorrect.
Correcting the same.

Present patches numbering
100_0100--DO-NOT-MERGE-Fix-permanent-denial-of-service-via-setCompon.bulletin.patch
101_0101-Add-safety-checks-on-KEY_INTENT-mismatch-.bulletin.patch
102_0102-Validate-package-name-passed-to-setApplicationRestrictions-.bulletin.patch

Modified patches numbering
99_0100--DO-NOT-MERGE-Fix-permanent-denial-of-service-via-setCompon.bulletin.patch
99_0101-Add-safety-checks-on-KEY_INTENT-mismatch-.bulletin.patch
99_0102-Validate-package-name-passed-to-setApplicationRestrictions-.bulletin.patch
Tracked-On: OAM-105740
Signed-off-by: Reddy, Alavala Srinivasa <alavala.srinivasa.reddy@intel.com>