### PR TITLE
Add kernel patches to fix scaling_cur_freq read issue

### DIFF
--- a/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0001-x86-Expose-init_freq_invariance-to-topology-header.patch
+++ b/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0001-x86-Expose-init_freq_invariance-to-topology-header.patch
@@ -1,0 +1,71 @@
+From bb08aa7e7cb569efc38ace7ee0a6b59db36d64ec Mon Sep 17 00:00:00 2001
+From: "Xie, Chao" <chao.xie@intel.com>
+Date: Mon, 19 Jun 2023 10:55:35 +0800
+Subject: [PATCH 1/9] x86: Expose init_freq_invariance() to topology header
+
+The function init_freq_invariance will be used on x86 CPPC, so expose it in
+the topology header.
+
+Signed-off-by: Huang Rui <ray.huang@amd.com>
+[ rjw: Subject adjustment ]
+Signed-off-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
+
+Signed-off-by: Xie, Chao <chao.xie@intel.com>
+---
+ arch/x86/include/asm/topology.h | 4 ++++
+ arch/x86/kernel/smpboot.c       | 8 +-------
+ 2 files changed, 5 insertions(+), 7 deletions(-)
+
+diff --git a/arch/x86/include/asm/topology.h b/arch/x86/include/asm/topology.h
+index 55160445ea78..f7d35393f5df 100644
+--- a/arch/x86/include/asm/topology.h
++++ b/arch/x86/include/asm/topology.h
+@@ -212,10 +212,14 @@ extern void arch_scale_freq_tick(void);
+ #define arch_scale_freq_tick arch_scale_freq_tick
+ 
+ extern void arch_set_max_freq_ratio(bool turbo_disabled);
++void init_freq_invariance(bool secondary, bool cppc_ready);
+ #else
+ static inline void arch_set_max_freq_ratio(bool turbo_disabled)
+ {
+ }
++static inline void init_freq_invariance(bool secondary, bool cppc_ready)
++{
++}
+ #endif
+ 
+ #if defined(CONFIG_ACPI_CPPC_LIB) && defined(CONFIG_SMP)
+diff --git a/arch/x86/kernel/smpboot.c b/arch/x86/kernel/smpboot.c
+index 85f6e242b6b4..3c97c0b070e3 100644
+--- a/arch/x86/kernel/smpboot.c
++++ b/arch/x86/kernel/smpboot.c
+@@ -153,8 +153,6 @@ static inline void smpboot_restore_warm_reset_vector(void)
+ 	*((volatile u32 *)phys_to_virt(TRAMPOLINE_PHYS_LOW)) = 0;
+ }
+ 
+-static void init_freq_invariance(bool secondary, bool cppc_ready);
+-
+ /*
+  * Report back to the Boot Processor during boot time or to the caller processor
+  * during CPU online.
+@@ -2105,7 +2103,7 @@ static void register_freq_invariance_syscore_ops(void)
+ static inline void register_freq_invariance_syscore_ops(void) {}
+ #endif
+ 
+-static void init_freq_invariance(bool secondary, bool cppc_ready)
++void init_freq_invariance(bool secondary, bool cppc_ready)
+ {
+ 	bool ret = false;
+ 
+@@ -2202,8 +2200,4 @@ void arch_scale_freq_tick(void)
+ 	pr_warn("Scheduler frequency invariance went wobbly, disabling!\n");
+ 	schedule_work(&disable_freq_invariance_work);
+ }
+-#else
+-static inline void init_freq_invariance(bool secondary, bool cppc_ready)
+-{
+-}
+ #endif /* CONFIG_X86_64 */
+-- 
+2.34.1
+

--- a/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0002-x86-aperfmperf-Dont-wake-idle-CPUs-in-arch_freq_get_.patch
+++ b/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0002-x86-aperfmperf-Dont-wake-idle-CPUs-in-arch_freq_get_.patch
@@ -1,0 +1,37 @@
+From 647144d678918cac7c892a79c660c9f292e6a0f6 Mon Sep 17 00:00:00 2001
+From: "Xie, Chao" <chao.xie@intel.com>
+Date: Fri, 16 Jun 2023 14:17:57 +0800
+Subject: [PATCH 2/9] x86/aperfmperf: Dont wake idle CPUs in
+ arch_freq_get_on_cpu()
+
+aperfmperf_get_khz() already excludes idle CPUs from APERF/MPERF sampling
+and that's a reasonable decision. There is no point in sending up to two
+IPIs to an idle CPU just because someone reads a sysfs file.
+
+Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
+Acked-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
+Acked-by: Peter Zijlstra (Intel) <peterz@infradead.org>
+Acked-by: Paul E. McKenney <paulmck@kernel.org>
+
+Signed-off-by: Xie, Chao <chao.xie@intel.com>
+---
+ arch/x86/kernel/cpu/aperfmperf.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/arch/x86/kernel/cpu/aperfmperf.c b/arch/x86/kernel/cpu/aperfmperf.c
+index 22911deacb6e..fc850b18d2b9 100644
+--- a/arch/x86/kernel/cpu/aperfmperf.c
++++ b/arch/x86/kernel/cpu/aperfmperf.c
+@@ -139,6 +139,9 @@ unsigned int arch_freq_get_on_cpu(int cpu)
+ 	if (!housekeeping_cpu(cpu, HK_FLAG_MISC))
+ 		return 0;
+ 
++	if (rcu_is_idle_cpu(cpu))
++		return 0;
++
+ 	if (aperfmperf_snapshot_cpu(cpu, ktime_get(), true))
+ 		return per_cpu(samples.khz, cpu);
+ 
+-- 
+2.34.1
+

--- a/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0003-x86-smp-Move-APERF-MPERF-code-where-it-belongs.patch
+++ b/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0003-x86-smp-Move-APERF-MPERF-code-where-it-belongs.patch
@@ -1,0 +1,901 @@
+From 580bcb7f08ae4dc1080c78ad25765ac659273958 Mon Sep 17 00:00:00 2001
+From: "Xie, Chao" <chao.xie@intel.com>
+Date: Mon, 19 Jun 2023 11:00:29 +0800
+Subject: [PATCH 3/9] x86/smp: Move APERF/MPERF code where it belongs
+
+as this can share code with the preexisting APERF/MPERF code.
+
+No functional change.
+
+Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
+Acked-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
+Acked-by: Peter Zijlstra (Intel) <peterz@infradead.org>
+Acked-by: Paul E. McKenney <paulmck@kernel.org>
+
+Signed-off-by: Xie, Chao <chao.xie@intel.com>
+---
+ arch/x86/kernel/cpu/aperfmperf.c | 427 ++++++++++++++++++++++++++++++-
+ arch/x86/kernel/smpboot.c        | 416 ------------------------------
+ 2 files changed, 424 insertions(+), 419 deletions(-)
+
+diff --git a/arch/x86/kernel/cpu/aperfmperf.c b/arch/x86/kernel/cpu/aperfmperf.c
+index fc850b18d2b9..e6a306bacb37 100644
+--- a/arch/x86/kernel/cpu/aperfmperf.c
++++ b/arch/x86/kernel/cpu/aperfmperf.c
+@@ -7,14 +7,23 @@
+  * Author: Len Brown <len.brown@intel.com>
+  */
+ 
++#include <linux/cpufreq.h>
+ #include <linux/delay.h>
+ #include <linux/ktime.h>
+ #include <linux/math64.h>
+ #include <linux/percpu.h>
+-#include <linux/cpufreq.h>
+-#include <linux/smp.h>
+-#include <linux/sched/isolation.h>
+ #include <linux/rcupdate.h>
++#include <linux/sched/isolation.h>
++#include <linux/sched/topology.h>
++#include <linux/smp.h>
++#include <linux/syscore_ops.h>
++
++#include <asm/cpu_device_id.h>
++#include <asm/intel-family.h>
++
++#ifdef CONFIG_ACPI_CPPC_LIB
++#include <acpi/cppc_acpi.h>
++#endif
+ 
+ #include "cpu.h"
+ 
+@@ -152,3 +161,415 @@ unsigned int arch_freq_get_on_cpu(int cpu)
+ 
+ 	return per_cpu(samples.khz, cpu);
+ }
++
++#ifdef CONFIG_X86_64
++/*
++ * APERF/MPERF frequency ratio computation.
++ *
++ * The scheduler wants to do frequency invariant accounting and needs a <1
++ * ratio to account for the 'current' frequency, corresponding to
++ * freq_curr / freq_max.
++ *
++ * Since the frequency freq_curr on x86 is controlled by micro-controller and
++ * our P-state setting is little more than a request/hint, we need to observe
++ * the effective frequency 'BusyMHz', i.e. the average frequency over a time
++ * interval after discarding idle time. This is given by:
++ *
++ *   BusyMHz = delta_APERF / delta_MPERF * freq_base
++ *
++ * where freq_base is the max non-turbo P-state.
++ *
++ * The freq_max term has to be set to a somewhat arbitrary value, because we
++ * can't know which turbo states will be available at a given point in time:
++ * it all depends on the thermal headroom of the entire package. We set it to
++ * the turbo level with 4 cores active.
++ *
++ * Benchmarks show that's a good compromise between the 1C turbo ratio
++ * (freq_curr/freq_max would rarely reach 1) and something close to freq_base,
++ * which would ignore the entire turbo range (a conspicuous part, making
++ * freq_curr/freq_max always maxed out).
++ *
++ * An exception to the heuristic above is the Atom uarch, where we choose the
++ * highest turbo level for freq_max since Atom's are generally oriented towards
++ * power efficiency.
++ *
++ * Setting freq_max to anything less than the 1C turbo ratio makes the ratio
++ * freq_curr / freq_max to eventually grow >1, in which case we clip it to 1.
++ */
++
++DEFINE_STATIC_KEY_FALSE(arch_scale_freq_key);
++
++static DEFINE_PER_CPU(u64, arch_prev_aperf);
++static DEFINE_PER_CPU(u64, arch_prev_mperf);
++static u64 arch_turbo_freq_ratio = SCHED_CAPACITY_SCALE;
++static u64 arch_max_freq_ratio = SCHED_CAPACITY_SCALE;
++
++void arch_set_max_freq_ratio(bool turbo_disabled)
++{
++	arch_max_freq_ratio = turbo_disabled ? SCHED_CAPACITY_SCALE :
++					arch_turbo_freq_ratio;
++}
++EXPORT_SYMBOL_GPL(arch_set_max_freq_ratio);
++
++static bool turbo_disabled(void)
++{
++	u64 misc_en;
++	int err;
++
++	err = rdmsrl_safe(MSR_IA32_MISC_ENABLE, &misc_en);
++	if (err)
++		return false;
++
++	return (misc_en & MSR_IA32_MISC_ENABLE_TURBO_DISABLE);
++}
++
++static bool slv_set_max_freq_ratio(u64 *base_freq, u64 *turbo_freq)
++{
++	int err;
++
++	err = rdmsrl_safe(MSR_ATOM_CORE_RATIOS, base_freq);
++	if (err)
++		return false;
++
++	err = rdmsrl_safe(MSR_ATOM_CORE_TURBO_RATIOS, turbo_freq);
++	if (err)
++		return false;
++
++	*base_freq = (*base_freq >> 16) & 0x3F;     /* max P state */
++	*turbo_freq = *turbo_freq & 0x3F;           /* 1C turbo    */
++
++	return true;
++}
++
++#define X86_MATCH(model)					\
++	X86_MATCH_VENDOR_FAM_MODEL_FEATURE(INTEL, 6,		\
++		INTEL_FAM6_##model, X86_FEATURE_APERFMPERF, NULL)
++
++static const struct x86_cpu_id has_knl_turbo_ratio_limits[] = {
++	X86_MATCH(XEON_PHI_KNL),
++	X86_MATCH(XEON_PHI_KNM),
++	{}
++};
++
++static const struct x86_cpu_id has_skx_turbo_ratio_limits[] = {
++	X86_MATCH(SKYLAKE_X),
++	{}
++};
++
++static const struct x86_cpu_id has_glm_turbo_ratio_limits[] = {
++	X86_MATCH(ATOM_GOLDMONT),
++	X86_MATCH(ATOM_GOLDMONT_D),
++	X86_MATCH(ATOM_GOLDMONT_PLUS),
++	{}
++};
++
++static bool knl_set_max_freq_ratio(u64 *base_freq, u64 *turbo_freq,
++				int num_delta_fratio)
++{
++	int fratio, delta_fratio, found;
++	int err, i;
++	u64 msr;
++
++	err = rdmsrl_safe(MSR_PLATFORM_INFO, base_freq);
++	if (err)
++		return false;
++
++	*base_freq = (*base_freq >> 8) & 0xFF;	    /* max P state */
++
++	err = rdmsrl_safe(MSR_TURBO_RATIO_LIMIT, &msr);
++	if (err)
++		return false;
++
++	fratio = (msr >> 8) & 0xFF;
++	i = 16;
++	found = 0;
++	do {
++		if (found >= num_delta_fratio) {
++			*turbo_freq = fratio;
++			return true;
++		}
++
++		delta_fratio = (msr >> (i + 5)) & 0x7;
++
++		if (delta_fratio) {
++			found += 1;
++			fratio -= delta_fratio;
++		}
++
++		i += 8;
++	} while (i < 64);
++
++	return true;
++}
++
++static bool skx_set_max_freq_ratio(u64 *base_freq, u64 *turbo_freq, int size)
++{
++	u64 ratios, counts;
++	u32 group_size;
++	int err, i;
++
++	err = rdmsrl_safe(MSR_PLATFORM_INFO, base_freq);
++	if (err)
++		return false;
++
++	*base_freq = (*base_freq >> 8) & 0xFF;      /* max P state */
++
++	err = rdmsrl_safe(MSR_TURBO_RATIO_LIMIT, &ratios);
++	if (err)
++		return false;
++
++	err = rdmsrl_safe(MSR_TURBO_RATIO_LIMIT1, &counts);
++	if (err)
++		return false;
++
++	for (i = 0; i < 64; i += 8) {
++		group_size = (counts >> i) & 0xFF;
++		if (group_size >= size) {
++			*turbo_freq = (ratios >> i) & 0xFF;
++			return true;
++		}
++	}
++
++	return false;
++}
++
++static bool core_set_max_freq_ratio(u64 *base_freq, u64 *turbo_freq)
++{
++	u64 msr;
++	int err;
++
++	err = rdmsrl_safe(MSR_PLATFORM_INFO, base_freq);
++	if (err)
++		return false;
++
++	err = rdmsrl_safe(MSR_TURBO_RATIO_LIMIT, &msr);
++	if (err)
++		return false;
++
++	*base_freq = (*base_freq >> 8) & 0xFF;    /* max P state */
++	*turbo_freq = (msr >> 24) & 0xFF;         /* 4C turbo    */
++
++	/* The CPU may have less than 4 cores */
++	if (!*turbo_freq)
++		*turbo_freq = msr & 0xFF;         /* 1C turbo    */
++
++	return true;
++}
++
++static bool intel_set_max_freq_ratio(void)
++{
++	u64 base_freq, turbo_freq;
++	u64 turbo_ratio;
++
++	if (slv_set_max_freq_ratio(&base_freq, &turbo_freq))
++		goto out;
++
++	if (x86_match_cpu(has_glm_turbo_ratio_limits) &&
++	    skx_set_max_freq_ratio(&base_freq, &turbo_freq, 1))
++		goto out;
++
++	if (x86_match_cpu(has_knl_turbo_ratio_limits) &&
++	    knl_set_max_freq_ratio(&base_freq, &turbo_freq, 1))
++		goto out;
++
++	if (x86_match_cpu(has_skx_turbo_ratio_limits) &&
++	    skx_set_max_freq_ratio(&base_freq, &turbo_freq, 4))
++		goto out;
++
++	if (core_set_max_freq_ratio(&base_freq, &turbo_freq))
++		goto out;
++
++	return false;
++
++out:
++	/*
++	 * Some hypervisors advertise X86_FEATURE_APERFMPERF
++	 * but then fill all MSR's with zeroes.
++	 * Some CPUs have turbo boost but don't declare any turbo ratio
++	 * in MSR_TURBO_RATIO_LIMIT.
++	 */
++	if (!base_freq || !turbo_freq) {
++		pr_debug("Couldn't determine cpu base or turbo frequency, necessary for scale-invariant accounting.\n");
++		return false;
++	}
++
++	turbo_ratio = div_u64(turbo_freq * SCHED_CAPACITY_SCALE, base_freq);
++	if (!turbo_ratio) {
++		pr_debug("Non-zero turbo and base frequencies led to a 0 ratio.\n");
++		return false;
++	}
++
++	arch_turbo_freq_ratio = turbo_ratio;
++	arch_set_max_freq_ratio(turbo_disabled());
++
++	return true;
++}
++
++#ifdef CONFIG_ACPI_CPPC_LIB
++static bool amd_set_max_freq_ratio(void)
++{
++	struct cppc_perf_caps perf_caps;
++	u64 highest_perf, nominal_perf;
++	u64 perf_ratio;
++	int rc;
++
++	rc = cppc_get_perf_caps(0, &perf_caps);
++	if (rc) {
++		pr_debug("Could not retrieve perf counters (%d)\n", rc);
++		return false;
++	}
++
++	highest_perf = amd_get_highest_perf();
++	nominal_perf = perf_caps.nominal_perf;
++
++	if (!highest_perf || !nominal_perf) {
++		pr_debug("Could not retrieve highest or nominal performance\n");
++		return false;
++	}
++
++	perf_ratio = div_u64(highest_perf * SCHED_CAPACITY_SCALE, nominal_perf);
++	/* midpoint between max_boost and max_P */
++	perf_ratio = (perf_ratio + SCHED_CAPACITY_SCALE) >> 1;
++	if (!perf_ratio) {
++		pr_debug("Non-zero highest/nominal perf values led to a 0 ratio\n");
++		return false;
++	}
++
++	arch_turbo_freq_ratio = perf_ratio;
++	arch_set_max_freq_ratio(false);
++
++	return true;
++}
++#else
++static bool amd_set_max_freq_ratio(void)
++{
++	return false;
++}
++#endif
++
++static void init_counter_refs(void)
++{
++	u64 aperf, mperf;
++
++	rdmsrl(MSR_IA32_APERF, aperf);
++	rdmsrl(MSR_IA32_MPERF, mperf);
++
++	this_cpu_write(arch_prev_aperf, aperf);
++	this_cpu_write(arch_prev_mperf, mperf);
++}
++
++#ifdef CONFIG_PM_SLEEP
++static struct syscore_ops freq_invariance_syscore_ops = {
++	.resume = init_counter_refs,
++};
++
++static void register_freq_invariance_syscore_ops(void)
++{
++	/* Bail out if registered already. */
++	if (freq_invariance_syscore_ops.node.prev)
++		return;
++
++	register_syscore_ops(&freq_invariance_syscore_ops);
++}
++#else
++static inline void register_freq_invariance_syscore_ops(void) {}
++#endif
++
++void init_freq_invariance(bool secondary, bool cppc_ready)
++{
++	bool ret = false;
++
++	if (!boot_cpu_has(X86_FEATURE_APERFMPERF))
++		return;
++
++	if (secondary) {
++		if (static_branch_likely(&arch_scale_freq_key)) {
++			init_counter_refs();
++		}
++		return;
++	}
++
++	if (boot_cpu_data.x86_vendor == X86_VENDOR_INTEL)
++		ret = intel_set_max_freq_ratio();
++	else if (boot_cpu_data.x86_vendor == X86_VENDOR_AMD) {
++		if (!cppc_ready) {
++			return;
++		}
++		ret = amd_set_max_freq_ratio();
++	}
++
++	if (ret) {
++		init_counter_refs();
++		static_branch_enable(&arch_scale_freq_key);
++		register_freq_invariance_syscore_ops();
++		pr_info("Estimated ratio of average max frequency by base frequency (times 1024): %llu\n", arch_max_freq_ratio);
++	} else {
++		pr_debug("Couldn't determine max cpu frequency, necessary for scale-invariant accounting.\n");
++	}
++}
++
++#ifdef CONFIG_ACPI_CPPC_LIB
++static DEFINE_MUTEX(freq_invariance_lock);
++
++void init_freq_invariance_cppc(void)
++{
++	static bool secondary;
++
++	mutex_lock(&freq_invariance_lock);
++
++	init_freq_invariance(secondary, true);
++	secondary = true;
++
++	mutex_unlock(&freq_invariance_lock);
++}
++#endif
++
++static void disable_freq_invariance_workfn(struct work_struct *work)
++{
++	static_branch_disable(&arch_scale_freq_key);
++}
++
++static DECLARE_WORK(disable_freq_invariance_work,
++		    disable_freq_invariance_workfn);
++
++DEFINE_PER_CPU(unsigned long, arch_freq_scale) = SCHED_CAPACITY_SCALE;
++
++void arch_scale_freq_tick(void)
++{
++	u64 freq_scale = SCHED_CAPACITY_SCALE;
++	u64 aperf, mperf;
++	u64 acnt, mcnt;
++
++	if (!arch_scale_freq_invariant())
++		return;
++
++	rdmsrl(MSR_IA32_APERF, aperf);
++	rdmsrl(MSR_IA32_MPERF, mperf);
++
++	acnt = aperf - this_cpu_read(arch_prev_aperf);
++	mcnt = mperf - this_cpu_read(arch_prev_mperf);
++
++	this_cpu_write(arch_prev_aperf, aperf);
++	this_cpu_write(arch_prev_mperf, mperf);
++
++	if (check_shl_overflow(acnt, 2*SCHED_CAPACITY_SHIFT, &acnt))
++		goto error;
++
++	if (check_mul_overflow(mcnt, arch_max_freq_ratio, &mcnt) || !mcnt)
++		goto error;
++
++	freq_scale = div64_u64(acnt, mcnt);
++	if (!freq_scale)
++		goto error;
++
++	if (freq_scale > SCHED_CAPACITY_SCALE)
++		freq_scale = SCHED_CAPACITY_SCALE;
++
++	this_cpu_write(arch_freq_scale, freq_scale);
++	return;
++
++error:
++	pr_warn("Scheduler frequency invariance went wobbly, disabling!\n");
++	schedule_work(&disable_freq_invariance_work);
++}
++#endif /* CONFIG_X86_64 */
+diff --git a/arch/x86/kernel/smpboot.c b/arch/x86/kernel/smpboot.c
+index 3c97c0b070e3..2661a9388091 100644
+--- a/arch/x86/kernel/smpboot.c
++++ b/arch/x86/kernel/smpboot.c
+@@ -83,10 +83,6 @@
+ #include <asm/hw_irq.h>
+ #include <asm/stackprotector.h>
+ 
+-#ifdef CONFIG_ACPI_CPPC_LIB
+-#include <acpi/cppc_acpi.h>
+-#endif
+-
+ /* representing HT siblings of each logical CPU */
+ DEFINE_PER_CPU_READ_MOSTLY(cpumask_var_t, cpu_sibling_map);
+ EXPORT_PER_CPU_SYMBOL(cpu_sibling_map);
+@@ -1789,415 +1785,3 @@ void native_play_dead(void)
+ }
+ 
+ #endif
+-
+-#ifdef CONFIG_X86_64
+-/*
+- * APERF/MPERF frequency ratio computation.
+- *
+- * The scheduler wants to do frequency invariant accounting and needs a <1
+- * ratio to account for the 'current' frequency, corresponding to
+- * freq_curr / freq_max.
+- *
+- * Since the frequency freq_curr on x86 is controlled by micro-controller and
+- * our P-state setting is little more than a request/hint, we need to observe
+- * the effective frequency 'BusyMHz', i.e. the average frequency over a time
+- * interval after discarding idle time. This is given by:
+- *
+- *   BusyMHz = delta_APERF / delta_MPERF * freq_base
+- *
+- * where freq_base is the max non-turbo P-state.
+- *
+- * The freq_max term has to be set to a somewhat arbitrary value, because we
+- * can't know which turbo states will be available at a given point in time:
+- * it all depends on the thermal headroom of the entire package. We set it to
+- * the turbo level with 4 cores active.
+- *
+- * Benchmarks show that's a good compromise between the 1C turbo ratio
+- * (freq_curr/freq_max would rarely reach 1) and something close to freq_base,
+- * which would ignore the entire turbo range (a conspicuous part, making
+- * freq_curr/freq_max always maxed out).
+- *
+- * An exception to the heuristic above is the Atom uarch, where we choose the
+- * highest turbo level for freq_max since Atom's are generally oriented towards
+- * power efficiency.
+- *
+- * Setting freq_max to anything less than the 1C turbo ratio makes the ratio
+- * freq_curr / freq_max to eventually grow >1, in which case we clip it to 1.
+- */
+-
+-DEFINE_STATIC_KEY_FALSE(arch_scale_freq_key);
+-
+-static DEFINE_PER_CPU(u64, arch_prev_aperf);
+-static DEFINE_PER_CPU(u64, arch_prev_mperf);
+-static u64 arch_turbo_freq_ratio = SCHED_CAPACITY_SCALE;
+-static u64 arch_max_freq_ratio = SCHED_CAPACITY_SCALE;
+-
+-void arch_set_max_freq_ratio(bool turbo_disabled)
+-{
+-	arch_max_freq_ratio = turbo_disabled ? SCHED_CAPACITY_SCALE :
+-					arch_turbo_freq_ratio;
+-}
+-EXPORT_SYMBOL_GPL(arch_set_max_freq_ratio);
+-
+-static bool turbo_disabled(void)
+-{
+-	u64 misc_en;
+-	int err;
+-
+-	err = rdmsrl_safe(MSR_IA32_MISC_ENABLE, &misc_en);
+-	if (err)
+-		return false;
+-
+-	return (misc_en & MSR_IA32_MISC_ENABLE_TURBO_DISABLE);
+-}
+-
+-static bool slv_set_max_freq_ratio(u64 *base_freq, u64 *turbo_freq)
+-{
+-	int err;
+-
+-	err = rdmsrl_safe(MSR_ATOM_CORE_RATIOS, base_freq);
+-	if (err)
+-		return false;
+-
+-	err = rdmsrl_safe(MSR_ATOM_CORE_TURBO_RATIOS, turbo_freq);
+-	if (err)
+-		return false;
+-
+-	*base_freq = (*base_freq >> 16) & 0x3F;     /* max P state */
+-	*turbo_freq = *turbo_freq & 0x3F;           /* 1C turbo    */
+-
+-	return true;
+-}
+-
+-#define X86_MATCH(model)					\
+-	X86_MATCH_VENDOR_FAM_MODEL_FEATURE(INTEL, 6,		\
+-		INTEL_FAM6_##model, X86_FEATURE_APERFMPERF, NULL)
+-
+-static const struct x86_cpu_id has_knl_turbo_ratio_limits[] = {
+-	X86_MATCH(XEON_PHI_KNL),
+-	X86_MATCH(XEON_PHI_KNM),
+-	{}
+-};
+-
+-static const struct x86_cpu_id has_skx_turbo_ratio_limits[] = {
+-	X86_MATCH(SKYLAKE_X),
+-	{}
+-};
+-
+-static const struct x86_cpu_id has_glm_turbo_ratio_limits[] = {
+-	X86_MATCH(ATOM_GOLDMONT),
+-	X86_MATCH(ATOM_GOLDMONT_D),
+-	X86_MATCH(ATOM_GOLDMONT_PLUS),
+-	{}
+-};
+-
+-static bool knl_set_max_freq_ratio(u64 *base_freq, u64 *turbo_freq,
+-				int num_delta_fratio)
+-{
+-	int fratio, delta_fratio, found;
+-	int err, i;
+-	u64 msr;
+-
+-	err = rdmsrl_safe(MSR_PLATFORM_INFO, base_freq);
+-	if (err)
+-		return false;
+-
+-	*base_freq = (*base_freq >> 8) & 0xFF;	    /* max P state */
+-
+-	err = rdmsrl_safe(MSR_TURBO_RATIO_LIMIT, &msr);
+-	if (err)
+-		return false;
+-
+-	fratio = (msr >> 8) & 0xFF;
+-	i = 16;
+-	found = 0;
+-	do {
+-		if (found >= num_delta_fratio) {
+-			*turbo_freq = fratio;
+-			return true;
+-		}
+-
+-		delta_fratio = (msr >> (i + 5)) & 0x7;
+-
+-		if (delta_fratio) {
+-			found += 1;
+-			fratio -= delta_fratio;
+-		}
+-
+-		i += 8;
+-	} while (i < 64);
+-
+-	return true;
+-}
+-
+-static bool skx_set_max_freq_ratio(u64 *base_freq, u64 *turbo_freq, int size)
+-{
+-	u64 ratios, counts;
+-	u32 group_size;
+-	int err, i;
+-
+-	err = rdmsrl_safe(MSR_PLATFORM_INFO, base_freq);
+-	if (err)
+-		return false;
+-
+-	*base_freq = (*base_freq >> 8) & 0xFF;      /* max P state */
+-
+-	err = rdmsrl_safe(MSR_TURBO_RATIO_LIMIT, &ratios);
+-	if (err)
+-		return false;
+-
+-	err = rdmsrl_safe(MSR_TURBO_RATIO_LIMIT1, &counts);
+-	if (err)
+-		return false;
+-
+-	for (i = 0; i < 64; i += 8) {
+-		group_size = (counts >> i) & 0xFF;
+-		if (group_size >= size) {
+-			*turbo_freq = (ratios >> i) & 0xFF;
+-			return true;
+-		}
+-	}
+-
+-	return false;
+-}
+-
+-static bool core_set_max_freq_ratio(u64 *base_freq, u64 *turbo_freq)
+-{
+-	u64 msr;
+-	int err;
+-
+-	err = rdmsrl_safe(MSR_PLATFORM_INFO, base_freq);
+-	if (err)
+-		return false;
+-
+-	err = rdmsrl_safe(MSR_TURBO_RATIO_LIMIT, &msr);
+-	if (err)
+-		return false;
+-
+-	*base_freq = (*base_freq >> 8) & 0xFF;    /* max P state */
+-	*turbo_freq = (msr >> 24) & 0xFF;         /* 4C turbo    */
+-
+-	/* The CPU may have less than 4 cores */
+-	if (!*turbo_freq)
+-		*turbo_freq = msr & 0xFF;         /* 1C turbo    */
+-
+-	return true;
+-}
+-
+-static bool intel_set_max_freq_ratio(void)
+-{
+-	u64 base_freq, turbo_freq;
+-	u64 turbo_ratio;
+-
+-	if (slv_set_max_freq_ratio(&base_freq, &turbo_freq))
+-		goto out;
+-
+-	if (x86_match_cpu(has_glm_turbo_ratio_limits) &&
+-	    skx_set_max_freq_ratio(&base_freq, &turbo_freq, 1))
+-		goto out;
+-
+-	if (x86_match_cpu(has_knl_turbo_ratio_limits) &&
+-	    knl_set_max_freq_ratio(&base_freq, &turbo_freq, 1))
+-		goto out;
+-
+-	if (x86_match_cpu(has_skx_turbo_ratio_limits) &&
+-	    skx_set_max_freq_ratio(&base_freq, &turbo_freq, 4))
+-		goto out;
+-
+-	if (core_set_max_freq_ratio(&base_freq, &turbo_freq))
+-		goto out;
+-
+-	return false;
+-
+-out:
+-	/*
+-	 * Some hypervisors advertise X86_FEATURE_APERFMPERF
+-	 * but then fill all MSR's with zeroes.
+-	 * Some CPUs have turbo boost but don't declare any turbo ratio
+-	 * in MSR_TURBO_RATIO_LIMIT.
+-	 */
+-	if (!base_freq || !turbo_freq) {
+-		pr_debug("Couldn't determine cpu base or turbo frequency, necessary for scale-invariant accounting.\n");
+-		return false;
+-	}
+-
+-	turbo_ratio = div_u64(turbo_freq * SCHED_CAPACITY_SCALE, base_freq);
+-	if (!turbo_ratio) {
+-		pr_debug("Non-zero turbo and base frequencies led to a 0 ratio.\n");
+-		return false;
+-	}
+-
+-	arch_turbo_freq_ratio = turbo_ratio;
+-	arch_set_max_freq_ratio(turbo_disabled());
+-
+-	return true;
+-}
+-
+-#ifdef CONFIG_ACPI_CPPC_LIB
+-static bool amd_set_max_freq_ratio(void)
+-{
+-	struct cppc_perf_caps perf_caps;
+-	u64 highest_perf, nominal_perf;
+-	u64 perf_ratio;
+-	int rc;
+-
+-	rc = cppc_get_perf_caps(0, &perf_caps);
+-	if (rc) {
+-		pr_debug("Could not retrieve perf counters (%d)\n", rc);
+-		return false;
+-	}
+-
+-	highest_perf = amd_get_highest_perf();
+-	nominal_perf = perf_caps.nominal_perf;
+-
+-	if (!highest_perf || !nominal_perf) {
+-		pr_debug("Could not retrieve highest or nominal performance\n");
+-		return false;
+-	}
+-
+-	perf_ratio = div_u64(highest_perf * SCHED_CAPACITY_SCALE, nominal_perf);
+-	/* midpoint between max_boost and max_P */
+-	perf_ratio = (perf_ratio + SCHED_CAPACITY_SCALE) >> 1;
+-	if (!perf_ratio) {
+-		pr_debug("Non-zero highest/nominal perf values led to a 0 ratio\n");
+-		return false;
+-	}
+-
+-	arch_turbo_freq_ratio = perf_ratio;
+-	arch_set_max_freq_ratio(false);
+-
+-	return true;
+-}
+-#else
+-static bool amd_set_max_freq_ratio(void)
+-{
+-	return false;
+-}
+-#endif
+-
+-static void init_counter_refs(void)
+-{
+-	u64 aperf, mperf;
+-
+-	rdmsrl(MSR_IA32_APERF, aperf);
+-	rdmsrl(MSR_IA32_MPERF, mperf);
+-
+-	this_cpu_write(arch_prev_aperf, aperf);
+-	this_cpu_write(arch_prev_mperf, mperf);
+-}
+-
+-#ifdef CONFIG_PM_SLEEP
+-static struct syscore_ops freq_invariance_syscore_ops = {
+-	.resume = init_counter_refs,
+-};
+-
+-static void register_freq_invariance_syscore_ops(void)
+-{
+-	/* Bail out if registered already. */
+-	if (freq_invariance_syscore_ops.node.prev)
+-		return;
+-
+-	register_syscore_ops(&freq_invariance_syscore_ops);
+-}
+-#else
+-static inline void register_freq_invariance_syscore_ops(void) {}
+-#endif
+-
+-void init_freq_invariance(bool secondary, bool cppc_ready)
+-{
+-	bool ret = false;
+-
+-	if (!boot_cpu_has(X86_FEATURE_APERFMPERF))
+-		return;
+-
+-	if (secondary) {
+-		if (static_branch_likely(&arch_scale_freq_key)) {
+-			init_counter_refs();
+-		}
+-		return;
+-	}
+-
+-	if (boot_cpu_data.x86_vendor == X86_VENDOR_INTEL)
+-		ret = intel_set_max_freq_ratio();
+-	else if (boot_cpu_data.x86_vendor == X86_VENDOR_AMD) {
+-		if (!cppc_ready) {
+-			return;
+-		}
+-		ret = amd_set_max_freq_ratio();
+-	}
+-
+-	if (ret) {
+-		init_counter_refs();
+-		static_branch_enable(&arch_scale_freq_key);
+-		register_freq_invariance_syscore_ops();
+-		pr_info("Estimated ratio of average max frequency by base frequency (times 1024): %llu\n", arch_max_freq_ratio);
+-	} else {
+-		pr_debug("Couldn't determine max cpu frequency, necessary for scale-invariant accounting.\n");
+-	}
+-}
+-
+-#ifdef CONFIG_ACPI_CPPC_LIB
+-static DEFINE_MUTEX(freq_invariance_lock);
+-
+-void init_freq_invariance_cppc(void)
+-{
+-	static bool secondary;
+-
+-	mutex_lock(&freq_invariance_lock);
+-
+-	init_freq_invariance(secondary, true);
+-	secondary = true;
+-
+-	mutex_unlock(&freq_invariance_lock);
+-}
+-#endif
+-
+-static void disable_freq_invariance_workfn(struct work_struct *work)
+-{
+-	static_branch_disable(&arch_scale_freq_key);
+-}
+-
+-static DECLARE_WORK(disable_freq_invariance_work,
+-		    disable_freq_invariance_workfn);
+-
+-DEFINE_PER_CPU(unsigned long, arch_freq_scale) = SCHED_CAPACITY_SCALE;
+-
+-void arch_scale_freq_tick(void)
+-{
+-	u64 freq_scale = SCHED_CAPACITY_SCALE;
+-	u64 aperf, mperf;
+-	u64 acnt, mcnt;
+-
+-	if (!arch_scale_freq_invariant())
+-		return;
+-
+-	rdmsrl(MSR_IA32_APERF, aperf);
+-	rdmsrl(MSR_IA32_MPERF, mperf);
+-
+-	acnt = aperf - this_cpu_read(arch_prev_aperf);
+-	mcnt = mperf - this_cpu_read(arch_prev_mperf);
+-
+-	this_cpu_write(arch_prev_aperf, aperf);
+-	this_cpu_write(arch_prev_mperf, mperf);
+-
+-	if (check_shl_overflow(acnt, 2*SCHED_CAPACITY_SHIFT, &acnt))
+-		goto error;
+-
+-	if (check_mul_overflow(mcnt, arch_max_freq_ratio, &mcnt) || !mcnt)
+-		goto error;
+-
+-	freq_scale = div64_u64(acnt, mcnt);
+-	if (!freq_scale)
+-		goto error;
+-
+-	if (freq_scale > SCHED_CAPACITY_SCALE)
+-		freq_scale = SCHED_CAPACITY_SCALE;
+-
+-	this_cpu_write(arch_freq_scale, freq_scale);
+-	return;
+-
+-error:
+-	pr_warn("Scheduler frequency invariance went wobbly, disabling!\n");
+-	schedule_work(&disable_freq_invariance_work);
+-}
+-#endif /* CONFIG_X86_64 */
+-- 
+2.34.1
+

--- a/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0004-x86-aperfmperf-Put-frequency-invariance-aperf-mperf-.patch
+++ b/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0004-x86-aperfmperf-Put-frequency-invariance-aperf-mperf-.patch
@@ -1,0 +1,90 @@
+From f096cfcd06fa789c1077e89911d7ac9a6aec6dcf Mon Sep 17 00:00:00 2001
+From: "Xie, Chao" <chao.xie@intel.com>
+Date: Fri, 16 Jun 2023 14:50:03 +0800
+Subject: [PATCH 4/9] x86/aperfmperf: Put frequency invariance aperf/mperf data
+ into a struct
+
+Preparation for sharing code with the CPU frequency portion of the
+aperf/mperf code.
+
+No functional change.
+
+Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
+Reviewed-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
+Acked-by: Peter Zijlstra (Intel) <peterz@infradead.org>
+Acked-by: Paul E. McKenney <paulmck@kernel.org>
+
+Signed-off-by: Xie, Chao <chao.xie@intel.com>
+---
+ arch/x86/kernel/cpu/aperfmperf.c | 26 +++++++++++++++-----------
+ 1 file changed, 15 insertions(+), 11 deletions(-)
+
+diff --git a/arch/x86/kernel/cpu/aperfmperf.c b/arch/x86/kernel/cpu/aperfmperf.c
+index e6a306bacb37..7efe94e74b82 100644
+--- a/arch/x86/kernel/cpu/aperfmperf.c
++++ b/arch/x86/kernel/cpu/aperfmperf.c
+@@ -27,6 +27,13 @@
+ 
+ #include "cpu.h"
+ 
++struct aperfmperf {
++	u64		aperf;
++	u64		mperf;
++};
++
++static DEFINE_PER_CPU_SHARED_ALIGNED(struct aperfmperf, cpu_samples);
++
+ struct aperfmperf_sample {
+ 	unsigned int	khz;
+ 	atomic_t	scfpending;
+@@ -199,8 +206,6 @@ unsigned int arch_freq_get_on_cpu(int cpu)
+ 
+ DEFINE_STATIC_KEY_FALSE(arch_scale_freq_key);
+ 
+-static DEFINE_PER_CPU(u64, arch_prev_aperf);
+-static DEFINE_PER_CPU(u64, arch_prev_mperf);
+ static u64 arch_turbo_freq_ratio = SCHED_CAPACITY_SCALE;
+ static u64 arch_max_freq_ratio = SCHED_CAPACITY_SCALE;
+ 
+@@ -454,8 +459,8 @@ static void init_counter_refs(void)
+ 	rdmsrl(MSR_IA32_APERF, aperf);
+ 	rdmsrl(MSR_IA32_MPERF, mperf);
+ 
+-	this_cpu_write(arch_prev_aperf, aperf);
+-	this_cpu_write(arch_prev_mperf, mperf);
++	this_cpu_write(cpu_samples.aperf, aperf);
++	this_cpu_write(cpu_samples.mperf, mperf);
+ }
+ 
+ #ifdef CONFIG_PM_SLEEP
+@@ -536,9 +541,8 @@ DEFINE_PER_CPU(unsigned long, arch_freq_scale) = SCHED_CAPACITY_SCALE;
+ 
+ void arch_scale_freq_tick(void)
+ {
+-	u64 freq_scale = SCHED_CAPACITY_SCALE;
+-	u64 aperf, mperf;
+-	u64 acnt, mcnt;
++	struct aperfmperf *s = this_cpu_ptr(&cpu_samples);
++	u64 aperf, mperf, acnt, mcnt, freq_scale;
+ 
+ 	if (!arch_scale_freq_invariant())
+ 		return;
+@@ -546,11 +550,11 @@ void arch_scale_freq_tick(void)
+ 	rdmsrl(MSR_IA32_APERF, aperf);
+ 	rdmsrl(MSR_IA32_MPERF, mperf);
+ 
+-	acnt = aperf - this_cpu_read(arch_prev_aperf);
+-	mcnt = mperf - this_cpu_read(arch_prev_mperf);
++	acnt = aperf - s->aperf;
++	mcnt = mperf - s->mperf;
+ 
+-	this_cpu_write(arch_prev_aperf, aperf);
+-	this_cpu_write(arch_prev_mperf, mperf);
++	s->aperf = aperf;
++	s->mperf = mperf;
+ 
+ 	if (check_shl_overflow(acnt, 2*SCHED_CAPACITY_SHIFT, &acnt))
+ 		goto error;
+-- 
+2.34.1
+

--- a/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0005-x86-aperfmperf-Restructure-arch_scale_freq_tick.patch
+++ b/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0005-x86-aperfmperf-Restructure-arch_scale_freq_tick.patch
@@ -1,0 +1,76 @@
+From 96299a4bae390a2137bf27e225f0c1cee5a38875 Mon Sep 17 00:00:00 2001
+From: "Xie, Chao" <chao.xie@intel.com>
+Date: Mon, 19 Jun 2023 11:02:20 +0800
+Subject: [PATCH 5/9] x86/aperfmperf: Restructure arch_scale_freq_tick()
+
+Preparation for sharing code with the CPU frequency portion of the
+aperf/mperf code.
+
+No functional change.
+
+Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
+Reviewed-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
+Acked-by: Peter Zijlstra (Intel) <peterz@infradead.org>
+Acked-by: Paul E. McKenney <paulmck@kernel.org>
+
+Signed-off-by: Xie, Chao <chao.xie@intel.com>
+---
+ arch/x86/kernel/cpu/aperfmperf.c | 36 +++++++++++++++++++-------------
+ 1 file changed, 21 insertions(+), 15 deletions(-)
+
+diff --git a/arch/x86/kernel/cpu/aperfmperf.c b/arch/x86/kernel/cpu/aperfmperf.c
+index 7efe94e74b82..420820c33379 100644
+--- a/arch/x86/kernel/cpu/aperfmperf.c
++++ b/arch/x86/kernel/cpu/aperfmperf.c
+@@ -539,22 +539,9 @@ static DECLARE_WORK(disable_freq_invariance_work,
+ 
+ DEFINE_PER_CPU(unsigned long, arch_freq_scale) = SCHED_CAPACITY_SCALE;
+ 
+-void arch_scale_freq_tick(void)
++static void scale_freq_tick(u64 acnt, u64 mcnt)
+ {
+-	struct aperfmperf *s = this_cpu_ptr(&cpu_samples);
+-	u64 aperf, mperf, acnt, mcnt, freq_scale;
+-
+-	if (!arch_scale_freq_invariant())
+-		return;
+-
+-	rdmsrl(MSR_IA32_APERF, aperf);
+-	rdmsrl(MSR_IA32_MPERF, mperf);
+-
+-	acnt = aperf - s->aperf;
+-	mcnt = mperf - s->mperf;
+-
+-	s->aperf = aperf;
+-	s->mperf = mperf;
++	u64 freq_scale;
+ 
+ 	if (check_shl_overflow(acnt, 2*SCHED_CAPACITY_SHIFT, &acnt))
+ 		goto error;
+@@ -576,4 +563,23 @@ void arch_scale_freq_tick(void)
+ 	pr_warn("Scheduler frequency invariance went wobbly, disabling!\n");
+ 	schedule_work(&disable_freq_invariance_work);
+ }
++
++void arch_scale_freq_tick(void)
++{
++	struct aperfmperf *s = this_cpu_ptr(&cpu_samples);
++	u64 acnt, mcnt, aperf, mperf;
++
++	if (!arch_scale_freq_invariant())
++		return;
++
++	rdmsrl(MSR_IA32_APERF, aperf);
++	rdmsrl(MSR_IA32_MPERF, mperf);
++	acnt = aperf - s->aperf;
++	mcnt = mperf - s->mperf;
++
++	s->aperf = aperf;
++	s->mperf = mperf;
++
++	scale_freq_tick(acnt, mcnt);
++}
+ #endif /* CONFIG_X86_64 */
+-- 
+2.34.1
+

--- a/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0006-x86-aperfmperf-Store-aperf-mperf-data-for-cpu-freque.patch
+++ b/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0006-x86-aperfmperf-Store-aperf-mperf-data-for-cpu-freque.patch
@@ -1,0 +1,59 @@
+From 9296cfb346d8e15ed29715216853b6b0a62b31e6 Mon Sep 17 00:00:00 2001
+From: "Xie, Chao" <chao.xie@intel.com>
+Date: Fri, 16 Jun 2023 14:55:50 +0800
+Subject: [PATCH 6/9] x86/aperfmperf: Store aperf/mperf data for cpu frequency
+ reads
+
+Now that the MSR readout is unconditional, store the results in the per CPU
+data structure along with a jiffies timestamp for the CPU frequency readout
+code.
+
+Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
+Acked-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
+Acked-by: Peter Zijlstra (Intel) <peterz@infradead.org>
+Acked-by: Paul E. McKenney <paulmck@kernel.org>
+
+Signed-off-by: Xie, Chao <chao.xie@intel.com>
+---
+ arch/x86/kernel/cpu/aperfmperf.c | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/arch/x86/kernel/cpu/aperfmperf.c b/arch/x86/kernel/cpu/aperfmperf.c
+index 420820c33379..5f156bf665ca 100644
+--- a/arch/x86/kernel/cpu/aperfmperf.c
++++ b/arch/x86/kernel/cpu/aperfmperf.c
+@@ -28,11 +28,17 @@
+ #include "cpu.h"
+ 
+ struct aperfmperf {
++	seqcount_t	seq;
++	unsigned long	last_update;
++	u64		acnt;
++	u64		mcnt;
+ 	u64		aperf;
+ 	u64		mperf;
+ };
+ 
+-static DEFINE_PER_CPU_SHARED_ALIGNED(struct aperfmperf, cpu_samples);
++static DEFINE_PER_CPU_SHARED_ALIGNED(struct aperfmperf, cpu_samples) = {
++	.seq = SEQCNT_ZERO(cpu_samples.seq)
++};
+ 
+ struct aperfmperf_sample {
+ 	unsigned int	khz;
+@@ -580,6 +586,12 @@ void arch_scale_freq_tick(void)
+ 	s->aperf = aperf;
+ 	s->mperf = mperf;
+ 
++	raw_write_seqcount_begin(&s->seq);
++	s->last_update = jiffies;
++	s->acnt = acnt;
++	s->mcnt = mcnt;
++	raw_write_seqcount_end(&s->seq);
++
+ 	scale_freq_tick(acnt, mcnt);
+ }
+ #endif /* CONFIG_X86_64 */
+-- 
+2.34.1
+

--- a/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0007-x86-aperfmperf-Replace-aperfmperf_get_khz.patch
+++ b/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0007-x86-aperfmperf-Replace-aperfmperf_get_khz.patch
@@ -1,0 +1,158 @@
+From c8196da1deffaa80bd4ddaf9b03b9589e0d5e71c Mon Sep 17 00:00:00 2001
+From: "Xie, Chao" <chao.xie@intel.com>
+Date: Mon, 19 Jun 2023 11:04:04 +0800
+Subject: [PATCH 7/9] x86/aperfmperf: Replace aperfmperf_get_khz()
+
+The frequency invariance infrastructure provides the APERF/MPERF samples
+already. Utilize them for the cpu frequency display in /proc/cpuinfo.
+
+The sample is considered valid for 20ms. So for idle or isolated NOHZ full
+CPUs the function returns 0, which is matching the previous behaviour.
+
+This gets rid of the mass IPIs and a delay of 20ms for stabilizing observed
+by Eric when reading /proc/cpuinfo.
+
+Reported-by: Eric Dumazet <eric.dumazet@gmail.com>
+Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
+Tested-by: Eric Dumazet <edumazet@google.com>
+Reviewed-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
+Acked-by: Peter Zijlstra (Intel) <peterz@infradead.org>
+Acked-by: Paul E. McKenney <paulmck@kernel.org>
+
+Signed-off-by: Xie, Chao <chao.xie@intel.com>
+---
+ arch/x86/kernel/cpu/aperfmperf.c | 77 ++++++++++++++------------------
+ fs/proc/cpuinfo.c                |  6 +--
+ include/linux/cpufreq.h          |  1 -
+ 3 files changed, 35 insertions(+), 49 deletions(-)
+
+diff --git a/arch/x86/kernel/cpu/aperfmperf.c b/arch/x86/kernel/cpu/aperfmperf.c
+index 5f156bf665ca..8c780624483d 100644
+--- a/arch/x86/kernel/cpu/aperfmperf.c
++++ b/arch/x86/kernel/cpu/aperfmperf.c
+@@ -105,49 +105,6 @@ static bool aperfmperf_snapshot_cpu(int cpu, ktime_t now, bool wait)
+ 	return time_delta <= APERFMPERF_STALE_THRESHOLD_MS;
+ }
+ 
+-unsigned int aperfmperf_get_khz(int cpu)
+-{
+-	if (!cpu_khz)
+-		return 0;
+-
+-	if (!boot_cpu_has(X86_FEATURE_APERFMPERF))
+-		return 0;
+-
+-	if (!housekeeping_cpu(cpu, HK_FLAG_MISC))
+-		return 0;
+-
+-	if (rcu_is_idle_cpu(cpu))
+-		return 0; /* Idle CPUs are completely uninteresting. */
+-
+-	aperfmperf_snapshot_cpu(cpu, ktime_get(), true);
+-	return per_cpu(samples.khz, cpu);
+-}
+-
+-void arch_freq_prepare_all(void)
+-{
+-	ktime_t now = ktime_get();
+-	bool wait = false;
+-	int cpu;
+-
+-	if (!cpu_khz)
+-		return;
+-
+-	if (!boot_cpu_has(X86_FEATURE_APERFMPERF))
+-		return;
+-
+-	for_each_online_cpu(cpu) {
+-		if (!housekeeping_cpu(cpu, HK_FLAG_MISC))
+-			continue;
+-		if (rcu_is_idle_cpu(cpu))
+-			continue; /* Idle CPUs are completely uninteresting. */
+-		if (!aperfmperf_snapshot_cpu(cpu, now, false))
+-			wait = true;
+-	}
+-
+-	if (wait)
+-		msleep(APERFMPERF_REFRESH_DELAY_MS);
+-}
+-
+ unsigned int arch_freq_get_on_cpu(int cpu)
+ {
+ 	struct aperfmperf_sample *s = per_cpu_ptr(&samples, cpu);
+@@ -482,6 +439,40 @@ static void register_freq_invariance_syscore_ops(void)
+ 
+ 	register_syscore_ops(&freq_invariance_syscore_ops);
+ }
++
++/*
++ * Discard samples older than the define maximum sample age of 20ms. There
++ * is no point in sending IPIs in such a case. If the scheduler tick was
++ * not running then the CPU is either idle or isolated.
++ */
++#define MAX_SAMPLE_AGE	((unsigned long)HZ / 50)
++
++unsigned int aperfmperf_get_khz(int cpu)
++{
++	struct aperfmperf *s = per_cpu_ptr(&cpu_samples, cpu);
++	unsigned long last;
++	unsigned int seq;
++	u64 acnt, mcnt;
++
++	if (!cpu_feature_enabled(X86_FEATURE_APERFMPERF))
++		return 0;
++
++	do {
++		seq = raw_read_seqcount_begin(&s->seq);
++		last = s->last_update;
++		acnt = s->acnt;
++		mcnt = s->mcnt;
++	} while (read_seqcount_retry(&s->seq, seq));
++
++	/*
++	 * Bail on invalid count and when the last update was too long ago,
++	 * which covers idle and NOHZ full CPUs.
++	 */
++	if (!mcnt || (jiffies - last) > MAX_SAMPLE_AGE)
++		return 0;
++
++	return div64_u64((cpu_khz * acnt), mcnt);
++}
+ #else
+ static inline void register_freq_invariance_syscore_ops(void) {}
+ #endif
+diff --git a/fs/proc/cpuinfo.c b/fs/proc/cpuinfo.c
+index 419760fd77bd..f38bda5b83ec 100644
+--- a/fs/proc/cpuinfo.c
++++ b/fs/proc/cpuinfo.c
+@@ -5,14 +5,10 @@
+ #include <linux/proc_fs.h>
+ #include <linux/seq_file.h>
+ 
+-__weak void arch_freq_prepare_all(void)
+-{
+-}
+-
+ extern const struct seq_operations cpuinfo_op;
++
+ static int cpuinfo_open(struct inode *inode, struct file *file)
+ {
+-	arch_freq_prepare_all();
+ 	return seq_open(file, &cpuinfo_op);
+ }
+ 
+diff --git a/include/linux/cpufreq.h b/include/linux/cpufreq.h
+index 4b4fbf4cf5be..22280e33fad0 100644
+--- a/include/linux/cpufreq.h
++++ b/include/linux/cpufreq.h
+@@ -1083,7 +1083,6 @@ static inline int of_perf_domain_get_sharing_cpumask(int pcpu, const char *list_
+ }
+ #endif
+ 
+-extern void arch_freq_prepare_all(void);
+ extern unsigned int arch_freq_get_on_cpu(int cpu);
+ 
+ #ifndef arch_set_freq_scale
+-- 
+2.34.1
+

--- a/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0008-x86-aperfmperf-Replace-arch_freq_get_on_cpu.patch
+++ b/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0008-x86-aperfmperf-Replace-arch_freq_get_on_cpu.patch
@@ -1,0 +1,160 @@
+From a56aa30c217ae9afb23130c636114a53bcf9efbb Mon Sep 17 00:00:00 2001
+From: "Xie, Chao" <chao.xie@intel.com>
+Date: Mon, 19 Jun 2023 11:05:11 +0800
+Subject: [PATCH 8/9] x86/aperfmperf: Replace arch_freq_get_on_cpu()
+
+Reading the current CPU frequency from /sys/..../scaling_cur_freq involves
+in the worst case two IPIs due to the ad hoc sampling.
+
+The frequency invariance infrastructure provides the APERF/MPERF samples
+already. Utilize them and consolidate this with the /proc/cpuinfo readout.
+
+The sample is considered valid for 20ms. So for idle or isolated NOHZ full
+CPUs the function returns 0, which is matching the previous behaviour.
+
+The resulting text size vs. the original APERF/MPERF plus the separate
+frequency invariance code:
+
+  text:         2411    ->   723
+  init.text:       0    ->   767
+
+Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
+Tested-by: Eric Dumazet <edumazet@google.com>
+Reviewed-by: Rafael J. Wysocki <rafael.j.wysocki@intel.com>
+Acked-by: Peter Zijlstra (Intel) <peterz@infradead.org>
+Acked-by: Paul E. McKenney <paulmck@kernel.org>
+
+Signed-off-by: Xie, Chao <chao.xie@intel.com>
+---
+ arch/x86/kernel/cpu/aperfmperf.c | 94 +-------------------------------
+ arch/x86/kernel/cpu/proc.c       |  2 +-
+ 2 files changed, 2 insertions(+), 94 deletions(-)
+
+diff --git a/arch/x86/kernel/cpu/aperfmperf.c b/arch/x86/kernel/cpu/aperfmperf.c
+index 8c780624483d..a24cb5bc3ecb 100644
+--- a/arch/x86/kernel/cpu/aperfmperf.c
++++ b/arch/x86/kernel/cpu/aperfmperf.c
+@@ -40,98 +40,6 @@ static DEFINE_PER_CPU_SHARED_ALIGNED(struct aperfmperf, cpu_samples) = {
+ 	.seq = SEQCNT_ZERO(cpu_samples.seq)
+ };
+ 
+-struct aperfmperf_sample {
+-	unsigned int	khz;
+-	atomic_t	scfpending;
+-	ktime_t	time;
+-	u64	aperf;
+-	u64	mperf;
+-};
+-
+-static DEFINE_PER_CPU(struct aperfmperf_sample, samples);
+-
+-#define APERFMPERF_CACHE_THRESHOLD_MS	10
+-#define APERFMPERF_REFRESH_DELAY_MS	10
+-#define APERFMPERF_STALE_THRESHOLD_MS	1000
+-
+-/*
+- * aperfmperf_snapshot_khz()
+- * On the current CPU, snapshot APERF, MPERF, and jiffies
+- * unless we already did it within 10ms
+- * calculate kHz, save snapshot
+- */
+-static void aperfmperf_snapshot_khz(void *dummy)
+-{
+-	u64 aperf, aperf_delta;
+-	u64 mperf, mperf_delta;
+-	struct aperfmperf_sample *s = this_cpu_ptr(&samples);
+-	unsigned long flags;
+-
+-	local_irq_save(flags);
+-	rdmsrl(MSR_IA32_APERF, aperf);
+-	rdmsrl(MSR_IA32_MPERF, mperf);
+-	local_irq_restore(flags);
+-
+-	aperf_delta = aperf - s->aperf;
+-	mperf_delta = mperf - s->mperf;
+-
+-	/*
+-	 * There is no architectural guarantee that MPERF
+-	 * increments faster than we can read it.
+-	 */
+-	if (mperf_delta == 0)
+-		return;
+-
+-	s->time = ktime_get();
+-	s->aperf = aperf;
+-	s->mperf = mperf;
+-	s->khz = div64_u64((cpu_khz * aperf_delta), mperf_delta);
+-	atomic_set_release(&s->scfpending, 0);
+-}
+-
+-static bool aperfmperf_snapshot_cpu(int cpu, ktime_t now, bool wait)
+-{
+-	s64 time_delta = ktime_ms_delta(now, per_cpu(samples.time, cpu));
+-	struct aperfmperf_sample *s = per_cpu_ptr(&samples, cpu);
+-
+-	/* Don't bother re-computing within the cache threshold time. */
+-	if (time_delta < APERFMPERF_CACHE_THRESHOLD_MS)
+-		return true;
+-
+-	if (!atomic_xchg(&s->scfpending, 1) || wait)
+-		smp_call_function_single(cpu, aperfmperf_snapshot_khz, NULL, wait);
+-
+-	/* Return false if the previous iteration was too long ago. */
+-	return time_delta <= APERFMPERF_STALE_THRESHOLD_MS;
+-}
+-
+-unsigned int arch_freq_get_on_cpu(int cpu)
+-{
+-	struct aperfmperf_sample *s = per_cpu_ptr(&samples, cpu);
+-
+-	if (!cpu_khz)
+-		return 0;
+-
+-	if (!boot_cpu_has(X86_FEATURE_APERFMPERF))
+-		return 0;
+-
+-	if (!housekeeping_cpu(cpu, HK_FLAG_MISC))
+-		return 0;
+-
+-	if (rcu_is_idle_cpu(cpu))
+-		return 0;
+-
+-	if (aperfmperf_snapshot_cpu(cpu, ktime_get(), true))
+-		return per_cpu(samples.khz, cpu);
+-
+-	msleep(APERFMPERF_REFRESH_DELAY_MS);
+-	atomic_set(&s->scfpending, 1);
+-	smp_mb(); /* ->scfpending before smp_call_function_single(). */
+-	smp_call_function_single(cpu, aperfmperf_snapshot_khz, NULL, 1);
+-
+-	return per_cpu(samples.khz, cpu);
+-}
+-
+ #ifdef CONFIG_X86_64
+ /*
+  * APERF/MPERF frequency ratio computation.
+@@ -447,7 +355,7 @@ static void register_freq_invariance_syscore_ops(void)
+  */
+ #define MAX_SAMPLE_AGE	((unsigned long)HZ / 50)
+ 
+-unsigned int aperfmperf_get_khz(int cpu)
++unsigned int arch_freq_get_on_cpu(int cpu)
+ {
+ 	struct aperfmperf *s = per_cpu_ptr(&cpu_samples, cpu);
+ 	unsigned long last;
+diff --git a/arch/x86/kernel/cpu/proc.c b/arch/x86/kernel/cpu/proc.c
+index 4eec8889b0ff..0a0ee55830c7 100644
+--- a/arch/x86/kernel/cpu/proc.c
++++ b/arch/x86/kernel/cpu/proc.c
+@@ -84,7 +84,7 @@ static int show_cpuinfo(struct seq_file *m, void *v)
+ 		seq_printf(m, "microcode\t: 0x%x\n", c->microcode);
+ 
+ 	if (cpu_has(c, X86_FEATURE_TSC)) {
+-		unsigned int freq = aperfmperf_get_khz(cpu);
++		unsigned int freq = arch_freq_get_on_cpu(cpu);
+ 
+ 		if (!freq)
+ 			freq = cpufreq_quick_get(cpu);
+-- 
+2.34.1
+

--- a/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0009-x86-aperfmperf-Integrate-the-fallback-code-from-show.patch
+++ b/bsp_diff/celadon_ivi/kernel/linux-intel-lts2021/0009-x86-aperfmperf-Integrate-the-fallback-code-from-show.patch
@@ -1,0 +1,81 @@
+From a5ecd4bc42348998e9636466d18d0780d7bbd7bf Mon Sep 17 00:00:00 2001
+From: "Xie, Chao" <chao.xie@intel.com>
+Date: Mon, 19 Jun 2023 11:06:06 +0800
+Subject: [PATCH 9/9] x86/aperfmperf: Integrate the fallback code from
+ show_cpuinfo()
+
+Due to the avoidance of IPIs to idle CPUs arch_freq_get_on_cpu() can return
+0 when the last sample was too long ago.
+
+show_cpuinfo() has a fallback to cpufreq_quick_get() and if that fails to
+return cpu_khz, but the readout code for the per CPU scaling frequency in
+sysfs does not.
+
+Move that fallback into arch_freq_get_on_cpu() so the behaviour is the same
+when reading /proc/cpuinfo and /sys/..../cur_scaling_freq.
+
+Suggested-by: "Rafael J. Wysocki" <rafael@kernel.org>
+Signed-off-by: Thomas Gleixner <tglx@linutronix.de>
+Tested-by: Doug Smythies <dsmythies@telus.net>
+
+Signed-off-by: Xie, Chao <chao.xie@intel.com>
+---
+ arch/x86/kernel/cpu/aperfmperf.c | 10 +++++++---
+ arch/x86/kernel/cpu/proc.c       |  7 +------
+ 2 files changed, 8 insertions(+), 9 deletions(-)
+
+diff --git a/arch/x86/kernel/cpu/aperfmperf.c b/arch/x86/kernel/cpu/aperfmperf.c
+index a24cb5bc3ecb..3c73508b76d8 100644
+--- a/arch/x86/kernel/cpu/aperfmperf.c
++++ b/arch/x86/kernel/cpu/aperfmperf.c
+@@ -358,12 +358,12 @@ static void register_freq_invariance_syscore_ops(void)
+ unsigned int arch_freq_get_on_cpu(int cpu)
+ {
+ 	struct aperfmperf *s = per_cpu_ptr(&cpu_samples, cpu);
++	unsigned int seq, freq;
+ 	unsigned long last;
+-	unsigned int seq;
+ 	u64 acnt, mcnt;
+ 
+ 	if (!cpu_feature_enabled(X86_FEATURE_APERFMPERF))
+-		return 0;
++		goto fallback;
+ 
+ 	do {
+ 		seq = raw_read_seqcount_begin(&s->seq);
+@@ -377,9 +377,13 @@ unsigned int arch_freq_get_on_cpu(int cpu)
+ 	 * which covers idle and NOHZ full CPUs.
+ 	 */
+ 	if (!mcnt || (jiffies - last) > MAX_SAMPLE_AGE)
+-		return 0;
++		goto fallback;
+ 
+ 	return div64_u64((cpu_khz * acnt), mcnt);
++
++fallback:
++	freq = cpufreq_quick_get(cpu);
++	return freq ? freq : cpu_khz;
+ }
+ #else
+ static inline void register_freq_invariance_syscore_ops(void) {}
+diff --git a/arch/x86/kernel/cpu/proc.c b/arch/x86/kernel/cpu/proc.c
+index 0a0ee55830c7..099b6f0d96bd 100644
+--- a/arch/x86/kernel/cpu/proc.c
++++ b/arch/x86/kernel/cpu/proc.c
+@@ -86,12 +86,7 @@ static int show_cpuinfo(struct seq_file *m, void *v)
+ 	if (cpu_has(c, X86_FEATURE_TSC)) {
+ 		unsigned int freq = arch_freq_get_on_cpu(cpu);
+ 
+-		if (!freq)
+-			freq = cpufreq_quick_get(cpu);
+-		if (!freq)
+-			freq = cpu_khz;
+-		seq_printf(m, "cpu MHz\t\t: %u.%03u\n",
+-			   freq / 1000, (freq % 1000));
++		seq_printf(m, "cpu MHz\t\t: %u.%03u\n", freq / 1000, (freq % 1000));
+ 	}
+ 
+ 	/* Cache size */
+-- 
+2.34.1
+


### PR DESCRIPTION
Please see JIRA https://jira.devtools.intel.com/browse/OAM-109373 for details.

The old implementation will has msleep(10) between two reads from aperfmerf.
The patches are ported from 5.19. Some patches can not be directly "git am" and need resolve the conflicts by hand.