### PR TITLE
Update media-driver, gmmlib to agama-ci-devel-588 release

### DIFF
--- a/bsp_diff/common/hardware/intel/gmmlib/0001-Add-Android.mk-for-intel-gmmlib-22.3.5.patch
+++ b/bsp_diff/common/hardware/intel/gmmlib/0001-Add-Android.mk-for-intel-gmmlib-22.3.5.patch
@@ -1,10 +1,10 @@
-From f367b301eaba8b3ba27d6592999f64b7ae4fba5f Mon Sep 17 00:00:00 2001
+From 79910d46f9050e5cdd92b9cf37810cb6ca57a50f Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Fri, 15 Jul 2022 22:02:24 +0530
-Subject: [PATCH] Add Android.mk for intel-gmmlib-22.3.3
+Subject: [PATCH] Add Android.mk for intel-gmmlib-22.3.5
 
-Change-Id: I12acd0c5e6a9cc9d281e313f7ea68d45ef8b1d70
-Tracked-On: OAM-105683
+Change-Id: I134da0c5e6a9cc9d281e313f7ea68d45ef8b1d70
+Tracked-On: OAM-106860
 Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Signed-off-by: Yerriswamy <yerriswamy.kt@intel.com>
 ---

--- a/bsp_diff/common/hardware/intel/libva/0001-Update-Android.mk-for-libva-2.18.0.patch
+++ b/bsp_diff/common/hardware/intel/libva/0001-Update-Android.mk-for-libva-2.18.0.patch
@@ -1,13 +1,13 @@
-From 27de074c629a84e8d9cd44bb3966a0aa93bb1b81 Mon Sep 17 00:00:00 2001
+From 0ed11b11903ea0c8bdb0214bf39a25974cf2e3e0 Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
-Date: Fri, 28 Oct 2022 14:11:57 +0530
-Subject: [PATCH] Update Android.mk for libva 2.17.0
+Date: Thu, 30 Mar 2023 16:23:14 +0530
+Subject: [PATCH] Update Android.mk for libva 2.18.0
 
 added va_version.h
 updated the va/Android.mk
 
-Change-Id: I12faa0d2d2488e48e79a672d7a99bb6ddaf52a07
-Tracked-On: OAM-105683
+Change-Id: I143ea0d2d2488e48e79a672d7a99bb6ddaf52a07
+Tracked-On: OAM-106860
 Signed-off-by: Ratnesh Kumar Rai <ratnesh.kumar.rai@intel.com>
 Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
@@ -31,7 +31,7 @@ index 18d0234..e63b8ed 100644
  /doc/Doxyfile
  /doc/html-out
 diff --git a/va/Android.mk b/va/Android.mk
-index 050c377..51498f8 100644
+index a8f05f1..75334db 100644
 --- a/va/Android.mk
 +++ b/va/Android.mk
 @@ -25,8 +25,9 @@
@@ -59,10 +59,10 @@ index 050c377..51498f8 100644
  
  LOCAL_CFLAGS_32 += \
  	-DVA_DRIVERS_PATH="\"$(LIBVA_DRIVERS_PATH_32)\"" \
-@@ -52,9 +57,46 @@ LOCAL_CFLAGS_64 += \
+@@ -51,9 +56,46 @@ LOCAL_CFLAGS_64 += \
+ 
  LOCAL_CFLAGS := \
  	$(IGNORED_WARNNING) \
- 	$(if $(filter user,$(TARGET_BUILD_VARIANT)),,-DENABLE_VA_MESSAGING) \
 -	-DLOG_TAG=\"libva\"
 -
 -LOCAL_C_INCLUDES := $(LOCAL_PATH)/..
@@ -109,7 +109,7 @@ index 050c377..51498f8 100644
  
  LOCAL_MODULE_TAGS := optional
  LOCAL_MODULE := libva
-@@ -69,13 +111,6 @@ LOCAL_EXPORT_C_INCLUDE_DIRS := \
+@@ -68,13 +110,6 @@ LOCAL_EXPORT_C_INCLUDE_DIRS := \
  	$(intermediates) \
  	$(LOCAL_C_INCLUDES)
  
@@ -123,7 +123,7 @@ index 050c377..51498f8 100644
  include $(BUILD_SHARED_LIBRARY)
  
  # For libva-android
-@@ -98,6 +133,10 @@ LOCAL_MODULE_TAGS := optional
+@@ -97,6 +132,10 @@ LOCAL_MODULE_TAGS := optional
  LOCAL_MODULE := libva-android
  LOCAL_PROPRIETARY_MODULE := true
  
@@ -136,7 +136,7 @@ index 050c377..51498f8 100644
  include $(BUILD_SHARED_LIBRARY)
 diff --git a/va/va_version.h b/va/va_version.h
 new file mode 100644
-index 0000000..33f6ea6
+index 0000000..80077d5
 --- /dev/null
 +++ b/va/va_version.h
 @@ -0,0 +1,87 @@
@@ -179,7 +179,7 @@ index 0000000..33f6ea6
 + *
 + * The minor version of VA-API (2, if %VA_VERSION is 1.2.3)
 + */
-+#define VA_MINOR_VERSION    17
++#define VA_MINOR_VERSION    18
 +
 +/**
 + * VA_MICRO_VERSION:
@@ -193,7 +193,7 @@ index 0000000..33f6ea6
 + *
 + * The full version of VA-API, like 1.2.3
 + */
-+#define VA_VERSION          2.17.0
++#define VA_VERSION          2.18.0
 +
 +/**
 + * VA_VERSION_S:
@@ -201,7 +201,7 @@ index 0000000..33f6ea6
 + * The full version of VA-API, in string form (suited for string
 + * concatenation)
 + */
-+#define VA_VERSION_S       "2.17.0"
++#define VA_VERSION_S       "2.18.0"
 +
 +/**
 + * VA_VERSION_HEX:

--- a/bsp_diff/common/hardware/intel/libva/0002-Support-media-stack-on-specified-render-node.patch
+++ b/bsp_diff/common/hardware/intel/libva/0002-Support-media-stack-on-specified-render-node.patch
@@ -1,4 +1,4 @@
-From 5128d4b79dccf60705bc63987aed6619283706ee Mon Sep 17 00:00:00 2001
+From 8e1007d916c8ff055a045cb273d37552f6482831 Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
 Date: Fri, 28 Oct 2022 14:32:50 +0530
 Subject: [PATCH] Support media stack on specified render node
@@ -13,7 +13,7 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  1 file changed, 14 insertions(+), 3 deletions(-)
 
 diff --git a/va/android/va_android.cpp b/va/android/va_android.cpp
-index 06f8646..540baf4 100644
+index f103d15..d2c167f 100644
 --- a/va/android/va_android.cpp
 +++ b/va/android/va_android.cpp
 @@ -38,10 +38,11 @@
@@ -27,9 +27,9 @@ index 06f8646..540baf4 100644
  #define CHECK_SYMBOL(func) { if (!func) printf("func %s not found\n", #func); return VA_STATUS_ERROR_UNKNOWN; }
 -#define DEVICE_NAME "/dev/dri/renderD128"
  
- static int va_DisplayContextIsValid(
+ static void va_DisplayContextDestroy(
      VADisplayContextP pDisplayContext
-@@ -76,13 +77,23 @@ static VAStatus va_DisplayContextGetNumCandidates(
+@@ -68,13 +69,23 @@ static VAStatus va_DisplayContextGetNumCandidates(
  {
      VADriverContextP const ctx = pDisplayContext->pDriverContext;
      struct drm_state * drm_state = (struct drm_state *)ctx->drm_state;

--- a/bsp_diff/common/hardware/intel/media-driver/0001-Add-changes-to-build-latest-media-driver-in-Android.patch
+++ b/bsp_diff/common/hardware/intel/media-driver/0001-Add-changes-to-build-latest-media-driver-in-Android.patch
@@ -1,6 +1,6 @@
-From aed2779e59a3819672d950c5c3f0b6e9596ba8f6 Mon Sep 17 00:00:00 2001
+From 68427036e7ddb0a552148fb1a4a71ec08c0bbdd4 Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
-Date: Thu, 2 Feb 2023 10:26:34 +0530
+Date: Thu, 30 Mar 2023 14:31:29 +0530
 Subject: [PATCH] Add changes to build latest media driver in Android
 
 Changes include:
@@ -11,8 +11,8 @@ added to generated Android.mk file
 - Added generated Android.mk files
 - Updated Android.mk with paths missing
 
-Change-Id: I212cd1d036783dabca1b18c2bade9f882b56a8a0
-Tracked-On: OAM-105683
+Change-Id: I243ac1d036783dabca1b18c2bade9f882b56a8a0
+Tracked-On: OAM-106860
 Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Signed-off-by: Ratnesh Kumar Rai <ratnesh.kumar.rai@intel.com>
 Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
@@ -25,14 +25,13 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  cmrtlib/Android.mk                            |   86 +
  .../agnostic/common/cp/media_srcs.cmake       |    4 +-
  .../common/heap_manager/media_srcs.cmake      |    1 +
- .../agnostic/common/hw/media_srcs.cmake       |    6 +
+ .../agnostic/common/hw/media_srcs.cmake       |   10 +-
  .../agnostic/common/hw/vdbox/media_srcs.cmake |    8 +-
  .../common/media_interfaces/media_srcs.cmake  |    4 +-
  media_common/agnostic/common/media_srcs.cmake |    9 +-
  .../agnostic/common/os/media_srcs.cmake       |    1 +
  .../common/renderhal/media_srcs.cmake         |    1 +
  .../agnostic/common/shared/media_srcs.cmake   |    2 +
- .../shared/user_setting/media_srcs.cmake      |    1 +
  .../agnostic/common/vp/hal/media_srcs.cmake   |    2 +
  .../agnostic/common/vp/kdll/media_srcs.cmake  |    1 +
  .../common/vp/kernel/media_srcs.cmake         |    4 +-
@@ -45,7 +44,7 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  .../agnostic/Xe_M/Xe_XPM/hw/media_srcs.cmake  |    2 +
  .../Xe_M/Xe_XPM/hw/vdbox/media_srcs.cmake     |    1 +
  .../Xe_M/Xe_XPM/vp/hal/media_srcs.cmake       |    2 +
- .../vp/kernel/cmfcpatch/media_srcs.cmake      |    4 +-
+ .../vp/kernel/cmfcpatch/media_srcs.cmake      |    2 +
  .../Xe_M/Xe_XPM/vp/kernel/media_srcs.cmake    |    2 +
  .../Xe_XPM_plus/hw/vdbox/media_srcs.cmake     |    1 +
  .../Xe_M/Xe_XPM_plus/shared/media_srcs.cmake  |    4 +-
@@ -65,7 +64,6 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  .../common/renderhal/media_srcs.cmake         |    1 +
  .../agnostic/common/shared/media_srcs.cmake   |    1 +
  .../common/shared/mediacopy/media_srcs.cmake  |    1 +
- .../shared/user_setting/media_srcs.cmake      |    1 +
  .../agnostic/common/vp/hal/media_srcs.cmake   |    2 +
  .../agnostic/common/vp/kdll/media_srcs.cmake  |    4 +-
  .../g12/g12_base/hw/render/media_srcs.cmake   |    1 +
@@ -90,9 +88,9 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  .../agnostic/gen12/hw/vdbox/media_srcs.cmake  |    1 +
  .../agnostic/gen12/vp/hal/media_srcs.cmake    |    4 +-
  .../gen12_tgllp/vp/hal/media_srcs.cmake       |    4 +-
- .../vp/kernel/cmfc/media_srcs.cmake           |    2 +
+ .../vp/kernel/cmfc/media_srcs.cmake           |    4 +-
  .../vp/kernel/cmfccmlpch/media_srcs.cmake     |    4 +-
- .../vp/kernel/cmfcpatch/media_srcs.cmake      |    2 +
+ .../vp/kernel/cmfcpatch/media_srcs.cmake      |    4 +-
  .../gen12_tgllp/vp/kernel/media_srcs.cmake    |    5 +-
  .../vp/kernel/swsb/media_srcs.cmake           |   23 +
  .../Source/Common/media_srcs.cmake            |   23 +
@@ -126,7 +124,7 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  .../agnostic/gen9_glk/vp/hal/media_srcs.cmake |    2 +
  .../gen9_kbl/hw/vdbox/media_srcs.cmake        |    1 +
  .../gen9_skl/hw/vdbox/media_srcs.cmake        |    1 +
- media_driver/agnostic/media_srcs.cmake        |   31 +-
+ media_driver/agnostic/media_srcs.cmake        |   19 +-
  media_driver/agnostic/ult/cm/media_srcs.cmake |   23 +
  media_driver/agnostic/ult/media_srcs.cmake    |   23 +
  media_driver/linux/common/os/media_srcs.cmake |    2 +
@@ -206,15 +204,17 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  .../enc/shared/statusreport/media_srcs.cmake  |    1 +
  .../agnostic/common/hw/media_srcs.cmake       |    3 +-
  .../agnostic/common/hw/vdbox/media_srcs.cmake |    4 +-
+ .../common/media_bin_mgr/media_srcs.cmake     |    5 +-
  .../common/media_interfaces/media_srcs.cmake  |    4 +-
  .../agnostic/common/os/media_srcs.cmake       |    1 +
+ .../common/os/user_setting/media_srcs.cmake   |    5 +-
  .../common/renderhal/media_srcs.cmake         |    3 +-
  .../agnostic/common/shared/media_srcs.cmake   |    4 +-
  .../shared/mediacontext/media_srcs.cmake      |    3 +-
  .../shared/scalability/media_srcs.cmake       |    1 +
  .../common/vp/cm_fc_ld/media_srcs.cmake       |    2 +
  .../common/vp/hal/bufferMgr/media_srcs.cmake  |    4 +-
- .../common/vp/hal/bufferMgr/vp_allocator.cpp  |    4 +-
+ .../common/vp/hal/bufferMgr/vp_allocator.cpp  |    2 +-
  .../vp/hal/feature_manager/media_srcs.cmake   |    4 +-
  .../common/vp/hal/features/media_srcs.cmake   |    4 +-
  .../common/vp/hal/mmc/media_srcs.cmake        |    4 +-
@@ -236,7 +236,7 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  .../os/osservice/mos_utilities_specific.cpp   |    6 +-
  .../os/osservice/mos_utilities_specific.h     |    1 +
  .../media_interfaces_mtl/media_srcs.cmake     |    5 +-
- 219 files changed, 2700 insertions(+), 147 deletions(-)
+ 219 files changed, 2703 insertions(+), 144 deletions(-)
  create mode 100644 cmrtlib/Android.mk
  create mode 100644 media_driver/Android.mk
  create mode 100644 media_driver/agnostic/gen12_tgllp/vp/kernel/swsb/media_srcs.cmake
@@ -252,10 +252,10 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  create mode 100644 media_softlet/agnostic/Xe_R/Xe_HPG/vp/kernel_free/Source/media_srcs.cmake
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c5b07257a..acae38f80 100755
+index 7e3fd415b..eebdcf6f0 100755
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -49,9 +49,9 @@ cmake_dependent_option( ENABLE_NONFREE_KERNELS
+@@ -51,9 +51,9 @@ cmake_dependent_option( ENABLE_NONFREE_KERNELS
  cmake_dependent_option( BUILD_KERNELS
      "Rebuild shaders (kernels) from sources" OFF
      "ENABLE_KERNELS;NOT ENABLE_NONFREE_KERNELS" OFF)
@@ -521,22 +521,31 @@ index f882c7e7f..54650883b 100644
  set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
      ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
 diff --git a/media_common/agnostic/common/hw/media_srcs.cmake b/media_common/agnostic/common/hw/media_srcs.cmake
-index 3155aef53..61e479ec8 100644
+index 45dc8126c..47fc06985 100644
 --- a/media_common/agnostic/common/hw/media_srcs.cmake
 +++ b/media_common/agnostic/common/hw/media_srcs.cmake
-@@ -40,6 +40,12 @@ set(SOFTLET_COMMON_HEADERS_
- )
- 
- source_group("MHW" FILES ${TMP_HEADERS_})
+@@ -90,6 +90,14 @@ source_group("MHW\\BLT" FILES ${TMP_BLT_HEADERS_})
+ source_group("MHW\\Common MI" FILES ${TMP_MI_HEADERS_})
+ source_group("MHW\\SFC" FILES ${TMP_SFC_HEADERS_})
+ source_group("MHW\\VEBOX" FILES ${TMP_VEBOX_HEADERS_})
++
 +media_add_curr_to_include_path()
 +media_include_subdirectory(vdbox)
 +media_include_subdirectory(media_interfaces)
 +media_include_subdirectory(os)
 +media_include_subdirectory(renderhal)
 +media_include_subdirectory(shared)
- 
- set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
-     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
++
+ set(SOFTLET_MHW_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_MHW_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+@@ -118,4 +126,4 @@ set(SOFTLET_MHW_SFC_PRIVATE_INCLUDE_DIRS_
+ set(SOFTLET_MHW_VEBOX_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_MHW_VEBOX_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
 diff --git a/media_common/agnostic/common/hw/vdbox/media_srcs.cmake b/media_common/agnostic/common/hw/vdbox/media_srcs.cmake
 index 912dc9f1f..1ff9ea292 100644
 --- a/media_common/agnostic/common/hw/vdbox/media_srcs.cmake
@@ -597,10 +606,10 @@ index 4c96dc832..7191460a9 100644
 +media_include_subdirectory(vp)
 +
 diff --git a/media_common/agnostic/common/os/media_srcs.cmake b/media_common/agnostic/common/os/media_srcs.cmake
-index b0440703f..210cd38d7 100644
+index 2d6f2cb65..d3e2932ed 100644
 --- a/media_common/agnostic/common/os/media_srcs.cmake
 +++ b/media_common/agnostic/common/os/media_srcs.cmake
-@@ -38,4 +38,5 @@ set(SOFTLET_MOS_PUBLIC_INCLUDE_DIRS_
+@@ -40,4 +40,5 @@ set(SOFTLET_MOS_PUBLIC_INCLUDE_DIRS_
      ${CMAKE_CURRENT_LIST_DIR}
  )
  
@@ -619,26 +628,14 @@ index 821a1c2ac..eb5fbe949 100644
  set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
      ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
 diff --git a/media_common/agnostic/common/shared/media_srcs.cmake b/media_common/agnostic/common/shared/media_srcs.cmake
-index 42e677ce6..7feca639d 100644
+index bdb57f148..5643055ad 100644
 --- a/media_common/agnostic/common/shared/media_srcs.cmake
 +++ b/media_common/agnostic/common/shared/media_srcs.cmake
-@@ -32,6 +32,8 @@ set(SOFTLET_COMMON_HEADERS_
+@@ -30,6 +30,8 @@ set(SOFTLET_COMMON_HEADERS_
  )
  
  source_group( "Common Files" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
 +media_include_subdirectory(user_setting)
-+media_add_curr_to_include_path()
- 
- set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
-     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
-diff --git a/media_common/agnostic/common/shared/user_setting/media_srcs.cmake b/media_common/agnostic/common/shared/user_setting/media_srcs.cmake
-index 0e56ba2bb..29d1a6d05 100644
---- a/media_common/agnostic/common/shared/user_setting/media_srcs.cmake
-+++ b/media_common/agnostic/common/shared/user_setting/media_srcs.cmake
-@@ -32,6 +32,7 @@ set(SOFTLET_COMMON_HEADERS_
-     ${TMP_HEADERS_})
- 
- source_group( "Common Files" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
 +media_add_curr_to_include_path()
  
  set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
@@ -700,7 +697,7 @@ index e117b5e8d..828fa2060 100644
  endif() # CMAKE_WDDM_LINUX
 diff --git a/media_driver/Android.mk b/media_driver/Android.mk
 new file mode 100644
-index 000000000..d1b44d39e
+index 000000000..ec06a2dce
 --- /dev/null
 +++ b/media_driver/Android.mk
 @@ -0,0 +1,1881 @@
@@ -750,7 +747,6 @@ index 000000000..d1b44d39e
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/packet/encode_vp9_vdenc_packet_xe_lpm_plus.cpp \
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/pipeline/encode_vp9_vdenc_pipeline_adapter_xe_lpm_plus.cpp \
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/pipeline/encode_vp9_vdenc_pipeline_xe_lpm_plus.cpp \
-+    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/mhw_blt_hwcmd_xe_lpm_plus_next.cpp \
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/mhw_sfc_hwcmd_xe_lpm_plus_next.cpp \
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/mhw_vebox_hwcmd_xe_lpm_plus_next.cpp \
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox/mhw_vdbox_avp_hwcmd_xe_lpm_plus.cpp \
@@ -851,7 +847,7 @@ index 000000000..d1b44d39e
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/packet/vp_render_sfc_xe_lpm_plus_base.cpp \
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/packet/vp_vebox_cmd_packet_xe_lpm_plus_base.cpp \
 +    ../media_softlet/agnostic/Xe_R/Xe_HPG_Base/hw/mhw_state_heap_hwcmd_xe_hpg.cpp \
-+    ../media_softlet/agnostic/Xe_R/Xe_HPG_Base/hw/mhw_state_heap_xe_hpg.c \
++    ../media_softlet/agnostic/Xe_R/Xe_HPG_Base/hw/mhw_state_heap_xe_hpg.cpp \
 +    ../media_softlet/agnostic/Xe_R/Xe_HPG_Base/renderhal/renderhal_xe_hpg_base.cpp \
 +    ../media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/cmfcpatch/igvpkrn_xe_hpg_cmfcpatch.c \
 +    ../media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/igvpkrn_isa_xe_hpg.c \
@@ -1107,10 +1103,10 @@ index 000000000..d1b44d39e
 +    ../media_softlet/agnostic/common/heap_manager/heap_manager.cpp \
 +    ../media_softlet/agnostic/common/heap_manager/memory_block.cpp \
 +    ../media_softlet/agnostic/common/heap_manager/memory_block_manager.cpp \
-+    ../media_softlet/agnostic/common/hw/mhw_block_manager.c \
++    ../media_softlet/agnostic/common/hw/mhw_block_manager.cpp \
 +    ../media_softlet/agnostic/common/hw/mhw_blt.cpp \
-+    ../media_softlet/agnostic/common/hw/mhw_memory_pool.c \
-+    ../media_softlet/agnostic/common/hw/mhw_state_heap.c \
++    ../media_softlet/agnostic/common/hw/mhw_memory_pool.cpp \
++    ../media_softlet/agnostic/common/hw/mhw_state_heap.cpp \
 +    ../media_softlet/agnostic/common/hw/mhw_utilities_next.cpp \
 +    ../media_softlet/agnostic/common/os/memory_policy_manager.cpp \
 +    ../media_softlet/agnostic/common/os/mos_cmdbufmgr_next.cpp \
@@ -1132,6 +1128,10 @@ index 000000000..d1b44d39e
 +    ../media_softlet/agnostic/common/os/mos_util_debug.cpp \
 +    ../media_softlet/agnostic/common/os/mos_utilities_next.cpp \
 +    ../media_softlet/agnostic/common/os/private/mos_utilities_usersetting.cpp \
++    ../media_softlet/agnostic/common/os/user_setting/media_user_setting.cpp \
++    ../media_softlet/agnostic/common/os/user_setting/media_user_setting_configure.cpp \
++    ../media_softlet/agnostic/common/os/user_setting/media_user_setting_definition.cpp \
++    ../media_softlet/agnostic/common/os/user_setting/media_user_setting_value.cpp \
 +    ../media_softlet/agnostic/common/renderhal/renderhal.cpp \
 +    ../media_softlet/agnostic/common/renderhal/renderhal_platform_interface_next.cpp \
 +    ../media_softlet/agnostic/common/shared/bufferMgr/media_allocator.cpp \
@@ -1148,6 +1148,7 @@ index 000000000..d1b44d39e
 +    ../media_softlet/agnostic/common/shared/mediacontext/media_context.cpp \
 +    ../media_softlet/agnostic/common/shared/mediacopy/media_blt_copy_next.cpp \
 +    ../media_softlet/agnostic/common/shared/mediacopy/media_copy.cpp \
++    ../media_softlet/agnostic/common/shared/mediacopy/media_copy_wrapper.cpp \
 +    ../media_softlet/agnostic/common/shared/mediacopy/media_render_copy_next.cpp \
 +    ../media_softlet/agnostic/common/shared/mediacopy/media_vebox_copy_next.cpp \
 +    ../media_softlet/agnostic/common/shared/mmc/media_mem_compression.cpp \
@@ -1297,9 +1298,9 @@ index 000000000..d1b44d39e
 +    ../media_softlet/linux/common/os/private/mos_mediacopy.cpp \
 +    ../media_softlet/linux/common/os/private/mos_os_specific.cpp \
 +    ../media_softlet/linux/common/os/private/mos_utilities_specific_usersetting.cpp \
++    ../media_softlet/linux/common/os/user_setting/media_user_setting_configure_specific.cpp \
 +    ../media_softlet/linux/common/shared/hal_oca_interface_next.cpp \
 +    ../media_softlet/linux/common/shared/skuwa_dumper_specific.c \
-+    ../media_softlet/linux/common/shared/user_setting/media_user_setting_configure_specific.cpp \
 +    ../media_softlet/linux/common/vp/ddi/ddi_vp_functions.cpp \
 +    ../media_softlet/linux/common/vp/ddi/ddi_vp_tools.cpp \
 +    ../media_softlet/linux/common/vp/hal/vphal_common_specific_next.c \
@@ -1514,10 +1515,6 @@ index 000000000..d1b44d39e
 +    agnostic/common/shared/mediacopy/media_render_copy.cpp \
 +    agnostic/common/shared/mediacopy/media_vebox_copy.cpp \
 +    agnostic/common/shared/null_hardware.cpp \
-+    agnostic/common/shared/user_setting/media_user_setting.cpp \
-+    agnostic/common/shared/user_setting/media_user_setting_configure.cpp \
-+    agnostic/common/shared/user_setting/media_user_setting_definition.cpp \
-+    agnostic/common/shared/user_setting/media_user_setting_value.cpp \
 +    agnostic/common/vp/hal/vphal.cpp \
 +    agnostic/common/vp/hal/vphal_common.c \
 +    agnostic/common/vp/hal/vphal_ddi.c \
@@ -2248,8 +2245,8 @@ index 000000000..d1b44d39e
 +    -DIGFX_XEHP_SDV_SUPPORTED \
 +    -DIGFX_XE_HPG_CMFCPATCH_SUPPORTED \
 +    -DIGFX_XE_HPG_SUPPORTED \
-+    -DMEDIA_VERSION=\"23.1.0\" \
-+    -DMEDIA_VERSION_DETAILS=\"13fd55974\" \
++    -DMEDIA_VERSION=\"23.1.3\" \
++    -DMEDIA_VERSION_DETAILS=\"032125825\" \
 +    -DVEBOX_AUTO_DENOISE_SUPPORTED=1 \
 +    -DX11_FOUND \
 +    -D_AV1_DECODE_SUPPORTED \
@@ -2291,7 +2288,6 @@ index 000000000..d1b44d39e
 +    $(LOCAL_PATH)/../media_common/agnostic/common/media_interfaces \
 +    $(LOCAL_PATH)/../media_common/agnostic/common/os \
 +    $(LOCAL_PATH)/../media_common/agnostic/common/renderhal \
-+    $(LOCAL_PATH)/../media_common/agnostic/common/shared/user_setting \
 +    $(LOCAL_PATH)/../media_common/agnostic/common/shared \
 +    $(LOCAL_PATH)/../media_common/agnostic/common/vp/hal \
 +    $(LOCAL_PATH)/../media_common/agnostic/common/vp/kernel \
@@ -2307,7 +2303,6 @@ index 000000000..d1b44d39e
 +    $(LOCAL_PATH)/agnostic/common/media_interfaces \
 +    $(LOCAL_PATH)/agnostic/common/os \
 +    $(LOCAL_PATH)/agnostic/common/renderhal \
-+    $(LOCAL_PATH)/agnostic/common/shared/user_setting \
 +    $(LOCAL_PATH)/agnostic/common/shared/mediacopy \
 +    $(LOCAL_PATH)/agnostic/common/shared \
 +    $(LOCAL_PATH)/agnostic/common/vp/hal \
@@ -2537,6 +2532,7 @@ index 000000000..d1b44d39e
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/mediacontext \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/classtrace \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/os/user_setting \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/os \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/vp/hal/bufferMgr \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/vp/hal/feature_manager \
@@ -2557,12 +2553,12 @@ index 000000000..d1b44d39e
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/hw \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/renderhal \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/media_interfaces \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/media_bin_mgr \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_R/Xe_HPG_Base/renderhal \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/cmfcpatch \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_R/Xe_HPG_Base/hw \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_R/Xe_HPG/renderhal \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw \
 +    $(LOCAL_PATH)/../media_softlet/linux/common/os/osservice \
 +    $(LOCAL_PATH)/../media_softlet/linux/common/os/i915/include/uapi \
 +    $(LOCAL_PATH)/../media_softlet/linux/common/os/i915/include \
@@ -2578,6 +2574,7 @@ index 000000000..d1b44d39e
 +    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/decode/vp8/ddi \
 +    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/decode/vp9/ddi \
 +    $(LOCAL_PATH)/../media_softlet/media_interface/media_interfaces_mtl \
++
 +
 +#LOCAL_CPP_FEATURES := rtti exceptions
 +
@@ -2655,16 +2652,13 @@ index c30e91b25..96c2195e7 100644
 +
 +media_add_curr_to_include_path()
 diff --git a/media_driver/agnostic/Xe_M/Xe_XPM/vp/kernel/cmfcpatch/media_srcs.cmake b/media_driver/agnostic/Xe_M/Xe_XPM/vp/kernel/cmfcpatch/media_srcs.cmake
-index a8a9965d6..d6370a186 100644
+index 731a08290..d6370a186 100644
 --- a/media_driver/agnostic/Xe_M/Xe_XPM/vp/kernel/cmfcpatch/media_srcs.cmake
 +++ b/media_driver/agnostic/Xe_M/Xe_XPM/vp/kernel/cmfcpatch/media_srcs.cmake
-@@ -45,4 +45,6 @@ set(TMP_HEADERS_ "")
- set(VP_PRIVATE_INCLUDE_DIRS_
+@@ -46,3 +46,5 @@ set(VP_PRIVATE_INCLUDE_DIRS_
      ${VP_PRIVATE_INCLUDE_DIRS_}
      ${CMAKE_CURRENT_LIST_DIR}
--)
-\ No newline at end of file
-+)
+ )
 +
 +media_add_curr_to_include_path()
 diff --git a/media_driver/agnostic/Xe_M/Xe_XPM/vp/kernel/media_srcs.cmake b/media_driver/agnostic/Xe_M/Xe_XPM/vp/kernel/media_srcs.cmake
@@ -2874,12 +2868,12 @@ index 0db298627..110920eb2 100644
  set(COMMON_PRIVATE_INCLUDE_DIRS_
      ${COMMON_PRIVATE_INCLUDE_DIRS_}
 diff --git a/media_driver/agnostic/common/shared/media_srcs.cmake b/media_driver/agnostic/common/shared/media_srcs.cmake
-index 5b736d5df..dc357cf90 100644
+index b7fa736bb..b318d4519 100644
 --- a/media_driver/agnostic/common/shared/media_srcs.cmake
 +++ b/media_driver/agnostic/common/shared/media_srcs.cmake
-@@ -20,6 +20,7 @@
+@@ -19,6 +19,7 @@
+ # OTHER DEALINGS IN THE SOFTWARE.
  
- media_include_subdirectory(user_setting)
  media_include_subdirectory(mediacopy)
 +media_add_curr_to_include_path()
  
@@ -2890,18 +2884,6 @@ index 518cbb013..baa2dcc5f 100644
 --- a/media_driver/agnostic/common/shared/mediacopy/media_srcs.cmake
 +++ b/media_driver/agnostic/common/shared/mediacopy/media_srcs.cmake
 @@ -34,6 +34,7 @@ set(COMMON_SOURCES_
-     ${TMP_SOURCES_})
- 
- source_group( "Common Files" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
-+media_add_curr_to_include_path()
- 
- set(COMMON_PRIVATE_INCLUDE_DIRS_
-     ${COMMON_PRIVATE_INCLUDE_DIRS_}
-diff --git a/media_driver/agnostic/common/shared/user_setting/media_srcs.cmake b/media_driver/agnostic/common/shared/user_setting/media_srcs.cmake
-index e0e1700e4..f84a77aa9 100644
---- a/media_driver/agnostic/common/shared/user_setting/media_srcs.cmake
-+++ b/media_driver/agnostic/common/shared/user_setting/media_srcs.cmake
-@@ -30,6 +30,7 @@ set(COMMON_SOURCES_
      ${TMP_SOURCES_})
  
  source_group( "Common Files" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
@@ -3200,22 +3182,25 @@ index 0013249d4..c35b0d4ed 100644
 +
 +media_add_curr_to_include_path()
 diff --git a/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfc/media_srcs.cmake b/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfc/media_srcs.cmake
-index 7e85d9342..887d1ba7f 100644
+index c405f0727..5db359453 100644
 --- a/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfc/media_srcs.cmake
 +++ b/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfc/media_srcs.cmake
-@@ -46,3 +46,5 @@ set(VP_PRIVATE_INCLUDE_DIRS_
-     ${VP_PRIVATE_INCLUDE_DIRS_}
+@@ -57,4 +57,6 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+ set(MEDIA_BIN_INCLUDE_DIR
+     ${MEDIA_BIN_INCLUDE_DIR}
      ${CMAKE_CURRENT_LIST_DIR}
- )
+-)
+\ No newline at end of file
++)
 +
 +media_add_curr_to_include_path()
 diff --git a/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfccmlpch/media_srcs.cmake b/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfccmlpch/media_srcs.cmake
-index 9a7b7f204..7b7c6d36a 100644
+index e99c37459..311c435b2 100644
 --- a/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfccmlpch/media_srcs.cmake
 +++ b/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfccmlpch/media_srcs.cmake
-@@ -44,4 +44,6 @@ set(TMP_HEADERS_ "")
- set(VP_PRIVATE_INCLUDE_DIRS_
-     ${VP_PRIVATE_INCLUDE_DIRS_}
+@@ -58,4 +58,6 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+ set(MEDIA_BIN_INCLUDE_DIR
+     ${MEDIA_BIN_INCLUDE_DIR}
      ${CMAKE_CURRENT_LIST_DIR}
 -)
 \ No newline at end of file
@@ -3223,17 +3208,20 @@ index 9a7b7f204..7b7c6d36a 100644
 +
 +media_add_curr_to_include_path()
 diff --git a/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfcpatch/media_srcs.cmake b/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfcpatch/media_srcs.cmake
-index 6a65956c7..f574371c0 100644
+index c09182328..aebeddde1 100644
 --- a/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfcpatch/media_srcs.cmake
 +++ b/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfcpatch/media_srcs.cmake
-@@ -46,3 +46,5 @@ set(VP_PRIVATE_INCLUDE_DIRS_
-     ${VP_PRIVATE_INCLUDE_DIRS_}
+@@ -58,4 +58,6 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+ set(MEDIA_BIN_INCLUDE_DIR
+     ${MEDIA_BIN_INCLUDE_DIR}
      ${CMAKE_CURRENT_LIST_DIR}
- )
+-)
+\ No newline at end of file
++)
 +
 +media_add_curr_to_include_path()
 diff --git a/media_driver/agnostic/gen12_tgllp/vp/kernel/media_srcs.cmake b/media_driver/agnostic/gen12_tgllp/vp/kernel/media_srcs.cmake
-index a3ab42875..11067d2bb 100644
+index 4ac44154d..0f16285aa 100644
 --- a/media_driver/agnostic/gen12_tgllp/vp/kernel/media_srcs.cmake
 +++ b/media_driver/agnostic/gen12_tgllp/vp/kernel/media_srcs.cmake
 @@ -22,6 +22,7 @@
@@ -3244,9 +3232,9 @@ index a3ab42875..11067d2bb 100644
  
  set(TMP_SOURCES_
      ${CMAKE_CURRENT_LIST_DIR}/igvpkrn_isa_g12_tgllp.c
-@@ -49,4 +50,6 @@ set(TMP_HEADERS_ "")
- set(VP_PRIVATE_INCLUDE_DIRS_
-     ${VP_PRIVATE_INCLUDE_DIRS_}
+@@ -62,4 +63,6 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+ set(MEDIA_BIN_INCLUDE_DIR
+     ${MEDIA_BIN_INCLUDE_DIR}
      ${CMAKE_CURRENT_LIST_DIR}
 -)
 \ No newline at end of file
@@ -3731,7 +3719,7 @@ index 3c8610a93..e8f445314 100644
  set(COMMON_PRIVATE_INCLUDE_DIRS_
      ${COMMON_PRIVATE_INCLUDE_DIRS_}
 diff --git a/media_driver/agnostic/media_srcs.cmake b/media_driver/agnostic/media_srcs.cmake
-index c47d64f0a..fddf09d5b 100755
+index 99ca74ba9..d0660aabf 100755
 --- a/media_driver/agnostic/media_srcs.cmake
 +++ b/media_driver/agnostic/media_srcs.cmake
 @@ -290,6 +290,12 @@ endif()
@@ -3747,43 +3735,20 @@ index c47d64f0a..fddf09d5b 100755
  if(GEN8)
      media_include_subdirectory(gen8)
  endif()
-@@ -302,6 +308,10 @@ if(ENABLE_REQUIRED_GEN_CODE OR GEN9)
-     media_include_subdirectory(gen9)
- endif()
- 
-+if(ENABLE_REQUIRED_GEN_CODE OR GEN9_BXT)
-+    media_include_subdirectory(gen9_bxt)
-+endif()
-+
- if(ENABLE_REQUIRED_GEN_CODE OR GEN9_CML)
-     media_include_subdirectory(gen9_cml)
- endif()
-@@ -310,14 +320,6 @@ if(ENABLE_REQUIRED_GEN_CODE OR GEN9_CMPV)
+@@ -310,11 +316,11 @@ if(GEN9_CMPV)
      media_include_subdirectory(gen9_cmpv)
  endif()
  
--if(ENABLE_REQUIRED_GEN_CODE OR GEN9_BXT)
--    media_include_subdirectory(gen9_bxt)
--endif()
--
--if(ENABLE_REQUIRED_GEN_CODE OR GEN9_SKL)
--    media_include_subdirectory(gen9_skl)
--endif()
--
- if(ENABLE_REQUIRED_GEN_CODE OR GEN9_GLK)
-     media_include_subdirectory(gen9_glk)
- endif()
-@@ -326,6 +328,10 @@ if(ENABLE_REQUIRED_GEN_CODE OR GEN9_KBL)
-     media_include_subdirectory(gen9_kbl)
+-if(GEN9_BXT)
++if(ENABLE_REQUIRED_GEN_CODE OR GEN9_BXT)
+     media_include_subdirectory(gen9_bxt)
  endif()
  
+-if(GEN9_SKL)
 +if(ENABLE_REQUIRED_GEN_CODE OR GEN9_SKL)
-+    media_include_subdirectory(gen9_skl)
-+endif()
-+
- if(ENABLE_REQUIRED_GEN_CODE OR GEN10)
-     media_include_subdirectory(gen10)
+     media_include_subdirectory(gen9_skl)
  endif()
+ 
 @@ -344,17 +350,12 @@ endif()
  
  if(ENABLE_REQUIRED_GEN_CODE OR GEN12)
@@ -4599,7 +4564,7 @@ index ff4cf7054..54c9be3e2 100644
 +
 +media_add_curr_to_include_path()
 diff --git a/media_driver/media_top_cmake.cmake b/media_driver/media_top_cmake.cmake
-index 7fa29b04e..49bb58763 100755
+index 2d8cec45b..d7640ff35 100755
 --- a/media_driver/media_top_cmake.cmake
 +++ b/media_driver/media_top_cmake.cmake
 @@ -36,7 +36,8 @@ include(${MEDIA_DRIVER_CMAKE}/media_feature_flags.cmake)
@@ -4736,12 +4701,12 @@ index 000000000..91cac7cff
 +media_include_subdirectory(Core_Kernels)
 +media_add_curr_to_include_path()
 diff --git a/media_softlet/agnostic/Xe_R/Xe_HPG_Base/hw/media_srcs.cmake b/media_softlet/agnostic/Xe_R/Xe_HPG_Base/hw/media_srcs.cmake
-index addddabb1..864ae94cf 100644
+index f97b43e65..703536195 100644
 --- a/media_softlet/agnostic/Xe_R/Xe_HPG_Base/hw/media_srcs.cmake
 +++ b/media_softlet/agnostic/Xe_R/Xe_HPG_Base/hw/media_srcs.cmake
 @@ -50,4 +50,5 @@ source_group("MHW\\State Heap" FILES ${TMP_STATE_HEAP_SOURCES_} ${TMP_STATE_HEAP
- set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
-     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+ set(SOFTLET_MHW_RENDER_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_MHW_RENDER_PRIVATE_INCLUDE_DIRS_}
      ${CMAKE_CURRENT_LIST_DIR}
 -)
 \ No newline at end of file
@@ -4760,12 +4725,12 @@ index d67416111..22d765332 100644
 +)
 +media_add_curr_to_include_path()
 diff --git a/media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/cmfcpatch/media_srcs.cmake b/media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/cmfcpatch/media_srcs.cmake
-index 039768d2d..791342f0b 100644
+index 47f03f549..0666fa119 100644
 --- a/media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/cmfcpatch/media_srcs.cmake
 +++ b/media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/cmfcpatch/media_srcs.cmake
-@@ -45,4 +45,6 @@ set(TMP_HEADERS_ "")
- set(SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
-     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+@@ -58,4 +58,6 @@ set(SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+ set(MEDIA_BIN_INCLUDE_DIR
+     ${MEDIA_BIN_INCLUDE_DIR}
      ${CMAKE_CURRENT_LIST_DIR}
 -)
 \ No newline at end of file
@@ -4773,12 +4738,12 @@ index 039768d2d..791342f0b 100644
 +
 +media_add_curr_to_include_path()
 diff --git a/media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/media_srcs.cmake b/media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/media_srcs.cmake
-index e9b5fd5fa..ae2dea09b 100644
+index c7ccc516a..58f0337ea 100644
 --- a/media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/media_srcs.cmake
 +++ b/media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/media_srcs.cmake
-@@ -50,4 +50,6 @@ set(TMP_HEADERS_ "")
- set (SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
-     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+@@ -64,4 +64,6 @@ set (SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+ set(MEDIA_BIN_INCLUDE_DIR
+     ${MEDIA_BIN_INCLUDE_DIR}
      ${CMAKE_CURRENT_LIST_DIR}
 -)
 \ No newline at end of file
@@ -4829,12 +4794,12 @@ index 0800891e6..64dbc62eb 100644
 +media_add_curr_to_include_path()
 \ No newline at end of file
 diff --git a/media_softlet/agnostic/common/hw/media_srcs.cmake b/media_softlet/agnostic/common/hw/media_srcs.cmake
-index efc223878..3245ff643 100644
+index 67d384c2a..bb6ac71a2 100644
 --- a/media_softlet/agnostic/common/hw/media_srcs.cmake
 +++ b/media_softlet/agnostic/common/hw/media_srcs.cmake
-@@ -68,4 +68,5 @@ source_group( "MHW" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
- set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
-     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+@@ -154,4 +154,5 @@ set(SOFTLET_MHW_BLT_PRIVATE_INCLUDE_DIRS_
+ set(SOFTLET_MHW_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_MHW_COMMON_PRIVATE_INCLUDE_DIRS_}
      ${CMAKE_CURRENT_LIST_DIR}
 -)
 \ No newline at end of file
@@ -4853,6 +4818,27 @@ index 3df8104e4..b05d02898 100644
 +)
 +
 +media_add_curr_to_include_path()
+diff --git a/media_softlet/agnostic/common/media_bin_mgr/media_srcs.cmake b/media_softlet/agnostic/common/media_bin_mgr/media_srcs.cmake
+index d2dd4d270..4d8255cb3 100644
+--- a/media_softlet/agnostic/common/media_bin_mgr/media_srcs.cmake
++++ b/media_softlet/agnostic/common/media_bin_mgr/media_srcs.cmake
+@@ -27,6 +27,9 @@ set(SOFTLET_COMMON_HEADERS_
+     ${TMP_HEADERS_}
+ )
+ 
++source_group( "Common Files" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
++media_add_curr_to_include_path()
++
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+@@ -39,4 +42,4 @@ set(MEDIA_BIN_HEADERS_
+ set(MEDIA_BIN_INCLUDE_DIR
+     ${MEDIA_BIN_INCLUDE_DIR}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
 diff --git a/media_softlet/agnostic/common/media_interfaces/media_srcs.cmake b/media_softlet/agnostic/common/media_interfaces/media_srcs.cmake
 index 25254a832..7a6261827 100644
 --- a/media_softlet/agnostic/common/media_interfaces/media_srcs.cmake
@@ -4867,15 +4853,35 @@ index 25254a832..7a6261827 100644
 +
 +media_add_curr_to_include_path()
 diff --git a/media_softlet/agnostic/common/os/media_srcs.cmake b/media_softlet/agnostic/common/os/media_srcs.cmake
-index d944b827a..7f22fffe2 100644
+index 91e56f3fe..98d0c1e81 100644
 --- a/media_softlet/agnostic/common/os/media_srcs.cmake
 +++ b/media_softlet/agnostic/common/os/media_srcs.cmake
-@@ -91,4 +91,5 @@ set(SOFTLET_MOS_PUBLIC_INCLUDE_DIRS_
+@@ -92,4 +92,5 @@ set(SOFTLET_MOS_PUBLIC_INCLUDE_DIRS_
      ${CMAKE_CURRENT_LIST_DIR}
  )
  
 +media_add_curr_to_include_path()
  source_group( "mos_softlet" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+diff --git a/media_softlet/agnostic/common/os/user_setting/media_srcs.cmake b/media_softlet/agnostic/common/os/user_setting/media_srcs.cmake
+index 8adcfd108..faca53fbf 100644
+--- a/media_softlet/agnostic/common/os/user_setting/media_srcs.cmake
++++ b/media_softlet/agnostic/common/os/user_setting/media_srcs.cmake
+@@ -33,10 +33,13 @@ set(TMP_SHARED_SOURCES_
+     ${CMAKE_CURRENT_LIST_DIR}/media_user_setting_value.cpp
+ )
+ 
++source_group( "Common Files" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
++media_add_curr_to_include_path()
++
+ set(SOFTLET_COMMON_HAL_DDI_SHARED_SOURCES_
+     ${SOFTLET_COMMON_HAL_DDI_SHARED_SOURCES_}
+     ${TMP_SHARED_SOURCES_}
+ )
+ 
+ source_group( "mos_softlet" FILES ${TMP_SOURCES_})
+-source_group( "Hal_DDI_Shared" FILES ${TMP_SHARED_SOURCES_})
+\ No newline at end of file
++source_group( "Hal_DDI_Shared" FILES ${TMP_SHARED_SOURCES_})
 diff --git a/media_softlet/agnostic/common/renderhal/media_srcs.cmake b/media_softlet/agnostic/common/renderhal/media_srcs.cmake
 index 33eb9908d..0d59e6fd7 100644
 --- a/media_softlet/agnostic/common/renderhal/media_srcs.cmake
@@ -4946,10 +4952,10 @@ index 5ac1ca5ae..a1e4b5488 100644
 +
 +media_add_curr_to_include_path()
 diff --git a/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_allocator.cpp b/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_allocator.cpp
-index 4c5e53a51..5c79918f6 100644
+index 36e119f63..74f135b09 100644
 --- a/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_allocator.cpp
 +++ b/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_allocator.cpp
-@@ -708,7 +708,7 @@ MOS_STATUS VpAllocator::AllocParamsInitType(
+@@ -711,7 +711,7 @@ MOS_STATUS VpAllocator::AllocParamsInitType(
      VP_FUNC_CALL();
      VP_PUBLIC_CHK_NULL_RETURN(surface);
  
@@ -4958,15 +4964,6 @@ index 4c5e53a51..5c79918f6 100644
      //  Need to reallocate surface according to expected tiletype instead of tiletype of the surface what we have
      if ( surface                           != nullptr &&
           surface->OsResource.pGmmResInfo   != nullptr &&
-@@ -1334,7 +1334,7 @@ uint64_t VP_SURFACE::GetAllocationHandle(MOS_INTERFACE* osIntf)
-     }
- #endif
- 
--#if(LINUX) && !(WDDM_LINUX)
-+#if(LINUX || ANDROID) && !(WDDM_LINUX)
-     if (osSurface && osSurface->OsResource.bo)
-     {
-         return osSurface->OsResource.bo->handle;
 diff --git a/media_softlet/agnostic/common/vp/hal/feature_manager/media_srcs.cmake b/media_softlet/agnostic/common/vp/hal/feature_manager/media_srcs.cmake
 index e2b60d58d..9849de677 100644
 --- a/media_softlet/agnostic/common/vp/hal/feature_manager/media_srcs.cmake
@@ -5157,7 +5154,7 @@ index a610f569f..3aa448a80 100644
 +media_add_curr_to_include_path()
  #Do not add this dir to include dir
 diff --git a/media_softlet/linux/common/os/media_srcs.cmake b/media_softlet/linux/common/os/media_srcs.cmake
-index 7b04ce4f5..59f3bd7f9 100644
+index 3d0858ea4..489998ea5 100644
 --- a/media_softlet/linux/common/os/media_srcs.cmake
 +++ b/media_softlet/linux/common/os/media_srcs.cmake
 @@ -104,5 +104,5 @@ ${MEDIA_SOFTLET}/agnostic/common/shared/classtrace
@@ -5177,7 +5174,7 @@ index 4e8aad1d8..c1fa6e626 100644
  source_group( "mos_softlet" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
 +media_add_curr_to_include_path()
 diff --git a/media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp b/media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp
-index b2e89ee13..8765bf1ce 100644
+index ad75b78c8..58a66b3f8 100644
 --- a/media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp
 +++ b/media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp
 @@ -34,13 +34,13 @@

--- a/bsp_diff/common/hardware/intel/media-driver/0002-Resolved-compilation-issue-for-media-driver.patch
+++ b/bsp_diff/common/hardware/intel/media-driver/0002-Resolved-compilation-issue-for-media-driver.patch
@@ -1,23 +1,22 @@
-From 31767694c4e459cd4ee8b5bc246054b01cf27f85 Mon Sep 17 00:00:00 2001
+From ef48f4841d9e795b28cf043a3abaa733ad5a25bb Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
-Date: Thu, 2 Feb 2023 21:26:00 +0530
+Date: Thu, 16 Mar 2023 14:58:41 +0530
 Subject: [PATCH] Resolved compilation issue for media driver
 
 Changes include:
-- Added Android flag to disable error mode similar to
-Linux
+- Added Android flag to disable error mode similar to Linux
 
-Change-Id: Iad43d1d036783dabca1b18c2bade9f882b56a8a0
-Tracked-On: OAM-105683
+Change-Id: Ia54ad1d036783dabca1b18c2bade9f882b56a8a0
+Tracked-On: OAM-106860
 Signed-off-by: Ratnesh Kumar Rai <ratnesh.kumar.rai@intel.com>
 Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
 ---
  cmrtlib/linux/hardware/cm_device_os.cpp       |   6 +-
- media_driver/Android.mk                       | 172 +++++++++++++++++-
+ media_driver/Android.mk                       | 174 +++++++++++++++++-
  .../common/vp/kdll/hal_kerneldll_next.c       |   5 +-
  .../ddi/media_libva_caps_mtl_base.cpp         |   1 +
  .../os/osservice/mos_utilities_specific.cpp   |   2 +
- 5 files changed, 177 insertions(+), 9 deletions(-)
+ 5 files changed, 179 insertions(+), 9 deletions(-)
 
 diff --git a/cmrtlib/linux/hardware/cm_device_os.cpp b/cmrtlib/linux/hardware/cm_device_os.cpp
 index 36b98c13a..e21292283 100644
@@ -37,18 +36,18 @@ index 36b98c13a..e21292283 100644
  
      // New Surface Manager
 diff --git a/media_driver/Android.mk b/media_driver/Android.mk
-index d1b44d39e..8d36c4dff 100644
+index ec06a2dce..bd5a9b524 100644
 --- a/media_driver/Android.mk
 +++ b/media_driver/Android.mk
-@@ -425,7 +425,6 @@ LOCAL_SRC_FILES := \
+@@ -424,7 +424,6 @@ LOCAL_SRC_FILES := \
      ../media_softlet/agnostic/common/os/mos_user_setting.cpp \
      ../media_softlet/agnostic/common/os/mos_util_debug.cpp \
      ../media_softlet/agnostic/common/os/mos_utilities_next.cpp \
 -    ../media_softlet/agnostic/common/os/private/mos_utilities_usersetting.cpp \
-     ../media_softlet/agnostic/common/renderhal/renderhal.cpp \
-     ../media_softlet/agnostic/common/renderhal/renderhal_platform_interface_next.cpp \
-     ../media_softlet/agnostic/common/shared/bufferMgr/media_allocator.cpp \
-@@ -587,10 +586,6 @@ LOCAL_SRC_FILES := \
+     ../media_softlet/agnostic/common/os/user_setting/media_user_setting.cpp \
+     ../media_softlet/agnostic/common/os/user_setting/media_user_setting_configure.cpp \
+     ../media_softlet/agnostic/common/os/user_setting/media_user_setting_definition.cpp \
+@@ -591,10 +590,6 @@ LOCAL_SRC_FILES := \
      ../media_softlet/linux/common/os/mos_vma.c \
      ../media_softlet/linux/common/os/osservice/mos_util_debug_specific.cpp \
      ../media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp \
@@ -56,10 +55,18 @@ index d1b44d39e..8d36c4dff 100644
 -    ../media_softlet/linux/common/os/private/mos_mediacopy.cpp \
 -    ../media_softlet/linux/common/os/private/mos_os_specific.cpp \
 -    ../media_softlet/linux/common/os/private/mos_utilities_specific_usersetting.cpp \
+     ../media_softlet/linux/common/os/user_setting/media_user_setting_configure_specific.cpp \
      ../media_softlet/linux/common/shared/hal_oca_interface_next.cpp \
      ../media_softlet/linux/common/shared/skuwa_dumper_specific.c \
-     ../media_softlet/linux/common/shared/user_setting/media_user_setting_configure_specific.cpp \
-@@ -1872,6 +1867,173 @@ LOCAL_C_INCLUDES  = \
+@@ -1584,6 +1579,7 @@ LOCAL_C_INCLUDES  = \
+     $(LOCAL_PATH)/../media_common/agnostic/common/hw \
+     $(LOCAL_PATH)/../media_common/agnostic/common/media_interfaces \
+     $(LOCAL_PATH)/../media_common/agnostic/common/os \
++    $(LOCAL_PATH)/../media_common/agnostic/common/os/user_setting \
+     $(LOCAL_PATH)/../media_common/agnostic/common/renderhal \
+     $(LOCAL_PATH)/../media_common/agnostic/common/shared \
+     $(LOCAL_PATH)/../media_common/agnostic/common/vp/hal \
+@@ -1871,6 +1867,174 @@ LOCAL_C_INCLUDES  = \
      $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/decode/vp8/ddi \
      $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/decode/vp9/ddi \
      $(LOCAL_PATH)/../media_softlet/media_interface/media_interfaces_mtl \
@@ -217,6 +224,7 @@ index d1b44d39e..8d36c4dff 100644
 +    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/jpeg \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/mpeg2 \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw \
 +    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/encode/jpeg/ddi \
 +    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/encode/hevc/ddi \
 +    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/encode/vp9/ddi \
@@ -231,8 +239,8 @@ index d1b44d39e..8d36c4dff 100644
 +    $(LOCAL_PATH)/../../libva/va \
 +    $(LOCAL_PATH)/../cmrtlib/linux/hardware
  
- #LOCAL_CPP_FEATURES := rtti exceptions
  
+ #LOCAL_CPP_FEATURES := rtti exceptions
 diff --git a/media_softlet/agnostic/common/vp/kdll/hal_kerneldll_next.c b/media_softlet/agnostic/common/vp/kdll/hal_kerneldll_next.c
 index 4f6e97798..5b6a72085 100644
 --- a/media_softlet/agnostic/common/vp/kdll/hal_kerneldll_next.c
@@ -264,7 +272,7 @@ index 4f6e97798..5b6a72085 100644
  #endif
      return res;
 diff --git a/media_softlet/linux/Xe_M_plus/ddi/media_libva_caps_mtl_base.cpp b/media_softlet/linux/Xe_M_plus/ddi/media_libva_caps_mtl_base.cpp
-index 337dbbc89..b215e2799 100644
+index b11887ca4..e8fd6efb0 100644
 --- a/media_softlet/linux/Xe_M_plus/ddi/media_libva_caps_mtl_base.cpp
 +++ b/media_softlet/linux/Xe_M_plus/ddi/media_libva_caps_mtl_base.cpp
 @@ -37,6 +37,7 @@
@@ -276,10 +284,10 @@ index 337dbbc89..b215e2799 100644
  const VAImageFormat m_supportedImageformatsXe_Lpm_Plus_Base[] =
  {   {VA_FOURCC_BGRA,           VA_LSB_FIRST,   32, 32, 0x0000ff00, 0x00ff0000, 0xff000000,  0x000000ff}, /* [31:0] B:G:R:A 8:8:8:8 little endian */
 diff --git a/media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp b/media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp
-index 8765bf1ce..5fe17335f 100644
+index 58a66b3f8..6005c0a1e 100644
 --- a/media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp
 +++ b/media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp
-@@ -2506,6 +2506,7 @@ void MosUtilities::MosTraceEvent(
+@@ -2540,6 +2540,7 @@ void MosUtilities::MosTraceEvent(
                  MOS_FreeMemory(pTraceBuf);
              }
          }
@@ -287,7 +295,7 @@ index 8765bf1ce..5fe17335f 100644
  #if Backtrace_FOUND
          if (m_mosTraceFilter(TR_KEY_CALL_STACK))
          {
-@@ -2526,6 +2527,7 @@ void MosUtilities::MosTraceEvent(
+@@ -2560,6 +2561,7 @@ void MosUtilities::MosTraceEvent(
                  size_t ret = write(MosUtilitiesSpecificNext::m_mosTraceFd, traceBuf, nLen);
              }
          }

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0001-Changes-for-OneVPL-integration.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0001-Changes-for-OneVPL-integration.patch
@@ -1,4 +1,4 @@
-From 02b411f8078a07e521931cfd70eb81d88ee880b8 Mon Sep 17 00:00:00 2001
+From 12bb80bbe947831a481ef2b386b91b2f4b8ccc69 Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
 Date: Fri, 28 Oct 2022 23:23:43 +0530
 Subject: [PATCH] Changes for OneVPL integration
@@ -388,7 +388,7 @@ index 00000000..34d7652a
 +
 +include $(BUILD_SHARED_LIBRARY)
 diff --git a/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h b/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
-index 7f5199b5..47bab7ba 100644
+index d3713f6f..e25dfe51 100644
 --- a/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
 +++ b/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
 @@ -35,9 +35,9 @@
@@ -403,7 +403,7 @@ index 7f5199b5..47bab7ba 100644
  #include "asc.h"
  #endif
 diff --git a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
-index c958564d..5ea759f9 100644
+index 0be0d533..091e711f 100644
 --- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
 +++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
 @@ -974,8 +974,10 @@ mfxStatus ImplementationAvc::InitScd(mfxFrameAllocRequest& request)
@@ -464,12 +464,12 @@ index c958564d..5ea759f9 100644
      task.m_frameLtrReassign = 0;
      task.m_LtrOrder = m_LtrOrder;
 diff --git a/_studio/mfx_lib/ext/asc/src/asc_cm.cpp b/_studio/mfx_lib/ext/asc/src/asc_cm.cpp
-index e1a759b8..cee4048a 100644
+index 5a4380cb..c05b48f2 100644
 --- a/_studio/mfx_lib/ext/asc/src/asc_cm.cpp
 +++ b/_studio/mfx_lib/ext/asc/src/asc_cm.cpp
-@@ -179,9 +179,10 @@ mfxStatus ASC_Cm::InitGPUsurf(CmDevice* pCmDevice) {
-     case PLATFORM_INTEL_RKL:
-     case PLATFORM_INTEL_DG1:
+@@ -180,9 +180,10 @@ mfxStatus ASC_Cm::InitGPUsurf(CmDevice* pCmDevice) {
+     case PLATFORM_INTEL_ADL_S:
+     case PLATFORM_INTEL_ADL_P:
      case PLATFORM_INTEL_ADL_N:
 -
 +#ifdef MFX_ENABLE_ASC
@@ -867,7 +867,7 @@ index 00000000..e22c3eb9
 +
 +include $(BUILD_STATIC_LIBRARY)
 diff --git a/_studio/shared/src/libmfx_core.cpp b/_studio/shared/src/libmfx_core.cpp
-index 0ccb4ce1..715626ef 100644
+index ef1e42e5..19280fc4 100644
 --- a/_studio/shared/src/libmfx_core.cpp
 +++ b/_studio/shared/src/libmfx_core.cpp
 @@ -1157,6 +1157,7 @@ mfxStatus CoreDoSWFastCopy(mfxFrameSurface1 & dst, const mfxFrameSurface1 & src,

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0002-Restore-SG1-as-a-VPL-platform.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0002-Restore-SG1-as-a-VPL-platform.patch
@@ -1,4 +1,4 @@
-From caec5c084f75f8060a34f360c16c3a0428cd93d6 Mon Sep 17 00:00:00 2001
+From db2985dd68cf7ca20ce088762572e50620951993 Mon Sep 17 00:00:00 2001
 From: Ratnesh Kumar Rai <ratnesh.kumar.rai@intel.com>
 Date: Sat, 9 Apr 2022 09:57:38 +0530
 Subject: [PATCH] Restore SG1 as a VPL platform

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0003-Resolved-runtime-error-for-onevpl.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0003-Resolved-runtime-error-for-onevpl.patch
@@ -1,4 +1,4 @@
-From 6b7a9354c7bd4c622d1b8a43b13fb34f37615039 Mon Sep 17 00:00:00 2001
+From c8d1a4749d9cb137f69fb821fc4b3bec23a0afb5 Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
 Date: Fri, 3 Feb 2023 11:50:32 +0530
 Subject: [PATCH] Resolved runtime error for onevpl
@@ -74,7 +74,7 @@ index 34d7652a..8592de3b 100644
  
  MFX_SHARED_FILES_HW := \
 diff --git a/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp b/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
-index a31dec10..4e4c354f 100644
+index 00edf784..d833e43a 100644
 --- a/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
 +++ b/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
 @@ -2328,6 +2328,7 @@ mfxStatus VideoVPPHW::CheckFormatLimitation(mfxU32 filter, mfxU32 format, mfxU32

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0004-Remove-ITT-vtune-support.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0004-Remove-ITT-vtune-support.patch
@@ -1,4 +1,4 @@
-From 36dba165ad569e34676ed6b7c6ec8405b3855818 Mon Sep 17 00:00:00 2001
+From 44223ed893d6fbb6c04e53d6b981321e5106e24e Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Thu, 10 Nov 2022 00:23:21 +0530
 Subject: [PATCH] Remove ITT (vtune) support
@@ -33,7 +33,7 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  delete mode 100644 builder/FindVTune.cmake
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 6b8905cd..e4394fa8 100644
+index 92a3cd34..bc8cd796 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -74,7 +74,6 @@ include( ${BUILDER_ROOT}/FindOpenCL.cmake )
@@ -229,7 +229,7 @@ index dfa860ae..7f5aa468 100644
  #endif
  #endif // #ifndef MFX_TRACE_DISABLE
 diff --git a/_studio/shared/include/mfx_trace.h b/_studio/shared/include/mfx_trace.h
-index 33722c6d..8864ef1f 100644
+index 6847f411..a78d79c7 100644
 --- a/_studio/shared/include/mfx_trace.h
 +++ b/_studio/shared/include/mfx_trace.h
 @@ -154,7 +154,6 @@ enum
@@ -368,7 +368,7 @@ index cc59b617..00000000
 -#endif // #ifdef MFX_TRACE_ENABLE_TEXTLOG
 -#endif // #ifndef __MFX_TRACE_ITT_LOG_H__
 diff --git a/_studio/shared/mfx_trace/src/mfx_trace.cpp b/_studio/shared/mfx_trace/src/mfx_trace.cpp
-index 7eacb329..55e171c6 100644
+index b62cb9f0..ec501cf8 100644
 --- a/_studio/shared/mfx_trace/src/mfx_trace.cpp
 +++ b/_studio/shared/mfx_trace/src/mfx_trace.cpp
 @@ -39,7 +39,6 @@ extern "C"
@@ -399,7 +399,7 @@ index 7eacb329..55e171c6 100644
  #ifdef MFX_TRACE_ENABLE_FTRACE
      {
          0,
-@@ -312,9 +298,6 @@ mfxTraceU32 MFXTrace_Init()
+@@ -305,9 +291,6 @@ mfxTraceU32 MFXTrace_Init()
  #if defined(MFX_TRACE_ENABLE_TAL)
      g_OutputMode |= MFX_TRACE_OUTPUT_TAL;
  #endif
@@ -596,7 +596,7 @@ index 1674cefe..389dbfd1 100644
 \ No newline at end of file
 +include $(MFX_HOME)/android/mfx_defs_internal.mk
 diff --git a/builder/BuildOptions.cmake b/builder/BuildOptions.cmake
-index 770fe7f2..8d626af4 100644
+index f066d0f1..57ff83dc 100644
 --- a/builder/BuildOptions.cmake
 +++ b/builder/BuildOptions.cmake
 @@ -42,8 +42,6 @@ option( ENABLE_OPENCL "Build targets dependent on OpenCL?" ON )
@@ -609,7 +609,7 @@ index 770fe7f2..8d626af4 100644
  option( ENABLE_STAT "Enable stat tracing?" ${ENABLE_ALL})
  
 diff --git a/builder/FindGlobals.cmake b/builder/FindGlobals.cmake
-index 174b3e06..c589eda1 100644
+index 6997eedb..2de5b8fa 100644
 --- a/builder/FindGlobals.cmake
 +++ b/builder/FindGlobals.cmake
 @@ -275,7 +275,6 @@ target_compile_definitions(mfx_common_properties

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0005-Fix-for-HEVC-rendering-failing-with-usptream-ffmpeg.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0005-Fix-for-HEVC-rendering-failing-with-usptream-ffmpeg.patch
@@ -1,4 +1,4 @@
-From 005ed999595a77eac591cf0f2b985eb49e0f9fa8 Mon Sep 17 00:00:00 2001
+From 68c018658d7d9e3375b858fc585420c438a7f983 Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Wed, 8 Mar 2023 15:42:09 +0530
 Subject: [PATCH] Fix for HEVC rendering failing with usptream ffmpeg
@@ -42,5 +42,5 @@ index 389dbfd1..2397ac3d 100644
  # Enable feature with output decoded frames without latency regarding
  # SPS.VUI.max_num_reorder_frames
 -- 
-2.39.2
+2.17.1
 

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0006-Changes-to-be-in-sync-with-features-enabled-in-linux.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0006-Changes-to-be-in-sync-with-features-enabled-in-linux.patch
@@ -1,4 +1,4 @@
-From df60fe5001b3994e5acbf90274451293823e6e2d Mon Sep 17 00:00:00 2001
+From c411ca8fff48c17058a24bbfb3329cf5cbc0d52c Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Wed, 8 Mar 2023 15:46:04 +0530
 Subject: [PATCH] Changes to be in sync with features enabled in linux variant
@@ -162,5 +162,5 @@ index 2397ac3d..5707e4a4 100644
  MFX_CFLAGS += \
    -DMFX_FILE_VERSION=\"`echo $(MFX_VERSION) | cut -f 1 -d.``date +.%-y.%-m.%-d`\" \
 -- 
-2.39.2
+2.17.1
 

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0007-Enable-avx2.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0007-Enable-avx2.patch
@@ -1,0 +1,29 @@
+From 0db71fd09632a9e5cbd9c4fe990d856a10740378 Mon Sep 17 00:00:00 2001
+From: yerriswamy <yerriswamy.kt@intel.com>
+Date: Wed, 29 Mar 2023 15:42:03 +0530
+Subject: [PATCH] Enable avx2
+
+Change-Id: I123e4907bfa5658230ebb42846dc0651fba31aa4
+Tracked-On: OAM-106860
+Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
+---
+ android/mfx_defs.mk | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/android/mfx_defs.mk b/android/mfx_defs.mk
+index 5707e4a4..fbe8056b 100644
+--- a/android/mfx_defs.mk
++++ b/android/mfx_defs.mk
+@@ -61,7 +61,8 @@ MFX_CFLAGS += \
+   -O2 -D_FORTIFY_SOURCE=2 \
+   -Wformat -Wformat-security \
+   -fexceptions -frtti -msse4.1 \
+-  -Wno-non-virtual-dtor
++  -Wno-non-virtual-dtor \
++  -mavx2
+ 
+ # Enable feature with output decoded frames without latency regarding
+ # SPS.VUI.max_num_reorder_frames
+-- 
+2.17.1
+

--- a/bsp_diff/common/hardware/intel/onevpl/0001-Changes-for-OneVPL-integration.patch
+++ b/bsp_diff/common/hardware/intel/onevpl/0001-Changes-for-OneVPL-integration.patch
@@ -1,4 +1,4 @@
-From 9f67deccd93c2f31cdc04e6aba99fc0bb9e6e841 Mon Sep 17 00:00:00 2001
+From da76e118377bc7aae41491408e4556a3b6d10000 Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
 Date: Fri, 3 Feb 2023 10:42:18 +0530
 Subject: [PATCH] Changes for OneVPL integration
@@ -7,8 +7,8 @@ Subject: [PATCH] Changes for OneVPL integration
 - Updated search path for core vpl
 - Added dGPU device ids
 
-Change-Id: I65ae4907bfa5658230ebb42846dc0651fba31aa4
-Tracked-On: OAM-105683
+Change-Id: I645ae907bfa5658230ebb42846dc0651fba31aa4
+Tracked-On: OAM-106860
 Signed-off-by: neeraj solanki <neeraj.solanki@intel.com>
 Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
@@ -246,7 +246,7 @@ index adeca49..59ec3cf 100644
      #error Unsupported architecture
  #endif
 diff --git a/dispatcher/vpl/mfx_dispatcher_vpl.h b/dispatcher/vpl/mfx_dispatcher_vpl.h
-index 519afb9..5822d72 100644
+index 443bbe8..6a0d1b2 100644
 --- a/dispatcher/vpl/mfx_dispatcher_vpl.h
 +++ b/dispatcher/vpl/mfx_dispatcher_vpl.h
 @@ -15,11 +15,20 @@
@@ -298,7 +298,7 @@ index c9aff94..c73f9d4 100644
          STRING_TYPE nextDir = (*it);
 diff --git a/examples/Android.mk b/examples/Android.mk
 new file mode 100644
-index 0000000..db9f289
+index 0000000..c444bc2
 --- /dev/null
 +++ b/examples/Android.mk
 @@ -0,0 +1,96 @@
@@ -308,7 +308,7 @@ index 0000000..db9f289
 +include $(CLEAR_VARS)
 +
 +LOCAL_SRC_FILES := \
-+    coreAPI/legacy-decode/src/legacy-decode.cpp
++	api1x_core/legacy-decode/src/legacy-decode.cpp
 +
 +LOCAL_CPPFLAGS := \
 +    -std=c++11 \
@@ -339,7 +339,7 @@ index 0000000..db9f289
 +include $(CLEAR_VARS)
 +
 +LOCAL_SRC_FILES := \
-+    coreAPI/legacy-encode/src/legacy-encode.cpp
++    api1x_core/legacy-encode/src/legacy-encode.cpp
 +
 +LOCAL_CPPFLAGS := \
 +    -std=c++11 \
@@ -370,7 +370,7 @@ index 0000000..db9f289
 +include $(CLEAR_VARS)
 +
 +LOCAL_SRC_FILES := \
-+    coreAPI/legacy-vpp/src/legacy-vpp.cpp
++    api1x_core/legacy-vpp/src/legacy-vpp.cpp
 +
 +LOCAL_CPPFLAGS := \
 +    -std=c++11 \

--- a/bsp_diff/common/hardware/intel/onevpl/0002-Fix-for-HEVC-rendering-failing-with-usptream-ffmpeg.patch
+++ b/bsp_diff/common/hardware/intel/onevpl/0002-Fix-for-HEVC-rendering-failing-with-usptream-ffmpeg.patch
@@ -1,4 +1,4 @@
-From c8b329cbf539031ae9355b0f0cf293551a5fbe26 Mon Sep 17 00:00:00 2001
+From e0a2a87090afee3e149f092ae86d3e489ff0ba1b Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Wed, 8 Mar 2023 14:59:44 +0530
 Subject: [PATCH] Fix for HEVC rendering failing with usptream ffmpeg
@@ -43,5 +43,5 @@ index 526d839..0b8ab86 100644
  LOCAL_CPPFLAGS += -Wl,--version-script=$(LOCAL_PATH)/linux/libvpl.map
  
 -- 
-2.39.2
+2.17.1
 


### PR DESCRIPTION
media-driver: tag: intel-media-23.1.3

gmmlib: tag: intel-gmmlib-22.3.4

Onevpl dispatcher: tag: v2023.1.2

Onevpl runtime: tag: intel-onevpl-23.1.3

Change-Id: I65acb16f49af380994e65358a9e958e67ecb5c11
Tracked-On: OAM-106860