### PR TITLE
Change H263 and VP8 software decoders from Codec2.0 to OMX

### DIFF
--- a/aosp_diff/cic_cloud/frameworks/av/0001-Change-H263-and-VP8-software-decoders-from-Codec2.0-.patch
+++ b/aosp_diff/cic_cloud/frameworks/av/0001-Change-H263-and-VP8-software-decoders-from-Codec2.0-.patch
@@ -1,0 +1,44 @@
+From 47b6e36a8c2f355d5cd783b5c737d892b996d1ae Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Tue, 14 Feb 2023 23:31:16 +0530
+Subject: [PATCH] Change H263 and VP8 software decoders from Codec2.0 to OMX
+
+Some of the H263 and VP8 files are not getting played when Codec2.0
+software codec is used.
+
+Fix the issue to use OMX software decoders for VP8 and H263 files.
+
+Change-Id: Ie8addf1265c11ef17fd7d9d75dc454043b6efefe
+Tracked-On: OAM-105820
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ media/libstagefright/data/media_codecs_sw.xml | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/media/libstagefright/data/media_codecs_sw.xml b/media/libstagefright/data/media_codecs_sw.xml
+index 65711628d9..07caedb3e1 100644
+--- a/media/libstagefright/data/media_codecs_sw.xml
++++ b/media/libstagefright/data/media_codecs_sw.xml
+@@ -98,8 +98,7 @@
+             <Limit name="bitrate" range="1-384000" />
+             <Feature name="adaptive-playback" />
+         </MediaCodec>
+-        <MediaCodec name="c2.android.h263.decoder" type="video/3gpp">
+-            <Alias name="OMX.google.h263.decoder" />
++        <MediaCodec name="OMX.google.h263.decoder" type="video/3gpp">
+             <!-- profiles and levels:  ProfileBaseline : Level30, ProfileBaseline : Level45
+                     ProfileISWV2 : Level30, ProfileISWV2 : Level45 -->
+             <Limit name="size" min="2x2" max="352x288" />
+@@ -147,8 +146,7 @@
+             </Variant>
+             <Feature name="adaptive-playback" />
+         </MediaCodec>
+-        <MediaCodec name="c2.android.vp8.decoder" type="video/x-vnd.on2.vp8" variant="slow-cpu,!slow-cpu">
+-            <Alias name="OMX.google.vp8.decoder" />
++        <MediaCodec name="OMX.google.vp8.decoder" type="video/x-vnd.on2.vp8" variant="slow-cpu,!slow-cpu">
+             <Limit name="size" min="2x2" max="2048x2048" />
+             <Limit name="alignment" value="2x2" />
+             <Limit name="block-size" value="16x16" />
+-- 
+2.39.1
+


### PR DESCRIPTION
Some of the H263 and VP8 files are not getting played when Codec2.0 software codec is used.

Fix the issue to use OMX software decoders for VP8 and H263 files.

Tracked-On: OAM-105820
Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>