### PR TITLE
Keep Default AAOS Behavior with Multi-Display Launcher.

### DIFF
--- a/aosp_diff/celadon_ivi/frameworks/base/0002-Keep-Default-AAOS-Behavior-with-Multi-Display-Launch.patch
+++ b/aosp_diff/celadon_ivi/frameworks/base/0002-Keep-Default-AAOS-Behavior-with-Multi-Display-Launch.patch
@@ -1,0 +1,35 @@
+From 6834f1ac5c2228f1439e4a0e72f56623eb56dd67 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Tue, 9 May 2023 15:32:05 +0530
+Subject: [PATCH] Keep Default AAOS Behavior with Multi-Display Launcher.
+
+Enabling multi-display Secondary Home Launcher
+for secondary displays.
+
+Tracked-On: OAM-109879
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ core/res/res/values/config.xml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/core/res/res/values/config.xml b/core/res/res/values/config.xml
+index f9b951e92736..c393aaded175 100644
+--- a/core/res/res/values/config.xml
++++ b/core/res/res/values/config.xml
+@@ -4219,11 +4219,11 @@
+          This launcher package must have an activity that supports multiple instances and has
+          corresponding launch mode set in AndroidManifest.
+          {@see android.view.Display#FLAG_SHOULD_SHOW_SYSTEM_DECORATIONS} -->
+-    <string name="config_secondaryHomePackage" translatable="false">com.android.launcher3</string>
++    <string name="config_secondaryHomePackage" translatable="false">com.android.car.multidisplay</string>
+ 
+     <!-- Force secondary home launcher specified in config_secondaryHomePackage always. If this is
+          not set, secondary home launcher can be replaced by user. -->
+-    <bool name ="config_useSystemProvidedLauncherForSecondary">false</bool>
++    <bool name ="config_useSystemProvidedLauncherForSecondary">true</bool>
+ 
+     <!-- If device supports corner radius on windows.
+          This should be turned off on low-end devices to improve animation performance. -->
+-- 
+2.17.1
+

--- a/aosp_diff/celadon_ivi/packages/services/Car/0006-Keep-Default-AAOS-Behavior-with-Multi-Display-Launch.patch
+++ b/aosp_diff/celadon_ivi/packages/services/Car/0006-Keep-Default-AAOS-Behavior-with-Multi-Display-Launch.patch
@@ -1,0 +1,91 @@
+From 5ead5fd2b1899351aa22e657c871cee5a0a02701 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Tue, 9 May 2023 15:36:17 +0530
+Subject: [PATCH] Keep Default AAOS Behavior with Multi-Display Launcher.
+
+Enabling System decoration supports for secondary displays,
+So it can support Secondary Home Launcher.
+
+Also updating navigation keys behaviour based on
+displayId as well as userId.
+
+Tracked-On: OAM-109879
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../base/core/res/res/values/config.xml       |  2 +-
+ .../launcher/LauncherActivity.java            | 30 +++++++++++++------
+ 2 files changed, 22 insertions(+), 10 deletions(-)
+
+diff --git a/car_product/overlay/frameworks/base/core/res/res/values/config.xml b/car_product/overlay/frameworks/base/core/res/res/values/config.xml
+index 6726c031a..89614aaa4 100644
+--- a/car_product/overlay/frameworks/base/core/res/res/values/config.xml
++++ b/car_product/overlay/frameworks/base/core/res/res/values/config.xml
+@@ -98,7 +98,7 @@
+     <bool name="config_supportsSplitScreenMultiWindow">false</bool>
+ 
+     <!-- True if the device supports system decorations on secondary displays. -->
+-    <bool name="config_supportsSystemDecorsOnSecondaryDisplays">false</bool>
++    <bool name="config_supportsSystemDecorsOnSecondaryDisplays">true</bool>
+ 
+     <string name="config_dataUsageSummaryComponent">com.android.car.settings/com.android.car.settings.datausage.DataWarningAndLimitActivity</string>
+ 
+diff --git a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/LauncherActivity.java b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/LauncherActivity.java
+index bcd900497..549ac1006 100644
+--- a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/LauncherActivity.java
++++ b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/LauncherActivity.java
+@@ -20,6 +20,7 @@ import static com.android.car.multidisplay.launcher.PinnedAppListViewModel.PINNE
+ 
+ import android.animation.Animator;
+ import android.animation.AnimatorListenerAdapter;
++import android.app.ActivityManager;
+ import android.app.ActivityOptions;
+ import android.app.AlertDialog;
+ import android.app.Application;
+@@ -229,24 +230,35 @@ public class LauncherActivity extends FragmentActivity implements AppPickedCallb
+         mBackKey.setOnClickListener(new View.OnClickListener() {
+             @Override
+             public void onClick(View v) {
+-                injectInputEvent(KeyEvent.KEYCODE_BACK);
++                injectInputEvent(v, KeyEvent.KEYCODE_BACK);
+             }
+         });
+ 
+         mHomeKey.setOnClickListener(new View.OnClickListener() {
+             @Override
+-             public void onClick(View v) {
+-                 Intent appIntent = new Intent();
+-                 appIntent.setComponent(new ComponentName("com.android.car.multidisplay", "com.android.car.multidisplay.launcher.LauncherActivity"));
+-                 appIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+-                 getApplicationContext().startActivityAsUser(appIntent, android.os.Process.myUserHandle());
+-             }
++            public void onClick(View v) {
++                Intent appIntent = new Intent();
++                appIntent.setComponent(new ComponentName("com.android.car.multidisplay",
++                        "com.android.car.multidisplay.launcher.LauncherActivity"));
++                appIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
++                if (android.os.Process.myUserHandle().getIdentifier() != ActivityManager.getCurrentUser()) {
++                    getApplicationContext().startActivityAsUser(appIntent, android.os.Process.myUserHandle());
++                } else {
++                    final ActivityOptions options = ActivityOptions.makeBasic();
++                    options.setLaunchDisplayId(v.getDisplay().getDisplayId());
++                    try {
++                        getApplicationContext().startActivity(appIntent, options.toBundle());
++                    } catch (Exception e) {
++                        // Exception
++                    }
++                }
++            }
+         });
+ 
+     }
+ 
+-    void injectInputEvent(int keycode) {
+-        mDisplayId = getLauncherDisplayId();
++    void injectInputEvent(View view, int keycode) {
++        mDisplayId = view.getDisplay().getDisplayId();
+         long downTime = SystemClock.uptimeMillis();
+         KeyEvent keyEvent_down = new KeyEvent(downTime, downTime, KeyEvent.ACTION_DOWN, keycode, 0);
+         keyEvent_down.setDisplayId(mDisplayId);
+-- 
+2.17.1
+


### PR DESCRIPTION
Enabling System decoration supports for secondary displays, So it can support Secondary Home Launcher and adding multi-display Secondary Home Launcher for secondary displays.

Also updating navigation keys behaviour based on
displayId as well as userId.

Tracked-On: OAM-109879