### PR TITLE
Fix the Virtio boot fail on Android S stable

### DIFF
--- a/bsp_diff/common/hardware/intel/external/mesa3d-intel/0001-INTERNAL-WA-to-disable-virgl-disk-cache-for-VirtIO-b.patch
+++ b/bsp_diff/common/hardware/intel/external/mesa3d-intel/0001-INTERNAL-WA-to-disable-virgl-disk-cache-for-VirtIO-b.patch
@@ -1,0 +1,53 @@
+From 158cb5e65dc6e53e0bb8888e2b285b1dcd16a185 Mon Sep 17 00:00:00 2001
+From: HeYue <yue.he@intel.com>
+Date: Thu, 6 Apr 2023 15:17:20 +0800
+Subject: [PATCH] INTERNAL: WA to disable virgl disk cache for VirtIO boot
+
+Feature virgl disk cache is not workable on Celadon with
+mesa above 22.0.3, which blocks virgl_create_screen for
+VirtIO-GPU solution. According to commit d6db4d2, virgl
+disk cache is only for performance improvment, so we
+disable it as workaround for VirtIO-GPU boot issue.
+
+Tracked-On: OAM-102653
+Signed-off-by: Lu Yang A <yang.a.lu@intel.com>
+---
+ src/gallium/drivers/virgl/virgl_screen.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/gallium/drivers/virgl/virgl_screen.c b/src/gallium/drivers/virgl/virgl_screen.c
+index cd96aeb46dd9..b678debe0c05 100644
+--- a/src/gallium/drivers/virgl/virgl_screen.c
++++ b/src/gallium/drivers/virgl/virgl_screen.c
+@@ -955,7 +955,9 @@ virgl_destroy_screen(struct pipe_screen *screen)
+    if (vws)
+       vws->destroy(vws);
+ 
++#if !defined(__ANDROID__)
+    disk_cache_destroy(vscreen->disk_cache);
++#endif
+ 
+    FREE(vscreen);
+ }
+@@ -1152,7 +1154,9 @@ virgl_create_screen(struct virgl_winsys *vws, const struct pipe_screen_config *c
+    screen->base.fence_finish = virgl_fence_finish;
+    screen->base.fence_get_fd = virgl_fence_get_fd;
+    screen->base.query_memory_info = virgl_query_memory_info;
++#if !defined(__ANDROID__)
+    screen->base.get_disk_shader_cache = virgl_get_disk_shader_cache;
++#endif
+    screen->base.is_dmabuf_modifier_supported = virgl_is_dmabuf_modifier_supported;
+    screen->base.get_dmabuf_modifier_planes = virgl_get_dmabuf_modifier_planes;
+ 
+@@ -1183,6 +1187,8 @@ virgl_create_screen(struct virgl_winsys *vws, const struct pipe_screen_config *c
+ 
+    slab_create_parent(&screen->transfer_pool, sizeof(struct virgl_transfer), 16);
+ 
++#if !defined(__ANDROID__)
+    virgl_disk_cache_create(screen);
++#endif
+    return &screen->base;
+ }
+-- 
+2.17.1
+


### PR DESCRIPTION
Android S stable use the 5.10 kernel, still need
this WA to boot virtio-gpu

Tracked-On: OAM-108599
Signed-off-by: HeYue <yue.he@intel.com>