### PR TITLE
Update init.rc for llkd-1.

### DIFF
--- a/aosp_diff/preliminary/system/core/03_0003-Add-blacklist-properties-of-llkd-to-avoid-the-discon.patch
+++ b/aosp_diff/preliminary/system/core/03_0003-Add-blacklist-properties-of-llkd-to-avoid-the-discon.patch
@@ -1,0 +1,26 @@
+From 9e26338d466a807af48c09ecf7354ffc85636dd8 Mon Sep 17 00:00:00 2001
+From: "Lu, Xingjiang" <xingjiang.lu@intel.com>
+Date: Mon, 15 May 2023 14:59:13 +0800
+Subject: [PATCH] Add blacklist properties of llkd to avoid the disconnection.
+
+Signed-off-by: Lu, Xingjiang <xingjiang.lu@intel.com>
+---
+ llkd/llkd.rc | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/llkd/llkd.rc b/llkd/llkd.rc
+index b1f96a8f3..45dcb6210 100644
+--- a/llkd/llkd.rc
++++ b/llkd/llkd.rc
+@@ -32,6 +32,8 @@ on property:khungtask.enable=false
+     write /proc/sys/kernel/hung_task_panic 0
+ 
+ on property:llk.enable=true
++    setprop ro.llk.blacklist.process adbd
++    setprop ro.llk.blacklist.parent adbd
+     start llkd-${ro.debuggable:-0}
+ 
+ service llkd-0 /system/bin/llkd
+-- 
+2.34.1
+


### PR DESCRIPTION
Add ro.llk.blacklist.process and ro.llk.blacklist.parent to avoid adbd to be killed by llkd-1 (Livelock) daemon in stress test.

Tracked-On: OAM-108924