### PR TITLE
The cameraId of uvc camera is video device number + CameraIdOffset,

### DIFF
--- a/aosp_diff/celadon_ivi/frameworks/av/services/camera/libcameraservice/0001-Camera-fix-uvc-cameraid-mNumberOfCameras-issue.patch
+++ b/aosp_diff/celadon_ivi/frameworks/av/services/camera/libcameraservice/0001-Camera-fix-uvc-cameraid-mNumberOfCameras-issue.patch
@@ -1,0 +1,84 @@
+From 36aaaf05ed51b71a38f36cbecf3c5976ee722106 Mon Sep 17 00:00:00 2001
+From: neofang7 <neo.fang@intel.com>
+Date: Wed, 31 May 2023 02:04:12 +0000
+Subject: [PATCH] Camera: fix uvc cameraid>mNumberOfCameras issue
+
+Tencent Meeting cannot use uvc camera in Celadon ivi platform,
+which caused by cameraId check in both jni and cameraservice.
+CameraId is video device number + CameraIdOffset, CameraIdOffset
+of uvc is 200, so it is definitely larger than the real camera
+numbers and causes Invalid cameraId errors.
+
+The fix contains two parts:
+1. libcameraservice.so: change the condition check of cameraId,
+   iterately check app required cameraId with deviceIds;
+2. Camera Jni: remove cameraId > NumberOfCameras condition.
+Test: verify camera functionalities with meeting/camera apps
+
+Tracked-On: OAM-109947
+Signed-off-by: neofang7 <neo.fang@intel.com>
+---
+ .../camera/libcameraservice/CameraService.cpp | 28 ++++++++++++-------
+ 1 file changed, 18 insertions(+), 10 deletions(-)
+
+diff --git a/services/camera/libcameraservice/CameraService.cpp b/services/camera/libcameraservice/CameraService.cpp
+index 701bec2313..682b543952 100644
+--- a/services/camera/libcameraservice/CameraService.cpp
++++ b/services/camera/libcameraservice/CameraService.cpp
+@@ -25,6 +25,7 @@
+ #include <cstring>
+ #include <ctime>
+ #include <string>
++#include <iostream>
+ #include <sys/types.h>
+ #include <inttypes.h>
+ #include <pthread.h>
+@@ -660,14 +661,7 @@ Status CameraService::getCameraInfo(int cameraId,
+         return STATUS_ERROR(ERROR_DISCONNECTED,
+                 "Camera subsystem is not available");
+     }
+-    bool hasSystemCameraPermissions =
+-            hasPermissionsForSystemCamera(CameraThreadState::getCallingPid(),
+-                    CameraThreadState::getCallingUid());
+-    int cameraIdBound = mNumberOfCamerasWithoutSystemCamera;
+-    if (hasSystemCameraPermissions) {
+-        cameraIdBound = mNumberOfCameras;
+-    }
+-    if (cameraId < 0 || cameraId >= cameraIdBound) {
++    if (cameraId < 0) {
+         return STATUS_ERROR(ERROR_ILLEGAL_ARGUMENT,
+                 "CameraId is not valid");
+     }
+@@ -694,13 +688,27 @@ std::string CameraService::cameraIdIntToStrLocked(int cameraIdInt) {
+             getpid() == callingPid) {
+         deviceIds = &mNormalDeviceIds;
+     }
+-    if (cameraIdInt < 0 || cameraIdInt >= static_cast<int>(deviceIds->size())) {
++    if (cameraIdInt < 0) {
+         ALOGE("%s: input id %d invalid: valid range  (0, %zu)",
+                 __FUNCTION__, cameraIdInt, deviceIds->size());
+         return std::string{};
+     }
++    unsigned int i = 0;
++    bool found = false;
++    for (i = 0; i < deviceIds->size(); i++) {
++        ALOGE("deviceIds[%d]=%s", i, (*deviceIds)[i].c_str());
++        if (std::stoi((*deviceIds)[i]) == cameraIdInt) {
++            found = true;
++            break;
++        }
++    }
+ 
+-    return (*deviceIds)[cameraIdInt];
++    if (found == false) {
++        ALOGE("%s: input id %d invalid: valid range  (0, %zu), cameraIdInt not available",
++                 __FUNCTION__, cameraIdInt, deviceIds->size());
++        return std::string{};
++    }
++    return (*deviceIds)[i];
+ }
+ 
+ String8 CameraService::cameraIdIntToStr(int cameraIdInt) {
+-- 
+2.17.1
+

--- a/aosp_diff/celadon_ivi/frameworks/base/0001-Condition-check-change-of-uvc-camera-id-in-jni.patch
+++ b/aosp_diff/celadon_ivi/frameworks/base/0001-Condition-check-change-of-uvc-camera-id-in-jni.patch
@@ -1,0 +1,39 @@
+From d15e9e8f9f332542815e085a990a28fe2219f21f Mon Sep 17 00:00:00 2001
+From: neofang7 <neo.fang@intel.com>
+Date: Wed, 31 May 2023 02:39:18 +0000
+Subject: [PATCH] Condition check change of uvc camera id in jni.
+
+Tencent Meeting cannot use uvc camera in Celadon ivi platform,
+which caused by cameraId check in both jni and cameraservice.
+CameraId is video device number + CameraIdOffset, CameraIdOffset
+of uvc is 200, so it is definitely larger than the real camera
+numbers and causes Invalid cameraId errors.
+
+The fix contains two parts:
+1. libcameraservice.so: change the condition check of cameraId,
+iterate check app required cameraId with deviceIds;
+2. Camera Jni: remove cameraId > NumberOfCameras condition.
+Test: verify camera functionalities with meeting/camera apps.
+
+Bug: OAM-109947
+Signed-off-by: neofang7 <neo.fang@intel.com>
+---
+ core/jni/android_hardware_Camera.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/core/jni/android_hardware_Camera.cpp b/core/jni/android_hardware_Camera.cpp
+index 365a18d174c9..cdb735ed811c 100644
+--- a/core/jni/android_hardware_Camera.cpp
++++ b/core/jni/android_hardware_Camera.cpp
+@@ -533,7 +533,7 @@ static void android_hardware_Camera_getCameraInfo(JNIEnv *env, jobject thiz,
+     jint cameraId, jobject info_obj)
+ {
+     CameraInfo cameraInfo;
+-    if (cameraId >= Camera::getNumberOfCameras() || cameraId < 0) {
++    if (cameraId < 0) {
+         ALOGE("%s: Unknown camera ID %d", __FUNCTION__, cameraId);
+         jniThrowRuntimeException(env, "Unknown camera ID");
+         return;
+-- 
+2.17.1
+


### PR DESCRIPTION
which is larger than the real camera numbers and causes Invalid cameraId errors. Hence, Android app failed to use uvc camera through external cameraHAL. The fix contains two parts:
- libcameraservice.so: change the condition check of cameraId, iterate check app required cameraId with deviceIds;
- Camera Jni: remove cameraId > NumberOfCameras condition. This patch is delivered in base/core/jni project.

Bug: OAM-109947
Test: verify camera functionalities with meeting/camera apps