### PR TITLE
health: disable wakeup while polling for netlink event

### DIFF
--- a/bsp_diff/celadon_ivi/vendor/intel/hardware/interfaces/0001-disable-wakeup-while-polling-for-netlink-event.patch
+++ b/bsp_diff/celadon_ivi/vendor/intel/hardware/interfaces/0001-disable-wakeup-while-polling-for-netlink-event.patch
@@ -1,0 +1,44 @@
+From 06054912ddb0c22076a040dc4053557478c9054d Mon Sep 17 00:00:00 2001
+From: Shwetha B <shwetha.b@intel.com>
+Date: Tue, 18 Apr 2023 15:36:31 +0530
+Subject: [PATCH] disable wakeup while polling for netlink event
+
+Patch to disable wakeup while polling for
+netlink event.
+Solves the suspend failure on Baremetal.
+
+Signed-off-by: Shwetha B <shwetha.b@intel.com>
+---
+ health/2.0/healthd_common.cpp                 | 2 --
+ health/2.1/utils/libhealthloop/HealthLoop.cpp | 2 --
+ 2 files changed, 4 deletions(-)
+
+diff --git a/health/2.0/healthd_common.cpp b/health/2.0/healthd_common.cpp
+index d655395..48484de 100644
+--- a/health/2.0/healthd_common.cpp
++++ b/health/2.0/healthd_common.cpp
+@@ -97,8 +97,6 @@ int healthd_register_event(int fd, void (*handler)(uint32_t), EventWakeup wakeup
+ 
+     ev.events = EPOLLIN;
+ 
+-    if (wakeup == EVENT_WAKEUP_FD) ev.events |= EPOLLWAKEUP;
+-
+     ev.data.ptr = (void*)handler;
+     if (epoll_ctl(epollfd, EPOLL_CTL_ADD, fd, &ev) == -1) {
+         KLOG_ERROR(LOG_TAG, "epoll_ctl failed; errno=%d\n", errno);
+diff --git a/health/2.1/utils/libhealthloop/HealthLoop.cpp b/health/2.1/utils/libhealthloop/HealthLoop.cpp
+index c4cda2b..d424e3e 100644
+--- a/health/2.1/utils/libhealthloop/HealthLoop.cpp
++++ b/health/2.1/utils/libhealthloop/HealthLoop.cpp
+@@ -68,8 +68,6 @@ int HealthLoop::RegisterEvent(int fd, BoundFunction func, EventWakeup wakeup) {
+ 
+     ev.events = EPOLLIN;
+ 
+-    if (wakeup == EVENT_WAKEUP_FD) ev.events |= EPOLLWAKEUP;
+-
+     ev.data.ptr = reinterpret_cast<void*>(event_handler);
+ 
+     if (epoll_ctl(epollfd_, EPOLL_CTL_ADD, fd, &ev) == -1) {
+-- 
+2.17.1
+


### PR DESCRIPTION
Dislable device wakeup when polling
for netlink event.
Solves suspend failure in Baremetal.

Tracked-On: OAM-108832