### PR TITLE
CVE: Update build_weekly.sh with latest commit tag for v5.10.118

### DIFF
--- a/host/kernel/lts2020-chromium/build_weekly.sh
+++ b/host/kernel/lts2020-chromium/build_weekly.sh
@@ -4,7 +4,7 @@ rm -rf host_kernel
 mkdir -p host_kernel
 cd host_kernel
 
-tag="lts-v5.10.118-20230310-r7"
+tag="lts-v5.10.118-20230321-r8"
 git clone -b $tag https://github.com/projectceladon/linux-intel-lts2020-chromium.git
 cd linux-intel-lts2020-chromium
 


### PR DESCRIPTION
CVE-2023-23000 - Fix Applied
CVE-2023-22998 - Fix Applied
New commit tag lts-v5.10.118-20230321-r8

Tracked-On: OAM-106888