### PR TITLE
Update the host patch for qemu 7.1.0

### DIFF
--- a/host/qemu/0005-ui-gtk-new-param-monitor-to-specify-target-monitor-f.patch
+++ b/host/qemu/0005-ui-gtk-new-param-monitor-to-specify-target-monitor-f.patch
@@ -1,7 +1,7 @@
-From 956f7fbda5984fa604f50c2e43422040e17ffc26 Mon Sep 17 00:00:00 2001
+From b764518654aa0c3d0b197410f028c507b635c97c Mon Sep 17 00:00:00 2001
 From: HeYue <yue.he@intel.com>
 Date: Mon, 11 Jul 2022 11:19:30 +0800
-Subject: [PATCH 5/7] ui/gtk: new param monitor to specify target monitor for
+Subject: [PATCH] ui/gtk: new param monitor to specify target monitor for
  launching QEMU
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -30,52 +30,51 @@ Cc: sweeaun <swee.aun.khor@intel.com>
 Cc: Khairul Anuar Romli <khairul.anuar.romli@intel.com>
 Signed-off-by: Dongwon Kim <dongwon.kim@intel.com>
 ---
- qapi/ui.json    | 6 +++++-
+ qapi/ui.json    | 4 ++++
  qemu-options.hx | 2 +-
  ui/gtk.c        | 9 +++++++++
- 3 files changed, 15 insertions(+), 2 deletions(-)
+ 3 files changed, 14 insertions(+), 1 deletion(-)
 
 diff --git a/qapi/ui.json b/qapi/ui.json
-index 13a8bb82aa05..760c448c2488 100644
+index cf58ab4283..19d0438065 100644
 --- a/qapi/ui.json
 +++ b/qapi/ui.json
-@@ -1186,13 +1186,17 @@
+@@ -1195,6 +1195,9 @@
  #               assuming the guest will resize the display to match
  #               the window size then.  Otherwise it defaults to "off".
  #               Since 3.1
 +# @monitor:     Indicate monitor where QEMU window is lauched. monitor
 +#               could be any number from 0 to (total num of monitors - 1).
 +#               since 7.0
- #
- # Since: 2.12
- #
- ##
+ # @show-tabs:   Display the tab bar for switching between the various graphical
+ #               interfaces (e.g. VGA and virtual console character devices)
+ #               by default.
+@@ -1205,6 +1208,7 @@
  { 'struct'  : 'DisplayGTK',
    'data'    : { '*grab-on-hover' : 'bool',
--                '*zoom-to-fit'   : 'bool'  } }
-+                '*zoom-to-fit'   : 'bool',
-+                '*monitor'       : 'uint32' } }
+                 '*zoom-to-fit'   : 'bool',
++                '*monitor'       : 'uint32',
+                 '*show-tabs'     : 'bool'  } }
  
  ##
- # @DisplayEGLHeadless:
 diff --git a/qemu-options.hx b/qemu-options.hx
-index 34e9b32a5c00..1cff7b89df5f 100644
+index 31c04f7eea..df936243b7 100644
 --- a/qemu-options.hx
 +++ b/qemu-options.hx
-@@ -1907,7 +1907,7 @@ DEF("display", HAS_ARG, QEMU_OPTION_display,
-     "            [,grab-mod=<mod>][,show-cursor=on|off][,window-close=on|off]\n"
+@@ -1943,7 +1943,7 @@ DEF("display", HAS_ARG, QEMU_OPTION_display,
+     "            [,window-close=on|off]\n"
  #endif
  #if defined(CONFIG_GTK)
 -    "-display gtk[,full-screen=on|off][,gl=on|off][,grab-on-hover=on|off]\n"
 +    "-display gtk[,full-screen=on|off][,gl=on|off][,grab-on-hover=on|off][,monitor=<value>]\n"
-     "            [,show-cursor=on|off][,window-close=on|off]\n"
+     "            [,show-tabs=on|off][,show-cursor=on|off][,window-close=on|off]\n"
  #endif
  #if defined(CONFIG_VNC)
 diff --git a/ui/gtk.c b/ui/gtk.c
-index c57c36749e0e..705a86055bb6 100644
+index 1467b8c7d7..a82378fb9a 100644
 --- a/ui/gtk.c
 +++ b/ui/gtk.c
-@@ -2375,6 +2375,15 @@ static void gtk_display_init(DisplayState *ds, DisplayOptions *opts)
+@@ -2382,6 +2382,15 @@ static void gtk_display_init(DisplayState *ds, DisplayOptions *opts)
                               vc && vc->type == GD_VC_VTE);
  #endif
  
@@ -92,5 +91,5 @@ index c57c36749e0e..705a86055bb6 100644
          opts->full_screen) {
          gtk_menu_item_activate(GTK_MENU_ITEM(s->full_screen_item));
 -- 
-2.17.1
+2.40.1
 


### PR DESCRIPTION
adjust horizontal patch to resolve conflict

Qemu patch that introduced new integer parameter to specify the monitor where the Qemu window is placed upon launching resulted into conflicts due to incompatibility in v7.1.0

Tracked-On: OAM-110614