### PR TITLE
Fix gfxbench vulkan test fail

### DIFF
--- a/bsp_diff/common/hardware/intel/external/mesa3d-intel/0005-vulkan-fix-buf-map-failure-in-32bits-app.patch
+++ b/bsp_diff/common/hardware/intel/external/mesa3d-intel/0005-vulkan-fix-buf-map-failure-in-32bits-app.patch
@@ -1,0 +1,51 @@
+From bad7564349b211c3bef2d497a2ae89106dee02c6 Mon Sep 17 00:00:00 2001
+From: "Chen, Yu" <yu.y.chen@intel.com>
+Date: Sat, 22 Oct 2022 21:11:35 +0800
+Subject: [PATCH] vulkan:fix buf map failure in 32bits app
+
+1) fix buf map failure in 32bits app
+2) and when has_tiling_uapi is false
+   return I915_TILING_NONE which means ISL_TILING_LINEAR
+   On mesa, it returns -1, will cause vulkan app always crash
+   has_tiling_uapi is always false, because DRM_IOCTL_I915_GEM_SET_TILING
+   is not supported in has_get_tiling() function
+
+commit 1de5d2ac010502913777086849e4b4dabbf89d57
+Signed-off-by: Chen, Yu <yu.y.chen@intel.com>
+Change-Id: I94fe62080909841aff2ec2d57f942453989e11e1
+Signed-off-by: Marc Mao <marc.mao@intel.com>
+---
+ src/intel/vulkan/anv_gem.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/src/intel/vulkan/anv_gem.c b/src/intel/vulkan/anv_gem.c
+index 80b45e344c5..5f00dc9fd8d 100644
+--- a/src/intel/vulkan/anv_gem.c
++++ b/src/intel/vulkan/anv_gem.c
+@@ -113,8 +113,12 @@ anv_gem_mmap_offset(struct anv_device *device, uint32_t gem_handle,
+       return MAP_FAILED;
+ 
+    /* And map it */
+-   void *map = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED,
+-                    device->fd, gem_mmap.offset);
++   #ifdef __x86_64__
++   void *map = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, device->fd, gem_mmap.offset);
++   #else
++   void *map = mmap64(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, device->fd, gem_mmap.offset);
++   #endif
++
+    return map;
+ }
+ 
+@@ -232,7 +236,7 @@ int
+ anv_gem_get_tiling(struct anv_device *device, uint32_t gem_handle)
+ {
+    if (!device->info->has_tiling_uapi)
+-      return -1;
++      return I915_TILING_NONE;
+ 
+    struct drm_i915_gem_get_tiling get_tiling = {
+       .handle = gem_handle,
+-- 
+2.39.2
+

--- a/bsp_diff/common/hardware/intel/external/mesa3d-intel/0006-Fix-Android-Swapchain-alignment-issue.patch
+++ b/bsp_diff/common/hardware/intel/external/mesa3d-intel/0006-Fix-Android-Swapchain-alignment-issue.patch
@@ -1,0 +1,97 @@
+From f67f54fb78d39f8a19369758ba0280f6294a6536 Mon Sep 17 00:00:00 2001
+From: "Chen, Yu" <yu.y.chen@intel.com>
+Date: Fri, 29 Apr 2022 10:44:16 +0800
+Subject: [PATCH] Fix Android Swapchain alignment issue
+
+Use gralloc stride for Android buffer images but not calculate it by
+Vulkan itself.
+
+Tracked-On: OAM-102011
+Signed-off-by: Chen, Yu <yu.y.chen@intel.com>
+Change-Id: Ida8cb28b18fbb902c43bca0f24b6bfc2044c29bc
+Signed-off-by: Marc Mao <marc.mao@intel.com>
+---
+ src/intel/vulkan/anv_android.c | 31 +++++++++++++++++++++++++++++++
+ src/intel/vulkan/anv_image.c   |  2 +-
+ src/intel/vulkan/anv_private.h |  3 +++
+ 3 files changed, 35 insertions(+), 1 deletion(-)
+
+diff --git a/src/intel/vulkan/anv_android.c b/src/intel/vulkan/anv_android.c
+index 204c4a1fca9..ea7c02b26b3 100644
+--- a/src/intel/vulkan/anv_android.c
++++ b/src/intel/vulkan/anv_android.c
+@@ -142,6 +142,34 @@ vk_format_from_android(unsigned android_format, unsigned android_usage)
+    }
+ }
+ 
++static inline uint32_t
++get_pixel_size(unsigned android_format, unsigned android_usage)
++{
++   switch (android_format) {
++   case AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM:
++   case AHARDWAREBUFFER_FORMAT_R8G8B8X8_UNORM:
++   case AHARDWAREBUFFER_FORMAT_R8G8B8_UNORM:
++      return 4;
++   case AHARDWAREBUFFER_FORMAT_R5G6B5_UNORM:
++      return 2;
++   case AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT:
++      return 8;
++   case AHARDWAREBUFFER_FORMAT_R10G10B10A2_UNORM:
++      return 4;
++   case AHARDWAREBUFFER_FORMAT_Y8Cb8Cr8_420:
++   case HAL_PIXEL_FORMAT_NV12_Y_TILED_INTEL:
++      return 1;
++   case AHARDWAREBUFFER_FORMAT_IMPLEMENTATION_DEFINED:
++      if (android_usage & BUFFER_USAGE_CAMERA_MASK)
++         return 1;
++      else
++         return 4;
++   case AHARDWAREBUFFER_FORMAT_BLOB:
++   default:
++      return 0;
++   }
++}
++
+ static inline unsigned
+ android_format_from_vk(unsigned vk_format)
+ {
+@@ -536,6 +564,9 @@ anv_image_init_from_gralloc(struct anv_device *device,
+                                                base_info->tiling);
+    assert(format != ISL_FORMAT_UNSUPPORTED);
+ 
++   anv_info.row_pitch_B = gralloc_info->stride *
++      get_pixel_size(gralloc_info->format, gralloc_info->usage);
++
+    result = anv_image_init(device, image, &anv_info);
+    if (result != VK_SUCCESS)
+       goto fail_init;
+diff --git a/src/intel/vulkan/anv_image.c b/src/intel/vulkan/anv_image.c
+index ef31b327ead..4b162347bb2 100644
+--- a/src/intel/vulkan/anv_image.c
++++ b/src/intel/vulkan/anv_image.c
+@@ -1365,7 +1365,7 @@ anv_image_init(struct anv_device *device, struct anv_image *image,
+                                            mod_explicit_info, isl_tiling_flags,
+                                            create_info->isl_extra_usage_flags);
+    } else {
+-      r = add_all_surfaces_implicit_layout(device, image, fmt_list, 0,
++      r = add_all_surfaces_implicit_layout(device, image, fmt_list, create_info->row_pitch_B,
+                                            isl_tiling_flags,
+                                            create_info->isl_extra_usage_flags);
+    }
+diff --git a/src/intel/vulkan/anv_private.h b/src/intel/vulkan/anv_private.h
+index 1a8fbbd3fa8..6eb89226b38 100644
+--- a/src/intel/vulkan/anv_private.h
++++ b/src/intel/vulkan/anv_private.h
+@@ -3931,6 +3931,9 @@ struct anv_image_create_info {
+ 
+    /** These flags will be added to any derived from VkImageCreateInfo. */
+    isl_surf_usage_flags_t isl_extra_usage_flags;
++
++   /** Row pitch for external buffer **/
++   uint32_t row_pitch_B;
+ };
+ 
+ VkResult anv_image_init(struct anv_device *device, struct anv_image *image,
+-- 
+2.39.2
+


### PR DESCRIPTION
0005-vulkan-fix-buf-map-failure-in-32bits-app.patch
1) fix buf map failure in 32bits app
2) and when has_tiling_uapi is false
   return I915_TILING_NONE which means ISL_TILING_LINEAR
   On mesa, it returns -1, will cause vulkan app always crash
   has_tiling_uapi is always false, because DRM_IOCTL_I915_GEM_SET_TILING
   is not supported in has_get_tiling() function

0006-Fix-Android-Swapchain-alignment-issue.patch
1) fix gfxbench vulkan test show glitching image

Tracked-On: OAM-109724
Signed-off-by: Kanli Hu kanli.hu@intel.com