### PR TITLE
Use normal SCO connected instead of enhanced SCO

### DIFF
--- a/aosp_diff/preliminary/packages/modules/Bluetooth/0025-Use-SCO-connection-instead-of-enhanced-SCO.patch
+++ b/aosp_diff/preliminary/packages/modules/Bluetooth/0025-Use-SCO-connection-instead-of-enhanced-SCO.patch
@@ -1,0 +1,26 @@
+From 05d8641f06ad4b1ac22cff32eec7830f154fa740 Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Fri, 17 Mar 2023 19:37:13 +0530
+Subject: [PATCH] Use SCO connection instead of enhanced SCO
+
+BT 4.1 - Hci_Enhanced_Setup_Synchronous_Connection
+---
+ system/stack/btm/btm_sco.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/system/stack/btm/btm_sco.cc b/system/stack/btm/btm_sco.cc
+index f35fe2adec..f1edc63d86 100644
+--- a/system/stack/btm/btm_sco.cc
++++ b/system/stack/btm/btm_sco.cc
+@@ -341,7 +341,7 @@ static tBTM_STATUS btm_send_connect_request(uint16_t acl_handle,
+ 
+     /* Use Enhanced Synchronous commands if supported */
+     if (controller_get_interface()
+-            ->supports_enhanced_setup_synchronous_connection()) {
++            ->supports_enhanced_setup_synchronous_connection() && false) {
+       LOG_INFO("Sending enhanced SCO connect request over handle:0x%04x",
+                acl_handle);
+       /* Use the saved SCO routing */
+-- 
+2.17.1
+


### PR DESCRIPTION
Enhanced SCO requries additional HCI parameters to configure the stream. These parameters should be tunned and decided. Disable this until we decide and use normal SCO connection instead which was working in previous Android release.

Tracked-On: OAM-106763