### PR TITLE
Update build_weekly.sh with latest commit tag for

### DIFF
--- a/host/kernel/linux-intel-lts2021/build_weekly.sh
+++ b/host/kernel/linux-intel-lts2021/build_weekly.sh
@@ -9,7 +9,7 @@ cd vendor-intel-utils
 git checkout f127397f7ae23b6a8cc3344ab94423685115d5f8
 cd ../
 
-git clone -b lts-v5.15.71-20230424-r1 https://github.com/projectceladon/linux-intel-lts2021.git
+git clone -b lts-v5.15.71-20230504-r1 https://github.com/projectceladon/linux-intel-lts2021.git
 cd linux-intel-lts2021
 
 cp ../vendor-intel-utils/host/kernel/linux-intel-lts2021/x86_64_defconfig .config


### PR DESCRIPTION
linux-intel-lts2021 kernel

CVE-2023-0045 - Fix Applied
New commit tag lts-v5.15.71-20230504-r1

Tracked-On: OAM-109705