### PR TITLE
Fixing the sts CVE-2023-20913 for VoicemailSettings

### DIFF
--- a/aosp_diff/preliminary/packages/services/Telephony/03_0003-Fix-for-android.security.cts.CVE_2023_20913-failure.patch
+++ b/aosp_diff/preliminary/packages/services/Telephony/03_0003-Fix-for-android.security.cts.CVE_2023_20913-failure.patch
@@ -1,0 +1,33 @@
+From c464de79c09241f650aa73a95b9b28821d0b002b Mon Sep 17 00:00:00 2001
+From: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+Date: Thu, 27 Apr 2023 13:39:56 +0530
+Subject: [PATCH] Fix for android.security.cts.CVE_2023_20913 failure
+
+VoicemailSettings Activity was set to portrait modee.
+This was causing issue with Overlay being drawn on top
+of it. Causing CVE-2023-20913 failure.
+
+As the celadon target is landscape, fix the issue by removing
+the hardcoding of screenOrientation.
+
+Tracked-On: OAM-109681
+Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+---
+ AndroidManifest.xml | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/AndroidManifest.xml b/AndroidManifest.xml
+index 41ff21683..c4acf15a5 100644
+--- a/AndroidManifest.xml
++++ b/AndroidManifest.xml
+@@ -509,7 +509,6 @@
+         <activity android:name="com.android.phone.settings.VoicemailSettingsActivity"
+             android:label="@string/voicemail"
+             android:configChanges="orientation|screenSize|keyboardHidden|screenLayout"
+-            android:screenOrientation="portrait"
+             android:exported="true"
+             android:theme="@style/CallSettingsWithoutDividerTheme">
+             <intent-filter >
+-- 
+2.17.1
+


### PR DESCRIPTION
VoicemailSettings Activity is default to portrait mode. Removing the hard fix.

Tracked-On: OAM-109681