### PR TITLE
CVE: Update build_weekly.sh with latest commit tag for v5.10.118

### DIFF
--- a/host/kernel/lts2020-chromium/build_weekly.sh
+++ b/host/kernel/lts2020-chromium/build_weekly.sh
@@ -4,7 +4,7 @@ rm -rf host_kernel
 mkdir -p host_kernel
 cd host_kernel
 
-tag="lts-v5.10.118-20230301-r6"
+tag="lts-v5.10.118-20230310-r7"
 git clone -b $tag https://github.com/projectceladon/linux-intel-lts2020-chromium.git
 cd linux-intel-lts2020-chromium
 


### PR DESCRIPTION
CVE-2022-3707 - Fix Applied
CVE-2022-3424 - Fix Applied
CVE-2023-26545 - Fix Applied
New commit tag lts-v5.10.118-20230310-r7

Tracked-On: OAM-106735