### PR TITLE
Fix EVS sample driver not getting started as service

### DIFF
--- a/aosp_diff/celadon_ivi/packages/services/Car/0001-Fix-EVS-sample-driver-not-getting-started-as-service.patch
+++ b/aosp_diff/celadon_ivi/packages/services/Car/0001-Fix-EVS-sample-driver-not-getting-started-as-service.patch
@@ -1,0 +1,74 @@
+From 071a2a4cd1d78b6fb1b890aa2df6506ea5fdd005 Mon Sep 17 00:00:00 2001
+From: "Pillai, Venkatesh" <venkatesh.pillai@intel.com>
+Date: Fri, 21 Apr 2023 14:56:39 +0530
+Subject: [PATCH] Fix EVS sample driver not getting started as service
+
+EVS sample driver not getting started as service due to missing
+sepolicies and onrestart automotive_display trigger.
+
+Changes done to fix the issue:
+- Allow carservice_app with service find rights
+- Allow carservice_app with open, read and search access for sysfs dir
+- Allow carservice_app with search access for data folder
+
+Tracked-On:OAM-108929
+Signed-off-by: Pillai, Venkatesh <venkatesh.pillai@intel.com>
+---
+ car_product/sepolicy/private/carservice_app.te             | 5 +++++
+ car_product/sepolicy/public/carservice_app.te              | 7 +++++++
+ .../android.hardware.automotive.evs@1.1-sample.rc          | 1 +
+ 3 files changed, 13 insertions(+)
+
+diff --git a/car_product/sepolicy/private/carservice_app.te b/car_product/sepolicy/private/carservice_app.te
+index 04a5808e0..615acf80b 100644
+--- a/car_product/sepolicy/private/carservice_app.te
++++ b/car_product/sepolicy/private/carservice_app.te
+@@ -26,9 +26,11 @@ allow carservice_app {
+     autofill_service
+     bluetooth_manager_service
+     connectivity_service
++    content_capture_service
+     content_service
+     deviceidle_service
+     display_service
++    game_service
+     graphicsstats_service
+     input_method_service
+     input_service
+@@ -69,6 +71,9 @@ allow carservice_app procfsinspector:binder call;
+ # Allow binder calls with statsd
+ allow carservice_app statsd:binder call;
+ 
++allow carservice_app system_data_file:dir search;
++allow carservice_app user_profile_root_file:dir search;
++
+ # To access /sys/fs/<type>/<partition>/lifetime_write_kbytes
+ allow carservice_app sysfs:dir { open read search };
+ allow carservice_app sysfs_fs_ext4_features:dir { open read search};
+diff --git a/car_product/sepolicy/public/carservice_app.te b/car_product/sepolicy/public/carservice_app.te
+index fd276b63f..abdfd7b5a 100644
+--- a/car_product/sepolicy/public/carservice_app.te
++++ b/car_product/sepolicy/public/carservice_app.te
+@@ -1,2 +1,9 @@
+ # Domain to run Car Service (com.android.car)
+ type carservice_app, domain, coredomain;
++
++#allowing
++allow carservice_app content_capture_service:service_manager find;
++allow carservice_app game_service:service_manager find;
++allow carservice_app media_communication_service:service_manager find;
++allow carservice_app system_data_file:dir search;
++allow carservice_app user_profile_root_file:dir search;
+diff --git a/cpp/evs/sampleDriver/android.hardware.automotive.evs@1.1-sample.rc b/cpp/evs/sampleDriver/android.hardware.automotive.evs@1.1-sample.rc
+index e7d7217fe..f3cb43af4 100644
+--- a/cpp/evs/sampleDriver/android.hardware.automotive.evs@1.1-sample.rc
++++ b/cpp/evs/sampleDriver/android.hardware.automotive.evs@1.1-sample.rc
+@@ -4,4 +4,5 @@ service evs_sample_driver /vendor/bin/android.hardware.automotive.evs@1.1-sample
+     user graphics
+     group automotive_evs camera
+     onrestart restart evs_manager
++    onrestart restart automotive_display
+     disabled # will not automatically start with its class; must be explictly started.
+-- 
+2.17.1
+


### PR DESCRIPTION
EVS sample driver not getting started as service due to missing sepolicies and onrestart automotive_display trigger.

Changes done to fix the issue:

Allow carservice_app with service find rights
Allow carservice_app with open, read and search access for sysfs dir Allow carservice_app with search access for data folder

Tracked-On: OAM-108929