### PR TITLE
Fix for Home Button When Google Assistant is disabled.

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/58_0058-Fix-for-Home-Button-When-Google-Assistant-is-disable.patch
+++ b/aosp_diff/preliminary/frameworks/base/58_0058-Fix-for-Home-Button-When-Google-Assistant-is-disable.patch
@@ -1,0 +1,206 @@
+From eca7accc23f2fafb555d0d63a6c05263df93f012 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Fri, 24 Mar 2023 10:55:59 +0530
+Subject: [PATCH] Fix for Home Button When Google Assistant is disabled.
+
+When user disables long press of home button option in settings
+to launch Google assistant, still it launch Google assistant on
+doing long press of Home button.
+
+Added flag to check, if Google assistant is disabled or not.
+
+Tracked-On: OAM-106871
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../systemui/shared/recents/IOverviewProxy.aidl      |  3 ++-
+ .../android/systemui/navigationbar/NavBarHelper.java | 10 +++++-----
+ .../systemui/navigationbar/NavigationBar.java        | 10 +++++-----
+ .../systemui/navigationbar/TaskbarDelegate.java      |  8 ++++----
+ .../systemui/navigationbar/NavBarHelperTest.java     | 12 ++++++------
+ 5 files changed, 22 insertions(+), 21 deletions(-)
+
+diff --git a/packages/SystemUI/shared/src/com/android/systemui/shared/recents/IOverviewProxy.aidl b/packages/SystemUI/shared/src/com/android/systemui/shared/recents/IOverviewProxy.aidl
+index 4613e8b1060f..3a33acf4dbc1 100644
+--- a/packages/SystemUI/shared/src/com/android/systemui/shared/recents/IOverviewProxy.aidl
++++ b/packages/SystemUI/shared/src/com/android/systemui/shared/recents/IOverviewProxy.aidl
+@@ -51,8 +51,9 @@ oneway interface IOverviewProxy {
+ 
+     /**
+      * Sent when device assistant changes its default assistant whether it is available or not.
++     * @param longPressHomeEnabled if 3-button nav assistant can be invoked or not
+      */
+-    void onAssistantAvailable(boolean available) = 13;
++    void onAssistantAvailable(boolean available, boolean longPressHomeEnabled) = 13;
+ 
+     /**
+      * Sent when the assistant changes how visible it is to the user.
+diff --git a/packages/SystemUI/src/com/android/systemui/navigationbar/NavBarHelper.java b/packages/SystemUI/src/com/android/systemui/navigationbar/NavBarHelper.java
+index da9fefab0b66..a2404e8d9f27 100644
+--- a/packages/SystemUI/src/com/android/systemui/navigationbar/NavBarHelper.java
++++ b/packages/SystemUI/src/com/android/systemui/navigationbar/NavBarHelper.java
+@@ -172,7 +172,7 @@ public final class NavBarHelper implements
+     public void registerNavTaskStateUpdater(NavbarTaskbarStateUpdater listener) {
+         mA11yEventListeners.add(listener);
+         listener.updateAccessibilityServicesState();
+-        listener.updateAssistantAvailable(mAssistantAvailable);
++        listener.updateAssistantAvailable(mAssistantAvailable, mLongPressHomeEnabled);
+     }
+ 
+     public void removeNavTaskStateUpdater(NavbarTaskbarStateUpdater listener) {
+@@ -185,9 +185,9 @@ public final class NavBarHelper implements
+         }
+     }
+ 
+-    private void dispatchAssistantEventUpdate(boolean assistantAvailable) {
++    private void dispatchAssistantEventUpdate(boolean assistantAvailable, boolean longPressHomeEnabled) {
+         for (NavbarTaskbarStateUpdater listener : mA11yEventListeners) {
+-            listener.updateAssistantAvailable(assistantAvailable);
++            listener.updateAssistantAvailable(assistantAvailable, longPressHomeEnabled);
+         }
+     }
+ 
+@@ -298,7 +298,7 @@ public final class NavBarHelper implements
+         mAssistantAvailable = assistantAvailableForUser
+                 && mAssistantTouchGestureEnabled
+                 && QuickStepContract.isGesturalMode(mNavBarMode);
+-        dispatchAssistantEventUpdate(mAssistantAvailable);
++        dispatchAssistantEventUpdate(mAssistantAvailable, mLongPressHomeEnabled);
+     }
+ 
+     public boolean getLongPressHomeEnabled() {
+@@ -339,7 +339,7 @@ public final class NavBarHelper implements
+      */
+     public interface NavbarTaskbarStateUpdater {
+         void updateAccessibilityServicesState();
+-        void updateAssistantAvailable(boolean available);
++        void updateAssistantAvailable(boolean available, boolean longPressHomeEnabled);
+     }
+ 
+     static @TransitionMode int transitionMode(boolean isTransient, int appearance) {
+diff --git a/packages/SystemUI/src/com/android/systemui/navigationbar/NavigationBar.java b/packages/SystemUI/src/com/android/systemui/navigationbar/NavigationBar.java
+index 50a10bc0b15a..13c5f0da1f97 100644
+--- a/packages/SystemUI/src/com/android/systemui/navigationbar/NavigationBar.java
++++ b/packages/SystemUI/src/com/android/systemui/navigationbar/NavigationBar.java
+@@ -330,15 +330,15 @@ public class NavigationBar extends ViewController<NavigationBarView> implements
+                 }
+ 
+                 @Override
+-                public void updateAssistantAvailable(boolean available) {
++                public void updateAssistantAvailable(boolean available, boolean longPressHomeEnabled) {
+                     // TODO(b/198002034): Content observers currently can still be called back after
+                     //  being unregistered, and in this case we can ignore the change if the nav bar
+                     //  has been destroyed already
+                     if (mView == null) {
+                         return;
+                     }
+-                    mLongPressHomeEnabled = mNavBarHelper.getLongPressHomeEnabled();
+-                    updateAssistantEntrypoints(available);
++                    mLongPressHomeEnabled = longPressHomeEnabled;
++                    updateAssistantEntrypoints(available, longPressHomeEnabled);
+                 }
+             };
+ 
+@@ -1417,10 +1417,10 @@ public class NavigationBar extends ViewController<NavigationBarView> implements
+                 .commitUpdate(mDisplayId);
+     }
+ 
+-    private void updateAssistantEntrypoints(boolean assistantAvailable) {
++    private void updateAssistantEntrypoints(boolean assistantAvailable, boolean longPressHomeEnabled) {
+         if (mOverviewProxyService.getProxy() != null) {
+             try {
+-                mOverviewProxyService.getProxy().onAssistantAvailable(assistantAvailable);
++                mOverviewProxyService.getProxy().onAssistantAvailable(assistantAvailable, longPressHomeEnabled);
+             } catch (RemoteException e) {
+                 Log.w(TAG, "Unable to send assistant availability data to launcher");
+             }
+diff --git a/packages/SystemUI/src/com/android/systemui/navigationbar/TaskbarDelegate.java b/packages/SystemUI/src/com/android/systemui/navigationbar/TaskbarDelegate.java
+index 9e0c49641e72..71d910d02d94 100644
+--- a/packages/SystemUI/src/com/android/systemui/navigationbar/TaskbarDelegate.java
++++ b/packages/SystemUI/src/com/android/systemui/navigationbar/TaskbarDelegate.java
+@@ -112,8 +112,8 @@ public class TaskbarDelegate implements CommandQueue.Callbacks,
+                 }
+ 
+                 @Override
+-                public void updateAssistantAvailable(boolean available) {
+-                    updateAssistantAvailability(available);
++                public void updateAssistantAvailable(boolean available, boolean longPressHomeEnabled) {
++                    updateAssistantAvailability(available, longPressHomeEnabled);
+                 }
+             };
+     private int mDisabledFlags;
+@@ -304,13 +304,13 @@ public class TaskbarDelegate implements CommandQueue.Callbacks,
+         return (mSysUiState.getFlags() & View.STATUS_BAR_DISABLE_RECENT) == 0;
+     }
+ 
+-    private void updateAssistantAvailability(boolean assistantAvailable) {
++    private void updateAssistantAvailability(boolean assistantAvailable, boolean longPressHomeEnabled) {
+         if (mOverviewProxyService.getProxy() == null) {
+             return;
+         }
+ 
+         try {
+-            mOverviewProxyService.getProxy().onAssistantAvailable(assistantAvailable);
++            mOverviewProxyService.getProxy().onAssistantAvailable(assistantAvailable, longPressHomeEnabled);
+         } catch (RemoteException e) {
+             Log.e(TAG, "onAssistantAvailable() failed, available: " + assistantAvailable, e);
+         }
+diff --git a/packages/SystemUI/tests/src/com/android/systemui/navigationbar/NavBarHelperTest.java b/packages/SystemUI/tests/src/com/android/systemui/navigationbar/NavBarHelperTest.java
+index 80731037481a..86e638768b46 100644
+--- a/packages/SystemUI/tests/src/com/android/systemui/navigationbar/NavBarHelperTest.java
++++ b/packages/SystemUI/tests/src/com/android/systemui/navigationbar/NavBarHelperTest.java
+@@ -138,7 +138,7 @@ public class NavBarHelperTest extends SysuiTestCase {
+         verify(mNavbarTaskbarStateUpdater, times(1))
+                 .updateAccessibilityServicesState();
+         verify(mNavbarTaskbarStateUpdater, times(1))
+-                .updateAssistantAvailable(anyBoolean());
++                .updateAssistantAvailable(anyBoolean(), anyBoolean());
+     }
+ 
+     @Test
+@@ -152,14 +152,14 @@ public class NavBarHelperTest extends SysuiTestCase {
+         verify(mNavbarTaskbarStateUpdater, times(1))
+                 .updateAccessibilityServicesState();
+         verify(mNavbarTaskbarStateUpdater, times(1))
+-                .updateAssistantAvailable(anyBoolean());
++                .updateAssistantAvailable(anyBoolean(), anyBoolean());
+ 
+         mNavBarHelper.onConnectionChanged(true);
+         // assert no more callbacks fired
+         verify(mNavbarTaskbarStateUpdater, times(1))
+                 .updateAccessibilityServicesState();
+         verify(mNavbarTaskbarStateUpdater, times(2))
+-                .updateAssistantAvailable(anyBoolean());
++                .updateAssistantAvailable(anyBoolean(), anyBoolean());
+     }
+ 
+     @Test
+@@ -172,7 +172,7 @@ public class NavBarHelperTest extends SysuiTestCase {
+         verify(mNavbarTaskbarStateUpdater, times(2))
+                 .updateAccessibilityServicesState();
+         verify(mNavbarTaskbarStateUpdater, times(1))
+-                .updateAssistantAvailable(anyBoolean());
++                .updateAssistantAvailable(anyBoolean(), anyBoolean());
+     }
+ 
+     @Test
+@@ -185,7 +185,7 @@ public class NavBarHelperTest extends SysuiTestCase {
+         verify(mNavbarTaskbarStateUpdater, times(1))
+                 .updateAccessibilityServicesState();
+         verify(mNavbarTaskbarStateUpdater, times(2))
+-                .updateAssistantAvailable(anyBoolean());
++                .updateAssistantAvailable(anyBoolean(), anyBoolean());
+     }
+ 
+     @Test
+@@ -204,7 +204,7 @@ public class NavBarHelperTest extends SysuiTestCase {
+         verify(mNavbarTaskbarStateUpdater, times(1))
+                 .updateAccessibilityServicesState();
+         verify(mNavbarTaskbarStateUpdater, times(1))
+-                .updateAssistantAvailable(anyBoolean());
++                .updateAssistantAvailable(anyBoolean()), anyBoolean();
+     }
+ 
+     @Test
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/packages/apps/Launcher3/0001-Fix-for-Home-Button-When-Google-Assistant-is-disable.patch
+++ b/aosp_diff/preliminary/packages/apps/Launcher3/0001-Fix-for-Home-Button-When-Google-Assistant-is-disable.patch
@@ -1,0 +1,123 @@
+From e9bf1ef80ad50ddaa53f103bb4d6f5f3b9e4a2d2 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Fri, 24 Mar 2023 10:50:04 +0530
+Subject: [PATCH] Fix for Home Button When Google Assistant is disabled.
+
+When user disables long press of home button option in settings
+to launch Google assistant, still it launch Google assistant on
+doing long press of Home button.
+
+Added flag to check, if Google assistant is disabled or not.
+
+Tracked-On: OAM-106871
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../com/android/launcher3/taskbar/TaskbarManager.java |  6 ++++++
+ .../launcher3/taskbar/TaskbarNavButtonController.java |  7 ++++++-
+ .../android/quickstep/TouchInteractionService.java    |  4 +++-
+ .../taskbar/TaskbarNavButtonControllerTest.java       | 11 ++++++++++-
+ 4 files changed, 25 insertions(+), 3 deletions(-)
+
+diff --git a/quickstep/src/com/android/launcher3/taskbar/TaskbarManager.java b/quickstep/src/com/android/launcher3/taskbar/TaskbarManager.java
+index bc69088416..1fc5019357 100644
+--- a/quickstep/src/com/android/launcher3/taskbar/TaskbarManager.java
++++ b/quickstep/src/com/android/launcher3/taskbar/TaskbarManager.java
+@@ -314,6 +314,12 @@ public class TaskbarManager {
+         }
+     }
+ 
++    public void onLongPressHomeEnabled(boolean assistantLongPressEnabled) {
++        if (mNavButtonController != null) {
++            mNavButtonController.setAssistantLongPressEnabled(assistantLongPressEnabled);
++        }
++    }
++
+     /**
+      * Sets the flag indicating setup UI is visible
+      */
+diff --git a/quickstep/src/com/android/launcher3/taskbar/TaskbarNavButtonController.java b/quickstep/src/com/android/launcher3/taskbar/TaskbarNavButtonController.java
+index a395548f84..5bb958a713 100644
+--- a/quickstep/src/com/android/launcher3/taskbar/TaskbarNavButtonController.java
++++ b/quickstep/src/com/android/launcher3/taskbar/TaskbarNavButtonController.java
+@@ -67,6 +67,7 @@ public class TaskbarNavButtonController implements TaskbarControllers.LoggableTa
+ 
+     private long mLastScreenPinLongPress;
+     private boolean mScreenPinned;
++    private boolean mAssistantLongPressEnabled;
+ 
+     @Override
+     public void dumpLogs(String prefix, PrintWriter pw) {
+@@ -251,6 +252,10 @@ public class TaskbarNavButtonController implements TaskbarControllers.LoggableTa
+         mStatsLogManager = null;
+     }
+ 
++    public void setAssistantLongPressEnabled(boolean assistantLongPressEnabled) {
++        mAssistantLongPressEnabled = assistantLongPressEnabled;
++    }
++
+     private void logEvent(StatsLogManager.LauncherEvent event) {
+         if (mStatsLogManager == null) {
+             Log.w(TAG, "No stats log manager to log taskbar button event");
+@@ -289,7 +294,7 @@ public class TaskbarNavButtonController implements TaskbarControllers.LoggableTa
+     }
+ 
+     private void startAssistant() {
+-        if (mScreenPinned) {
++        if (mScreenPinned || !mAssistantLongPressEnabled) {
+             return;
+         }
+         Bundle args = new Bundle();
+diff --git a/quickstep/src/com/android/quickstep/TouchInteractionService.java b/quickstep/src/com/android/quickstep/TouchInteractionService.java
+index 1999701f61..42d4ef859f 100644
+--- a/quickstep/src/com/android/quickstep/TouchInteractionService.java
++++ b/quickstep/src/com/android/quickstep/TouchInteractionService.java
+@@ -237,10 +237,12 @@ public class TouchInteractionService extends Service
+ 
+         @BinderThread
+         @Override
+-        public void onAssistantAvailable(boolean available) {
++        public void onAssistantAvailable(boolean available, boolean longPressHomeEnabled) {
+             MAIN_EXECUTOR.execute(() -> {
+                 mDeviceState.setAssistantAvailable(available);
+                 TouchInteractionService.this.onAssistantVisibilityChanged();
++                executeForTaskbarManager(() -> mTaskbarManager
++                        .onLongPressHomeEnabled(longPressHomeEnabled));
+             });
+         }
+ 
+diff --git a/quickstep/tests/src/com/android/launcher3/taskbar/TaskbarNavButtonControllerTest.java b/quickstep/tests/src/com/android/launcher3/taskbar/TaskbarNavButtonControllerTest.java
+index 4eec319f4a..962261940c 100644
+--- a/quickstep/tests/src/com/android/launcher3/taskbar/TaskbarNavButtonControllerTest.java
++++ b/quickstep/tests/src/com/android/launcher3/taskbar/TaskbarNavButtonControllerTest.java
+@@ -18,6 +18,7 @@ import static com.android.systemui.shared.system.QuickStepContract.SYSUI_STATE_S
+ 
+ import static org.mockito.ArgumentMatchers.any;
+ import static org.mockito.Mockito.doReturn;
++import static org.mockito.Mockito.never;
+ import static org.mockito.Mockito.times;
+ import static org.mockito.Mockito.verify;
+ import static org.mockito.Mockito.when;
+@@ -103,11 +104,19 @@ public class TaskbarNavButtonControllerTest {
+     }
+ 
+     @Test
+-    public void testLongPressHome() {
++    public void testLongPressHome_enabled() {
++        mNavButtonController.setAssistantLongPressEnabled(true /*assistantLongPressEnabled*/);
+         mNavButtonController.onButtonLongClick(BUTTON_HOME, mockView);
+         verify(mockSystemUiProxy, times(1)).startAssistant(any());
+     }
+ 
++    @Test
++    public void testLongPressHome_disabled() {
++        mNavButtonController.setAssistantLongPressEnabled(false /*assistantLongPressEnabled*/);
++        mNavButtonController.onButtonLongClick(BUTTON_HOME, mockView);
++        verify(mockSystemUiProxy, never()).startAssistant(any());
++    }
++
+     @Test
+     public void testPressHome() {
+         mNavButtonController.onButtonClick(BUTTON_HOME, mockView);
+-- 
+2.17.1
+


### PR DESCRIPTION
When user disables long press of home button option in settings to launch Google assistant, still it launch Google assistant on doing long press of Home button.

Added flag to check, if Google assistant is disabled or not.

Tracked-On: OAM-106871