### PR TITLE
Fix for HEVC rendering failing with usptream ffmpeg

### DIFF
--- a/bsp_diff/common/hardware/intel/onevpl/0002-Fix-for-HEVC-rendering-failing-with-usptream-ffmpeg.patch
+++ b/bsp_diff/common/hardware/intel/onevpl/0002-Fix-for-HEVC-rendering-failing-with-usptream-ffmpeg.patch
@@ -1,0 +1,47 @@
+From c8b329cbf539031ae9355b0f0cf293551a5fbe26 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Wed, 8 Mar 2023 14:59:44 +0530
+Subject: [PATCH] Fix for HEVC rendering failing with usptream ffmpeg
+
+With upstream FFmpeg setting of extended device id config filter
+properties fails resulting in HEVC rendering failure with
+ICR inside android configuration.
+
+Extended device id are under ONEVPL_EXPERIMENTAL macro. As the
+ONEVPL_EXPERIMENTAL is not enabled, vpl returns failure on
+set config filter property request.
+
+Define macro ONEVPL_EXPERIMENTAL to fix the issue.
+
+Change-Id: I76ce4907bfa5658230ebb42846dc0651fba31aa4
+Tracked-On: OAM-106567
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ dispatcher/Android.mk | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/dispatcher/Android.mk b/dispatcher/Android.mk
+index 526d839..0b8ab86 100644
+--- a/dispatcher/Android.mk
++++ b/dispatcher/Android.mk
+@@ -48,13 +48,15 @@ LOCAL_CPPFLAGS := \
+     -DANDROID \
+     -DMFX_DEPRECATED_OFF \
+     -DVPL_EXPORTS \
+-    -D_FORTIFY_SOURCE=2
++    -D_FORTIFY_SOURCE=2 \
++    -DONEVPL_EXPERIMENTAL \
+ 
+ LOCAL_CPPFLAGS += \
+     -Wno-error \
+     -Wno-missing-braces \
+     -Wno-unused-parameter \
+-    -Wno-missing-field-initializers
++    -Wno-missing-field-initializers \
++    -DONEVPL_EXPERIMENTAL \
+ 
+ LOCAL_CPPFLAGS += -Wl,--version-script=$(LOCAL_PATH)/linux/libvpl.map
+ 
+-- 
+2.39.2
+


### PR DESCRIPTION
With upstream FFmpeg setting of extended device id config filter properties fails resulting in the HEVC rendering failure.

Extended device id are under ONEVPL_EXPERIMENTAL macro. As the ONEVPL_EXPERIMENTAL is not enabled, vpl returns failure on set config filter property request.

Define macro ONEVPL_EXPERIMENTAL to fix the issue.

Change-Id: I76ce4907bfa5658230ebb42846dc0651fba31aa4
Tracked-On: OAM-106567