### PR TITLE
Revert "CVE-2023-20942 has been removed from the 2023-02-01 SPL"

### DIFF
--- a/aosp_diff/preliminary/frameworks/av/0010-audio-policy-fix-sensor-privacy-listener.bulletin.patch
+++ b/aosp_diff/preliminary/frameworks/av/0010-audio-policy-fix-sensor-privacy-listener.bulletin.patch
@@ -1,0 +1,45 @@
+From b072419650958c41c87d2baa572dc2fe6da9ea6b Mon Sep 17 00:00:00 2001
+From: Eric Laurent <elaurent@google.com>
+Date: Thu, 17 Nov 2022 11:47:19 +0100
+Subject: [PATCH] audio policy: fix sensor privacy listener
+
+Current way of registering to the sensor privacy listener works
+only when disabling sensors from the developer settings.
+This CL also registers a listener for when the mic privacy toggle
+is used.
+This change is temporary until problems around app ops start/stop
+notifications from audio framework are sorted out and we can rely
+on app ops to silence audio when the mic privacy toggle is used.
+
+Test: make
+Bug: 258021433
+Change-Id: I1178a15583596cd025d5cb1e424f9fe3bf7854b4
+Merged-In: I1178a15583596cd025d5cb1e424f9fe3bf7854b4
+(cherry picked from commit 60aa4d06161f40e9f18c44caf0fc057b86deceb9)
+Merged-In: I1178a15583596cd025d5cb1e424f9fe3bf7854b4
+---
+ services/audiopolicy/service/AudioPolicyService.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/services/audiopolicy/service/AudioPolicyService.cpp b/services/audiopolicy/service/AudioPolicyService.cpp
+index e7d945fad6..bfce4bab01 100644
+--- a/services/audiopolicy/service/AudioPolicyService.cpp
++++ b/services/audiopolicy/service/AudioPolicyService.cpp
+@@ -1803,12 +1803,14 @@ void AudioPolicyService::UidPolicy::dumpInternals(int fd) {
+ void AudioPolicyService::SensorPrivacyPolicy::registerSelf() {
+     SensorPrivacyManager spm;
+     mSensorPrivacyEnabled = spm.isSensorPrivacyEnabled();
++    (void)spm.addToggleSensorPrivacyListener(this);
+     spm.addSensorPrivacyListener(this);
+ }
+ 
+ void AudioPolicyService::SensorPrivacyPolicy::unregisterSelf() {
+     SensorPrivacyManager spm;
+     spm.removeSensorPrivacyListener(this);
++    spm.removeToggleSensorPrivacyListener(this);
+ }
+ 
+ bool AudioPolicyService::SensorPrivacyPolicy::isSensorPrivacyEnabled() {
+-- 
+2.39.0.rc1.256.g54fd8350bd-goog
+


### PR DESCRIPTION
This reverts commit ec485b363eaa0bf03dbdcc4d435aac8fd440aab4.