### PR TITLE
Add allowZip64=True for ZipFile in RebuildAndWriteSuperImages

### DIFF
--- a/aosp_diff/preliminary/build/tools/03_0003-Add-allowZip64-True-for-ZipFile-in-RebuildAndWriteSu.patch
+++ b/aosp_diff/preliminary/build/tools/03_0003-Add-allowZip64-True-for-ZipFile-in-RebuildAndWriteSu.patch
@@ -1,0 +1,30 @@
+From 49ed1fc4979e49f7a3c2c1c332f5c6d455403d1a Mon Sep 17 00:00:00 2001
+From: jizhenlo <zhenlong.z.ji@intel.com>
+Date: Mon, 29 May 2023 16:50:52 +0800
+Subject: [PATCH] Add allowZip64=True for ZipFile in RebuildAndWriteSuperImages
+
+Zip failure will be seen if the size of super image is larger than
+4G. So, fix the issue by setting allowZip64 to true.
+
+Tracked-On: OAM-110514
+Signed-off-by: jizhenlo <zhenlong.z.ji@intel.com>
+---
+ tools/releasetools/img_from_target_files.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/releasetools/img_from_target_files.py b/tools/releasetools/img_from_target_files.py
+index 76da89c865..f8bdd81ce6 100755
+--- a/tools/releasetools/img_from_target_files.py
++++ b/tools/releasetools/img_from_target_files.py
+@@ -173,7 +173,7 @@ def RebuildAndWriteSuperImages(input_file, output_file):
+   logger.info('Writing super.img to archive...')
+   with zipfile.ZipFile(
+       output_file, 'a', compression=zipfile.ZIP_DEFLATED,
+-      allowZip64=not OPTIONS.sparse_userimages) as output_zip:
++      allowZip64=True) as output_zip:
+     common.ZipWrite(output_zip, super_file, 'super.img')
+ 
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
Zip failure will be seen if the size of super image is larger than 4G. So, fix the issue by setting allowZip64 to true.

Tracked-On: OAM-110514