### PR TITLE
Force stop bootanimation when CarLauncher UI ready

### DIFF
--- a/aosp_diff/celadon_ivi/packages/services/Car/0006-WA-Force-stop-bootanimation-when-CarLauncher-UI-read.patch
+++ b/aosp_diff/celadon_ivi/packages/services/Car/0006-WA-Force-stop-bootanimation-when-CarLauncher-UI-read.patch
@@ -1,0 +1,68 @@
+From 38b6c40fc80542eabeda35e185d9e84a9eb21fb8 Mon Sep 17 00:00:00 2001
+From: Zhou Jingyu <jingyu.zhou@intel.com>
+Date: Thu, 11 May 2023 12:40:25 +0800
+Subject: [PATCH] [WA] Force stop bootanimation when CarLauncher UI ready
+
+The default bootanimation has all its segments' type set
+to 'c',wihch means "this part will play to completion,
+no matter what".
+On ADL IVI platform, it takes less than 2 seconds from
+bootanimation start to boot finished (and system property
+'service.bootanim.exit' set). But the default bootanimation
+is about 6 seconds long, which means the bootanimation
+will continue playing for 3~4 seconds after the system
+boot finished and UI ready.
+This change is a workaround to force stop bootanimation
+when CarLauncer UI ready to improve the cold boot time.
+
+Tracked-On: OAM-109795
+Signed-off-by: Zhou Jingyu <jingyu.zhou@intel.com>
+---
+ .../car/SystemActivityMonitoringService.java    | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/service/src/com/android/car/SystemActivityMonitoringService.java b/service/src/com/android/car/SystemActivityMonitoringService.java
+index 897fde381..8bea946b2 100644
+--- a/service/src/com/android/car/SystemActivityMonitoringService.java
++++ b/service/src/com/android/car/SystemActivityMonitoringService.java
+@@ -31,6 +31,7 @@ import android.os.HandlerThread;
+ import android.os.Looper;
+ import android.os.Message;
+ import android.os.RemoteException;
++import android.os.SystemProperties;
+ import android.os.UserHandle;
+ import android.util.ArrayMap;
+ import android.util.ArraySet;
+@@ -123,6 +124,8 @@ public class SystemActivityMonitoringService implements CarServiceBase {
+     @GuardedBy("mLock")
+     private ActivityLaunchListener mActivityLaunchListener;
+ 
++    private boolean mCheckLauncherStartedDone = false;
++
+     public SystemActivityMonitoringService(Context context) {
+         mContext = context;
+         mProcessObserver = new ProcessObserver();
+@@ -322,6 +325,20 @@ public class SystemActivityMonitoringService implements CarServiceBase {
+                         Slog.i(CarLog.TAG_AM, "Updating top task to: " + newTopTaskInfo);
+                     }
+                 }
++                // workaround to force stop bootanimation when CarLauncher UI ready
++                // to improve the cold boot time
++                if (!mCheckLauncherStartedDone) {
++                    if (newTopTaskInfo.topActivity.getPackageName().equals("com.android.car.mapsplaceholder")) {
++                        mHandler.postDelayed(new Runnable() {
++                            @Override
++                            public void run() {
++                                Slog.i(CarLog.TAG_AM, "force stop bootanimation");
++                                SystemProperties.set("ctl.stop", "bootanim");
++                            }
++                        }, 10);
++                        mCheckLauncherStartedDone = true;
++                    }
++                }
+             }
+             // Assuming displays remains the same.
+             for (int i = 0; i < topTasks.size(); i++) {
+-- 
+2.40.1
+


### PR DESCRIPTION
The default bootanimation has all its segments' type set to 'c',wihch means "this part will play to completion, no matter what".
On ADL IVI platform, it takes less than 2 seconds from bootanimation start to boot finished (and system property 'service.bootanim.exit' set). But the default bootanimation is about 6 seconds long, which means the bootanimation will continue playing for 3~4 seconds after the system boot finished and UI ready.
This change is a workaround to force stop bootanimation when CarLauncer UI ready, so as to benchmark the time from cold boot to launcher UI correctly.

Tracked-On: OAM-109795