### PR TITLE
CVE: Update build_weekly.sh with latest commit tag for v5.15.78

### DIFF
--- a/host/kernel/lts2021-chromium/build_weekly.sh
+++ b/host/kernel/lts2021-chromium/build_weekly.sh
@@ -9,7 +9,7 @@ cd vendor-intel-utils
 git checkout e936af4e95a4cb52bd5808323f99dda832aa58b2
 cd ../
 
-tag="lts-v5.15.78-20230327-r12"
+tag="lts-v5.15.78-20230405-r13"
 git clone -b $tag https://github.com/projectceladon/linux-intel-lts2021-chromium.git
 cd linux-intel-lts2021-chromium
 


### PR DESCRIPTION
CVE-2023-1079 - Fix Applied
CVE-2023-1078 - Fix Applied
CVE-2023-1073 - Fix Applied
CVE-2023-28328 - Fix Applied
CVE-2023-1074 - Fix Applied
CVE-2023-1077 - Fix Applied
CVE-2023-1076 - Fix Applied

Tracked-On: OAM-108677