### PR TITLE
update media stack to media 23.2.1 release (devel-647)

### DIFF
--- a/bsp_diff/common/hardware/intel/gmmlib/0001-Add-Android.mk.patch
+++ b/bsp_diff/common/hardware/intel/gmmlib/0001-Add-Android.mk.patch
@@ -1,7 +1,7 @@
-From 79910d46f9050e5cdd92b9cf37810cb6ca57a50f Mon Sep 17 00:00:00 2001
+From 52c6b08ba82c2e852cf91fc1849d32d7dddecd98 Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Fri, 15 Jul 2022 22:02:24 +0530
-Subject: [PATCH] Add Android.mk for intel-gmmlib-22.3.5
+Subject: [PATCH] Add Android.mk
 
 Change-Id: I134da0c5e6a9cc9d281e313f7ea68d45ef8b1d70
 Tracked-On: OAM-106860
@@ -145,5 +145,5 @@ index 0000000..c388889
 +
 +include $(BUILD_STATIC_LIBRARY)
 -- 
-2.17.1
+2.40.1
 

--- a/bsp_diff/common/hardware/intel/libva/0001-Update-Android.mk-for-libva-2.18.0.patch
+++ b/bsp_diff/common/hardware/intel/libva/0001-Update-Android.mk-for-libva-2.18.0.patch
@@ -1,4 +1,4 @@
-From 0ed11b11903ea0c8bdb0214bf39a25974cf2e3e0 Mon Sep 17 00:00:00 2001
+From a6f82fc72b4a8ed6f777a6539558a22b69192cda Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
 Date: Thu, 30 Mar 2023 16:23:14 +0530
 Subject: [PATCH] Update Android.mk for libva 2.18.0
@@ -228,5 +228,5 @@ index 0000000..80077d5
 +
 +#endif /* VA_VERSION_H */
 -- 
-2.17.1
+2.40.1
 

--- a/bsp_diff/common/hardware/intel/libva/0002-Support-media-stack-on-specified-render-node.patch
+++ b/bsp_diff/common/hardware/intel/libva/0002-Support-media-stack-on-specified-render-node.patch
@@ -1,4 +1,4 @@
-From 8e1007d916c8ff055a045cb273d37552f6482831 Mon Sep 17 00:00:00 2001
+From 6e24121953512c064bacce19f18a6b3362e43358 Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
 Date: Fri, 28 Oct 2022 14:32:50 +0530
 Subject: [PATCH] Support media stack on specified render node
@@ -56,5 +56,5 @@ index f103d15..d2c167f 100644
      }
      drm_state->auth_type = VA_DRM_AUTH_CUSTOM;
 -- 
-2.17.1
+2.40.1
 

--- a/bsp_diff/common/hardware/intel/media-driver/0001-Add-changes-to-build-latest-media-driver-in-Android.patch
+++ b/bsp_diff/common/hardware/intel/media-driver/0001-Add-changes-to-build-latest-media-driver-in-Android.patch
@@ -1,4 +1,4 @@
-From b77d66fb7b9b17c2aaab5ee2a161ea7057706519 Mon Sep 17 00:00:00 2001
+From dfc364a8294357abfe7089297c75902aec7ff66f Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
 Date: Tue, 11 Apr 2023 15:01:20 +0530
 Subject: [PATCH] Add changes to build latest media driver in Android
@@ -25,19 +25,22 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  cmrtlib/Android.mk                            |   86 +
  .../agnostic/common/cp/media_srcs.cmake       |    4 +-
  .../common/heap_manager/media_srcs.cmake      |    1 +
- .../agnostic/common/hw/media_srcs.cmake       |   10 +-
- .../agnostic/common/hw/vdbox/media_srcs.cmake |    8 +-
+ .../agnostic/common/hw/media_srcs.cmake       |    4 +-
+ .../agnostic/common/hw/vdbox/media_srcs.cmake |    6 +-
  .../common/media_interfaces/media_srcs.cmake  |    4 +-
  media_common/agnostic/common/media_srcs.cmake |    9 +-
  .../agnostic/common/os/media_srcs.cmake       |    1 +
+ .../common/os/user_setting/media_srcs.cmake   |    3 +-
  .../common/renderhal/media_srcs.cmake         |    1 +
- .../agnostic/common/shared/media_srcs.cmake   |    2 +
+ .../agnostic/common/shared/media_srcs.cmake   |    3 +-
  .../agnostic/common/vp/hal/media_srcs.cmake   |    2 +
  .../agnostic/common/vp/kdll/media_srcs.cmake  |    1 +
  .../common/vp/kernel/media_srcs.cmake         |    4 +-
+ .../linux/common/codec/media_srcs.cmake       |    5 +-
+ .../linux/common/cp/ddi/media_srcs.cmake      |    2 +
  .../linux/common/cp/os/media_srcs.cmake       |    1 +
  media_common/linux/common/os/media_srcs.cmake |    1 +
- media_driver/Android.mk                       | 1817 +++++++++++++++++
+ media_driver/Android.mk                       | 1988 +++++++++++++++++
  .../agnostic/Xe_M/Xe_HPM/hw/media_srcs.cmake  |    1 +
  .../Xe_M/Xe_HPM/hw/vdbox/media_srcs.cmake     |    1 +
  .../Xe_M/Xe_HPM/vp/hal/media_srcs.cmake       |    2 +
@@ -57,7 +60,7 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  .../Xe_R/Xe_HPG/hw/render/media_srcs.cmake    |    1 +
  .../Xe_R/Xe_HP_base/hw/blt/media_srcs.cmake   |    1 +
  .../Xe_HP_base/hw/render/media_srcs.cmake     |    1 +
- .../agnostic/common/hw/media_srcs.cmake       |    7 +
+ .../agnostic/common/hw/media_srcs.cmake       |    3 +-
  .../agnostic/common/hw/vdbox/media_srcs.cmake |    1 +
  .../common/media_interfaces/media_srcs.cmake  |    4 +-
  .../agnostic/common/os/media_srcs.cmake       |    2 +-
@@ -154,18 +157,14 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  .../Xe_HPM/vp/hal/packet/media_srcs.cmake     |    4 +-
  .../Xe_HPM/vp/hal/pipeline/media_srcs.cmake   |    4 +-
  .../hal/platform_interface/media_srcs.cmake   |    4 +-
- .../codec/hal/dec/avc/media_srcs.cmake        |    1 -
- .../codec/hal/dec/hevc/media_srcs.cmake       |    2 -
- .../codec/hal/dec/jpeg/media_srcs.cmake       |    2 -
- .../codec/hal/dec/mpeg2/media_srcs.cmake      |    2 -
- .../codec/hal/dec/vp9/media_srcs.cmake        |    1 -
- .../Xe_M_base/codec/hal/enc/media_srcs.cmake  |    2 -
- .../Xe_M/Xe_M_base/codec/hal/media_srcs.cmake |    1 -
+ .../codec/hal/dec/avc/media_srcs.cmake        |    2 +-
+ .../codec/hal/dec/hevc/media_srcs.cmake       |    2 +-
+ .../codec/hal/dec/mpeg2/media_srcs.cmake      |    2 +-
  .../vp/hal/feature_manager/media_srcs.cmake   |    4 +-
  .../Xe_XPM/vp/hal/packet/media_srcs.cmake     |    4 +-
  .../Xe_XPM/vp/hal/pipeline/media_srcs.cmake   |    4 +-
  .../hal/platform_interface/media_srcs.cmake   |    4 +-
- .../Xe_XPM_base/codec/hal/media_srcs.cmake    |    1 -
+ .../Xe_M/Xe_XPM_base/hw/media_srcs.cmake      |    4 +-
  .../shared/mediacopy/media_srcs.cmake         |    3 +-
  .../vp/hal/feature_manager/media_srcs.cmake   |    4 +-
  .../vp/hal/packet/media_srcs.cmake            |    4 +-
@@ -182,14 +181,75 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  .../g12/g12_0/renderhal/media_srcs.cmake      |    3 +-
  .../g12/g12_1/renderhal/media_srcs.cmake      |    3 +-
  .../g12/g12_base/renderhal/media_srcs.cmake   |    3 +-
- .../gen12/codec/hal/dec/av1/media_srcs.cmake  |    4 +-
- .../agnostic/gen12/codec/hal/media_srcs.cmake |    4 +-
+ .../gen12/codec/hal/dec/av1/media_srcs.cmake  |    2 +-
+ .../agnostic/gen12/codec/hal/media_srcs.cmake |    2 +-
  .../agnostic/gen12/vp/hal/media_srcs.cmake    |    4 +-
  .../hal/platform_interface/media_srcs.cmake   |    4 +-
  .../m12/m12/vp/hal/packet/media_srcs.cmake    |    2 +
  .../m12_0/shared/mediacopy/media_srcs.cmake   |    3 +-
  .../vp/hal/feature_manager/media_srcs.cmake   |    4 +-
  media_driver/media_top_cmake.cmake            |    3 +-
+ .../hal/dec/av1/pipeline/media_srcs.cmake     |    3 +-
+ .../hal/dec/avc/pipeline/media_srcs.cmake     |    4 +-
+ .../hal/dec/hevc/pipeline/media_srcs.cmake    |    3 +-
+ .../codec/hal/dec/jpeg/media_srcs.cmake       |    4 +-
+ .../codec/hal/dec/mpeg2/media_srcs.cmake      |    3 +-
+ .../hal/dec/vp8/pipeline/media_srcs.cmake     |    4 +-
+ .../hal/dec/vp9/pipeline/media_srcs.cmake     |    4 +-
+ .../codec/hal/enc/av1/packet/media_srcs.cmake |    1 +
+ .../hal/enc/av1/pipeline/media_srcs.cmake     |    3 +-
+ .../hal/enc/hevc/features/media_srcs.cmake    |    3 +-
+ .../hal/enc/hevc/packet/media_srcs.cmake      |    3 +-
+ .../hal/enc/hevc/pipeline/media_srcs.cmake    |    3 +-
+ .../hal/enc/vp9/features/media_srcs.cmake     |    4 +-
+ .../codec/hal/enc/vp9/packet/media_srcs.cmake |    4 +-
+ .../hal/enc/vp9/pipeline/media_srcs.cmake     |    4 +-
+ .../Xe_M_plus/Xe_LPM_plus/hw/media_srcs.cmake |    3 +-
+ .../Xe_LPM_plus/hw/vdbox/media_srcs.cmake     |    4 +-
+ .../vp/hal/feature_manager/media_srcs.cmake   |    4 +-
+ .../vp/hal/packet/media_srcs.cmake            |    4 +-
+ .../vp/hal/pipeline/media_srcs.cmake          |    4 +-
+ .../hal/platform_interface/media_srcs.cmake   |    4 +-
+ .../hal/dec/av1/features/media_srcs.cmake     |    4 +-
+ .../codec/hal/dec/av1/packet/media_srcs.cmake |    1 +
+ .../hal/dec/av1/pipeline/media_srcs.cmake     |    2 +
+ .../codec/hal/dec/avc/packet/media_srcs.cmake |    2 +
+ .../hal/dec/avc/pipeline/media_srcs.cmake     |    2 +
+ .../codec/hal/dec/hevc/mmc/media_srcs.cmake   |    4 +-
+ .../hal/dec/hevc/packet/media_srcs.cmake      |    4 +-
+ .../hal/dec/hevc/pipeline/media_srcs.cmake    |    4 +-
+ .../hal/dec/jpeg/packet/media_srcs.cmake      |    2 +
+ .../hal/dec/jpeg/pipeline/media_srcs.cmake    |    2 +
+ .../codec/hal/dec/mpeg2/mmc/media_srcs.cmake  |    2 +
+ .../hal/dec/mpeg2/packet/media_srcs.cmake     |    2 +
+ .../hal/dec/mpeg2/pipeline/media_srcs.cmake   |    2 +
+ .../codec/hal/dec/shared/media_srcs.cmake     |    4 +-
+ .../codec/hal/dec/vp8/mmc/media_srcs.cmake    |    2 +
+ .../codec/hal/dec/vp8/packet/media_srcs.cmake |    2 +
+ .../hal/dec/vp8/pipeline/media_srcs.cmake     |    2 +
+ .../codec/hal/dec/vp9/mmc/media_srcs.cmake    |    4 +-
+ .../codec/hal/dec/vp9/packet/media_srcs.cmake |    4 +-
+ .../hal/dec/vp9/pipeline/media_srcs.cmake     |    4 +-
+ .../hal/enc/av1/features/media_srcs.cmake     |    2 +
+ .../enc/av1/features/preenc/media_srcs.cmake  |    4 +-
+ .../codec/hal/enc/av1/packet/media_srcs.cmake |    4 +-
+ .../hal/enc/av1/pipeline/media_srcs.cmake     |    2 +
+ .../hal/enc/avc/features/media_srcs.cmake     |    4 +-
+ .../hal/enc/avc/pipeline/media_srcs.cmake     |    4 +-
+ .../hal/enc/hevc/features/media_srcs.cmake    |    2 +
+ .../enc/hevc/features/preenc/media_srcs.cmake |    2 +
+ .../hal/enc/hevc/pipeline/media_srcs.cmake    |    4 +-
+ .../hal/enc/jpeg/pipeline/media_srcs.cmake    |    4 +-
+ .../hal/enc/shared/common/media_srcs.cmake    |    4 +-
+ .../codec/hal/enc/vp9/packet/media_srcs.cmake |    4 +-
+ .../hal/enc/vp9/pipeline/media_srcs.cmake     |    4 +-
+ .../codec/hal/shared/media_srcs.cmake         |    4 +-
+ .../Xe_LPM_plus_base/hw/media_srcs.cmake      |    2 +-
+ .../hw/vdbox/media_srcs.cmake                 |    4 +-
+ .../shared/mediaDecompress/media_srcs.cmake   |    4 +-
+ .../shared/mediacopy/media_srcs.cmake         |    4 +-
+ .../vp/hal/feature_manager/media_srcs.cmake   |    4 +-
+ .../vp/hal/packet/media_srcs.cmake            |    4 +-
  .../Xe_R/Xe_HPG/renderhal/media_srcs.cmake    |    3 +-
  .../Source/Common/media_srcs.cmake            |   21 +
  .../Source/Components/media_srcs.cmake        |   21 +
@@ -201,17 +261,94 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  .../Xe_HPG_Base/vp/kernel/media_srcs.cmake    |    4 +-
  .../vp/kernel_free/cmfcpatch/media_srcs.cmake |    3 +-
  .../vp/kernel_free/media_srcs.cmake           |    5 +-
- .../enc/shared/statusreport/media_srcs.cmake  |    1 +
+ media_softlet/agnostic/Xe_R/media_srcs.cmake  |    1 +
+ .../hal/dec/av1/features/media_srcs.cmake     |    2 +
+ .../codec/hal/dec/av1/packet/media_srcs.cmake |    4 +-
+ .../hal/dec/av1/pipeline/media_srcs.cmake     |    4 +-
+ .../hal/dec/avc/features/media_srcs.cmake     |    4 +-
+ .../codec/hal/dec/avc/packet/media_srcs.cmake |    4 +-
+ .../hal/dec/avc/pipeline/media_srcs.cmake     |    4 +-
+ .../hal/dec/hevc/features/media_srcs.cmake    |    4 +-
+ .../codec/hal/dec/hevc/mmc/media_srcs.cmake   |    4 +-
+ .../hal/dec/hevc/packet/media_srcs.cmake      |    4 +-
+ .../hal/dec/hevc/pipeline/media_srcs.cmake    |    4 +-
+ .../hal/dec/hevc/scalability/media_srcs.cmake |    4 +-
+ .../hal/dec/jpeg/bitstream/media_srcs.cmake   |    4 +-
+ .../hal/dec/jpeg/features/media_srcs.cmake    |    4 +-
+ .../hal/dec/jpeg/packet/media_srcs.cmake      |    4 +-
+ .../hal/dec/jpeg/pipeline/media_srcs.cmake    |    4 +-
+ .../hal/dec/mpeg2/features/media_srcs.cmake   |    4 +-
+ .../codec/hal/dec/mpeg2/mmc/media_srcs.cmake  |    4 +-
+ .../hal/dec/mpeg2/packet/media_srcs.cmake     |    4 +-
+ .../hal/dec/mpeg2/pipeline/media_srcs.cmake   |    4 +-
+ .../hal/dec/shared/bufferMgr/media_srcs.cmake |    4 +-
+ .../hal/dec/shared/features/media_srcs.cmake  |    3 +-
+ .../hal/dec/shared/hucItf/media_srcs.cmake    |    4 +-
+ .../codec/hal/dec/shared/media_srcs.cmake     |    1 +
+ .../codec/hal/dec/shared/mmc/media_srcs.cmake |    4 +-
+ .../hal/dec/shared/packet/media_srcs.cmake    |    1 +
+ .../hal/dec/shared/pipeline/media_srcs.cmake  |    1 +
+ .../dec/shared/scalability/media_srcs.cmake   |    1 +
+ .../dec/shared/statusreport/media_srcs.cmake  |    1 +
+ .../hal/dec/vp8/features/media_srcs.cmake     |    4 +-
+ .../codec/hal/dec/vp8/mmc/media_srcs.cmake    |    4 +-
+ .../codec/hal/dec/vp8/packet/media_srcs.cmake |    4 +-
+ .../hal/dec/vp8/pipeline/media_srcs.cmake     |    4 +-
+ .../hal/dec/vp9/features/media_srcs.cmake     |    4 +-
+ .../codec/hal/dec/vp9/mmc/media_srcs.cmake    |    4 +-
+ .../codec/hal/dec/vp9/packet/media_srcs.cmake |    4 +-
+ .../hal/dec/vp9/pipeline/media_srcs.cmake     |    4 +-
+ .../hal/dec/vp9/scalability/media_srcs.cmake  |    4 +-
+ .../hal/enc/av1/features/media_srcs.cmake     |    4 +-
+ .../codec/hal/enc/av1/packet/media_srcs.cmake |    4 +-
+ .../hal/enc/av1/pipeline/media_srcs.cmake     |    2 +
+ .../hal/enc/avc/features/media_srcs.cmake     |    4 +-
+ .../hal/enc/avc/features/roi/media_srcs.cmake |    2 +
+ .../codec/hal/enc/avc/packet/media_srcs.cmake |    2 +
+ .../hal/enc/avc/pipeline/media_srcs.cmake     |    2 +
+ .../hal/enc/hevc/features/media_srcs.cmake    |    2 +
+ .../enc/hevc/features/roi/media_srcs.cmake    |    2 +
+ .../hal/enc/hevc/packet/media_srcs.cmake      |    4 +-
+ .../hal/enc/hevc/pipeline/media_srcs.cmake    |    4 +-
+ .../hal/enc/jpeg/features/media_srcs.cmake    |    4 +-
+ .../hal/enc/jpeg/packet/media_srcs.cmake      |    2 +
+ .../hal/enc/jpeg/pipeline/media_srcs.cmake    |    4 +-
+ .../shared/bitstreamWriter/media_srcs.cmake   |    4 +-
+ .../hal/enc/shared/bufferMgr/media_srcs.cmake |    4 +-
+ .../hal/enc/shared/features/media_srcs.cmake  |    4 +-
+ .../codec/hal/enc/shared/media_srcs.cmake     |    4 +-
+ .../codec/hal/enc/shared/mmc/media_srcs.cmake |    4 +-
+ .../hal/enc/shared/packet/media_srcs.cmake    |    4 +-
+ .../hal/enc/shared/pipeline/media_srcs.cmake  |    4 +-
+ .../enc/shared/scalability/media_srcs.cmake   |    4 +-
+ .../enc/shared/statusreport/media_srcs.cmake  |    3 +
+ .../hal/enc/vp9/features/media_srcs.cmake     |    4 +-
+ .../codec/hal/enc/vp9/packet/media_srcs.cmake |    4 +-
+ .../hal/enc/vp9/pipeline/media_srcs.cmake     |    2 +
+ .../common/codec/hal/shared/media_srcs.cmake  |    2 +
+ .../agnostic/common/cp/media_srcs.cmake       |    4 +-
+ .../common/heap_manager/media_srcs.cmake      |    4 +-
  .../agnostic/common/hw/media_srcs.cmake       |    3 +-
  .../agnostic/common/hw/vdbox/media_srcs.cmake |    4 +-
  .../common/media_bin_mgr/media_srcs.cmake     |    5 +-
  .../common/media_interfaces/media_srcs.cmake  |    4 +-
  .../agnostic/common/os/media_srcs.cmake       |    1 +
- .../common/os/user_setting/media_srcs.cmake   |    5 +-
+ .../agnostic/common/os/share/media_srcs.cmake |    2 +
+ .../common/os/user_setting/media_srcs.cmake   |    3 +-
  .../common/renderhal/media_srcs.cmake         |    3 +-
+ .../common/shared/bufferMgr/media_srcs.cmake  |    2 +
+ .../common/shared/features/media_srcs.cmake   |    4 +-
+ .../media_sfc_interface/media_srcs.cmake      |    4 +-
  .../agnostic/common/shared/media_srcs.cmake   |    4 +-
  .../shared/mediacontext/media_srcs.cmake      |    3 +-
+ .../common/shared/mediacopy/media_srcs.cmake  |    4 +-
+ .../common/shared/mmc/media_srcs.cmake        |    4 +-
+ .../common/shared/packet/media_srcs.cmake     |    4 +-
+ .../common/shared/pipeline/media_srcs.cmake   |    4 +-
+ .../common/shared/profiler/media_srcs.cmake   |    2 +
  .../shared/scalability/media_srcs.cmake       |    1 +
+ .../shared/statusreport/media_srcs.cmake      |    1 +
+ .../common/shared/task/media_srcs.cmake       |    4 +-
  .../common/vp/cm_fc_ld/media_srcs.cmake       |    2 +
  .../common/vp/hal/bufferMgr/media_srcs.cmake  |    4 +-
  .../common/vp/hal/bufferMgr/vp_allocator.cpp  |    2 +-
@@ -224,8 +361,15 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  .../vp/hal/scalability/media_srcs.cmake       |    4 +-
  .../hal/shared/scalability/media_srcs.cmake   |    2 +
  .../vp/hal/statusreport/media_srcs.cmake      |    4 +-
+ .../hal/utils/hal_ddi_share/media_srcs.cmake  |    4 +-
  .../common/vp/hal/utils/media_srcs.cmake      |    4 +-
  .../agnostic/common/vp/kdll/media_srcs.cmake  |    2 +
+ .../common/codec/ddi/dec/media_srcs.cmake     |    4 +-
+ .../common/codec/ddi/enc/media_srcs.cmake     |    2 +
+ .../common/codec/ddi/shared/media_srcs.cmake  |    4 +-
+ .../linux/common/cp/ddi/media_srcs.cmake      |    2 +
+ .../linux/common/cp/media_srcs.cmake          |    2 +
+ .../linux/common/ddi/media_srcs.cmake         |    4 +-
  .../common/os/i915/include/media_srcs.cmake   |    2 +
  .../os/i915/include/uapi/media_srcs.cmake     |    1 +
  .../linux/common/os/i915/media_srcs.cmake     |    2 +
@@ -235,8 +379,16 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  .../common/os/osservice/media_srcs.cmake      |    1 +
  .../os/osservice/mos_utilities_specific.cpp   |    6 +-
  .../os/osservice/mos_utilities_specific.h     |    1 +
+ .../linux/common/vp/ddi/media_srcs.cmake      |    2 +
+ .../linux/xe_lpm_plus_r0/ddi/media_srcs.cmake |    4 +-
+ .../encode/av1/ddi/media_srcs.cmake           |    2 +
+ .../encode/avc/ddi/media_srcs.cmake           |    4 +-
+ .../encode/hevc/ddi/media_srcs.cmake          |    4 +-
+ .../encode/jpeg/ddi/media_srcs.cmake          |    2 +
+ .../encode/vp9/ddi/media_srcs.cmake           |    4 +-
+ .../xe_lpm_plus_r0/vp/ddi/media_srcs.cmake    |    4 +-
  .../media_interfaces_mtl/media_srcs.cmake     |    5 +-
- 219 files changed, 2639 insertions(+), 144 deletions(-)
+ 371 files changed, 3207 insertions(+), 246 deletions(-)
  create mode 100644 cmrtlib/Android.mk
  create mode 100644 media_driver/Android.mk
  create mode 100644 media_driver/agnostic/gen12_tgllp/vp/kernel/swsb/media_srcs.cmake
@@ -252,7 +404,7 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  create mode 100644 media_softlet/agnostic/Xe_R/Xe_HPG/vp/kernel_free/Source/media_srcs.cmake
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index dfb36ccac..e7f4e0b2f 100755
+index 9adc2dc4c..e9c2611e2 100755
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -53,9 +53,9 @@ cmake_dependent_option( ENABLE_NONFREE_KERNELS
@@ -521,25 +673,26 @@ index f882c7e7f..54650883b 100644
  set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
      ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
 diff --git a/media_common/agnostic/common/hw/media_srcs.cmake b/media_common/agnostic/common/hw/media_srcs.cmake
-index 45dc8126c..47fc06985 100644
+index 45dc8126c..7ad4170e6 100644
 --- a/media_common/agnostic/common/hw/media_srcs.cmake
 +++ b/media_common/agnostic/common/hw/media_srcs.cmake
-@@ -90,6 +90,14 @@ source_group("MHW\\BLT" FILES ${TMP_BLT_HEADERS_})
+@@ -18,6 +18,7 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
+ media_include_subdirectory(vdbox)
+ 
+ set(TMP_HEADERS_
+@@ -90,6 +91,7 @@ source_group("MHW\\BLT" FILES ${TMP_BLT_HEADERS_})
  source_group("MHW\\Common MI" FILES ${TMP_MI_HEADERS_})
  source_group("MHW\\SFC" FILES ${TMP_SFC_HEADERS_})
  source_group("MHW\\VEBOX" FILES ${TMP_VEBOX_HEADERS_})
 +
-+media_add_curr_to_include_path()
-+media_include_subdirectory(vdbox)
-+media_include_subdirectory(media_interfaces)
-+media_include_subdirectory(os)
-+media_include_subdirectory(renderhal)
-+media_include_subdirectory(shared)
-+
  set(SOFTLET_MHW_COMMON_PRIVATE_INCLUDE_DIRS_
      ${SOFTLET_MHW_COMMON_PRIVATE_INCLUDE_DIRS_}
      ${CMAKE_CURRENT_LIST_DIR}
-@@ -118,4 +126,4 @@ set(SOFTLET_MHW_SFC_PRIVATE_INCLUDE_DIRS_
+@@ -118,4 +120,4 @@ set(SOFTLET_MHW_SFC_PRIVATE_INCLUDE_DIRS_
  set(SOFTLET_MHW_VEBOX_PRIVATE_INCLUDE_DIRS_
      ${SOFTLET_MHW_VEBOX_PRIVATE_INCLUDE_DIRS_}
      ${CMAKE_CURRENT_LIST_DIR}
@@ -547,7 +700,7 @@ index 45dc8126c..47fc06985 100644
 \ No newline at end of file
 +)
 diff --git a/media_common/agnostic/common/hw/vdbox/media_srcs.cmake b/media_common/agnostic/common/hw/vdbox/media_srcs.cmake
-index 912dc9f1f..1ff9ea292 100644
+index 912dc9f1f..0867f0a67 100644
 --- a/media_common/agnostic/common/hw/vdbox/media_srcs.cmake
 +++ b/media_common/agnostic/common/hw/vdbox/media_srcs.cmake
 @@ -19,7 +19,7 @@
@@ -559,7 +712,7 @@ index 912dc9f1f..1ff9ea292 100644
  )
  
  set(SOFTLET_MHW_VDBOX_COMMON_HEADERS_
-@@ -53,4 +53,8 @@ set(TMP_SOFTLET_MHW_VDBOX_HUC_HEADERS_ "")
+@@ -53,4 +53,6 @@ set(TMP_SOFTLET_MHW_VDBOX_HUC_HEADERS_ "")
  set(SOFTLET_MHW_VDBOX_PRIVATE_INCLUDE_DIRS_
      ${SOFTLET_MHW_VDBOX_PRIVATE_INCLUDE_DIRS_}
      ${CMAKE_CURRENT_LIST_DIR}
@@ -568,8 +721,6 @@ index 912dc9f1f..1ff9ea292 100644
 +)
 +
 +media_add_curr_to_include_path()
-+
-+
 diff --git a/media_common/agnostic/common/media_interfaces/media_srcs.cmake b/media_common/agnostic/common/media_interfaces/media_srcs.cmake
 index a53df43bb..b76e57cfd 100644
 --- a/media_common/agnostic/common/media_interfaces/media_srcs.cmake
@@ -615,6 +766,25 @@ index 2d6f2cb65..d3e2932ed 100644
  
 +media_add_curr_to_include_path()
  source_group( "mos_softlet" FILES ${TMP_HEADERS_} )
+diff --git a/media_common/agnostic/common/os/user_setting/media_srcs.cmake b/media_common/agnostic/common/os/user_setting/media_srcs.cmake
+index 2f84e8ddd..6d72ac737 100644
+--- a/media_common/agnostic/common/os/user_setting/media_srcs.cmake
++++ b/media_common/agnostic/common/os/user_setting/media_srcs.cmake
+@@ -18,6 +18,7 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
+ 
+ set(TMP_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/media_user_setting_configure.h
+@@ -50,4 +51,4 @@ set(SOFTLET_COMMON_DLL_PRIVATE_INCLUDE_DIRS_
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+ 
+-source_group( "mos_softlet" FILES ${TMP_HEADERS_} ${TMP_SHARED_HEADERS_} )
+\ No newline at end of file
++source_group( "mos_softlet" FILES ${TMP_HEADERS_} ${TMP_SHARED_HEADERS_} )
 diff --git a/media_common/agnostic/common/renderhal/media_srcs.cmake b/media_common/agnostic/common/renderhal/media_srcs.cmake
 index 821a1c2ac..eb5fbe949 100644
 --- a/media_common/agnostic/common/renderhal/media_srcs.cmake
@@ -628,18 +798,21 @@ index 821a1c2ac..eb5fbe949 100644
  set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
      ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
 diff --git a/media_common/agnostic/common/shared/media_srcs.cmake b/media_common/agnostic/common/shared/media_srcs.cmake
-index bdb57f148..5643055ad 100644
+index bdb57f148..013af4f85 100644
 --- a/media_common/agnostic/common/shared/media_srcs.cmake
 +++ b/media_common/agnostic/common/shared/media_srcs.cmake
-@@ -30,6 +30,8 @@ set(SOFTLET_COMMON_HEADERS_
+@@ -30,8 +30,9 @@ set(SOFTLET_COMMON_HEADERS_
  )
  
  source_group( "Common Files" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
-+media_include_subdirectory(user_setting)
 +media_add_curr_to_include_path()
  
  set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
      ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
 diff --git a/media_common/agnostic/common/vp/hal/media_srcs.cmake b/media_common/agnostic/common/vp/hal/media_srcs.cmake
 index 986cc1521..2379696f1 100644
 --- a/media_common/agnostic/common/vp/hal/media_srcs.cmake
@@ -675,6 +848,33 @@ index 4833778f8..2d3a36130 100755
 +)
 +
 +media_add_curr_to_include_path()
+diff --git a/media_common/linux/common/codec/media_srcs.cmake b/media_common/linux/common/codec/media_srcs.cmake
+index 35f1d982b..a0fa05194 100644
+--- a/media_common/linux/common/codec/media_srcs.cmake
++++ b/media_common/linux/common/codec/media_srcs.cmake
+@@ -32,4 +32,7 @@ set(SOFTLET_CODEC_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_CODEC_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+-endif()
+\ No newline at end of file
++
++media_add_curr_to_include_path()
++
++endif()
+diff --git a/media_common/linux/common/cp/ddi/media_srcs.cmake b/media_common/linux/common/cp/ddi/media_srcs.cmake
+index ec1813eb8..5b7325733 100644
+--- a/media_common/linux/common/cp/ddi/media_srcs.cmake
++++ b/media_common/linux/common/cp/ddi/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/media_ddi_prot.h
+ )
 diff --git a/media_common/linux/common/cp/os/media_srcs.cmake b/media_common/linux/common/cp/os/media_srcs.cmake
 index cde44d828..c95b87248 100644
 --- a/media_common/linux/common/cp/os/media_srcs.cmake
@@ -697,10 +897,10 @@ index e117b5e8d..828fa2060 100644
  endif() # CMAKE_WDDM_LINUX
 diff --git a/media_driver/Android.mk b/media_driver/Android.mk
 new file mode 100644
-index 000000000..ce04740b2
+index 000000000..4bb53a2ae
 --- /dev/null
 +++ b/media_driver/Android.mk
-@@ -0,0 +1,1817 @@
+@@ -0,0 +1,1988 @@
 +
 +# Copyright(c) 2018 Intel Corporation
 +
@@ -738,6 +938,8 @@ index 000000000..ce04740b2
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/pipeline/encode_av1_vdenc_pipeline_adapter_xe_lpm_plus.cpp \
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/pipeline/encode_av1_vdenc_pipeline_xe_lpm_plus.cpp \
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/features/encode_hevc_vdenc_feature_manager_xe_lpm_plus.cpp \
++    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/packet/encode_hevc_vdenc_packet_xe_lpm_plus.cpp \
++    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/packet/encode_huc_brc_update_packet_xe_lpm_plus.cpp \
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/pipeline/encode_hevc_vdenc_pipeline_adapter_xe_lpm_plus.cpp \
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/pipeline/encode_hevc_vdenc_pipeline_xe_lpm_plus.cpp \
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/features/encode_vp9_vdenc_const_settings_xe_lpm_plus.cpp \
@@ -809,6 +1011,7 @@ index 000000000..ce04740b2
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/pipeline/decode_vp9_pipeline_adapter_xe_lpm_plus_base.cpp \
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/pipeline/decode_vp9_pipeline_xe_lpm_plus_base.cpp \
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/encode_av1_basic_feature_xe_lpm_plus_base.cpp \
++    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/encode_av1_superres.cpp \
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/encode_av1_vdenc_const_settings_xe_lpm_plus_base.cpp \
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/encode_av1_vdenc_feature_manager_xe_lpm_plus_base.cpp \
 +    ../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/preenc/encode_av1_vdenc_fullenc.cpp \
@@ -1116,7 +1319,6 @@ index 000000000..ce04740b2
 +    ../media_softlet/agnostic/common/os/mos_gpucontextmgr_next.cpp \
 +    ../media_softlet/agnostic/common/os/mos_graphicsresource_next.cpp \
 +    ../media_softlet/agnostic/common/os/mos_oca_rtlog_mgr.cpp \
-+    ../media_softlet/agnostic/common/os/mos_oca_util_debug.cpp \
 +    ../media_softlet/agnostic/common/os/mos_os.cpp \
 +    ../media_softlet/agnostic/common/os/mos_os_mock_adaptor.cpp \
 +    ../media_softlet/agnostic/common/os/mos_os_mock_adaptor_ext.cpp \
@@ -1126,8 +1328,10 @@ index 000000000..ce04740b2
 +    ../media_softlet/agnostic/common/os/mos_os_virtualengine_singlepipe_next.cpp \
 +    ../media_softlet/agnostic/common/os/mos_user_setting.cpp \
 +    ../media_softlet/agnostic/common/os/mos_util_debug.cpp \
++    ../media_softlet/agnostic/common/os/mos_utilities_inner.cpp \
 +    ../media_softlet/agnostic/common/os/mos_utilities_next.cpp \
 +    ../media_softlet/agnostic/common/os/private/mos_utilities_usersetting.cpp \
++    ../media_softlet/agnostic/common/os/share/mos_oca_util_debug.cpp \
 +    ../media_softlet/agnostic/common/os/user_setting/media_user_setting.cpp \
 +    ../media_softlet/agnostic/common/os/user_setting/media_user_setting_configure.cpp \
 +    ../media_softlet/agnostic/common/os/user_setting/media_user_setting_definition.cpp \
@@ -1154,6 +1358,7 @@ index 000000000..ce04740b2
 +    ../media_softlet/agnostic/common/shared/mmc/media_mem_compression.cpp \
 +    ../media_softlet/agnostic/common/shared/mmc/media_mem_decompression_next.cpp \
 +    ../media_softlet/agnostic/common/shared/null_hardware_next.cpp \
++    ../media_softlet/agnostic/common/shared/oca_rtlog_section_mgr.cpp \
 +    ../media_softlet/agnostic/common/shared/packet/media_cmd_packet.cpp \
 +    ../media_softlet/agnostic/common/shared/packet/media_packet_next.cpp \
 +    ../media_softlet/agnostic/common/shared/packet/media_render_cmd_packet.cpp \
@@ -1958,7 +2163,6 @@ index 000000000..ce04740b2
 +    media_softlet/agnostic/Xe_M/Xe_HPM/codec/hal/enc/av1/features/encode_av1_segmentation_xe_hpm.cpp \
 +    media_softlet/agnostic/Xe_M/Xe_HPM/codec/hal/enc/av1/features/encode_av1_vdenc_const_settings_xe_hpm.cpp \
 +    media_softlet/agnostic/Xe_M/Xe_HPM/codec/hal/enc/av1/features/encode_av1_vdenc_feature_manager_xe_hpm.cpp \
-+    media_softlet/agnostic/Xe_M/Xe_HPM/codec/hal/enc/av1/packet/encode_av1_vdenc_packet_xe_hpm.cpp \
 +    media_softlet/agnostic/Xe_M/Xe_HPM/codec/hal/enc/av1/pipeline/encode_av1_vdenc_pipeline_adapter_xe_hpm.cpp \
 +    media_softlet/agnostic/Xe_M/Xe_HPM/codec/hal/enc/av1/pipeline/encode_av1_vdenc_pipeline_xe_hpm.cpp \
 +    media_softlet/agnostic/Xe_M/Xe_HPM/codec/hal/enc/hevc/features/encode_hevc_vdenc_feature_manager_xe_hpm.cpp \
@@ -2193,8 +2397,8 @@ index 000000000..ce04740b2
 +    -DIGFX_XEHP_SDV_SUPPORTED \
 +    -DIGFX_XE_HPG_CMFCPATCH_SUPPORTED \
 +    -DIGFX_XE_HPG_SUPPORTED \
-+    -DMEDIA_VERSION=\"23.1.6\" \
-+    -DMEDIA_VERSION_DETAILS=\"d5dd7cd28\" \
++    -DMEDIA_VERSION=\"23.2.1\" \
++    -DMEDIA_VERSION_DETAILS=\"169aa0eed\" \
 +    -DVEBOX_AUTO_DENOISE_SUPPORTED=1 \
 +    -DX11_FOUND \
 +    -D_AV1_DECODE_SUPPORTED \
@@ -2231,9 +2435,10 @@ index 000000000..ce04740b2
 +    $(LOCAL_PATH)/../media_common/agnostic/common/codec/shared \
 +    $(LOCAL_PATH)/../media_common/agnostic/common/cp \
 +    $(LOCAL_PATH)/../media_common/agnostic/common/heap_manager \
-+    $(LOCAL_PATH)/../media_common/agnostic/common/hw/vdbox \
 +    $(LOCAL_PATH)/../media_common/agnostic/common/hw \
++    $(LOCAL_PATH)/../media_common/agnostic/common/hw/vdbox \
 +    $(LOCAL_PATH)/../media_common/agnostic/common/media_interfaces \
++    $(LOCAL_PATH)/../media_common/agnostic/common/os/user_setting \
 +    $(LOCAL_PATH)/../media_common/agnostic/common/os \
 +    $(LOCAL_PATH)/../media_common/agnostic/common/renderhal \
 +    $(LOCAL_PATH)/../media_common/agnostic/common/shared \
@@ -2241,7 +2446,9 @@ index 000000000..ce04740b2
 +    $(LOCAL_PATH)/../media_common/agnostic/common/vp/kernel \
 +    $(LOCAL_PATH)/../media_common/agnostic/common/vp/kdll \
 +    $(LOCAL_PATH)/../media_common/linux/common/os \
++    $(LOCAL_PATH)/../media_common/linux/common/cp/ddi \
 +    $(LOCAL_PATH)/../media_common/linux/common/cp/os \
++    $(LOCAL_PATH)/../media_common/linux/common/codec \
 +    $(LOCAL_PATH)/agnostic/common/cm \
 +    $(LOCAL_PATH)/agnostic/common/codec/hal \
 +    $(LOCAL_PATH)/agnostic/common/codec/kernel \
@@ -2268,9 +2475,11 @@ index 000000000..ce04740b2
 +    $(LOCAL_PATH)/media_softlet/agnostic/gen12/codec/hal/dec/av1/pipeline \
 +    $(LOCAL_PATH)/media_softlet/agnostic/gen12/codec/hal/dec/av1/packet \
 +    $(LOCAL_PATH)/media_softlet/agnostic/gen12/codec/hal/dec/av1/features \
++    $(LOCAL_PATH)/media_softlet/agnostic/gen12/codec/hal/dec/av1 \
 +    $(LOCAL_PATH)/media_softlet/agnostic/gen12/codec/hal/dec/shared \
 +    $(LOCAL_PATH)/media_softlet/agnostic/gen12/codec/hal/dec \
 +    $(LOCAL_PATH)/media_softlet/agnostic/gen12/codec/hal/shared \
++    $(LOCAL_PATH)/media_softlet/agnostic/gen12/codec/hal \
 +    $(LOCAL_PATH)/agnostic/gen8/cm \
 +    $(LOCAL_PATH)/agnostic/gen8/codec/hal \
 +    $(LOCAL_PATH)/agnostic/gen8/codec/kernel \
@@ -2403,9 +2612,11 @@ index 000000000..ce04740b2
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_XPM_base/vp/hal/feature_manager \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_XPM_base/vp/hal/packet \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_XPM_base/shared/mediacopy \
++    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_XPM_base/hw \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_XPM_base/codec/hal/enc/hevc/pipeline \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_XPM_base/codec/hal/enc/hevc/features \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_XPM_base/codec/hal/enc \
++    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_XPM_base/codec/hal \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/pipeline \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/platform_interface \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/packet \
@@ -2429,24 +2640,31 @@ index 000000000..ce04740b2
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/hevc/pipeline \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/hevc/packet \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/hevc/mmc \
++    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/hevc \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/avc/pipeline \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/avc/packet \
++    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/avc \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/vp9/pipeline \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/vp9/packet \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/vp9/mmc \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/vp9/hucitf \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/vp9/features \
++    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/vp9 \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/mpeg2/pipeline \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/mpeg2/packet \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/mpeg2/mmc \
++    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/mpeg2 \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/jpeg/pipeline \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/jpeg/packet \
++    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/jpeg \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/shared/pipeline \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/shared \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/enc/av1/packet \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/enc/av1/pipeline \
 +    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/enc/shared \
++    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/enc \
++    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal \
 +    $(LOCAL_PATH)/media_interface/media_interfaces_m8_bdw \
 +    $(LOCAL_PATH)/media_interface/media_interfaces_m9_bxt \
 +    $(LOCAL_PATH)/media_interface/media_interfaces_m9_skl \
@@ -2464,11 +2682,22 @@ index 000000000..ce04740b2
 +    $(LOCAL_PATH)/media_interface/media_interfaces_xehp_sdv \
 +    $(LOCAL_PATH)/media_interface/media_interfaces_dg2 \
 +    $(LOCAL_PATH)/media_interface/media_interfaces_pvc \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/task \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/scalability \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/mediacontext \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/statusreport \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/mmc \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/bufferMgr \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/mediacopy \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/media_sfc_interface \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/classtrace \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/profiler \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/os/user_setting \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/os/share \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/os \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/vp/hal/bufferMgr \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/vp/hal/feature_manager \
@@ -2478,13 +2707,79 @@ index 000000000..ce04740b2
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/vp/hal/pipeline \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/vp/hal/scalability \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/vp/hal/statusreport \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/vp/hal/utils/hal_ddi_share \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/vp/hal/utils \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/vp/hal/platform_interface \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/vp/hal/shared/scalability \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/vp/kdll \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/vp/cm_fc_ld \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/heap_manager \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/cp \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/av1/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/av1/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/av1/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/avc/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/avc/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/avc/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/hevc/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/hevc/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/hevc/scalability \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/hevc/mmc \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/hevc/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp9/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp9/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp9/scalability \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp9/mmc \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp9/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/mpeg2/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/mpeg2/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/mpeg2/mmc \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/mpeg2/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/jpeg/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/jpeg/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/jpeg/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/jpeg/bitstream \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared/bufferMgr \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared/scalability \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared/statusreport \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared/mmc \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared/hucItf \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp8/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp8/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp8/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp8/mmc \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/av1/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/av1/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/av1/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/avc/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/avc/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/avc/features/roi \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/avc/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/hevc/features/roi \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/hevc/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/hevc/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/hevc/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared/bitstreamWriter \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared/scalability \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared/statusreport \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared/mmc \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/jpeg/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/jpeg/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/jpeg/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/vp9/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/vp9/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/vp9/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/shared \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/hw/vdbox \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/hw \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/common/renderhal \
@@ -2495,6 +2790,68 @@ index 000000000..ce04740b2
 +    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_R/Xe_HPG_Base/hw \
 +    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_R/Xe_HPG/renderhal \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_R \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/preenc \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/preenc \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/jpeg/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/shared/common \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/shared \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/mmc \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/mmc \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/mmc \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/mmc \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/shared \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/vdbox \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediacopy \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediaDecompress \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/feature_manager \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/features \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/av1/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/hevc/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/avc/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/mpeg2 \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp9/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp8/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/jpeg \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/pipeline \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/platform_interface \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/packet \
++    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/feature_manager \
 +    $(LOCAL_PATH)/../media_softlet/linux/common/os/osservice \
 +    $(LOCAL_PATH)/../media_softlet/linux/common/os/i915/include/uapi \
 +    $(LOCAL_PATH)/../media_softlet/linux/common/os/i915/include \
@@ -2502,6 +2859,20 @@ index 000000000..ce04740b2
 +    $(LOCAL_PATH)/../media_softlet/linux/common/os/i915_production/include \
 +    $(LOCAL_PATH)/../media_softlet/linux/common/os/i915_production \
 +    $(LOCAL_PATH)/../media_softlet/linux/common/os \
++    $(LOCAL_PATH)/../media_softlet/linux/common/cp \
++    $(LOCAL_PATH)/../media_softlet/linux/common/cp/ddi \
++    $(LOCAL_PATH)/../media_softlet/linux/common/vp/ddi \
++    $(LOCAL_PATH)/../media_softlet/linux/common/ddi \
++    $(LOCAL_PATH)/../media_softlet/linux/common/codec/ddi/shared \
++    $(LOCAL_PATH)/../media_softlet/linux/common/codec/ddi/dec \
++    $(LOCAL_PATH)/../media_softlet/linux/common/codec/ddi/enc \
++    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/ddi \
++    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/encode/hevc/ddi \
++    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/encode/avc/ddi \
++    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/encode/jpeg/ddi \
++    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/encode/av1/ddi \
++    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/encode/vp9/ddi \
++    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/vp/ddi \
 +    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/decode/av1/ddi \
 +    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/decode/avc/ddi \
 +    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/decode/jpeg/ddi \
@@ -2738,23 +3109,21 @@ index 5b66048d4..c947d3f92 100644
  set(COMMON_PRIVATE_INCLUDE_DIRS_
      ${COMMON_PRIVATE_INCLUDE_DIRS_}
 diff --git a/media_driver/agnostic/common/hw/media_srcs.cmake b/media_driver/agnostic/common/hw/media_srcs.cmake
-index 6947c4300..72479e3f6 100644
+index 6947c4300..3c4e370d0 100644
 --- a/media_driver/agnostic/common/hw/media_srcs.cmake
 +++ b/media_driver/agnostic/common/hw/media_srcs.cmake
-@@ -90,6 +90,13 @@ set(COMMON_SOURCES_
+@@ -90,8 +90,9 @@ set(COMMON_SOURCES_
  )
  
  source_group("MHW\\BLT" FILES ${TMP_5_SOURCES_} ${TMP_5_HEADERS_})
-+media_include_subdirectory(vdbox)
-+media_include_subdirectory(media_interfaces)
-+media_include_subdirectory(os)
-+media_include_subdirectory(renderhal)
-+media_include_subdirectory(shared)
-+media_include_subdirectory(vp)
 +media_add_curr_to_include_path()
  
  set(COMMON_PRIVATE_INCLUDE_DIRS_
      ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
 diff --git a/media_driver/agnostic/common/hw/vdbox/media_srcs.cmake b/media_driver/agnostic/common/hw/vdbox/media_srcs.cmake
 index 184928a80..d85409919 100644
 --- a/media_driver/agnostic/common/hw/vdbox/media_srcs.cmake
@@ -4091,75 +4460,38 @@ index 3cab4c565..1938a0078 100644
 +
 +media_add_curr_to_include_path()
 diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/avc/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/avc/media_srcs.cmake
-index 4242176a1..33fdf1e3a 100644
+index 4242176a1..db9bb496c 100644
 --- a/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/avc/media_srcs.cmake
 +++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/avc/media_srcs.cmake
-@@ -20,4 +20,3 @@
+@@ -20,4 +20,4 @@
  
  media_include_subdirectory(pipeline)
  media_include_subdirectory(packet)
 -media_add_curr_to_include_path()
 \ No newline at end of file
++media_add_curr_to_include_path()
 diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/hevc/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/hevc/media_srcs.cmake
-index f859466e6..af39276a2 100644
+index f859466e6..dc3ec3947 100644
 --- a/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/hevc/media_srcs.cmake
 +++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/hevc/media_srcs.cmake
-@@ -21,5 +21,3 @@
- media_include_subdirectory(pipeline)
+@@ -22,4 +22,4 @@ media_include_subdirectory(pipeline)
  media_include_subdirectory(packet)
  media_include_subdirectory(mmc)
--
+ 
 -media_add_curr_to_include_path()
 \ No newline at end of file
-diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/jpeg/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/jpeg/media_srcs.cmake
-index a7816f750..ff278d329 100644
---- a/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/jpeg/media_srcs.cmake
-+++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/jpeg/media_srcs.cmake
-@@ -20,5 +20,3 @@
- 
- media_include_subdirectory(pipeline)
- media_include_subdirectory(packet)
--
--media_add_curr_to_include_path()
++media_add_curr_to_include_path()
 diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/mpeg2/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/mpeg2/media_srcs.cmake
-index 699e659b5..f13025755 100644
+index 699e659b5..e5d297009 100644
 --- a/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/mpeg2/media_srcs.cmake
 +++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/mpeg2/media_srcs.cmake
-@@ -21,5 +21,3 @@
- media_include_subdirectory(pipeline)
+@@ -22,4 +22,4 @@ media_include_subdirectory(pipeline)
  media_include_subdirectory(packet)
  media_include_subdirectory(mmc)
--
+ 
 -media_add_curr_to_include_path()
 \ No newline at end of file
-diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/vp9/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/vp9/media_srcs.cmake
-index 542d188ce..9c929d981 100644
---- a/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/vp9/media_srcs.cmake
-+++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/dec/vp9/media_srcs.cmake
-@@ -24,4 +24,3 @@ media_include_subdirectory(mmc)
- media_include_subdirectory(hucitf)
- media_include_subdirectory(features)
- 
--media_add_curr_to_include_path()
-diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/enc/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/enc/media_srcs.cmake
-index 3d78f82d0..53b2a1254 100644
---- a/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/enc/media_srcs.cmake
-+++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/enc/media_srcs.cmake
-@@ -36,5 +36,3 @@ set(CODEC_HEADERS_
- )
- 
- source_group(CodecHalNext\\Gen12\\encode FILES ${TMP_HEADERS_} ${TMP_SOURCES_})
--
--media_add_curr_to_include_path()
-diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/media_srcs.cmake
-index b663c071f..4ad9730a8 100644
---- a/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/media_srcs.cmake
-+++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_M_base/codec/hal/media_srcs.cmake
-@@ -20,4 +20,3 @@
- 
- media_include_subdirectory(dec)
- media_include_subdirectory(enc)
--media_add_curr_to_include_path()
++media_add_curr_to_include_path()
 diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/feature_manager/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/feature_manager/media_srcs.cmake
 index 6ec9c781a..01cef18bf 100644
 --- a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/feature_manager/media_srcs.cmake
@@ -4212,15 +4544,26 @@ index 82660d3a3..1727c7439 100644
 +)
 +
 +media_add_curr_to_include_path()
-diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/codec/hal/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/codec/hal/media_srcs.cmake
-index 50e8d4f24..6180df55c 100644
---- a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/codec/hal/media_srcs.cmake
-+++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/codec/hal/media_srcs.cmake
-@@ -19,4 +19,3 @@
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/hw/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/hw/media_srcs.cmake
+index b04b96a2a..32a9a1817 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/hw/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/hw/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  # OTHER DEALINGS IN THE SOFTWARE.
  
- media_include_subdirectory(enc)
--media_add_curr_to_include_path()
++media_add_curr_to_include_path()
++
+ set(TMP_MI_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/mhw_mi_hwcmd_xe_xpm_base.h
+     ${CMAKE_CURRENT_LIST_DIR}/mhw_mi_xe_xpm_base_impl.h
+@@ -34,4 +36,4 @@ source_group("MHW\\Common MI" FILES ${TMP_MI_HEADERS_})
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
 diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/shared/mediacopy/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/shared/mediacopy/media_srcs.cmake
 index f8704407f..01c8b536a 100644
 --- a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/shared/mediacopy/media_srcs.cmake
@@ -4411,33 +4754,27 @@ index 7131d56fa..6c02f19c6 100644
 +)
 +media_add_curr_to_include_path()
 diff --git a/media_driver/media_softlet/agnostic/gen12/codec/hal/dec/av1/media_srcs.cmake b/media_driver/media_softlet/agnostic/gen12/codec/hal/dec/av1/media_srcs.cmake
-index 31e3e2ade..e4e8464ff 100644
+index 31e3e2ade..a8c179906 100644
 --- a/media_driver/media_softlet/agnostic/gen12/codec/hal/dec/av1/media_srcs.cmake
 +++ b/media_driver/media_softlet/agnostic/gen12/codec/hal/dec/av1/media_srcs.cmake
-@@ -20,6 +20,4 @@
- 
- media_include_subdirectory(pipeline)
+@@ -22,4 +22,4 @@ media_include_subdirectory(pipeline)
  media_include_subdirectory(packet)
--media_include_subdirectory(features)
--
+ media_include_subdirectory(features)
+ 
 -media_add_curr_to_include_path()
 \ No newline at end of file
-+media_include_subdirectory(features)
-\ No newline at end of file
++media_add_curr_to_include_path()
 diff --git a/media_driver/media_softlet/agnostic/gen12/codec/hal/media_srcs.cmake b/media_driver/media_softlet/agnostic/gen12/codec/hal/media_srcs.cmake
-index bc01eb35a..1c36ce23a 100644
+index bc01eb35a..02aa99485 100644
 --- a/media_driver/media_softlet/agnostic/gen12/codec/hal/media_srcs.cmake
 +++ b/media_driver/media_softlet/agnostic/gen12/codec/hal/media_srcs.cmake
-@@ -19,6 +19,4 @@
- # OTHER DEALINGS IN THE SOFTWARE.
- 
+@@ -21,4 +21,4 @@
  media_include_subdirectory(dec)
--media_include_subdirectory(shared)
--
+ media_include_subdirectory(shared)
+ 
 -media_add_curr_to_include_path()
 \ No newline at end of file
-+media_include_subdirectory(shared)
-\ No newline at end of file
++media_add_curr_to_include_path()
 diff --git a/media_driver/media_softlet/agnostic/gen12/vp/hal/media_srcs.cmake b/media_driver/media_softlet/agnostic/gen12/vp/hal/media_srcs.cmake
 index 1ef7afca5..dde4d80fa 100644
 --- a/media_driver/media_softlet/agnostic/gen12/vp/hal/media_srcs.cmake
@@ -4500,7 +4837,7 @@ index ff4cf7054..54c9be3e2 100644
 +
 +media_add_curr_to_include_path()
 diff --git a/media_driver/media_top_cmake.cmake b/media_driver/media_top_cmake.cmake
-index 2d8cec45b..d7640ff35 100755
+index 7a2644571..5dfe06115 100755
 --- a/media_driver/media_top_cmake.cmake
 +++ b/media_driver/media_top_cmake.cmake
 @@ -36,7 +36,8 @@ include(${MEDIA_DRIVER_CMAKE}/media_feature_flags.cmake)
@@ -4513,6 +4850,1030 @@ index 2d8cec45b..d7640ff35 100755
  
      if(LIBGMM_FOUND)
          include_directories(BEFORE ${LIBGMM_INCLUDE_DIRS})
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/av1/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/av1/pipeline/media_srcs.cmake
+index d035c0eab..3a7352f75 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/av1/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/av1/pipeline/media_srcs.cmake
+@@ -29,6 +29,7 @@ set(SOFTLET_DECODE_AV1_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/decode_av1_pipeline_adapter_xe_lpm_plus.h
+ )
+ 
++media_add_curr_to_include_path()
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus\\Decode FILES ${SOFTLET_DECODE_AV1_SOURCES_} ${SOFTLET_DECODE_AV1_HEADERS_})
+ 
+@@ -38,4 +39,4 @@ endif()
+ set(SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/avc/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/avc/pipeline/media_srcs.cmake
+index de7cec332..66dd3c0a5 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/avc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/avc/pipeline/media_srcs.cmake
+@@ -31,10 +31,12 @@ set(SOFTLET_DECODE_AVC_HEADERS_
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus\\Decode FILES ${SOFTLET_DECODE_AVC_SOURCES_} ${SOFTLET_DECODE_AVC_HEADERS_})
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ 
+ set(SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/hevc/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/hevc/pipeline/media_srcs.cmake
+index e366ae5f5..e7122cb13 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/hevc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/hevc/pipeline/media_srcs.cmake
+@@ -29,6 +29,7 @@ set(SOFTLET_DECODE_HEVC_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/decode_hevc_pipeline_adapter_xe_lpm_plus.h
+ )
+ 
++media_add_curr_to_include_path()
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus\\Decode FILES ${SOFTLET_DECODE_HEVC_SOURCES_} ${SOFTLET_DECODE_HEVC_HEADERS_})
+ 
+@@ -38,4 +39,4 @@ endif()
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/jpeg/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/jpeg/media_srcs.cmake
+index 3d1de0441..8e911249d 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/jpeg/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/jpeg/media_srcs.cmake
+@@ -29,6 +29,8 @@ set(SOFTLET_DECODE_JPEG_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/decode_jpeg_pipeline_adapter_xe_lpm_plus.h
+ )
+ 
++media_add_curr_to_include_path()
++
+ source_group( CodecHalNext\\Xe_LPM_plus\\Decode FILES ${SOFTLET_DECODE_JPEG_SOURCES_} ${SOFTLET_DECODE_JPEG_HEADERS_})
+ 
+ endif()
+@@ -37,4 +39,4 @@ endif()
+ set(SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/mpeg2/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/mpeg2/media_srcs.cmake
+index 9d6a6d9de..696650544 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/mpeg2/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/mpeg2/media_srcs.cmake
+@@ -29,6 +29,7 @@ set(SOFTLET_DECODE_MPEG2_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/decode_mpeg2_pipeline_adapter_xe_lpm_plus.h
+ )
+ 
++media_add_curr_to_include_path()
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus\\Decode FILES ${SOFTLET_DECODE_MPEG2_SOURCES_} ${SOFTLET_DECODE_MPEG2_HEADERS_})
+ 
+@@ -38,4 +39,4 @@ endif()
+ set(SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp8/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp8/pipeline/media_srcs.cmake
+index a4c1cd446..1111b3a2c 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp8/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp8/pipeline/media_srcs.cmake
+@@ -29,6 +29,8 @@ set(SOFTLET_DECODE_VP8_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/decode_vp8_pipeline_adapter_xe_lpm_plus.h
+ )
+ 
++media_add_curr_to_include_path()
++
+ source_group( CodecHalNext\\Xe_LPM_plus\\Decode FILES ${SOFTLET_DECODE_VP8_SOURCES_} ${SOFTLET_DECODE_VP8_HEADERS_})
+ 
+ endif()
+@@ -37,4 +39,4 @@ endif()
+ set(SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp9/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp9/pipeline/media_srcs.cmake
+index 1465433ec..05502e6e3 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp9/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp9/pipeline/media_srcs.cmake
+@@ -29,6 +29,8 @@ set(SOFTLET_DECODE_VP9_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/decode_vp9_pipeline_adapter_xe_lpm_plus.h
+ )
+ 
++media_add_curr_to_include_path()
++
+ source_group( CodecHalNext\\Xe_LPM_plus\\Decode FILES ${SOFTLET_DECODE_VP9_SOURCES_} ${SOFTLET_DECODE_VP9_HEADERS_})
+ 
+ endif()
+@@ -37,4 +39,4 @@ endif()
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/packet/media_srcs.cmake
+index 7611cb7c1..1bb1d1c71 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/packet/media_srcs.cmake
+@@ -42,6 +42,7 @@ source_group( CodecHalNext\\Xe_LPM_plus\\Encode FILES ${TMP_SOURCES_} ${TMP_HEAD
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
+ endif()
+ 
+ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/pipeline/media_srcs.cmake
+index d0b91b211..79779755f 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/pipeline/media_srcs.cmake
+@@ -44,9 +44,10 @@ source_group( CodecHalNext\\Xe_LPM_plus\\Encode FILES ${TMP_SOURCES_} ${TMP_HEAD
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
+ endif()
+ 
+ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/features/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/features/media_srcs.cmake
+index 38071e2b3..b3fe58919 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/features/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/features/media_srcs.cmake
+@@ -44,9 +44,10 @@ source_group( CodecHalNext\\Xe_LPM_plus\\Encode FILES ${TMP_SOURCES_} ${TMP_HEAD
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
+ endif()
+ 
+ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/packet/media_srcs.cmake
+index d23d52d7c..3536ae841 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/packet/media_srcs.cmake
+@@ -44,9 +44,10 @@ source_group( CodecHalNext\\Xe_LPM_plus\\Encode FILES ${TMP_SOURCES_} ${TMP_HEAD
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
+ endif()
+ 
+ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/pipeline/media_srcs.cmake
+index 5066da8a5..8684e2464 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/pipeline/media_srcs.cmake
+@@ -44,9 +44,10 @@ source_group( CodecHalNext\\Xe_LPM_plus\\Encode FILES ${TMP_SOURCES_} ${TMP_HEAD
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
+ endif()
+ 
+ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/features/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/features/media_srcs.cmake
+index 90364a302..c02d6abd3 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/features/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/features/media_srcs.cmake
+@@ -45,7 +45,9 @@ source_group( CodecHalNext\\Xe_LPM_plus\\Encode FILES ${TMP_SOURCES_} ${TMP_HEAD
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ set(SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/packet/media_srcs.cmake
+index 9ad88f0a9..64b790d98 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/packet/media_srcs.cmake
+@@ -44,7 +44,9 @@ source_group( CodecHalNext\\Xe_LPM_plus\\Encode FILES ${TMP_SOURCES_} ${TMP_HEAD
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ set(SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/pipeline/media_srcs.cmake
+index 4e71d7ff1..29e9605f8 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/pipeline/media_srcs.cmake
+@@ -43,7 +43,9 @@ source_group( CodecHalNext\\Xe_LPM_plus\\Encode FILES ${TMP_SOURCES_} ${TMP_HEAD
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ set(SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/media_srcs.cmake
+index 7773c76b2..98ec749a7 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/media_srcs.cmake
+@@ -19,6 +19,7 @@
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
+ media_include_subdirectory(vdbox)
++media_add_curr_to_include_path()
+ 
+ set(TMP_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/mhw_mmio_xe_lpm_plus.h
+@@ -114,4 +115,4 @@ set(SOFTLET_MHW_SFC_PRIVATE_INCLUDE_DIRS_
+ set(SOFTLET_MHW_BLT_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_MHW_BLT_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox/media_srcs.cmake
+index 28d37874c..d2697c861 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox/media_srcs.cmake
+@@ -98,6 +98,8 @@ set(SOFTLET_MHW_VDBOX_MFX_HEADERS_
+     ${TMP_SOFTLET_MHW_VDBOX_MFX_HEADERS_}
+ )
+ 
++media_add_curr_to_include_path()
++
+ source_group( "MHW\\Vdbox" FILES ${TMP_SOFTLET_MHW_VDBOX_HUC_SOURCES_} 
+ ${TMP_SOFTLET_MHW_VDBOX_AVP_SOURCES_}
+ ${TMP_SOFTLET_MHW_VDBOX_MFX_SOURCES_}
+@@ -120,4 +122,4 @@ set(TMP_SOFTLET_MHW_VDBOX_MFX_HEADERS_ "")
+ set(SOFTLET_MHW_VDBOX_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_MHW_VDBOX_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/feature_manager/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/feature_manager/media_srcs.cmake
+index 3be1fce98..fafad7386 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/feature_manager/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/feature_manager/media_srcs.cmake
+@@ -37,10 +37,12 @@ set(SOFTLET_VP_HEADERS_
+     ${TMP_HEADERS_}
+ )
+ 
++media_add_curr_to_include_path()
++
+ source_group( VpHalNext\\Xe_LPM_plus\\FeatureManager FILES ${TMP_SOURCES_} ${TMP_HEADERS_})
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ set(SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/packet/media_srcs.cmake
+index 74a12953a..a9ec3ebe8 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/packet/media_srcs.cmake
+@@ -38,10 +38,12 @@ set(SOFTLET_VP_HEADERS_
+     ${TMP_HEADERS_}
+ )
+ 
++media_add_curr_to_include_path()
++
+ source_group( VpHalNext\\Xe_LPM_plus FILES ${TMP_SOURCES_} ${TMP_HEADERS_})
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ set(SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/pipeline/media_srcs.cmake
+index dcfe54539..a7fb9c9b2 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/pipeline/media_srcs.cmake
+@@ -36,10 +36,12 @@ set(SOFTLET_VP_HEADERS_
+     ${TMP_HEADERS_}
+ )
+ 
++media_add_curr_to_include_path()
++
+ source_group( VpHalNext\\Xe_LPM_plus FILES ${TMP_SOURCES_} ${TMP_HEADERS_})
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ set(SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/platform_interface/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/platform_interface/media_srcs.cmake
+index e3dcbf9cc..54456d2da 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/platform_interface/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/platform_interface/media_srcs.cmake
+@@ -36,10 +36,12 @@ set(SOFTLET_VP_HEADERS_
+     ${TMP_HEADERS_}
+ )
+ 
++media_add_curr_to_include_path()
++
+ source_group( VpHalNext\\Xe_LPM_plus\\PlatformInterface FILES ${TMP_SOURCES_} ${TMP_HEADERS_})
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ set(SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/features/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/features/media_srcs.cmake
+index 88aa77529..9d70e3075 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/features/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/features/media_srcs.cmake
+@@ -34,10 +34,12 @@ set(SOFTLET_DECODE_AV1_HEADERS_
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_AV1_SOURCES_} ${SOFTLET_DECODE_AV1_HEADERS_})
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ 
+ set(SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/packet/media_srcs.cmake
+index 559cea98d..bbf27c8ad 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/packet/media_srcs.cmake
+@@ -33,6 +33,7 @@ set(SOFTLET_DECODE_AV1_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/decode_av1_tile_packet_xe_lpm_plus_base.h
+ )
+ 
++media_add_curr_to_include_path()
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_AV1_SOURCES_} ${SOFTLET_DECODE_AV1_HEADERS_})
+ 
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/pipeline/media_srcs.cmake
+index 2c9e24b11..ba0b02c25 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/pipeline/media_srcs.cmake
+@@ -33,6 +33,8 @@ set(SOFTLET_DECODE_AV1_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/decode_av1_status_report_xe_lpm_plus_base.h
+ )
+ 
++media_add_curr_to_include_path()
++
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_AV1_SOURCES_} ${SOFTLET_DECODE_AV1_HEADERS_})
+ 
+ endif()
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/packet/media_srcs.cmake
+index 8e44b9575..4c9d54ce1 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/packet/media_srcs.cmake
+@@ -35,6 +35,8 @@ set(SOFTLET_DECODE_AVC_HEADERS_
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_AVC_SOURCES_} ${SOFTLET_DECODE_AVC_HEADERS_})
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ 
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/pipeline/media_srcs.cmake
+index 2fd0e3417..8688a2c2a 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/pipeline/media_srcs.cmake
+@@ -33,6 +33,8 @@ set(SOFTLET_DECODE_AVC_HEADERS_
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_AVC_SOURCES_} ${SOFTLET_DECODE_AVC_HEADERS_})
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ 
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/mmc/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/mmc/media_srcs.cmake
+index c56d30a06..57cbeb461 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/mmc/media_srcs.cmake
+@@ -31,10 +31,12 @@ set(SOFTLET_DECODE_HEVC_HEADERS_
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_HEVC_HEADERS_} ${SOFTLET_DECODE_HEVC_SOURCES_})
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ 
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/packet/media_srcs.cmake
+index 74527276e..82e2e9915 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/packet/media_srcs.cmake
+@@ -43,6 +43,8 @@ set(SOFTLET_DECODE_HEVC_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/decode_hevc_packet_real_tile_xe_lpm_plus_base.h
+ )
+ 
++media_add_curr_to_include_path()
++
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_HEVC_HEADERS_} ${SOFTLET_DECODE_HEVC_SOURCES_})
+ 
+ endif()
+@@ -51,4 +53,4 @@ endif()
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/pipeline/media_srcs.cmake
+index df29e8dc6..fd8565427 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/pipeline/media_srcs.cmake
+@@ -31,6 +31,8 @@ set(SOFTLET_DECODE_HEVC_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/decode_hevc_pipeline_adapter_xe_lpm_plus_base.h
+ )
+ 
++media_add_curr_to_include_path()
++
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_HEVC_HEADERS_} ${SOFTLET_DECODE_HEVC_SOURCES_})
+ 
+ endif()
+@@ -39,4 +41,4 @@ endif()
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/packet/media_srcs.cmake
+index 5d7a38417..a6b44b3f3 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/packet/media_srcs.cmake
+@@ -33,6 +33,8 @@ set(SOFTLET_DECODE_JPEG_HEADERS_
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_JPEG_SOURCES_} ${SOFTLET_DECODE_JPEG_HEADERS_})
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ 
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/pipeline/media_srcs.cmake
+index 5119f8a2b..5e96eeb09 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/pipeline/media_srcs.cmake
+@@ -34,6 +34,8 @@ set(SOFTLET_DECODE_JPEG_HEADERS_
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_JPEG_SOURCES_} ${SOFTLET_DECODE_JPEG_HEADERS_})
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ 
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/mmc/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/mmc/media_srcs.cmake
+index 1f2bc79d8..f18d780dc 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/mmc/media_srcs.cmake
+@@ -31,6 +31,8 @@ set(SOFTLET_DECODE_MPEG2_HEADERS_
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_MPEG2_SOURCES_} ${SOFTLET_DECODE_MPEG2_HEADERS_})
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ 
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/packet/media_srcs.cmake
+index 9f48819fa..b42a2ef16 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/packet/media_srcs.cmake
+@@ -37,6 +37,8 @@ set(SOFTLET_DECODE_MPEG2_HEADERS_
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_MPEG2_SOURCES_} ${SOFTLET_DECODE_MPEG2_HEADERS_})
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ 
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/pipeline/media_srcs.cmake
+index ea67db617..4dcfaf492 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/pipeline/media_srcs.cmake
+@@ -33,6 +33,8 @@ set(SOFTLET_DECODE_MPEG2_HEADERS_
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_JPEG_SOURCES_} ${SOFTLET_DECODE_JPEG_HEADERS_})
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/shared/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/shared/media_srcs.cmake
+index aa8b3019f..611f26b88 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/shared/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/shared/media_srcs.cmake
+@@ -29,7 +29,9 @@ set(SOFTLET_DECODE_COMMON_HEADERS_
+ )
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_COMMON_SOURCES_} ${SOFTLET_DECODE_COMMON_HEADERS_})
+ 
++media_add_curr_to_include_path()
++
+ set(SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/mmc/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/mmc/media_srcs.cmake
+index 19f267d62..02be28eae 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/mmc/media_srcs.cmake
+@@ -31,6 +31,8 @@ set(SOFTLET_DECODE_VP8_HEADERS_
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_VP8_SOURCES_} ${SOFTLET_DECODE_VP8_HEADERS_})
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ 
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/packet/media_srcs.cmake
+index 85cc09474..089a552d6 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/packet/media_srcs.cmake
+@@ -36,6 +36,8 @@ set(SOFTLET_DECODE_VP8_HEADERS_
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_VP8_SOURCES_} ${SOFTLET_DECODE_VP8_HEADERS_})
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ 
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/pipeline/media_srcs.cmake
+index f1bda272b..4968387a5 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/pipeline/media_srcs.cmake
+@@ -33,6 +33,8 @@ set(SOFTLET_DECODE_VP8_HEADERS_
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_VP8_SOURCES_} ${SOFTLET_DECODE_VP8_HEADERS_})
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ 
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/mmc/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/mmc/media_srcs.cmake
+index 5b9d2bc0d..2321d508b 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/mmc/media_srcs.cmake
+@@ -31,10 +31,12 @@ set(SOFTLET_DECODE_VP9_HEADERS_
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_VP9_SOURCES_} ${SOFTLET_DECODE_VP9_HEADERS_})
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ 
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/packet/media_srcs.cmake
+index 361fefa2f..5cc58daaf 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/packet/media_srcs.cmake
+@@ -43,10 +43,12 @@ set(SOFTLET_DECODE_VP9_HEADERS_
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_VP9_SOURCES_} ${SOFTLET_DECODE_VP9_HEADERS_})
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ 
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/pipeline/media_srcs.cmake
+index eeedb861f..c650acc70 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/pipeline/media_srcs.cmake
+@@ -33,10 +33,12 @@ set(SOFTLET_DECODE_VP9_HEADERS_
+ 
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_VP9_SOURCES_} ${SOFTLET_DECODE_VP9_HEADERS_})
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ 
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/media_srcs.cmake
+index 9a79a5efc..98ad379a5 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/media_srcs.cmake
+@@ -50,6 +50,8 @@ source_group( CodecHalNext\\Xe_LPM_plus_base\\Encode FILES ${TMP_SOURCES_} ${TMP
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/preenc/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/preenc/media_srcs.cmake
+index 76a15992f..14fc58a84 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/preenc/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/preenc/media_srcs.cmake
+@@ -46,9 +46,11 @@ source_group( CodecHalNext\\Xe_LPM_plus_base\\Encode FILES ${TMP_SOURCES_} ${TMP
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/packet/media_srcs.cmake
+index 0105efef7..29a7cf207 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/packet/media_srcs.cmake
+@@ -42,9 +42,11 @@ source_group( CodecHalNext\\Xe_LPM_plus_base\\Encode FILES ${TMP_SOURCES_} ${TMP
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/pipeline/media_srcs.cmake
+index 621eabf17..2d320f6b1 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/pipeline/media_srcs.cmake
+@@ -43,6 +43,8 @@ source_group( CodecHalNext\\Xe_LPM_plus_base\\Encode FILES ${TMP_SOURCES_} ${TMP
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/features/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/features/media_srcs.cmake
+index c1ad31949..4719cf4d0 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/features/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/features/media_srcs.cmake
+@@ -46,9 +46,11 @@ source_group( CodecHalNext\\Xe_LPM_plus_base\\Encode FILES ${TMP_SOURCES_} ${TMP
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/pipeline/media_srcs.cmake
+index 8e36c538c..4fcb479fb 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/pipeline/media_srcs.cmake
+@@ -44,9 +44,11 @@ source_group( CodecHalNext\\Xe_LPM_plus_base\\Encode FILES ${TMP_SOURCES_} ${TMP
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/media_srcs.cmake
+index ec46201dd..a7d517626 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/media_srcs.cmake
+@@ -48,6 +48,8 @@ source_group( CodecHalNext\\Xe_LPM_plus_base\\Encode FILES ${TMP_SOURCES_} ${TMP
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/preenc/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/preenc/media_srcs.cmake
+index 0cc377f8e..a96fa4721 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/preenc/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/preenc/media_srcs.cmake
+@@ -41,6 +41,8 @@ set(SOFTLET_ENCODE_HEVC_SOURCES_
+     ${TMP_SOURCES_}
+ )
+ 
++media_add_curr_to_include_path()
++
+ source_group( CodecHalNext\\Xe_LPM_plus_base\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ 
+ set(TMP_SOURCES_ "")
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/pipeline/media_srcs.cmake
+index 4a03820b6..3471799de 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/pipeline/media_srcs.cmake
+@@ -45,9 +45,11 @@ source_group( CodecHalNext\\Xe_LPM_plus_base\\Encode FILES ${TMP_SOURCES_} ${TMP
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/jpeg/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/jpeg/pipeline/media_srcs.cmake
+index 97f508717..eb47dfcbc 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/jpeg/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/jpeg/pipeline/media_srcs.cmake
+@@ -44,9 +44,11 @@ source_group( CodecHalNext\\Xe_LPM_plus_base\\Encode FILES ${TMP_SOURCES_} ${TMP
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/shared/common/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/shared/common/media_srcs.cmake
+index af54bfe69..75968831b 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/shared/common/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/shared/common/media_srcs.cmake
+@@ -41,7 +41,9 @@ source_group( CodecHalNext\\Xe_LPM_plus_base\\Encode FILES ${TMP_SOURCES_} ${TMP
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/packet/media_srcs.cmake
+index 2f395ffc2..7712e3cdc 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/packet/media_srcs.cmake
+@@ -42,7 +42,9 @@ source_group( CodecHalNext\\Xe_LPM_plus_base\\Encode FILES ${TMP_SOURCES_} ${TMP
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ set(SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/pipeline/media_srcs.cmake
+index ab1d6d0f6..c6e59d209 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/pipeline/media_srcs.cmake
+@@ -43,7 +43,9 @@ source_group( CodecHalNext\\Xe_LPM_plus_base\\Encode FILES ${TMP_SOURCES_} ${TMP
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ set(SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/shared/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/shared/media_srcs.cmake
+index ce4db0e96..1770c6c7d 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/shared/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/shared/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_MMC_SOURCES_
+     ${CMAKE_CURRENT_LIST_DIR}/codec_mem_compression_xe_lpm_plus_base_next.cpp
+ )
+@@ -56,4 +58,4 @@ set(TMP_HW_HEADERS_ "")
+ set(SOFTLET_CODEC_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_CODEC_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/media_srcs.cmake
+index 9d35b1e2b..ea936912b 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/media_srcs.cmake
+@@ -85,4 +85,4 @@ set(SOFTLET_MHW_BLT_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_MHW_BLT_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+-#media_add_curr_to_include_path()
+\ No newline at end of file
++media_add_curr_to_include_path()
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/vdbox/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/vdbox/media_srcs.cmake
+index ad443a2e7..cd07d0bf4 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/vdbox/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/vdbox/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOFTLET_MHW_VDBOX_AVP_SOURCES_
+     ${CMAKE_CURRENT_LIST_DIR}/mhw_vdbox_avp_impl_xe_lpm_plus_base.cpp
+ )
+@@ -103,4 +105,4 @@ set(TMP_SOFTLET_MHW_VDBOX_MFX_HEADERS_ "")
+ set(SOFTLET_MHW_VDBOX_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_MHW_VDBOX_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediaDecompress/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediaDecompress/media_srcs.cmake
+index 5bfd5d7b5..82b5d863a 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediaDecompress/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediaDecompress/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${CMAKE_CURRENT_LIST_DIR}/media_mem_decompress_xe_lpm_plus_base.cpp
+ )
+@@ -43,4 +45,4 @@ source_group( "SharedNext\\Xe_LPM_plus_base\\shared\\MediaMemDecompress" FILES $
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediacopy/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediacopy/media_srcs.cmake
+index 93cf0b65d..09f65a8ee 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediacopy/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediacopy/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${CMAKE_CURRENT_LIST_DIR}/media_copy_xe_lpm_plus_base.cpp
+     ${CMAKE_CURRENT_LIST_DIR}/media_blt_copy_xe_lpm_plus_base.cpp
+@@ -48,4 +50,4 @@ source_group( "SharedNext\\Xe_LPM_plus_base\\shared\\MediaCopy" FILES ${TMP_SOUR
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/feature_manager/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/feature_manager/media_srcs.cmake
+index 158bf289d..7bc92f75b 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/feature_manager/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/feature_manager/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${CMAKE_CURRENT_LIST_DIR}/vp_feature_manager_xe_lpm_plus_base.cpp
+ )
+@@ -42,4 +44,4 @@ set(TMP_HEADERS_ "")
+ set(SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/packet/media_srcs.cmake
+index 2c0179e0c..97338dbcc 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/packet/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${CMAKE_CURRENT_LIST_DIR}/vp_vebox_cmd_packet_xe_lpm_plus_base.cpp
+     ${CMAKE_CURRENT_LIST_DIR}/vp_render_sfc_xe_lpm_plus_base.cpp
+@@ -46,4 +48,4 @@ set(TMP_HEADERS_ "")
+ set(SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
 diff --git a/media_softlet/agnostic/Xe_R/Xe_HPG/renderhal/media_srcs.cmake b/media_softlet/agnostic/Xe_R/Xe_HPG/renderhal/media_srcs.cmake
 index 40e0c55f8..f4e6b3431 100644
 --- a/media_softlet/agnostic/Xe_R/Xe_HPG/renderhal/media_srcs.cmake
@@ -4719,16 +6080,1136 @@ index 7a3a772d6..65b40ab92 100644
 \ No newline at end of file
 +)
 +media_add_curr_to_include_path()
+diff --git a/media_softlet/agnostic/Xe_R/media_srcs.cmake b/media_softlet/agnostic/Xe_R/media_srcs.cmake
+index 1bba0f214..fecaead18 100644
+--- a/media_softlet/agnostic/Xe_R/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_R/media_srcs.cmake
+@@ -24,6 +24,7 @@
+ if(XE_HPG OR XE_LPG)
+     media_include_subdirectory(Xe_HPG_Base)
+     media_include_subdirectory(Xe_HPG)
++    media_add_curr_to_include_path()
+ endif()
+ 
+ set(MEDIA_BIN_HEADERS_
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/av1/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/av1/features/media_srcs.cmake
+index 86f9b87ec..2a6b7a3c4 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/av1/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/av1/features/media_srcs.cmake
+@@ -39,6 +39,8 @@ set(SOFTLET_DECODE_AV1_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_AV1_SOURCES_} ${SOFTLET_DECODE_AV1_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/av1/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/av1/packet/media_srcs.cmake
+index 7a439f5bc..8e3765428 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/av1/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/av1/packet/media_srcs.cmake
+@@ -35,9 +35,11 @@ set(SOFTLET_DECODE_AV1_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_AV1_SOURCES_} ${SOFTLET_DECODE_AV1_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/av1/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/av1/pipeline/media_srcs.cmake
+index 293a6a331..bf670cd5b 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/av1/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/av1/pipeline/media_srcs.cmake
+@@ -31,9 +31,11 @@ set(SOFTLET_DECODE_AV1_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_AV1_SOURCES_} ${SOFTLET_DECODE_AV1_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/avc/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/avc/features/media_srcs.cmake
+index 578955752..92e30bde4 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/avc/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/avc/features/media_srcs.cmake
+@@ -39,9 +39,11 @@ set(SOFTLET_DECODE_AVC_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_AVC_SOURCES_} ${SOFTLET_DECODE_AVC_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/avc/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/avc/packet/media_srcs.cmake
+index 704c5b8ef..b00cdaf44 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/avc/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/avc/packet/media_srcs.cmake
+@@ -37,9 +37,11 @@ set(SOFTLET_DECODE_AVC_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_AVC_SOURCES_} ${SOFTLET_DECODE_AVC_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/avc/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/avc/pipeline/media_srcs.cmake
+index 6c6804d24..bd07970c3 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/avc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/avc/pipeline/media_srcs.cmake
+@@ -32,9 +32,11 @@ set(SOFTLET_DECODE_AVC_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_AVC_SOURCES_} ${SOFTLET_DECODE_AVC_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/hevc/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/hevc/features/media_srcs.cmake
+index 28b13974f..23bdeb494 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/hevc/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/hevc/features/media_srcs.cmake
+@@ -41,9 +41,11 @@ set(SOFTLET_DECODE_HEVC_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_HEVC_SOURCES_} ${SOFTLET_DECODE_HEVC_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/hevc/mmc/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/hevc/mmc/media_srcs.cmake
+index 63f23fbff..83c370ead 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/hevc/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/hevc/mmc/media_srcs.cmake
+@@ -31,9 +31,11 @@ set(SOFTLET_DECODE_HEVC_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_HEVC_SOURCES_} ${SOFTLET_DECODE_HEVC_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/hevc/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/hevc/packet/media_srcs.cmake
+index ed49aeac7..1891d1e73 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/hevc/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/hevc/packet/media_srcs.cmake
+@@ -47,9 +47,11 @@ set(SOFTLET_DECODE_HEVC_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_HEVC_SOURCES_} ${SOFTLET_DECODE_HEVC_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/hevc/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/hevc/pipeline/media_srcs.cmake
+index 155de25a7..b89a9f550 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/hevc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/hevc/pipeline/media_srcs.cmake
+@@ -32,9 +32,11 @@ set(SOFTLET_DECODE_HEVC_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_HEVC_SOURCES_} ${SOFTLET_DECODE_HEVC_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/hevc/scalability/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/hevc/scalability/media_srcs.cmake
+index e55c775a8..1daa2b7a1 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/hevc/scalability/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/hevc/scalability/media_srcs.cmake
+@@ -43,9 +43,11 @@ set(SOFTLET_DECODE_HEVC_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_HEVC_SOURCES_} ${SOFTLET_DECODE_HEVC_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/jpeg/bitstream/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/jpeg/bitstream/media_srcs.cmake
+index b992f497d..7218e22df 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/jpeg/bitstream/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/jpeg/bitstream/media_srcs.cmake
+@@ -31,9 +31,11 @@ set(SOFTLET_DECODE_JPEG_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_JPEG_SOURCES_} ${SOFTLET_DECODE_JPEG_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/jpeg/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/jpeg/features/media_srcs.cmake
+index 9e917cf50..ba2a37ef1 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/jpeg/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/jpeg/features/media_srcs.cmake
+@@ -35,9 +35,11 @@ set(SOFTLET_DECODE_JPEG_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_JPEG_SOURCES_} ${SOFTLET_DECODE_JPEG_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/jpeg/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/jpeg/packet/media_srcs.cmake
+index 5d8711ed5..2054c1987 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/jpeg/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/jpeg/packet/media_srcs.cmake
+@@ -35,9 +35,11 @@ set(SOFTLET_DECODE_JPEG_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_JPEG_SOURCES_} ${SOFTLET_DECODE_JPEG_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/jpeg/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/jpeg/pipeline/media_srcs.cmake
+index 2d2ad7be5..8f540e370 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/jpeg/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/jpeg/pipeline/media_srcs.cmake
+@@ -32,9 +32,11 @@ set(SOFTLET_DECODE_JPEG_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_JPEG_SOURCES_} ${SOFTLET_DECODE_JPEG_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/mpeg2/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/mpeg2/features/media_srcs.cmake
+index 72ebf588c..e1fac38a5 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/mpeg2/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/mpeg2/features/media_srcs.cmake
+@@ -35,9 +35,11 @@ set(SOFTLET_DECODE_MPEG2_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_MPEG2_SOURCES_} ${SOFTLET_DECODE_MPEG2_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/mpeg2/mmc/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/mpeg2/mmc/media_srcs.cmake
+index 515685cf3..8d4d427d1 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/mpeg2/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/mpeg2/mmc/media_srcs.cmake
+@@ -31,9 +31,11 @@ set(SOFTLET_DECODE_MPEG2_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_MPEG2_SOURCES_} ${SOFTLET_DECODE_MPEG2_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/mpeg2/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/mpeg2/packet/media_srcs.cmake
+index e8d939c71..17c56df88 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/mpeg2/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/mpeg2/packet/media_srcs.cmake
+@@ -37,9 +37,11 @@ set(SOFTLET_DECODE_MPEG2_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_MPEG2_SOURCES_} ${SOFTLET_DECODE_MPEG2_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/mpeg2/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/mpeg2/pipeline/media_srcs.cmake
+index a99d3f79e..3efb99d09 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/mpeg2/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/mpeg2/pipeline/media_srcs.cmake
+@@ -32,9 +32,11 @@ set(SOFTLET_DECODE_MPEG2_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_MPEG2_SOURCES_} ${SOFTLET_DECODE_MPEG2_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/bufferMgr/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/bufferMgr/media_srcs.cmake
+index 2cea9ce6b..2c3e5bd32 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/bufferMgr/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/bufferMgr/media_srcs.cmake
+@@ -31,9 +31,11 @@ set(SOFTLET_DECODE_COMMON_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/decode_internal_target.h
+ )
+ 
++media_add_curr_to_include_path()
++
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_COMMON_SOURCES_} ${SOFTLET_DECODE_COMMON_HEADERS_} )
+ 
+ set(SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/features/media_srcs.cmake
+index 428c41069..558b7079c 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/features/media_srcs.cmake
+@@ -37,10 +37,11 @@ set(SOFTLET_DECODE_COMMON_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/decode_downsampling_feature.h
+ )
+ 
++media_add_curr_to_include_path()
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_COMMON_SOURCES_} ${SOFTLET_DECODE_COMMON_HEADERS_} )
+ 
+ set(SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/hucItf/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/hucItf/media_srcs.cmake
+index 2dae920b3..28f7cabee 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/hucItf/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/hucItf/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(SOFTLET_DECODE_COMMON_HEADERS_
+     ${SOFTLET_DECODE_COMMON_HEADERS_}
+     ${CMAKE_CURRENT_LIST_DIR}/decode_huc_packet_creator_base.h
+@@ -43,4 +45,4 @@ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_COMMON_SOURCES
+ set(SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/media_srcs.cmake
+index e0c830b96..df54d1386 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/media_srcs.cmake
+@@ -41,6 +41,7 @@ set(SOFTLET_DECODE_COMMON_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/decode_unique_id.h
+ )
+ 
++media_add_curr_to_include_path()
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_COMMON_SOURCES_} ${SOFTLET_DECODE_COMMON_HEADERS_} )
+ 
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/mmc/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/mmc/media_srcs.cmake
+index 9c21f6a3e..5fad6f6db 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/mmc/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(SOFTLET_DECODE_COMMON_SOURCES_
+     ${SOFTLET_DECODE_COMMON_SOURCES_}
+     ${CMAKE_CURRENT_LIST_DIR}/decode_mem_compression.cpp
+@@ -34,4 +36,4 @@ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_COMMON_SOURCES
+ set(SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/packet/media_srcs.cmake
+index ccb103b85..1b45ae68c 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/packet/media_srcs.cmake
+@@ -40,6 +40,7 @@ set(SOFTLET_DECODE_COMMON_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/decode_huc_copy_packet.h
+ )
+ 
++media_add_curr_to_include_path()
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_COMMON_SOURCES_} ${SOFTLET_DECODE_COMMON_HEADERS_} )
+ 
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/pipeline/media_srcs.cmake
+index 85c081f9b..598ac24bf 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/pipeline/media_srcs.cmake
+@@ -36,6 +36,7 @@ set(SOFTLET_DECODE_COMMON_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/decode_sfc_histogram_postsubpipeline.h
+ )
+ 
++media_add_curr_to_include_path()
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_COMMON_SOURCES_} ${SOFTLET_DECODE_COMMON_HEADERS_} )
+ 
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/scalability/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/scalability/media_srcs.cmake
+index c32ce5490..83f3a97e9 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/scalability/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/scalability/media_srcs.cmake
+@@ -36,6 +36,7 @@ set(SOFTLET_DECODE_COMMON_HEADERS_
+ )
+ endif()
+ 
++media_add_curr_to_include_path()
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_COMMON_SOURCES_} ${SOFTLET_DECODE_COMMON_HEADERS_} )
+ 
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/statusreport/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/statusreport/media_srcs.cmake
+index 8f54cdcec..5a4794673 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/statusreport/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/statusreport/media_srcs.cmake
+@@ -29,6 +29,7 @@ set(SOFTLET_DECODE_COMMON_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/decode_status_report_defs.h
+ )
+ 
++media_add_curr_to_include_path()
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_COMMON_SOURCES_} ${SOFTLET_DECODE_COMMON_HEADERS_} )
+ 
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp8/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp8/features/media_srcs.cmake
+index c6d8c02f8..0d4f77a60 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp8/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp8/features/media_srcs.cmake
+@@ -37,9 +37,11 @@ set(SOFTLET_DECODE_VP8_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_VP8_SOURCES_} ${SOFTLET_DECODE_VP8_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp8/mmc/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp8/mmc/media_srcs.cmake
+index fff300b33..984b12f14 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp8/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp8/mmc/media_srcs.cmake
+@@ -31,9 +31,11 @@ set(SOFTLET_DECODE_VP8_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_VP8_SOURCES_} ${SOFTLET_DECODE_VP8_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp8/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp8/packet/media_srcs.cmake
+index cf69e6dd5..8f9f5640e 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp8/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp8/packet/media_srcs.cmake
+@@ -35,9 +35,11 @@ set(SOFTLET_DECODE_VP8_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_VP8_SOURCES_} ${SOFTLET_DECODE_VP8_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp8/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp8/pipeline/media_srcs.cmake
+index 04dbdba1a..0b120fa87 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp8/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp8/pipeline/media_srcs.cmake
+@@ -31,9 +31,11 @@ set(SOFTLET_DECODE_VP8_HEADERS_
+ )
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_VP8_SOURCES_} ${SOFTLET_DECODE_VP8_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp9/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp9/features/media_srcs.cmake
+index b9eb744b1..0b34a2e69 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp9/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp9/features/media_srcs.cmake
+@@ -36,9 +36,11 @@ set(SOFTLET_DECODE_VP9_HEADERS_
+ )
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_VP9_SOURCES_} ${SOFTLET_DECODE_VP9_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp9/mmc/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp9/mmc/media_srcs.cmake
+index 455572f48..942b3ec65 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp9/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp9/mmc/media_srcs.cmake
+@@ -30,9 +30,11 @@ set(SOFTLET_DECODE_VP9_HEADERS_
+ )
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_VP9_SOURCES_} ${SOFTLET_DECODE_VP9_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp9/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp9/packet/media_srcs.cmake
+index 193d8b9a9..4133ee601 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp9/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp9/packet/media_srcs.cmake
+@@ -44,9 +44,11 @@ set(SOFTLET_DECODE_VP9_HEADERS_
+ )
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_VP9_SOURCES_} ${SOFTLET_DECODE_VP9_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp9/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp9/pipeline/media_srcs.cmake
+index 8c304faae..3e8a42bd2 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp9/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp9/pipeline/media_srcs.cmake
+@@ -34,10 +34,12 @@ set(SOFTLET_DECODE_VP9_HEADERS_
+ 
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_VP9_SOURCES_} ${SOFTLET_DECODE_VP9_HEADERS_})
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ 
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp9/scalability/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp9/scalability/media_srcs.cmake
+index 4d412499e..1df8f47d8 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp9/scalability/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp9/scalability/media_srcs.cmake
+@@ -35,9 +35,11 @@ set(SOFTLET_DECODE_VP9_HEADERS_
+ )
+ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_VP9_SOURCES_} ${SOFTLET_DECODE_VP9_HEADERS_} )
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/av1/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/av1/features/media_srcs.cmake
+index 149e2bb16..e0b0ca5b3 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/av1/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/av1/features/media_srcs.cmake
+@@ -57,9 +57,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/av1/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/av1/packet/media_srcs.cmake
+index e6906854b..15ff451b4 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/av1/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/av1/packet/media_srcs.cmake
+@@ -48,9 +48,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/av1/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/av1/pipeline/media_srcs.cmake
+index c8f9b8942..405265b98 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/av1/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/av1/pipeline/media_srcs.cmake
+@@ -47,6 +47,8 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/avc/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/avc/features/media_srcs.cmake
+index e83b3912b..bb0d8ab24 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/avc/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/avc/features/media_srcs.cmake
+@@ -65,9 +65,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/avc/features/roi/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/avc/features/roi/media_srcs.cmake
+index 0520f77a7..8648dec17 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/avc/features/roi/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/avc/features/roi/media_srcs.cmake
+@@ -48,6 +48,8 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/avc/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/avc/packet/media_srcs.cmake
+index b4ff07b8a..ddd65217b 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/avc/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/avc/packet/media_srcs.cmake
+@@ -46,6 +46,8 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/avc/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/avc/pipeline/media_srcs.cmake
+index ecf63fd3a..6dbd09e18 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/avc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/avc/pipeline/media_srcs.cmake
+@@ -46,6 +46,8 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/hevc/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/hevc/features/media_srcs.cmake
+index 7d3b89c5a..3c4ff8dac 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/hevc/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/hevc/features/media_srcs.cmake
+@@ -65,6 +65,8 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/hevc/features/roi/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/hevc/features/roi/media_srcs.cmake
+index 9c8e34da2..545ed1187 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/hevc/features/roi/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/hevc/features/roi/media_srcs.cmake
+@@ -62,6 +62,8 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/hevc/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/hevc/packet/media_srcs.cmake
+index 0ca0e943b..ba555276e 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/hevc/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/hevc/packet/media_srcs.cmake
+@@ -54,9 +54,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/hevc/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/hevc/pipeline/media_srcs.cmake
+index df035676d..ec646f7a2 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/hevc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/hevc/pipeline/media_srcs.cmake
+@@ -48,9 +48,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/jpeg/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/jpeg/features/media_srcs.cmake
+index c8715f695..8968b29d0 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/jpeg/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/jpeg/features/media_srcs.cmake
+@@ -47,9 +47,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/jpeg/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/jpeg/packet/media_srcs.cmake
+index 5db85359b..87878c1e3 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/jpeg/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/jpeg/packet/media_srcs.cmake
+@@ -42,6 +42,8 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_JPEG_PRIVATE_INCLUDE_DIRS_
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/jpeg/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/jpeg/pipeline/media_srcs.cmake
+index 9b958e478..5fc490c1d 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/jpeg/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/jpeg/pipeline/media_srcs.cmake
+@@ -46,9 +46,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/bitstreamWriter/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/bitstreamWriter/media_srcs.cmake
+index bf644c2c4..f78071a6c 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/bitstreamWriter/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/bitstreamWriter/media_srcs.cmake
+@@ -42,9 +42,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/media_srcs.cmake
+index 41ff2844f..96aecc9a6 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/media_srcs.cmake
+@@ -52,9 +52,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/features/media_srcs.cmake
+index 591f269ef..2352cdf44 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/features/media_srcs.cmake
+@@ -54,9 +54,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/media_srcs.cmake
+index f0d449023..d5e2a3b46 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/media_srcs.cmake
+@@ -43,9 +43,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_HEADERS_} )
+ 
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/mmc/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/mmc/media_srcs.cmake
+index 3ad2f687a..faa317fec 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/mmc/media_srcs.cmake
+@@ -36,6 +36,8 @@ set(SOFTLET_ENCODE_COMMON_SOURCES_
+     ${TMP_SOURCES_}
+ )
+ 
++media_add_curr_to_include_path()
++
+ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ 
+ set(TMP_SOURCES_ "")
+@@ -44,4 +46,4 @@ set(TMP_HEADERS_ "")
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/packet/media_srcs.cmake
+index f86a68d0c..62177c940 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/packet/media_srcs.cmake
+@@ -46,9 +46,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/pipeline/media_srcs.cmake
+index 6bb45c997..c27e10c4b 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/pipeline/media_srcs.cmake
+@@ -44,9 +44,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/scalability/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/scalability/media_srcs.cmake
+index 31ef7cb7c..89a3fa893 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/scalability/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/scalability/media_srcs.cmake
+@@ -47,9 +47,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
 diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/statusreport/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/statusreport/media_srcs.cmake
-index 0800891e6..64dbc62eb 100644
+index 0800891e6..fe01fc7c8 100644
 --- a/media_softlet/agnostic/common/codec/hal/enc/shared/statusreport/media_srcs.cmake
 +++ b/media_softlet/agnostic/common/codec/hal/enc/shared/statusreport/media_srcs.cmake
-@@ -49,3 +49,4 @@ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+@@ -43,9 +43,12 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
      ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
      ${CMAKE_CURRENT_LIST_DIR}
  )
 +media_add_curr_to_include_path()
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/vp9/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/vp9/features/media_srcs.cmake
+index be7e6e31e..02a7b610f 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/vp9/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/vp9/features/media_srcs.cmake
+@@ -59,9 +59,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
 \ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/vp9/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/vp9/packet/media_srcs.cmake
+index bec8c435f..b446d426b 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/vp9/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/vp9/packet/media_srcs.cmake
+@@ -52,9 +52,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/vp9/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/vp9/pipeline/media_srcs.cmake
+index 17179bf07..b08b47f85 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/vp9/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/vp9/pipeline/media_srcs.cmake
+@@ -46,6 +46,8 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+ 
++media_add_curr_to_include_path()
++
+ endif()
+ 
+ set(SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_
+diff --git a/media_softlet/agnostic/common/codec/hal/shared/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/shared/media_srcs.cmake
+index 6e2f41acd..c4031c666 100644
+--- a/media_softlet/agnostic/common/codec/hal/shared/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/shared/media_srcs.cmake
+@@ -43,6 +43,8 @@ set(SOFTLET_CODEC_COMMON_HEADERS_
+     ${TMP_HEADERS_}
+ )
+ 
++media_add_curr_to_include_path()
++
+ source_group( CodecHalNext\\Shared FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(TMP_SOURCES_ "")
+ set(TMP_HEADERS_ "")
+diff --git a/media_softlet/agnostic/common/cp/media_srcs.cmake b/media_softlet/agnostic/common/cp/media_srcs.cmake
+index 32887f8db..65a106799 100644
+--- a/media_softlet/agnostic/common/cp/media_srcs.cmake
++++ b/media_softlet/agnostic/common/cp/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${CMAKE_CURRENT_LIST_DIR}/cp_copy_interface.cpp
+ )
+@@ -68,4 +70,4 @@ set(SOFTLET_COMMON_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/heap_manager/media_srcs.cmake b/media_softlet/agnostic/common/heap_manager/media_srcs.cmake
+index 95d9875a1..16ecbe512 100644
+--- a/media_softlet/agnostic/common/heap_manager/media_srcs.cmake
++++ b/media_softlet/agnostic/common/heap_manager/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${CMAKE_CURRENT_LIST_DIR}/heap.cpp
+     ${CMAKE_CURRENT_LIST_DIR}/heap_manager.cpp
+@@ -36,4 +38,4 @@ source_group( "Common Files" FILES ${TMP_SOURCES_} )
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
 diff --git a/media_softlet/agnostic/common/hw/media_srcs.cmake b/media_softlet/agnostic/common/hw/media_srcs.cmake
 index 67d384c2a..bb6ac71a2 100644
 --- a/media_softlet/agnostic/common/hw/media_srcs.cmake
@@ -4789,35 +7270,39 @@ index 25254a832..7a6261827 100644
 +
 +media_add_curr_to_include_path()
 diff --git a/media_softlet/agnostic/common/os/media_srcs.cmake b/media_softlet/agnostic/common/os/media_srcs.cmake
-index 91e56f3fe..98d0c1e81 100644
+index 8cba88625..96a25c9de 100644
 --- a/media_softlet/agnostic/common/os/media_srcs.cmake
 +++ b/media_softlet/agnostic/common/os/media_srcs.cmake
-@@ -92,4 +92,5 @@ set(SOFTLET_MOS_PUBLIC_INCLUDE_DIRS_
-     ${CMAKE_CURRENT_LIST_DIR}
+@@ -106,3 +106,4 @@ set(SOFTLET_COMMON_DLL_PRIVATE_INCLUDE_DIRS_
  )
  
+ source_group( "mos_softlet" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} ${TMP_MOS_HAL_SHARED_SOURCES_} )
 +media_add_curr_to_include_path()
- source_group( "mos_softlet" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
-diff --git a/media_softlet/agnostic/common/os/user_setting/media_srcs.cmake b/media_softlet/agnostic/common/os/user_setting/media_srcs.cmake
-index 8adcfd108..faca53fbf 100644
---- a/media_softlet/agnostic/common/os/user_setting/media_srcs.cmake
-+++ b/media_softlet/agnostic/common/os/user_setting/media_srcs.cmake
-@@ -33,10 +33,13 @@ set(TMP_SHARED_SOURCES_
-     ${CMAKE_CURRENT_LIST_DIR}/media_user_setting_value.cpp
- )
+diff --git a/media_softlet/agnostic/common/os/share/media_srcs.cmake b/media_softlet/agnostic/common/os/share/media_srcs.cmake
+index 51d6a396e..994c597c2 100644
+--- a/media_softlet/agnostic/common/os/share/media_srcs.cmake
++++ b/media_softlet/agnostic/common/os/share/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
  
-+source_group( "Common Files" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
 +media_add_curr_to_include_path()
 +
- set(SOFTLET_COMMON_HAL_DDI_SHARED_SOURCES_
-     ${SOFTLET_COMMON_HAL_DDI_SHARED_SOURCES_}
+ set(TMP_SOURCES_
+     ${CMAKE_CURRENT_LIST_DIR}/mos_oca_util_debug.cpp
+ )
+diff --git a/media_softlet/agnostic/common/os/user_setting/media_srcs.cmake b/media_softlet/agnostic/common/os/user_setting/media_srcs.cmake
+index 3e115031b..ff87df2ca 100644
+--- a/media_softlet/agnostic/common/os/user_setting/media_srcs.cmake
++++ b/media_softlet/agnostic/common/os/user_setting/media_srcs.cmake
+@@ -39,4 +39,5 @@ set(SOFTLET_COMMON_DLL_SOURCES_
      ${TMP_SHARED_SOURCES_}
  )
  
- source_group( "mos_softlet" FILES ${TMP_SOURCES_})
--source_group( "Hal_DDI_Shared" FILES ${TMP_SHARED_SOURCES_})
+-source_group( "mos_softlet" FILES ${TMP_SOURCES_} ${TMP_SHARED_SOURCES_})
 \ No newline at end of file
-+source_group( "Hal_DDI_Shared" FILES ${TMP_SHARED_SOURCES_})
++source_group( "mos_softlet" FILES ${TMP_SOURCES_} ${TMP_SHARED_SOURCES_})
++media_add_curr_to_include_path()
 diff --git a/media_softlet/agnostic/common/renderhal/media_srcs.cmake b/media_softlet/agnostic/common/renderhal/media_srcs.cmake
 index 33eb9908d..0d59e6fd7 100644
 --- a/media_softlet/agnostic/common/renderhal/media_srcs.cmake
@@ -4830,11 +7315,64 @@ index 33eb9908d..0d59e6fd7 100644
 \ No newline at end of file
 +)
 +media_add_curr_to_include_path()
+diff --git a/media_softlet/agnostic/common/shared/bufferMgr/media_srcs.cmake b/media_softlet/agnostic/common/shared/bufferMgr/media_srcs.cmake
+index d29444c80..bd2417d55 100644
+--- a/media_softlet/agnostic/common/shared/bufferMgr/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/bufferMgr/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${TMP_SOURCES_}
+     ${CMAKE_CURRENT_LIST_DIR}/media_allocator.cpp
+diff --git a/media_softlet/agnostic/common/shared/features/media_srcs.cmake b/media_softlet/agnostic/common/shared/features/media_srcs.cmake
+index 61c017abd..ec4a19799 100644
+--- a/media_softlet/agnostic/common/shared/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/features/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${TMP_SOURCES_}
+     ${CMAKE_CURRENT_LIST_DIR}/media_feature.cpp
+@@ -34,4 +36,4 @@ set(TMP_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/shared/media_sfc_interface/media_srcs.cmake b/media_softlet/agnostic/common/shared/media_sfc_interface/media_srcs.cmake
+index 2df90d4fa..cab44a445 100644
+--- a/media_softlet/agnostic/common/shared/media_sfc_interface/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/media_sfc_interface/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${TMP_SOURCES_}
+     ${CMAKE_CURRENT_LIST_DIR}/media_sfc_interface.cpp
+@@ -35,4 +37,4 @@ set(TMP_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
 diff --git a/media_softlet/agnostic/common/shared/media_srcs.cmake b/media_softlet/agnostic/common/shared/media_srcs.cmake
-index b1611eaf4..1883e0886 100644
+index 4e585903e..8f07f9e4e 100644
 --- a/media_softlet/agnostic/common/shared/media_srcs.cmake
 +++ b/media_softlet/agnostic/common/shared/media_srcs.cmake
-@@ -76,4 +76,6 @@ source_group(SharedNext\\shared FILES ${TMP_HEADERS_} ${TMP_SOURCES_})
+@@ -78,4 +78,6 @@ source_group(SharedNext\\shared FILES ${TMP_HEADERS_} ${TMP_SOURCES_})
  set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
      ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
      ${CMAKE_CURRENT_LIST_DIR}
@@ -4855,6 +7393,99 @@ index 62dbdaedc..08052b1b8 100644
 \ No newline at end of file
 +)
 +media_add_curr_to_include_path()
+diff --git a/media_softlet/agnostic/common/shared/mediacopy/media_srcs.cmake b/media_softlet/agnostic/common/shared/mediacopy/media_srcs.cmake
+index cf6422371..884b598cf 100644
+--- a/media_softlet/agnostic/common/shared/mediacopy/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/mediacopy/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${TMP_SOURCES_}
+     ${CMAKE_CURRENT_LIST_DIR}/media_copy.cpp
+@@ -40,4 +42,4 @@ set(TMP_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/shared/mmc/media_srcs.cmake b/media_softlet/agnostic/common/shared/mmc/media_srcs.cmake
+index afbadafbe..11d9367b8 100644
+--- a/media_softlet/agnostic/common/shared/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/mmc/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${TMP_SOURCES_}
+     ${CMAKE_CURRENT_LIST_DIR}/media_mem_compression.cpp
+@@ -33,4 +35,4 @@ set(TMP_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/shared/packet/media_srcs.cmake b/media_softlet/agnostic/common/shared/packet/media_srcs.cmake
+index ef504496c..8aa2dcf23 100644
+--- a/media_softlet/agnostic/common/shared/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/packet/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${TMP_SOURCES_}
+     ${CMAKE_CURRENT_LIST_DIR}/media_cmd_packet.cpp
+@@ -34,4 +36,4 @@ set(TMP_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/shared/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/shared/pipeline/media_srcs.cmake
+index ee778547c..3efff8db2 100644
+--- a/media_softlet/agnostic/common/shared/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/pipeline/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${TMP_SOURCES_}
+     ${CMAKE_CURRENT_LIST_DIR}/media_pipeline.cpp
+@@ -32,4 +34,4 @@ set(TMP_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/agnostic/common/shared/profiler/media_srcs.cmake b/media_softlet/agnostic/common/shared/profiler/media_srcs.cmake
+index dc5233b33..b0c0d7f68 100644
+--- a/media_softlet/agnostic/common/shared/profiler/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/profiler/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${TMP_SOURCES_}
+     ${CMAKE_CURRENT_LIST_DIR}/media_perf_profiler.cpp
 diff --git a/media_softlet/agnostic/common/shared/scalability/media_srcs.cmake b/media_softlet/agnostic/common/shared/scalability/media_srcs.cmake
 index 9a990f3eb..67c7cf6b5 100644
 --- a/media_softlet/agnostic/common/shared/scalability/media_srcs.cmake
@@ -4864,6 +7495,38 @@ index 9a990f3eb..67c7cf6b5 100644
      ${CMAKE_CURRENT_LIST_DIR}
  )
 +media_add_curr_to_include_path()
+diff --git a/media_softlet/agnostic/common/shared/statusreport/media_srcs.cmake b/media_softlet/agnostic/common/shared/statusreport/media_srcs.cmake
+index 7b0ff3531..d4a4ee674 100644
+--- a/media_softlet/agnostic/common/shared/statusreport/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/statusreport/media_srcs.cmake
+@@ -18,6 +18,7 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
+ 
+ set(TMP_SOURCES_
+     ${TMP_SOURCES_}
+diff --git a/media_softlet/agnostic/common/shared/task/media_srcs.cmake b/media_softlet/agnostic/common/shared/task/media_srcs.cmake
+index 37a5d9a57..87cc1cbfa 100644
+--- a/media_softlet/agnostic/common/shared/task/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/task/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${TMP_SOURCES_}
+     ${CMAKE_CURRENT_LIST_DIR}/media_task.cpp
+@@ -33,4 +35,4 @@ set(TMP_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
 diff --git a/media_softlet/agnostic/common/vp/cm_fc_ld/media_srcs.cmake b/media_softlet/agnostic/common/vp/cm_fc_ld/media_srcs.cmake
 index c4bb0a7dd..021313a6b 100644
 --- a/media_softlet/agnostic/common/vp/cm_fc_ld/media_srcs.cmake
@@ -4888,10 +7551,10 @@ index 5ac1ca5ae..a1e4b5488 100644
 +
 +media_add_curr_to_include_path()
 diff --git a/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_allocator.cpp b/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_allocator.cpp
-index 36e119f63..74f135b09 100644
+index 2273915bf..4902c78a5 100644
 --- a/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_allocator.cpp
 +++ b/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_allocator.cpp
-@@ -711,7 +711,7 @@ MOS_STATUS VpAllocator::AllocParamsInitType(
+@@ -710,7 +710,7 @@ MOS_STATUS VpAllocator::AllocParamsInitType(
      VP_FUNC_CALL();
      VP_PUBLIC_CHK_NULL_RETURN(surface);
  
@@ -5014,6 +7677,26 @@ index e03c24c2f..fc626cd71 100644
 +)
 +
 +media_add_curr_to_include_path()
+diff --git a/media_softlet/agnostic/common/vp/hal/utils/hal_ddi_share/media_srcs.cmake b/media_softlet/agnostic/common/vp/hal/utils/hal_ddi_share/media_srcs.cmake
+index 478d8355c..ad5b13d39 100644
+--- a/media_softlet/agnostic/common/vp/hal/utils/hal_ddi_share/media_srcs.cmake
++++ b/media_softlet/agnostic/common/vp/hal/utils/hal_ddi_share/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${CMAKE_CURRENT_LIST_DIR}/vp_hal_ddi_utils.cpp
+     ${CMAKE_CURRENT_LIST_DIR}/vp_user_setting.cpp
+@@ -60,4 +62,4 @@ set(SOFTLET_VP_HAL_DDI_SHARED_INCLUDE_DIRS_
+ 
+ source_group( VpHalNext\\Shared FILES ${TMP_SOURCES_} ${TMP_HEADERS_})
+ set(TMP_SOURCES_ "")
+-set(TMP_HEADERS_ "")
+\ No newline at end of file
++set(TMP_HEADERS_ "")
 diff --git a/media_softlet/agnostic/common/vp/hal/utils/media_srcs.cmake b/media_softlet/agnostic/common/vp/hal/utils/media_srcs.cmake
 index ae20dcc2f..659553be8 100644
 --- a/media_softlet/agnostic/common/vp/hal/utils/media_srcs.cmake
@@ -5037,6 +7720,105 @@ index 7b43fec5c..1a7b12198 100644
  )
 +
 +media_add_curr_to_include_path()
+diff --git a/media_softlet/linux/common/codec/ddi/dec/media_srcs.cmake b/media_softlet/linux/common/codec/ddi/dec/media_srcs.cmake
+index e693d6d53..99e1dc76b 100644
+--- a/media_softlet/linux/common/codec/ddi/dec/media_srcs.cmake
++++ b/media_softlet/linux/common/codec/ddi/dec/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${CMAKE_CURRENT_LIST_DIR}/ddi_decode_functions.cpp
+     ${CMAKE_CURRENT_LIST_DIR}/ddi_decode_base_specific.cpp
+@@ -120,4 +122,4 @@ set(SOFTLET_DDI_HEADERS_
+ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/linux/common/codec/ddi/enc/media_srcs.cmake b/media_softlet/linux/common/codec/ddi/enc/media_srcs.cmake
+index 532b1125a..7d05414da 100644
+--- a/media_softlet/linux/common/codec/ddi/enc/media_srcs.cmake
++++ b/media_softlet/linux/common/codec/ddi/enc/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${CMAKE_CURRENT_LIST_DIR}/ddi_encode_functions.cpp
+     ${CMAKE_CURRENT_LIST_DIR}/ddi_encode_base_specific.cpp
+diff --git a/media_softlet/linux/common/codec/ddi/shared/media_srcs.cmake b/media_softlet/linux/common/codec/ddi/shared/media_srcs.cmake
+index ab1b9707a..9069ec576 100644
+--- a/media_softlet/linux/common/codec/ddi/shared/media_srcs.cmake
++++ b/media_softlet/linux/common/codec/ddi/shared/media_srcs.cmake
+@@ -27,6 +27,8 @@ set(TMP_HEADERS_
+     ${CMAKE_CURRENT_LIST_DIR}/ddi_codec_base_specific.h
+ )
+ 
++media_add_curr_to_include_path()
++
+ if(NOT "${Media_Reserved}" STREQUAL "yes")
+     set(TMP_SOURCES_
+             ${TMP_SOURCES_}
+@@ -48,4 +50,4 @@ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+-endif()
+\ No newline at end of file
++endif()
+diff --git a/media_softlet/linux/common/cp/ddi/media_srcs.cmake b/media_softlet/linux/common/cp/ddi/media_srcs.cmake
+index b3fb45fad..07a4cd64f 100644
+--- a/media_softlet/linux/common/cp/ddi/media_srcs.cmake
++++ b/media_softlet/linux/common/cp/ddi/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${CMAKE_CURRENT_LIST_DIR}/ddi_cp_caps_interface.cpp
+     ${CMAKE_CURRENT_LIST_DIR}/ddi_cp_interface_next.cpp
+diff --git a/media_softlet/linux/common/cp/media_srcs.cmake b/media_softlet/linux/common/cp/media_srcs.cmake
+index 6ea27109b..dd34d2c98 100644
+--- a/media_softlet/linux/common/cp/media_srcs.cmake
++++ b/media_softlet/linux/common/cp/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(CP_COMMON_SHARED_SOURCES_
+     ${CP_COMMON_SHARED_SOURCES_}
+     ${CMAKE_CURRENT_LIST_DIR}/decodecp_interface.cpp
+diff --git a/media_softlet/linux/common/ddi/media_srcs.cmake b/media_softlet/linux/common/ddi/media_srcs.cmake
+index 5c488766f..dc87b9d78 100644
+--- a/media_softlet/linux/common/ddi/media_srcs.cmake
++++ b/media_softlet/linux/common/ddi/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${CMAKE_CURRENT_LIST_DIR}/media_libva_util_next.cpp
+     ${CMAKE_CURRENT_LIST_DIR}/ddi_media_functions.cpp
+@@ -54,4 +56,4 @@ set(SOFTLET_DDI_HEADERS_
+ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
 diff --git a/media_softlet/linux/common/os/i915/include/media_srcs.cmake b/media_softlet/linux/common/os/i915/include/media_srcs.cmake
 index 6b5cb8efd..0b6dd3536 100644
 --- a/media_softlet/linux/common/os/i915/include/media_srcs.cmake
@@ -5142,6 +7924,125 @@ index 946fc178b..1fbaeaab1 100644
  #else
  #define USER_FEATURE_FILE                   "/etc/igfx_user_feature.txt"
  #define USER_FEATURE_FILE_NEXT              "/etc/igfx_user_feature_next.txt"
+diff --git a/media_softlet/linux/common/vp/ddi/media_srcs.cmake b/media_softlet/linux/common/vp/ddi/media_srcs.cmake
+index bf57d3277..271e0be8d 100644
+--- a/media_softlet/linux/common/vp/ddi/media_srcs.cmake
++++ b/media_softlet/linux/common/vp/ddi/media_srcs.cmake
+@@ -18,6 +18,8 @@
+ # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
++media_add_curr_to_include_path()
++
+ set(TMP_SOURCES_
+     ${CMAKE_CURRENT_LIST_DIR}/ddi_vp_functions.cpp
+     ${CMAKE_CURRENT_LIST_DIR}/ddi_vp_tools.cpp
+diff --git a/media_softlet/linux/xe_lpm_plus_r0/ddi/media_srcs.cmake b/media_softlet/linux/xe_lpm_plus_r0/ddi/media_srcs.cmake
+index 996feb4c3..e5b26595a 100644
+--- a/media_softlet/linux/xe_lpm_plus_r0/ddi/media_srcs.cmake
++++ b/media_softlet/linux/xe_lpm_plus_r0/ddi/media_srcs.cmake
+@@ -27,7 +27,9 @@ set(SOFTLET_DDI_HEADERS_
+     ${TMP_HEADERS_}
+ )
+ 
++media_add_curr_to_include_path()
++
+ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/linux/xe_lpm_plus_r0/encode/av1/ddi/media_srcs.cmake b/media_softlet/linux/xe_lpm_plus_r0/encode/av1/ddi/media_srcs.cmake
+index a4de5a6e0..6a0ecc52b 100644
+--- a/media_softlet/linux/xe_lpm_plus_r0/encode/av1/ddi/media_srcs.cmake
++++ b/media_softlet/linux/xe_lpm_plus_r0/encode/av1/ddi/media_srcs.cmake
+@@ -27,6 +27,8 @@ set (SOFTLET_DDI_HEADERS_
+     ${TMP_HEADERS_}
+ )
+ 
++media_add_curr_to_include_path()
++
+ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+diff --git a/media_softlet/linux/xe_lpm_plus_r0/encode/avc/ddi/media_srcs.cmake b/media_softlet/linux/xe_lpm_plus_r0/encode/avc/ddi/media_srcs.cmake
+index cde7f976a..a95bf9eda 100644
+--- a/media_softlet/linux/xe_lpm_plus_r0/encode/avc/ddi/media_srcs.cmake
++++ b/media_softlet/linux/xe_lpm_plus_r0/encode/avc/ddi/media_srcs.cmake
+@@ -27,7 +27,9 @@ set (SOFTLET_DDI_HEADERS_
+     ${TMP_HEADERS_}
+ )
+ 
++media_add_curr_to_include_path()
++
+ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/linux/xe_lpm_plus_r0/encode/hevc/ddi/media_srcs.cmake b/media_softlet/linux/xe_lpm_plus_r0/encode/hevc/ddi/media_srcs.cmake
+index 474f57d53..6b2befd53 100644
+--- a/media_softlet/linux/xe_lpm_plus_r0/encode/hevc/ddi/media_srcs.cmake
++++ b/media_softlet/linux/xe_lpm_plus_r0/encode/hevc/ddi/media_srcs.cmake
+@@ -27,7 +27,9 @@ set (SOFTLET_DDI_HEADERS_
+     ${TMP_HEADERS_}
+ )
+ 
++media_add_curr_to_include_path()
++
+ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/linux/xe_lpm_plus_r0/encode/jpeg/ddi/media_srcs.cmake b/media_softlet/linux/xe_lpm_plus_r0/encode/jpeg/ddi/media_srcs.cmake
+index bdf7b50b1..bf7cf972d 100644
+--- a/media_softlet/linux/xe_lpm_plus_r0/encode/jpeg/ddi/media_srcs.cmake
++++ b/media_softlet/linux/xe_lpm_plus_r0/encode/jpeg/ddi/media_srcs.cmake
+@@ -27,6 +27,8 @@ set (SOFTLET_DDI_HEADERS_
+     ${TMP_HEADERS_}
+ )
+ 
++media_add_curr_to_include_path()
++
+ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+diff --git a/media_softlet/linux/xe_lpm_plus_r0/encode/vp9/ddi/media_srcs.cmake b/media_softlet/linux/xe_lpm_plus_r0/encode/vp9/ddi/media_srcs.cmake
+index cd3c3530b..58b160323 100644
+--- a/media_softlet/linux/xe_lpm_plus_r0/encode/vp9/ddi/media_srcs.cmake
++++ b/media_softlet/linux/xe_lpm_plus_r0/encode/vp9/ddi/media_srcs.cmake
+@@ -27,7 +27,9 @@ set (SOFTLET_DDI_HEADERS_
+     ${TMP_HEADERS_}
+ )
+ 
++media_add_curr_to_include_path()
++
+ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
+diff --git a/media_softlet/linux/xe_lpm_plus_r0/vp/ddi/media_srcs.cmake b/media_softlet/linux/xe_lpm_plus_r0/vp/ddi/media_srcs.cmake
+index 60d8dd454..5783faad4 100644
+--- a/media_softlet/linux/xe_lpm_plus_r0/vp/ddi/media_srcs.cmake
++++ b/media_softlet/linux/xe_lpm_plus_r0/vp/ddi/media_srcs.cmake
+@@ -27,7 +27,9 @@ set(SOFTLET_DDI_HEADERS_
+     ${TMP_HEADERS_}
+ )
+ 
++media_add_curr_to_include_path()
++
+ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
 diff --git a/media_softlet/media_interface/media_interfaces_mtl/media_srcs.cmake b/media_softlet/media_interface/media_interfaces_mtl/media_srcs.cmake
 index 15c3d1e36..5ff007de8 100644
 --- a/media_softlet/media_interface/media_interfaces_mtl/media_srcs.cmake
@@ -5157,5 +8058,5 @@ index 15c3d1e36..5ff007de8 100644
 +media_add_curr_to_include_path()
 +
 -- 
-2.17.1
+2.40.1
 

--- a/bsp_diff/common/hardware/intel/media-driver/0002-Resolved-compilation-issue-for-media-driver.patch
+++ b/bsp_diff/common/hardware/intel/media-driver/0002-Resolved-compilation-issue-for-media-driver.patch
@@ -1,25 +1,29 @@
-From d1ba46a7588d1502fd7f6f7e231ab8c72d74eed6 Mon Sep 17 00:00:00 2001
-From: yerriswamy <yerriswamy.kt@intel.com>
-Date: Thu, 16 Mar 2023 14:58:41 +0530
+From 5af20ebc58c0cde441e63e15ddf832491ceb1a98 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Tue, 30 May 2023 22:01:00 +0530
 Subject: [PATCH] Resolved compilation issue for media driver
 
 Changes include:
 - Added Android flag to disable error mode similar to Linux
+- Added header file for errno
+- Added include path for libva and cmrtlib
+- Removed files resulting in duplicate symbol
 
 Change-Id: Ia54ad1d036783dabca1b18c2bade9f882b56a8a0
 Tracked-On: OAM-106860
 Signed-off-by: Ratnesh Kumar Rai <ratnesh.kumar.rai@intel.com>
 Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
 ---
- cmrtlib/linux/hardware/cm_device_os.cpp       |   6 +-
- media_driver/Android.mk                       | 174 +++++++++++++++++-
- .../common/vp/kdll/hal_kerneldll_next.c       |   5 +-
- .../ddi/media_libva_caps_mtl_base.cpp         |   1 +
- .../os/osservice/mos_utilities_specific.cpp   |   2 +
- 5 files changed, 179 insertions(+), 9 deletions(-)
+ cmrtlib/linux/hardware/cm_device_os.cpp                   | 6 ++++--
+ media_driver/Android.mk                                   | 8 ++------
+ .../agnostic/common/vp/kdll/hal_kerneldll_next.c          | 7 ++++---
+ .../linux/Xe_M_plus/ddi/media_libva_caps_mtl_base.cpp     | 1 +
+ media_softlet/linux/common/os/i915/include/mos_bufmgr.h   | 1 +
+ .../linux/common/os/osservice/mos_utilities_specific.cpp  | 2 ++
+ 6 files changed, 14 insertions(+), 11 deletions(-)
 
 diff --git a/cmrtlib/linux/hardware/cm_device_os.cpp b/cmrtlib/linux/hardware/cm_device_os.cpp
-index 36b98c13a..e21292283 100644
+index 36b98c13a..d63221f8f 100644
 --- a/cmrtlib/linux/hardware/cm_device_os.cpp
 +++ b/cmrtlib/linux/hardware/cm_device_os.cpp
 @@ -495,8 +495,10 @@ CmDevice_RT::CmDevice_RT(
@@ -30,24 +34,24 @@ index 36b98c13a..e21292283 100644
 -    m_driFileDescriptor(0)
 +    m_driverStoreEnabled(0)
 +#ifndef ANDROID
-+    ,m_driFileDescriptor(0)
++    , m_driFileDescriptor(0)
 +#endif
  {
  
      // New Surface Manager
 diff --git a/media_driver/Android.mk b/media_driver/Android.mk
-index 85d54edbf..21656e4e0 100644
+index 4bb53a2ae..e43b85c36 100644
 --- a/media_driver/Android.mk
 +++ b/media_driver/Android.mk
-@@ -424,7 +424,6 @@ LOCAL_SRC_FILES := \
-     ../media_softlet/agnostic/common/os/mos_user_setting.cpp \
+@@ -427,7 +427,6 @@ LOCAL_SRC_FILES := \
      ../media_softlet/agnostic/common/os/mos_util_debug.cpp \
+     ../media_softlet/agnostic/common/os/mos_utilities_inner.cpp \
      ../media_softlet/agnostic/common/os/mos_utilities_next.cpp \
 -    ../media_softlet/agnostic/common/os/private/mos_utilities_usersetting.cpp \
+     ../media_softlet/agnostic/common/os/share/mos_oca_util_debug.cpp \
      ../media_softlet/agnostic/common/os/user_setting/media_user_setting.cpp \
      ../media_softlet/agnostic/common/os/user_setting/media_user_setting_configure.cpp \
-     ../media_softlet/agnostic/common/os/user_setting/media_user_setting_definition.cpp \
-@@ -591,10 +590,6 @@ LOCAL_SRC_FILES := \
+@@ -596,10 +595,6 @@ LOCAL_SRC_FILES := \
      ../media_softlet/linux/common/os/mos_vma.c \
      ../media_softlet/linux/common/os/osservice/mos_util_debug_specific.cpp \
      ../media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp \
@@ -58,191 +62,18 @@ index 85d54edbf..21656e4e0 100644
      ../media_softlet/linux/common/os/user_setting/media_user_setting_configure_specific.cpp \
      ../media_softlet/linux/common/shared/hal_oca_interface_next.cpp \
      ../media_softlet/linux/common/shared/skuwa_dumper_specific.c \
-@@ -1532,6 +1527,7 @@ LOCAL_C_INCLUDES  = \
-     $(LOCAL_PATH)/../media_common/agnostic/common/hw \
-     $(LOCAL_PATH)/../media_common/agnostic/common/media_interfaces \
-     $(LOCAL_PATH)/../media_common/agnostic/common/os \
-+    $(LOCAL_PATH)/../media_common/agnostic/common/os/user_setting \
-     $(LOCAL_PATH)/../media_common/agnostic/common/renderhal \
-     $(LOCAL_PATH)/../media_common/agnostic/common/shared \
-     $(LOCAL_PATH)/../media_common/agnostic/common/vp/hal \
-@@ -1807,6 +1803,174 @@ LOCAL_C_INCLUDES  = \
+@@ -1978,7 +1973,8 @@ LOCAL_C_INCLUDES  = \
      $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/decode/vp8/ddi \
      $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/decode/vp9/ddi \
      $(LOCAL_PATH)/../media_softlet/media_interface/media_interfaces_mtl \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/shared \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/cp \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/vp/hal/utils/hal_ddi_share \
-+    $(LOCAL_PATH)/../media_softlet/linux/common/vp/ddi \
-+    $(LOCAL_PATH)/../media_softlet/linux/common/ddi \
-+    $(LOCAL_PATH)/../media_softlet/linux/common/codec/ddi/shared \
-+    $(LOCAL_PATH)/../media_softlet/linux/common/codec/ddi/enc \
-+    $(LOCAL_PATH)/../media_softlet/linux/common/codec/ddi/dec \
-+    $(LOCAL_PATH)/../media_softlet/linux/common/cp \
-+    $(LOCAL_PATH)/../media_softlet/linux/common/cp/ddi \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/profiler \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/media_sfc_interface \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/mediacopy \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/statusreport \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/mmc \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/bufferMgr \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/task \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/shared/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/avc/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/avc/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/avc/features/roi \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/avc/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/avc/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/avc/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared/bitstreamWriter \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/jpeg/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared/mmc \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared/scalability \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/hevc/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/av1 \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/av1/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/av1/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/av1/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/hevc/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/hevc/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/hevc/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/hevc/features/roi \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/shared/statusreport \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/vp9/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/vp9/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/vp9/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/jpeg/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/enc/jpeg/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/avc/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared/hucItf \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared/statusreport \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared/mmc \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/mpeg2/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/mpeg2/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/mpeg2/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/mpeg2/mmc \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp9/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp9/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp9/mmc \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp9/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp9/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp9/scalability \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp8/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp8/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp8/mmc \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/vp8/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/hevc/scalability \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/jpeg/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/jpeg/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/jpeg/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/avc/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/hevc/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/hevc/scalability \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared/scalability \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/shared/bufferMgr \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/hevc/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/hevc/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/hevc/mmc \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/avc/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/av1/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/av1/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/av1/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/codec/hal/dec/jpeg/bitstream \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/jpeg/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/feature_manager \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediacopy \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/feature_manager \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediaDecompress \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/mmc \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/mmc \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/preenc \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/mmc \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/preenc \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/shared/common \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/vdbox \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/shared \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/mmc \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/shared \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/avc/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/hevc/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/feature_manager \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/av1/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/mpeg2 \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp9/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp8/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp9/pipeline \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/platform_interface \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/packet \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/features \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/jpeg \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/mpeg2 \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw \
-+    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/encode/jpeg/ddi \
-+    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/encode/hevc/ddi \
-+    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/encode/vp9/ddi \
-+    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/encode/av1/ddi \
-+    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/ddi \
-+    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/vp/ddi \
-+    $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/encode/avc/ddi \
-+    $(LOCAL_PATH)/../media_softlet/agnostic/common/media_bin_mgr \
-+    $(LOCAL_PATH)/../media_common/linux/common/cp/ddi \
-+    $(LOCAL_PATH)/../media_common/linux/common/codec \
-+    $(LOCAL_PATH)/media_softlet/agnostic/Xe_M/Xe_XPM_base/hw \
+-
 +    $(LOCAL_PATH)/../../libva/va \
 +    $(LOCAL_PATH)/../cmrtlib/linux/hardware
  
- 
  #LOCAL_CPP_FEATURES := rtti exceptions
+ 
 diff --git a/media_softlet/agnostic/common/vp/kdll/hal_kerneldll_next.c b/media_softlet/agnostic/common/vp/kdll/hal_kerneldll_next.c
-index 4f6e97798..5b6a72085 100644
+index 4f6e97798..28c5db050 100644
 --- a/media_softlet/agnostic/common/vp/kdll/hal_kerneldll_next.c
 +++ b/media_softlet/agnostic/common/vp/kdll/hal_kerneldll_next.c
 @@ -3864,6 +3864,7 @@ bool KernelDll_BuildKernel_CmFc(Kdll_State *pState, Kdll_SearchState *pSearchSta
@@ -271,8 +102,15 @@ index 4f6e97798..5b6a72085 100644
      ::SetErrorMode(prevErrorMode);
  #endif
      return res;
+@@ -4400,4 +4401,4 @@ bool KernelDll_SetupFunctionPointers_Ext(
+ 
+ #ifdef __cplusplus
+ }
+-#endif  // __cplusplus
+\ No newline at end of file
++#endif  // __cplusplus
 diff --git a/media_softlet/linux/Xe_M_plus/ddi/media_libva_caps_mtl_base.cpp b/media_softlet/linux/Xe_M_plus/ddi/media_libva_caps_mtl_base.cpp
-index 03967c45d..f3cac227f 100644
+index e488e8fc0..0a6cde6d9 100644
 --- a/media_softlet/linux/Xe_M_plus/ddi/media_libva_caps_mtl_base.cpp
 +++ b/media_softlet/linux/Xe_M_plus/ddi/media_libva_caps_mtl_base.cpp
 @@ -37,6 +37,7 @@
@@ -283,6 +121,18 @@ index 03967c45d..f3cac227f 100644
  
  const VAImageFormat m_supportedImageformatsXe_Lpm_Plus_Base[] =
  {   {VA_FOURCC_BGRA,           VA_LSB_FIRST,   32, 32, 0x0000ff00, 0x00ff0000, 0xff000000,  0x000000ff}, /* [31:0] B:G:R:A 8:8:8:8 little endian */
+diff --git a/media_softlet/linux/common/os/i915/include/mos_bufmgr.h b/media_softlet/linux/common/os/i915/include/mos_bufmgr.h
+index 9c96dff44..5b08067a9 100644
+--- a/media_softlet/linux/common/os/i915/include/mos_bufmgr.h
++++ b/media_softlet/linux/common/os/i915/include/mos_bufmgr.h
+@@ -34,6 +34,7 @@
+ #ifndef MOS_BUFMGR_H
+ #define MOS_BUFMGR_H
+ 
++#include <errno.h>
+ #include <stdio.h>
+ #include <stdint.h>
+ #include <stdio.h>
 diff --git a/media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp b/media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp
 index 97ad15c62..6090a49aa 100644
 --- a/media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp
@@ -304,5 +154,5 @@ index 97ad15c62..6090a49aa 100644
      }
      return;
 -- 
-2.17.1
+2.40.1
 

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0001-Changes-for-OneVPL-integration.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0001-Changes-for-OneVPL-integration.patch
@@ -1,4 +1,4 @@
-From 647c5c3a7b73abe7e760eae94f057863474e06cb Mon Sep 17 00:00:00 2001
+From 2a2f7b0c18aecdaa930c4bfe43a8669fd2da3c7b Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
 Date: Fri, 28 Oct 2022 23:23:43 +0530
 Subject: [PATCH] Changes for OneVPL integration
@@ -17,7 +17,7 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
 ---
  Android.mk                                    |   4 +
  _studio/Android.mk                            |   3 +
- _studio/mfx_lib/Android.mk                    | 299 ++++++++++++++++++
+ _studio/mfx_lib/Android.mk                    | 305 ++++++++++++++++++
  .../h264/include/mfx_h264_encode_hw_utils.h   |   2 +-
  .../encode_hw/h264/src/mfx_h264_encode_hw.cpp |   8 +
  _studio/mfx_lib/ext/asc/src/asc_cm.cpp        |   3 +-
@@ -35,16 +35,16 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  _studio/shared/mfx_trace/Android.mk           |  30 ++
  _studio/shared/src/libmfx_core.cpp            |   3 +-
  _studio/shared/umc/Android.mk                 |   3 +
- _studio/shared/umc/codec/Android.mk           |  87 +++++
+ _studio/shared/umc/codec/Android.mk           |  86 +++++
  _studio/shared/umc/core/Android.mk            |  40 +++
  _studio/shared/umc/io/Android.mk              |  37 +++
  android/Android.bp                            |  10 +
  android/Android.mk                            |  12 +
  android/include/mfx_android_config.h          |  22 ++
  android/include/mfx_android_defs.h            |  60 ++++
- android/mfx_defs.mk                           | 112 +++++++
- android/mfx_defs_internal.mk                  |  32 ++
- 29 files changed, 915 insertions(+), 11 deletions(-)
+ android/mfx_defs.mk                           | 111 +++++++
+ android/mfx_defs_internal.mk                  |  46 +++
+ 29 files changed, 933 insertions(+), 11 deletions(-)
  create mode 100644 Android.mk
  create mode 100644 _studio/Android.mk
  create mode 100644 _studio/mfx_lib/Android.mk
@@ -84,10 +84,10 @@ index 00000000..86c9b78c
 \ No newline at end of file
 diff --git a/_studio/mfx_lib/Android.mk b/_studio/mfx_lib/Android.mk
 new file mode 100644
-index 00000000..34d7652a
+index 00000000..ccd2ea14
 --- /dev/null
 +++ b/_studio/mfx_lib/Android.mk
-@@ -0,0 +1,299 @@
+@@ -0,0 +1,305 @@
 +
 +LOCAL_PATH:= $(MFX_HOME)/_studio
 +
@@ -217,6 +217,7 @@ index 00000000..34d7652a
 +    $(MFX_HOME)/_studio/mfx_lib/encode_hw/hevc/linux/g12 \
 +    $(MFX_HOME)/_studio/mfx_lib/encode_hw/hevc/linux/xe_hpm \
 +    $(MFX_HOME)/_studio/mfx_lib/encode_hw/shared \
++    $(MFX_HOME)/_studio/mfx_lib/shared/include/feature_blocks \
 +    $(MFX_HOME)/_studio/mfx_lib/scheduler/linux/include \
 +    $(MFX_HOME)/_studio/shared/asc/include \
 +    $(MFX_HOME)/_studio/shared/mfx_logging/include
@@ -257,12 +258,17 @@ index 00000000..34d7652a
 +# =============================================================================
 +
 +MFX_SHARED_FILES_IMPL := $(addprefix mfx_lib/shared/src/, \
++    mfx_feature_blocks_base.cpp \
 +    mfx_brc_common.cpp \
++    mfx_common_decode_int.cpp \
 +    mfx_common_int.cpp \
 +    mfx_enc_common.cpp \
++    mfx_log.cpp \
++    mfx_enc_enctools_common.cpp \
++    mfx_mpeg2_dec_common.cpp \
 +    mfx_vc1_dec_common.cpp \
-+    mfx_vpx_dec_common.cpp \
-+    mfx_common_decode_int.cpp)
++    mfx_ddi_enc_dump.cpp \
++    mfx_vpx_dec_common.cpp)
 +
 +MFX_SHARED_FILES_HW := \
 +    $(MFX_SHARED_FILES_IMPL)
@@ -388,7 +394,7 @@ index 00000000..34d7652a
 +
 +include $(BUILD_SHARED_LIBRARY)
 diff --git a/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h b/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
-index d3713f6f..e25dfe51 100644
+index c87443a8..f23d3826 100644
 --- a/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
 +++ b/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
 @@ -35,9 +35,9 @@
@@ -403,7 +409,7 @@ index d3713f6f..e25dfe51 100644
  #include "asc.h"
  #endif
 diff --git a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
-index 0be0d533..091e711f 100644
+index 4ab28697..aa53f750 100644
 --- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
 +++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
 @@ -974,8 +974,10 @@ mfxStatus ImplementationAvc::InitScd(mfxFrameAllocRequest& request)
@@ -575,10 +581,10 @@ index 5b23cd6c..0911951e 100644
  #if defined (MFX_ENABLE_FOURCC_RGB565)
      case MFX_FOURCC_RGB565:
 diff --git a/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp b/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
-index 7e0b6ef1..69ca4084 100644
+index 863d38e0..2075476e 100644
 --- a/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
 +++ b/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
-@@ -910,7 +910,9 @@ mfxStatus VideoVPPBase::Query(VideoCORE * core, mfxVideoParam *in, mfxVideoParam
+@@ -952,7 +952,9 @@ mfxStatus VideoVPPBase::Query(VideoCORE * core, mfxVideoParam *in, mfxVideoParam
  #endif // MFX_ENABLE_FOURCC_RGB565
              out->vpp.In.FourCC != MFX_FOURCC_RGB4 &&
              out->vpp.In.FourCC != MFX_FOURCC_BGR4 &&
@@ -769,7 +775,7 @@ index de69ca7e..dfa860ae 100644
  #define SYNCHRONIZATION_BY_VA_MAP_BUFFER
  #if !defined(SYNCHRONIZATION_BY_VA_SYNC_SURFACE)
 diff --git a/_studio/shared/include/mfx_utils.h b/_studio/shared/include/mfx_utils.h
-index 34f10c7a..e3a71d1f 100644
+index 6455f38c..7b1d4662 100644
 --- a/_studio/shared/include/mfx_utils.h
 +++ b/_studio/shared/include/mfx_utils.h
 @@ -24,6 +24,7 @@
@@ -780,7 +786,7 @@ index 34f10c7a..e3a71d1f 100644
  
  #include "mfxdeprecated.h"
  #include "mfxplugin.h"
-@@ -799,6 +800,7 @@ struct mfxRefCountable
+@@ -800,6 +801,7 @@ struct mfxRefCountable
      virtual mfxU32    GetRefCounter() const = 0;
      virtual void      AddRef()              = 0;
      virtual mfxStatus Release()             = 0;
@@ -788,7 +794,7 @@ index 34f10c7a..e3a71d1f 100644
  };
  
  template <typename T>
-@@ -823,9 +825,11 @@ protected:
+@@ -824,9 +826,11 @@ protected:
      template <typename X, typename std::enable_if<HasRefInterface<X>::value, bool>::type = true>
      void AssignFunctionPointers()
      {
@@ -800,7 +806,7 @@ index 34f10c7a..e3a71d1f 100644
      }
  
      template <typename X, typename std::enable_if<!HasRefInterface<X>::value, bool>::type = true>
-@@ -918,6 +922,7 @@ public:
+@@ -919,6 +923,7 @@ public:
          return MFX_ERR_NONE;
      }
  
@@ -808,7 +814,7 @@ index 34f10c7a..e3a71d1f 100644
      static mfxStatus _AddRef2(mfxRefInterface* object)
      {
          MFX_CHECK_NULL_PTR1(object);
-@@ -948,6 +953,7 @@ public:
+@@ -949,6 +954,7 @@ public:
          *counter = instance->GetRefCounter();
          return MFX_ERR_NONE;
      }
@@ -899,15 +905,14 @@ index 00000000..86c9b78c
 \ No newline at end of file
 diff --git a/_studio/shared/umc/codec/Android.mk b/_studio/shared/umc/codec/Android.mk
 new file mode 100644
-index 00000000..47efbd1f
+index 00000000..1c29ae56
 --- /dev/null
 +++ b/_studio/shared/umc/codec/Android.mk
-@@ -0,0 +1,87 @@
+@@ -0,0 +1,86 @@
 +LOCAL_PATH:= $(call my-dir)
 +
 +# Setting subdirectories to march thru
 +MFX_CODEC_LOCAL_DIRS := \
-+    h264_enc \
 +    vc1_common \
 +    jpeg_common \
 +    color_space_converter \
@@ -990,7 +995,6 @@ index 00000000..47efbd1f
 +LOCAL_MODULE := libumc_codecs_hw
 +
 +include $(BUILD_STATIC_LIBRARY)
-\ No newline at end of file
 diff --git a/_studio/shared/umc/core/Android.mk b/_studio/shared/umc/core/Android.mk
 new file mode 100644
 index 00000000..edb036e5
@@ -1216,10 +1220,10 @@ index 00000000..026268e6
 \ No newline at end of file
 diff --git a/android/mfx_defs.mk b/android/mfx_defs.mk
 new file mode 100644
-index 00000000..1674cefe
+index 00000000..ab1b63f6
 --- /dev/null
 +++ b/android/mfx_defs.mk
-@@ -0,0 +1,112 @@
+@@ -0,0 +1,111 @@
 +# Purpose:
 +#   Defines include paths, compilation flags, etc. to build Media SDK targets.
 +#
@@ -1236,7 +1240,7 @@ index 00000000..1674cefe
 +MFX_CFLAGS := -DANDROID
 +
 +#Media Version
-+MEDIA_VERSION := 20.5
++MEDIA_VERSION := 23.2.1
 +MEDIA_VERSION_EXTRA := ""
 +MEDIA_VERSION_ALL := $(MEDIA_VERSION).pre$(MEDIA_VERSION_EXTRA)
 +
@@ -1269,8 +1273,7 @@ index 00000000..1674cefe
 +  -include mfx_android_config.h
 +
 +MFX_CFLAGS += \
-+    -DMFX_ENABLE_CPLIB \
-+    -DMFX_VERSION=2006
++  -DMFX_VERSION=2009
 +
 +MFX_CFLAGS += \
 +  -DMFX_FILE_VERSION=\"`echo $(MFX_VERSION) | cut -f 1 -d.``date +.%-y.%-m.%-d`\" \
@@ -1332,13 +1335,12 @@ index 00000000..1674cefe
 +
 +# Definitions specific to Media SDK internal things (do not apply for samples)
 +include $(MFX_HOME)/android/mfx_defs_internal.mk
-\ No newline at end of file
 diff --git a/android/mfx_defs_internal.mk b/android/mfx_defs_internal.mk
 new file mode 100644
-index 00000000..573a2e74
+index 00000000..0de07f85
 --- /dev/null
 +++ b/android/mfx_defs_internal.mk
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,46 @@
 +# Purpose:
 +#   Defines include paths, compilation flags, etc. to build Media SDK
 +# internal targets (libraries, test applications, etc.).
@@ -1350,7 +1352,21 @@ index 00000000..573a2e74
 +#   MFX_INCLUDES_INTERNAL_HW - all include paths needed to build MFX HW targets
 +
 +MFX_CFLAGS_INTERNAL := $(MFX_CFLAGS)
-+MFX_CFLAGS_INTERNAL_HW := $(MFX_CFLAGS_INTERNAL) -DMFX_VA
++MFX_CFLAGS_INTERNAL_HW := \
++  $(MFX_CFLAGS_INTERNAL) \
++  -DMFX_VA \
++  -DMFX_ONEVPL \
++  -DMFX_VERSION_USE_LATEST \
++  -DMFX_DEPRECATED_OFF \
++  -DONEVPL_EXPERIMENTAL \
++  -DSYNCHRONIZATION_BY_VA_SYNC_SURFACE \
++  -D_FILE_OFFSET_BITS=64 \
++  -D__USE_LARGEFILE64 \
++  -DMFX_GIT_COMMIT=\"c6573984\" \
++  -DMFX_API_VERSION=\"2.9+\" \
++  -DNDEBUG \
++  -DMSDK_BUILD=\"\"
++
 +MFX_CFLAGS_INTERNAL_32 := -DLINUX32
 +MFX_CFLAGS_INTERNAL_64 := -DLINUX32 -DLINUX64
 +
@@ -1373,5 +1389,5 @@ index 00000000..573a2e74
 +    $(MFX_INCLUDES_LIBVA)
 \ No newline at end of file
 -- 
-2.17.1
+2.40.1
 

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0002-Restore-SG1-as-a-VPL-platform.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0002-Restore-SG1-as-a-VPL-platform.patch
@@ -1,4 +1,4 @@
-From 894e3edd50de14bf81f9a19f9ec49d5729fe9a46 Mon Sep 17 00:00:00 2001
+From 5ad6991d899f1f0d98b9579709bdd3f3e62992f4 Mon Sep 17 00:00:00 2001
 From: Ratnesh Kumar Rai <ratnesh.kumar.rai@intel.com>
 Date: Sat, 9 Apr 2022 09:57:38 +0530
 Subject: [PATCH] Restore SG1 as a VPL platform
@@ -29,5 +29,5 @@ index 94fa0040..975f580f 100644
  
      inline bool CapsQueryOptimizationSupport(eMFXHWType platform)
 -- 
-2.17.1
+2.40.1
 

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0003-Resolved-runtime-error-for-onevpl.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0003-Resolved-runtime-error-for-onevpl.patch
@@ -1,4 +1,4 @@
-From 22246916749b98025035050ed6f13828fb2c916d Mon Sep 17 00:00:00 2001
+From a7d252f9d4495a0695e8d0ae9aefaac7fcd67f45 Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
 Date: Fri, 3 Feb 2023 11:50:32 +0530
 Subject: [PATCH] Resolved runtime error for onevpl
@@ -11,18 +11,18 @@ Tracked-On: OAM-105683
 Signed-off-by: Ratnesh Kumar Rai <ratnesh.kumar.rai@intel.com>
 Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
 ---
- _studio/mfx_lib/Android.mk                 | 11 +++--
+ _studio/mfx_lib/Android.mk                 |  9 ++--
  _studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp     |  6 ++-
  _studio/mfx_lib/vpp/src/mfx_vpp_utils.cpp  |  4 ++
  _studio/shared/include/mfx_vpp_interface.h | 54 ++++++++++++----------
  _studio/shared/mfx_logging/Android.mk      | 26 +++++++++++
  _studio/shared/umc/core/Android.mk         |  3 +-
  android/mfx_defs_internal.mk               | 10 +++-
- 7 files changed, 81 insertions(+), 33 deletions(-)
+ 7 files changed, 79 insertions(+), 33 deletions(-)
  create mode 100644 _studio/shared/mfx_logging/Android.mk
 
 diff --git a/_studio/mfx_lib/Android.mk b/_studio/mfx_lib/Android.mk
-index 34d7652a..8592de3b 100644
+index ccd2ea14..22280549 100644
 --- a/_studio/mfx_lib/Android.mk
 +++ b/_studio/mfx_lib/Android.mk
 @@ -78,6 +78,7 @@ MFX_LOCAL_SRC_FILES_HW += \
@@ -41,12 +41,13 @@ index 34d7652a..8592de3b 100644
      mfx_lib/ext/asc/src/asc_cm.cpp
  
  #scheduler/linux/include
-@@ -126,10 +126,10 @@ MFX_LOCAL_INCLUDES_HW := \
+@@ -126,11 +126,11 @@ MFX_LOCAL_INCLUDES_HW := \
      $(MFX_HOME)/_studio/mfx_lib/encode_hw/hevc/linux/base \
      $(MFX_HOME)/_studio/mfx_lib/encode_hw/hevc/linux/g12 \
      $(MFX_HOME)/_studio/mfx_lib/encode_hw/hevc/linux/xe_hpm \
 +    $(MFX_HOME)/_studio/mfx_lib/encode_hw/hevc/linux/xe_lpm_plus \
      $(MFX_HOME)/_studio/mfx_lib/encode_hw/shared \
+     $(MFX_HOME)/_studio/mfx_lib/shared/include/feature_blocks \
      $(MFX_HOME)/_studio/mfx_lib/scheduler/linux/include \
 -    $(MFX_HOME)/_studio/shared/asc/include \
 -    $(MFX_HOME)/_studio/shared/mfx_logging/include
@@ -54,7 +55,7 @@ index 34d7652a..8592de3b 100644
  
  MFX_LOCAL_STATIC_LIBRARIES_HW := \
      libmfx_core_hw \
-@@ -138,7 +138,8 @@ MFX_LOCAL_STATIC_LIBRARIES_HW := \
+@@ -139,7 +139,8 @@ MFX_LOCAL_STATIC_LIBRARIES_HW := \
      libumc_va \
      libumc_core_hw \
      libmfx_gen_trace \
@@ -64,17 +65,8 @@ index 34d7652a..8592de3b 100644
  
  MFX_LOCAL_LDFLAGS_HW := \
      $(MFX_LDFLAGS) \
-@@ -172,6 +173,8 @@ MFX_SHARED_FILES_IMPL := $(addprefix mfx_lib/shared/src/, \
-     mfx_enc_common.cpp \
-     mfx_vc1_dec_common.cpp \
-     mfx_vpx_dec_common.cpp \
-+    mfx_mpeg2_dec_common.cpp \
-+    mfx_log.cpp \ 
-     mfx_common_decode_int.cpp)
- 
- MFX_SHARED_FILES_HW := \
 diff --git a/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp b/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
-index c83b3187..cb6d8706 100644
+index 5be16feb..ffdb8744 100644
 --- a/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
 +++ b/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
 @@ -2330,6 +2330,7 @@ mfxStatus VideoVPPHW::CheckFormatLimitation(mfxU32 filter, mfxU32 format, mfxU32
@@ -109,7 +101,7 @@ index c83b3187..cb6d8706 100644
  
      m_config.m_IOPattern = 0;
      sts = ConfigureExecuteParams(
-@@ -5813,6 +5815,7 @@ mfxStatus ConfigureExecuteParams(
+@@ -5827,6 +5829,7 @@ mfxStatus ConfigureExecuteParams(
  
      executeParams.iBackgroundColor = get_background_color(videoParam);
  
@@ -117,7 +109,7 @@ index c83b3187..cb6d8706 100644
      for (mfxU32 i = 0; i < videoParam.NumExtParam; i++)
      {
          if (videoParam.ExtParam[i]->BufferId == MFX_EXTBUF_CAM_PIPECONTROL)
-@@ -5820,6 +5823,7 @@ mfxStatus ConfigureExecuteParams(
+@@ -5834,6 +5837,7 @@ mfxStatus ConfigureExecuteParams(
              bitmodeflag = TRUE;
          }
      }
@@ -305,10 +297,10 @@ index edb036e5..75d1ce3f 100644
 \ No newline at end of file
 +include $(BUILD_STATIC_LIBRARY)
 diff --git a/android/mfx_defs_internal.mk b/android/mfx_defs_internal.mk
-index 573a2e74..f63a9fb6 100644
+index 0de07f85..8d5ef227 100644
 --- a/android/mfx_defs_internal.mk
 +++ b/android/mfx_defs_internal.mk
-@@ -16,11 +16,17 @@ MFX_CFLAGS_INTERNAL_64 := -DLINUX32 -DLINUX64
+@@ -30,11 +30,17 @@ MFX_CFLAGS_INTERNAL_64 := -DLINUX32 -DLINUX64
  MFX_INCLUDES_INTERNAL :=  \
      $(MFX_INCLUDES) \
      $(MFX_HOME)/_studio/shared/include \
@@ -327,7 +319,7 @@ index 573a2e74..f63a9fb6 100644
      $(MFX_HOME)/_studio/mfx_lib/shared/include \
      $(MFX_HOME)/_studio/shared/include \
      $(MFX_HOME)/_studio/enctools/aenc/include \
-@@ -29,4 +35,4 @@ MFX_INCLUDES_INTERNAL :=  \
+@@ -43,4 +49,4 @@ MFX_INCLUDES_INTERNAL :=  \
  
  MFX_INCLUDES_INTERNAL_HW := \
      $(MFX_INCLUDES_INTERNAL) \
@@ -335,5 +327,5 @@ index 573a2e74..f63a9fb6 100644
 \ No newline at end of file
 +    $(MFX_INCLUDES_LIBVA)
 -- 
-2.17.1
+2.40.1
 

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0004-Remove-ITT-vtune-support.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0004-Remove-ITT-vtune-support.patch
@@ -1,4 +1,4 @@
-From 4b9586ba8cc531f49293e2034defcc993bd4adad Mon Sep 17 00:00:00 2001
+From 3498576d4dd3be2f98446d2cb43a9174aac0a860 Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Thu, 10 Nov 2022 00:23:21 +0530
 Subject: [PATCH] Remove ITT (vtune) support
@@ -10,7 +10,7 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
 ---
  CMakeLists.txt                                |   6 -
  README.md                                     |  21 ---
- _studio/mfx_lib/Android.mk                    |   7 +-
+ _studio/mfx_lib/Android.mk                    |   5 +-
  _studio/mfx_lib/CMakeLists.txt                |   1 -
  _studio/mfx_lib/vpp/src/mfx_vpp_utils.cpp     |   6 +-
  _studio/shared/include/mfx_config.h           |   7 +-
@@ -20,20 +20,20 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  .../shared/mfx_trace/include/mfx_trace_itt.h  |  79 ----------
  _studio/shared/mfx_trace/src/mfx_trace.cpp    |  17 ---
  .../shared/mfx_trace/src/mfx_trace_itt.cpp    | 143 ------------------
- android/mfx_defs.mk                           |  18 +--
+ android/mfx_defs.mk                           |  16 +-
  builder/BuildOptions.cmake                    |   2 -
  builder/FindGlobals.cmake                     |   1 -
  builder/FindITT.cmake                         |  76 ----------
  builder/FindTrace.cmake                       |   4 -
  builder/FindVTune.cmake                       |  63 --------
- 18 files changed, 12 insertions(+), 449 deletions(-)
+ 18 files changed, 10 insertions(+), 447 deletions(-)
  delete mode 100644 _studio/shared/mfx_trace/include/mfx_trace_itt.h
  delete mode 100644 _studio/shared/mfx_trace/src/mfx_trace_itt.cpp
  delete mode 100644 builder/FindITT.cmake
  delete mode 100644 builder/FindVTune.cmake
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 2a815402..2ea44db5 100644
+index 49a129a8..12c6fd60 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -74,7 +74,6 @@ include( ${BUILDER_ROOT}/FindOpenCL.cmake )
@@ -110,19 +110,10 @@ index ab15fbdf..c84d3785 100644
  
  * In case of GCC compiler it is strongly recommended to use GCC version 6 or later since that's the first GCC version which has non-experimental support of C++14 being used in oneVPL GPU Runtime.
 diff --git a/_studio/mfx_lib/Android.mk b/_studio/mfx_lib/Android.mk
-index 8592de3b..913687d6 100644
+index 22280549..b3fa839f 100644
 --- a/_studio/mfx_lib/Android.mk
 +++ b/_studio/mfx_lib/Android.mk
-@@ -174,7 +174,7 @@ MFX_SHARED_FILES_IMPL := $(addprefix mfx_lib/shared/src/, \
-     mfx_vc1_dec_common.cpp \
-     mfx_vpx_dec_common.cpp \
-     mfx_mpeg2_dec_common.cpp \
--    mfx_log.cpp \ 
-+    mfx_log.cpp \
-     mfx_common_decode_int.cpp)
- 
- MFX_SHARED_FILES_HW := \
-@@ -253,6 +253,7 @@ LOCAL_C_INCLUDES := \
+@@ -257,6 +257,7 @@ LOCAL_C_INCLUDES := \
      $(MFX_INCLUDES_INTERNAL_HW)
  
  LOCAL_CPPFLAGS += -std=c++14
@@ -130,7 +121,7 @@ index 8592de3b..913687d6 100644
  LOCAL_CFLAGS := \
      $(MFX_CFLAGS_INTERNAL_HW) \
      -Wno-error -Wno-unused-parameter -Wno-implicit-fallthrough
-@@ -292,10 +293,6 @@ LOCAL_HEADER_LIBRARIES := libmfx_gen_headers
+@@ -296,10 +297,6 @@ LOCAL_HEADER_LIBRARIES := libmfx_gen_headers
  LOCAL_WHOLE_STATIC_LIBRARIES := $(MFX_LOCAL_STATIC_LIBRARIES_HW)
  LOCAL_SHARED_LIBRARIES := libva liblog libcutils libdrm
  
@@ -229,7 +220,7 @@ index dfa860ae..7f5aa468 100644
  #endif
  #endif // #ifndef MFX_TRACE_DISABLE
 diff --git a/_studio/shared/include/mfx_trace.h b/_studio/shared/include/mfx_trace.h
-index 6847f411..a78d79c7 100644
+index b482f17d..e2554489 100644
 --- a/_studio/shared/include/mfx_trace.h
 +++ b/_studio/shared/include/mfx_trace.h
 @@ -154,7 +154,6 @@ enum
@@ -368,10 +359,10 @@ index cc59b617..00000000
 -#endif // #ifdef MFX_TRACE_ENABLE_TEXTLOG
 -#endif // #ifndef __MFX_TRACE_ITT_LOG_H__
 diff --git a/_studio/shared/mfx_trace/src/mfx_trace.cpp b/_studio/shared/mfx_trace/src/mfx_trace.cpp
-index b62cb9f0..ec501cf8 100644
+index c30824d3..a34bea0b 100644
 --- a/_studio/shared/mfx_trace/src/mfx_trace.cpp
 +++ b/_studio/shared/mfx_trace/src/mfx_trace.cpp
-@@ -39,7 +39,6 @@ extern "C"
+@@ -40,7 +40,6 @@ extern "C"
  #include "mfx_trace_utils.h"
  #include "mfx_trace_textlog.h"
  #include "mfx_trace_stat.h"
@@ -379,7 +370,7 @@ index b62cb9f0..ec501cf8 100644
  #include "mfx_trace_ftrace.h"
  }
  #include <stdlib.h>
-@@ -146,19 +145,6 @@ mfxTraceAlgorithm g_TraceAlgorithms[] =
+@@ -147,19 +146,6 @@ mfxTraceAlgorithm g_TraceAlgorithms[] =
          MFXTraceTAL_Close
      },
  #endif
@@ -399,7 +390,7 @@ index b62cb9f0..ec501cf8 100644
  #ifdef MFX_TRACE_ENABLE_FTRACE
      {
          0,
-@@ -305,9 +291,6 @@ mfxTraceU32 MFXTrace_Init()
+@@ -323,9 +309,6 @@ mfxTraceU32 MFXTrace_Init()
  #if defined(MFX_TRACE_ENABLE_TAL)
      g_OutputMode |= MFX_TRACE_OUTPUT_TAL;
  #endif
@@ -559,10 +550,10 @@ index 8c750d47..00000000
 -} // extern "C"
 -#endif // #ifdef MFX_TRACE_ENABLE_ITT
 diff --git a/android/mfx_defs.mk b/android/mfx_defs.mk
-index 1674cefe..389dbfd1 100644
+index ab1b63f6..b3f7c039 100644
 --- a/android/mfx_defs.mk
 +++ b/android/mfx_defs.mk
-@@ -62,17 +62,6 @@ MFX_CFLAGS += \
+@@ -61,17 +61,6 @@ MFX_CFLAGS += \
    -Wformat -Wformat-security \
    -fexceptions -frtti -msse4.1
  
@@ -580,7 +571,7 @@ index 1674cefe..389dbfd1 100644
  # Enable feature with output decoded frames without latency regarding
  # SPS.VUI.max_num_reorder_frames
  ifeq ($(ENABLE_MAX_NUM_REORDER_FRAMES_OUTPUT),)
-@@ -106,7 +95,12 @@ LOCAL_MODULE_OWNER := intel
+@@ -105,6 +94,11 @@ LOCAL_MODULE_OWNER := intel
  # Moving executables to proprietary location
  LOCAL_PROPRIETARY_MODULE := true
  
@@ -592,9 +583,6 @@ index 1674cefe..389dbfd1 100644
  # =============================================================================
  
  # Definitions specific to Media SDK internal things (do not apply for samples)
--include $(MFX_HOME)/android/mfx_defs_internal.mk
-\ No newline at end of file
-+include $(MFX_HOME)/android/mfx_defs_internal.mk
 diff --git a/builder/BuildOptions.cmake b/builder/BuildOptions.cmake
 index f066d0f1..57ff83dc 100644
 --- a/builder/BuildOptions.cmake
@@ -787,5 +775,5 @@ index 4a9418be..00000000
 -
 -endif()
 -- 
-2.17.1
+2.40.1
 

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0005-Fix-for-HEVC-rendering-failing-with-usptream-ffmpeg.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0005-Fix-for-HEVC-rendering-failing-with-usptream-ffmpeg.patch
@@ -1,4 +1,4 @@
-From 7f5788c3c456e904c782da6c5e02df2ddf40ada4 Mon Sep 17 00:00:00 2001
+From 96dffbe66f6614200e68effee7d1870c098352b6 Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Wed, 8 Mar 2023 15:42:09 +0530
 Subject: [PATCH] Fix for HEVC rendering failing with usptream ffmpeg
@@ -20,7 +20,7 @@ Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/android/mfx_defs.mk b/android/mfx_defs.mk
-index 389dbfd1..2397ac3d 100644
+index b3f7c039..465408cd 100644
 --- a/android/mfx_defs.mk
 +++ b/android/mfx_defs.mk
 @@ -19,6 +19,7 @@ MEDIA_VERSION_EXTRA := ""
@@ -31,7 +31,7 @@ index 389dbfd1..2397ac3d 100644
  
  # Android version preference:
  ifneq ($(filter 12 12.% S ,$(PLATFORM_VERSION)),)
-@@ -60,7 +61,8 @@ MFX_CFLAGS += \
+@@ -59,7 +60,8 @@ MFX_CFLAGS += \
    -fPIE -fPIC -pie \
    -O2 -D_FORTIFY_SOURCE=2 \
    -Wformat -Wformat-security \
@@ -42,5 +42,5 @@ index 389dbfd1..2397ac3d 100644
  # Enable feature with output decoded frames without latency regarding
  # SPS.VUI.max_num_reorder_frames
 -- 
-2.17.1
+2.40.1
 

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0006-Changes-to-be-in-sync-with-features-enabled-in-linux.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0006-Changes-to-be-in-sync-with-features-enabled-in-linux.patch
@@ -1,11 +1,10 @@
-From 59b1f14a681c2910a0e519a2b5d1900269359703 Mon Sep 17 00:00:00 2001
+From 6dbce949606d6606571075f66ebaa8a003135ad4 Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Wed, 8 Mar 2023 15:46:04 +0530
 Subject: [PATCH] Changes to be in sync with features enabled in linux variant
 
 - Added AV1 encode files
 - Enable mfx features enabled in linux
-- Updated version informations
 
 Change-Id: I65fa4907bfa5658230ebb42846dc0651fba31aa4
 Tracked-On: OAM-106860
@@ -14,11 +13,11 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
 ---
  _studio/mfx_lib/Android.mk         | 36 ++++++++++++++++++++++++++++++
  android/include/mfx_android_defs.h | 23 +++++++++----------
- android/mfx_defs.mk                |  7 +++---
- 3 files changed, 49 insertions(+), 17 deletions(-)
+ android/mfx_defs.mk                |  2 +-
+ 3 files changed, 47 insertions(+), 14 deletions(-)
 
 diff --git a/_studio/mfx_lib/Android.mk b/_studio/mfx_lib/Android.mk
-index 913687d6..af9ef0cc 100644
+index b3fa839f..90948048 100644
 --- a/_studio/mfx_lib/Android.mk
 +++ b/_studio/mfx_lib/Android.mk
 @@ -40,6 +40,32 @@ MFX_LOCAL_SRC_FILES_HW += $(addprefix mfx_lib/ext/genx/h264_encode/isa/, \
@@ -135,15 +134,10 @@ index 026268e6..7052485a 100644
 \ No newline at end of file
 +#endif // #ifndef __MFX_ANDROID_DEFS_H__
 diff --git a/android/mfx_defs.mk b/android/mfx_defs.mk
-index 2397ac3d..5ff814f2 100644
+index 465408cd..fe5bc2be 100644
 --- a/android/mfx_defs.mk
 +++ b/android/mfx_defs.mk
-@@ -14,11 +14,11 @@
- MFX_CFLAGS := -DANDROID
- 
- #Media Version
--MEDIA_VERSION := 20.5
-+MEDIA_VERSION := 23.1.4
+@@ -18,7 +18,7 @@ MEDIA_VERSION := 23.2.1
  MEDIA_VERSION_EXTRA := ""
  MEDIA_VERSION_ALL := $(MEDIA_VERSION).pre$(MEDIA_VERSION_EXTRA)
  
@@ -152,16 +146,6 @@ index 2397ac3d..5ff814f2 100644
  MFX_CFLAGS += -DONEVPL_EXPERIMENTAL
  
  # Android version preference:
-@@ -48,8 +48,7 @@ MFX_CFLAGS += \
-   -include mfx_android_config.h
- 
- MFX_CFLAGS += \
--    -DMFX_ENABLE_CPLIB \
--    -DMFX_VERSION=2006
-+    -DMFX_VERSION=2008
- 
- MFX_CFLAGS += \
-   -DMFX_FILE_VERSION=\"`echo $(MFX_VERSION) | cut -f 1 -d.``date +.%-y.%-m.%-d`\" \
 -- 
-2.17.1
+2.40.1
 

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0007-Enable-avx2.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0007-Enable-avx2.patch
@@ -1,4 +1,4 @@
-From 7d01d64bd36d41f3c16afd157051e1fb4580dc83 Mon Sep 17 00:00:00 2001
+From e1f50396a06e7c0dd2489091d3c992c6e8346c4a Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
 Date: Wed, 29 Mar 2023 15:42:03 +0530
 Subject: [PATCH] Enable avx2
@@ -11,7 +11,7 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/android/mfx_defs.mk b/android/mfx_defs.mk
-index 5ff814f2..ca4dbc95 100644
+index fe5bc2be..6cd24900 100644
 --- a/android/mfx_defs.mk
 +++ b/android/mfx_defs.mk
 @@ -61,7 +61,8 @@ MFX_CFLAGS += \
@@ -25,5 +25,5 @@ index 5ff814f2..ca4dbc95 100644
  # Enable feature with output decoded frames without latency regarding
  # SPS.VUI.max_num_reorder_frames
 -- 
-2.17.1
+2.40.1
 

--- a/bsp_diff/common/hardware/intel/onevpl/0001-Changes-for-OneVPL-integration.patch
+++ b/bsp_diff/common/hardware/intel/onevpl/0001-Changes-for-OneVPL-integration.patch
@@ -1,4 +1,4 @@
-From da76e118377bc7aae41491408e4556a3b6d10000 Mon Sep 17 00:00:00 2001
+From 6f3084b33e0cd10a71e7973662f4e24627a598a2 Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
 Date: Fri, 3 Feb 2023 10:42:18 +0530
 Subject: [PATCH] Changes for OneVPL integration
@@ -399,5 +399,5 @@ index 0000000..c444bc2
 +include $(BUILD_EXECUTABLE)
 +##################################################################
 -- 
-2.17.1
+2.40.1
 

--- a/bsp_diff/common/hardware/intel/onevpl/0002-Fix-for-HEVC-rendering-failing-with-usptream-ffmpeg.patch
+++ b/bsp_diff/common/hardware/intel/onevpl/0002-Fix-for-HEVC-rendering-failing-with-usptream-ffmpeg.patch
@@ -1,4 +1,4 @@
-From e0a2a87090afee3e149f092ae86d3e489ff0ba1b Mon Sep 17 00:00:00 2001
+From 586c992f543691fd40436deb9c2e6d85830a7446 Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Wed, 8 Mar 2023 14:59:44 +0530
 Subject: [PATCH] Fix for HEVC rendering failing with usptream ffmpeg
@@ -43,5 +43,5 @@ index 526d839..0b8ab86 100644
  LOCAL_CPPFLAGS += -Wl,--version-script=$(LOCAL_PATH)/linux/libvpl.map
  
 -- 
-2.17.1
+2.40.1
 


### PR DESCRIPTION
Included versions:
* libva: 2.18.0 (same as before)
* gmmlib: 22.3.5 (same as before)
* media-driver: 23.2.1 (was 23.1.4)
* onevpl-gpu: 23.2.1 (was 23.1.4)
* oneVPL: v2023.2.1 (was v2023.1.3)

Tracked-On: OAM-110543