### PR TITLE
Expand audio framework max channel count to 24

### DIFF
--- a/aosp_diff/preliminary/system/media/0002-Expand-audio-framework-max-channel-count-to-24.patch
+++ b/aosp_diff/preliminary/system/media/0002-Expand-audio-framework-max-channel-count-to-24.patch
@@ -1,0 +1,29 @@
+From 693a8ab48dc3398571565eec3e485affb3324b88 Mon Sep 17 00:00:00 2001
+From: "Martin, Chen" <haochuan.z.chen@intel.com>
+Date: Fri, 2 Jun 2023 09:24:14 -0400
+Subject: [PATCH] Expand audio framework max channel count to 24
+
+Update FCC_LIMIT to FCC_24 for audio 16 channel user case
+
+Tracked-On: OAM-110582
+Signed-off-by: Martin, Chen <haochuan.z.chen@intel.com>
+---
+ audio/include/system/audio.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/audio/include/system/audio.h b/audio/include/system/audio.h
+index b4110412..f91cf4e8 100644
+--- a/audio/include/system/audio.h
++++ b/audio/include/system/audio.h
+@@ -222,7 +222,7 @@ enum {
+     //
+     // This can be adjusted onto a value such as FCC_12 or FCC_24
+     // if the device HAL can support it.  Do not reduce below FCC_8.
+-    FCC_LIMIT = FCC_12,
++    FCC_LIMIT = FCC_24,
+ };
+ 
+ /* A channel mask per se only defines the presence or absence of a channel, not the order.
+-- 
+2.17.1
+


### PR DESCRIPTION
Update FCC_LIMIT to FCC_24 for audio 16 channel user case

Tracked-On: OAM-110582