### PR TITLE
Save app setting of "Peak Performance" to database immediately.

### DIFF
--- a/aosp_diff/celadon_ivi/packages/services/Car/0008-Save-app-setting-of-Peak-Performance-to-database-imm.patch
+++ b/aosp_diff/celadon_ivi/packages/services/Car/0008-Save-app-setting-of-Peak-Performance-to-database-imm.patch
@@ -1,0 +1,32 @@
+From f57de26893837601d98215d701a77217bba3ddde Mon Sep 17 00:00:00 2001
+From: Bing Xu <bing.xu@intel.com>
+Date: Thu, 15 Jun 2023 10:51:36 +0800
+Subject: [PATCH] Save app setting of "Peak Performance" to database
+ immediately.
+
+As per the code, save to database is done only on system shutdown
+and not on system reboot or unexpected shutdown.
+
+Fix the issue by saving the data immediately upon change.
+
+Tracked-On: OAM-108706
+Signed-off-by: Bing Xu <bing.xu@intel.com>
+---
+ service/src/com/android/car/watchdog/CarWatchdogService.java | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/service/src/com/android/car/watchdog/CarWatchdogService.java b/service/src/com/android/car/watchdog/CarWatchdogService.java
+index dc074a636..ecb8c92d5 100644
+--- a/service/src/com/android/car/watchdog/CarWatchdogService.java
++++ b/service/src/com/android/car/watchdog/CarWatchdogService.java
+@@ -436,6 +436,7 @@ public final class CarWatchdogService extends ICarWatchdogService.Stub implement
+             boolean isKillable) {
+         ICarImpl.assertPermission(mContext, Car.PERMISSION_CONTROL_CAR_WATCHDOG_CONFIG);
+         mWatchdogPerfHandler.setKillablePackageAsUser(packageName, userHandle, isKillable);
++        mWatchdogPerfHandler.writeToDatabase();
+     }
+ 
+     /**
+-- 
+2.34.1
+


### PR DESCRIPTION
From the code, save to database only when system shutdown, data will not be saved if the system reboot or shutdown unexpectly, so we save the data when it is changed.

Tracked-On: OAM-108706