### PR TITLE
revertme: Set device as unlocked state by default on userdebug

### DIFF
--- a/bsp_diff/celadon_ivi/hardware/intel/kernelflinger/0001-REVERT-ME-Set-device-as-unlocked-state-by-default-on.patch
+++ b/bsp_diff/celadon_ivi/hardware/intel/kernelflinger/0001-REVERT-ME-Set-device-as-unlocked-state-by-default-on.patch
@@ -1,0 +1,45 @@
+From 62501b7e27557a3136c582bc3bf0a4fe76088551 Mon Sep 17 00:00:00 2001
+From: "Chen, Gang G" <gang.g.chen@intel.com>
+Date: Wed, 19 Oct 2022 03:07:49 +0800
+Subject: [PATCH] [REVERT ME]: Set device as unlocked state by default on
+ userdebug
+
+This is only WA patch to set device as unlocked.
+The patch should be removed if fastboot is supported
+for BM.
+
+With this patch, device will be unlocked on userdebug build;
+For user build, it still locked.
+
+Tracked-On: OAM-108853
+Signed-off-by: Chen, Gang G <gang.g.chen@intel.com>
+Author: Chen, Gang G <gang.g.chen@intel.com>
+---
+ kernelflinger.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/kernelflinger.c b/kernelflinger.c
+index dba41f8..2aed959 100644
+--- a/kernelflinger.c
++++ b/kernelflinger.c
+@@ -1238,11 +1238,17 @@ EFI_STATUS efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *sys_table)
+ 	}
+ #endif
+ 
++#ifndef USER
++	/* WA patch to set device as unlocked by default for userdebug build
++	*/
++	set_current_state(UNLOCKED);
++#else
+ 	/* For civ, flash images to disk is not MUST. So set device to LOCKED
+ 	 * state by default on the first boot.
+ 	*/
+ 	if (need_lock)
+ 		set_current_state(LOCKED);
++#endif
+ 
+ 	ret = set_device_security_info(NULL);
+ 	if (EFI_ERROR(ret)) {
+-- 
+2.25.1
+


### PR DESCRIPTION
This is only WA patch to set device as unlocked.
The patch should be removed if fastboot is supported for BM.

With this patch, device will be unlocked on userdebug build; For user build, it still locked.

Tracked-On: OAM-108853

Author: Chen, Gang G <gang.g.chen@intel.com>