### PR TITLE
[REVERT ME] Allow install unknown source apks in ivi by default

### DIFF
--- a/aosp_diff/celadon_ivi/frameworks/base/0001-Allow-install-unknown-source-apks-in-ivi-by-default.patch
+++ b/aosp_diff/celadon_ivi/frameworks/base/0001-Allow-install-unknown-source-apks-in-ivi-by-default.patch
@@ -1,0 +1,36 @@
+From ac8db6ce2ba85017c2025578cb07071fffdb3770 Mon Sep 17 00:00:00 2001
+From: jizhenlo <zhenlong.z.ji@intel.com>
+Date: Tue, 14 Feb 2023 12:38:59 +0800
+Subject: [PATCH] [REVERT ME] Allow install unknown source apks in ivi by
+ default
+
+There is no "Allow unknown source apks" option in IVI Settings.
+With this patch, all the applications are allowed to install
+irrespective of user choice.
+
+Tracked-On: OAM-108915
+Signed-off-by: jizhenlo <zhenlong.z.ji@intel.com>
+---
+ .../com/android/packageinstaller/PackageInstallerActivity.java | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/packages/PackageInstaller/src/com/android/packageinstaller/PackageInstallerActivity.java b/packages/PackageInstaller/src/com/android/packageinstaller/PackageInstallerActivity.java
+index 9c6113ce4b47..5ad97c347b05 100644
+--- a/packages/PackageInstaller/src/com/android/packageinstaller/PackageInstallerActivity.java
++++ b/packages/PackageInstaller/src/com/android/packageinstaller/PackageInstallerActivity.java
+@@ -514,10 +514,11 @@ public class PackageInstallerActivity extends AlertActivity {
+         // Shouldn't use static constant directly, see b/65534401.
+         final int appOpCode =
+                 AppOpsManager.permissionToOpCode(Manifest.permission.REQUEST_INSTALL_PACKAGES);
+-        final int appOpMode = mAppOpsManager.noteOpNoThrow(appOpCode, mOriginatingUid,
++        int appOpMode = mAppOpsManager.noteOpNoThrow(appOpCode, mOriginatingUid,
+                 mOriginatingPackage, mCallingAttributionTag,
+                 "Started package installation activity");
+         if (mLocalLOGV) Log.i(TAG, "handleUnknownSources(): appMode=" + appOpMode);
++        appOpMode = AppOpsManager.MODE_ALLOWED;
+         switch (appOpMode) {
+             case AppOpsManager.MODE_DEFAULT:
+                 mAppOpsManager.setMode(appOpCode, mOriginatingUid,
+-- 
+2.25.1
+


### PR DESCRIPTION
There is no "Allow unknown source apks" option in IVI Settings.
With this patch, all the applications are allowed to install
irrespective of user choice.

Tracked-On: OAM-108915