### PR TITLE
CVE: Update build_weekly.sh with latest commit tag for v5.15.78

### DIFF
--- a/host/kernel/lts2021-chromium/build_weekly.sh
+++ b/host/kernel/lts2021-chromium/build_weekly.sh
@@ -9,7 +9,7 @@ cd vendor-intel-utils
 git checkout e936af4e95a4cb52bd5808323f99dda832aa58b2
 cd ../
 
-tag="lts-v5.15.78-20230227-r10"
+tag="lts-v5.15.78-20230318-r11"
 git clone -b $tag https://github.com/projectceladon/linux-intel-lts2021-chromium.git
 cd linux-intel-lts2021-chromium
 


### PR DESCRIPTION
BDSA-2023-0454(CVE-2023-0210) - Fix Applied
BDSA-2021-4809 (CVE-2023-23000) - Fix Applied
CVE-2022-3707 - Fix Applied
CVE-2022-3424 - Fix Applied
CVE-2023-0597 - Fix Applied

Tracked-On: OAM-106654