### PR TITLE
Fix for AOSP and EVS cameras not working

### DIFF
--- a/aosp_diff/celadon_ivi/packages/services/Car/0004-Fix-for-AOSP-and-EVS-cameras-not-working.patch
+++ b/aosp_diff/celadon_ivi/packages/services/Car/0004-Fix-for-AOSP-and-EVS-cameras-not-working.patch
@@ -1,0 +1,119 @@
+From 9f8dcc68584c2a83faef8f5f2219865b9fe0770a Mon Sep 17 00:00:00 2001
+From: shivasku82 <shiva.kumara.rudrappa@intel.com>
+Date: Thu, 29 Sep 2022 10:50:26 +0530
+Subject: [PATCH] Fix for AOSP and EVS cameras not working
+
+AOSP camera app not working as app fail to connect camera service.
+On reverse gear from vehicle HAL EVS Application failed to start.
+
+Camera server is disabled resulting in camera app not able to connect
+to camera server. EVS application failed to started as the EVS
+services are disabled.
+
+Fixed the issues by enabling camera server, EVS app, EVS manager.
+Also updated camera Id and display port for EVS application to
+work on reverse gear event.
+
+Tracked-On: OAM-109740
+Signed-off-by: shivasku82 <shiva.kumara.rudrappa@intel.com>
+---
+ car_product/build/car_base.mk                          |  3 ++-
+ cpp/evs/apps/default/config.json                       | 10 +++++-----
+ cpp/evs/apps/default/evs_app.rc                        |  1 -
+ .../manager/1.1/android.automotive.evs.manager@1.1.rc  |  1 -
+ .../android.hardware.automotive.evs@1.1-sample.rc      |  1 -
+ 5 files changed, 7 insertions(+), 9 deletions(-)
+
+diff --git a/car_product/build/car_base.mk b/car_product/build/car_base.mk
+index ecd503b1b..11088bc9c 100644
+--- a/car_product/build/car_base.mk
++++ b/car_product/build/car_base.mk
+@@ -65,7 +65,8 @@ PRODUCT_PACKAGES += \
+ # ENABLE_CAMERA_SERVICE must be set as true from the product's makefile if it wants to support
+ # Android Camera service.
+ ifneq ($(ENABLE_CAMERA_SERVICE), true)
+-PRODUCT_PROPERTY_OVERRIDES += config.disable_cameraservice=true
++#we want AOSP camera to support from legacy or external camera HAL
++#PRODUCT_PROPERTY_OVERRIDES += config.disable_cameraservice=true
+ endif
+ 
+ # EVS service
+diff --git a/cpp/evs/apps/default/config.json b/cpp/evs/apps/default/config.json
+index dc2771c58..0b573080c 100644
+--- a/cpp/evs/apps/default/config.json
++++ b/cpp/evs/apps/default/config.json
+@@ -8,7 +8,7 @@
+   },
+   "displays" : [
+     {
+-      "displayPort" : 129,
++      "displayPort" : 0,
+       "frontRange" : 100,
+       "rearRange" : 100
+     },
+@@ -24,7 +24,7 @@
+   },
+   "cameras" : [
+     {
+-      "cameraId" : "/dev/video10",
++      "cameraId" : "/dev/video0",
+       "function" : "reverse,park",
+       "x" : 0.0,
+       "y" : 20.0,
+@@ -38,7 +38,7 @@
+       "vflip" : false
+     },
+     {
+-      "cameraId" : "/dev/video11",
++      "cameraId" : "/dev/video2",
+       "function" : "front,park",
+       "x" : 0.0,
+       "y" : 100.0,
+@@ -52,7 +52,7 @@
+       "vflip" : false
+     },
+     {
+-      "cameraId" : "/dev/video12",
++      "cameraId" : "/dev/video4",
+       "function" : "right,park",
+       "x" : -25.0,
+       "y" : 60.0,
+@@ -66,7 +66,7 @@
+       "vflip" : false
+     },
+     {
+-      "cameraId" : "/dev/video13",
++      "cameraId" : "/dev/video6",
+       "function" : "left, park",
+       "x" : 20.0,
+       "y" : 60.0,
+diff --git a/cpp/evs/apps/default/evs_app.rc b/cpp/evs/apps/default/evs_app.rc
+index f155e11f2..a61edfef0 100644
+--- a/cpp/evs/apps/default/evs_app.rc
++++ b/cpp/evs/apps/default/evs_app.rc
+@@ -3,4 +3,3 @@ service evs_app /system/bin/evs_app
+     priority -20
+     user automotive_evs
+     group automotive_evs
+-    disabled # will not automatically start with its class; must be explictly started.
+diff --git a/cpp/evs/manager/1.1/android.automotive.evs.manager@1.1.rc b/cpp/evs/manager/1.1/android.automotive.evs.manager@1.1.rc
+index 5223822b8..778917b2b 100644
+--- a/cpp/evs/manager/1.1/android.automotive.evs.manager@1.1.rc
++++ b/cpp/evs/manager/1.1/android.automotive.evs.manager@1.1.rc
+@@ -3,4 +3,3 @@ service evs_manager /system/bin/android.automotive.evs.manager@1.1
+     priority -20
+     user automotive_evs
+     group automotive_evs system
+-    disabled # will not automatically start with its class; must be explictly started.
+diff --git a/cpp/evs/sampleDriver/android.hardware.automotive.evs@1.1-sample.rc b/cpp/evs/sampleDriver/android.hardware.automotive.evs@1.1-sample.rc
+index e7d7217fe..23487315e 100644
+--- a/cpp/evs/sampleDriver/android.hardware.automotive.evs@1.1-sample.rc
++++ b/cpp/evs/sampleDriver/android.hardware.automotive.evs@1.1-sample.rc
+@@ -4,4 +4,3 @@ service evs_sample_driver /vendor/bin/android.hardware.automotive.evs@1.1-sample
+     user graphics
+     group automotive_evs camera
+     onrestart restart evs_manager
+-    disabled # will not automatically start with its class; must be explictly started.
+-- 
+2.40.1
+

--- a/aosp_diff/celadon_ivi/packages/services/Car/0005-Fix-EVS-sample-driver-not-getting-started-as-service.patch
+++ b/aosp_diff/celadon_ivi/packages/services/Car/0005-Fix-EVS-sample-driver-not-getting-started-as-service.patch
@@ -1,4 +1,4 @@
-From 071a2a4cd1d78b6fb1b890aa2df6506ea5fdd005 Mon Sep 17 00:00:00 2001
+From e20f83a2a75ee2ebe81c9c562682ee142d3f579e Mon Sep 17 00:00:00 2001
 From: "Pillai, Venkatesh" <venkatesh.pillai@intel.com>
 Date: Fri, 21 Apr 2023 14:56:39 +0530
 Subject: [PATCH] Fix EVS sample driver not getting started as service
@@ -60,15 +60,14 @@ index fd276b63f..abdfd7b5a 100644
 +allow carservice_app system_data_file:dir search;
 +allow carservice_app user_profile_root_file:dir search;
 diff --git a/cpp/evs/sampleDriver/android.hardware.automotive.evs@1.1-sample.rc b/cpp/evs/sampleDriver/android.hardware.automotive.evs@1.1-sample.rc
-index e7d7217fe..f3cb43af4 100644
+index 23487315e..c332df5a4 100644
 --- a/cpp/evs/sampleDriver/android.hardware.automotive.evs@1.1-sample.rc
 +++ b/cpp/evs/sampleDriver/android.hardware.automotive.evs@1.1-sample.rc
-@@ -4,4 +4,5 @@ service evs_sample_driver /vendor/bin/android.hardware.automotive.evs@1.1-sample
+@@ -4,3 +4,4 @@ service evs_sample_driver /vendor/bin/android.hardware.automotive.evs@1.1-sample
      user graphics
      group automotive_evs camera
      onrestart restart evs_manager
 +    onrestart restart automotive_display
-     disabled # will not automatically start with its class; must be explictly started.
 -- 
-2.17.1
+2.40.1
 


### PR DESCRIPTION
AOSP camera app not working as app fail to connect camera service. On reverse gear from vehicle HAL EVS Application failed to start.

Camera server is disabled resulting in camera app not able to connect to camera server. EVS application failed to started as the EVS services are disabled.

Fixed the issues by enabling camera server, EVS app, EVS manager. Also updated camera Id and display port for EVS application to work on reverse gear event.

Tracked-On: OAM-109740