### PR TITLE
Fix for Calendar App to Launch in Passenger zone.

### DIFF
--- a/aosp_diff/celadon_ivi/packages/services/Car/0010-Fix-for-Calendar-App-to-Launch-in-Passenger-zone.patch
+++ b/aosp_diff/celadon_ivi/packages/services/Car/0010-Fix-for-Calendar-App-to-Launch-in-Passenger-zone.patch
@@ -1,0 +1,50 @@
+From ba6ad8e7bd5357ab3110d6ef64b8992767928e66 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Fri, 23 Jun 2023 10:14:17 +0530
+Subject: [PATCH] Fix for Calendar App to Launch in Passenger zone.
+
+Provider packages were not installed for profile type
+user, So user was not able to launch following apps
+in passenger zone-:
+Calendar, Contacts & Phone Apps.
+
+Added provider packages for above apps in pre-installed list.
+
+Tracked-On: OAM-106801
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ car_product/build/preinstalled-packages-product-car-base.xml | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/car_product/build/preinstalled-packages-product-car-base.xml b/car_product/build/preinstalled-packages-product-car-base.xml
+index b241c89e1..dcd93a843 100644
+--- a/car_product/build/preinstalled-packages-product-car-base.xml
++++ b/car_product/build/preinstalled-packages-product-car-base.xml
+@@ -204,7 +204,8 @@
+     <!-- Failed to find provider info for calendar error if not installed for system user -->
+     <install-in-user-type package="com.android.providers.calendar">
+         <install-in user-type="FULL" />
+-        <install-in user-type="SYSTEM" />
++	<install-in user-type="SYSTEM" />
++        <install-in user-type="PROFILE" />
+     </install-in-user-type>
+ 
+     <!-- Failed to pass CTS if not installed for system user -->
+@@ -284,12 +285,14 @@
+     </install-in-user-type>
+     <install-in-user-type package="com.android.providers.contacts">
+         <install-in user-type="FULL" />
++        <install-in user-type="PROFILE" />
+     </install-in-user-type>
+     <install-in-user-type package="com.android.providers.downloads.ui">
+         <install-in user-type="FULL" />
+     </install-in-user-type>
+     <install-in-user-type package="com.android.providers.media">
+         <install-in user-type="FULL" />
++        <install-in user-type="PROFILE" />
+     </install-in-user-type>
+     <install-in-user-type package="com.android.providers.userdictionary">
+         <install-in user-type="FULL" />
+-- 
+2.17.1
+


### PR DESCRIPTION
Provider packages were not installed for profile type user, So user was not able to launch following apps in passenger zone-:
Calendar, Contacts & Phone Apps.

Added provider packages for above apps in pre-installed list.

Tracked-On: OAM-106801