### PR TITLE
Increase number of patches limit from 100 to 500 for autopatch

### DIFF
--- a/autopatch.sh
+++ b/autopatch.sh
@@ -70,7 +70,7 @@ apply_patch() {
     cd $top_dir/$current_project
     a=`grep "Date: " ${pd}/$i | head -1`
     b=`echo ${a#"Date: "}`
-    c=`git log -100 --pretty=format:%aD | grep "$b"`
+    c=`git log -500 --pretty=format:%aD | grep "$b"`
 
     if [[ "$c" == "" ]] ; then
       git am -3 --keep-cr --whitespace=nowarn $pd/$i >& /dev/null


### PR DESCRIPTION
As of now autopatch only checks for 100 patches in a folder to apply "Already applied" tag. Increasing the same to 500 as the number of Patches in framework-base folder is more than 100. This will enable Lunch to not try and apply already applied patches till the number of Patches in a folder reaches 500+.

Tracked-On: OAM-105792
Signed-off-by: Reddy, Alavala Srinivasa <alavala.srinivasa.reddy@intel.com>