### PR TITLE
CVE: Update build_weekly.sh with latest commit tag for v5.15.78

### DIFF
--- a/host/kernel/lts2021-chromium/build_weekly.sh
+++ b/host/kernel/lts2021-chromium/build_weekly.sh
@@ -9,7 +9,7 @@ cd vendor-intel-utils
 git checkout e936af4e95a4cb52bd5808323f99dda832aa58b2
 cd ../
 
-tag="lts-v5.15.78-20230206-r9"
+tag="lts-v5.15.78-20230227-r10"
 git clone -b $tag https://github.com/projectceladon/linux-intel-lts2021-chromium.git
 cd linux-intel-lts2021-chromium
 


### PR DESCRIPTION
CVE-2023-0179 - Freshly Applied
CVE-2023-0266 - Freshly Applied
CVE-2022-4382 - Freshly Applied
CVE-2022-4842 - Freshly Applied
BDSA-2023-0054 - Freshly Applied
BDSA-2023-0042 - Freshly Applied
CVE-2023-0394 - Freshly Applied
CVE-2022-4129 - Freshly Applied

Tracked-On: OAM-105837