### PR TITLE
CVE: Update build_weekly.sh with latest commit tag for v5.10.118

### DIFF
--- a/host/kernel/lts2020-chromium/build_weekly.sh
+++ b/host/kernel/lts2020-chromium/build_weekly.sh
@@ -4,7 +4,7 @@ rm -rf host_kernel
 mkdir -p host_kernel
 cd host_kernel
 
-tag="lts-v5.10.118-20221128-r4"
+tag="lts-v5.10.118-20230221-r5"
 git clone -b $tag https://github.com/projectceladon/linux-intel-lts2020-chromium.git
 cd linux-intel-lts2020-chromium
 


### PR DESCRIPTION
CVE-2023-0179 - Fix Applied
CVE-2023-0266 -	Fix Applied
BDSA-2023-0051 - Fix Applied
CVE-2022-4696 - Fix Applied
BDSA-2023-0054 - Fix Applied
BDSA-2023-0042 - Fix Applied
CVE-2023-0590 - Fix Applied
CVE-2023-0394 - Fix Applied
CVE-2023-20928 - Fix Applied
CVE-2022-4378 - Fix Applied
CVE-2022-47946 - Fix Applied
CVE-2022-4662 - Fix Applied
CVE-2022-20566 - Fix Applied
CVE-2022-3643 - Fix Applied
CVE-2022-4129 - Fix Applied
CVE-2022-45934 - Fix Applied
CVE-2022-3534 - Fix Applied
New commit tag lts-v5.10.118-20230221-r5

Tracked-On: OAM-105708