### PR TITLE
Fix for camera preview not mirroring

### DIFF
--- a/aosp_diff/preliminary/frameworks/av/0015-Fix-for-Camera-Preview-not-mirroring.patch
+++ b/aosp_diff/preliminary/frameworks/av/0015-Fix-for-Camera-Preview-not-mirroring.patch
@@ -1,0 +1,36 @@
+From e9c616a41bfd0899a04b4acfa77dccf7b2e0cc19 Mon Sep 17 00:00:00 2001
+From: "Pillai, Venkatesh" <venkatesh.pillai@intel.com>
+Date: Mon, 26 Jun 2023 14:33:08 +0530
+Subject: [PATCH] Fix for Camera Preview not mirroring
+
+The Camera Preview is not mirroring resulting
+in the following test cases to fail.
+-test_Camera_Preview_Capture_Video_Recording
+
+The Camera used in CIV is external Camera, the
+AOSP Code expects the cameras to be fixed, either
+front or Back. So, modification is added to mirror
+external camera preview.
+
+Tracked-On: OAM-104233
+Signed-off-by: Pillai, Venkatesh <venkatesh.pillai@intel.com>
+---
+ camera/CameraUtils.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/camera/CameraUtils.cpp b/camera/CameraUtils.cpp
+index 34737806eb..254f191e97 100644
+--- a/camera/CameraUtils.cpp
++++ b/camera/CameraUtils.cpp
+@@ -58,7 +58,7 @@ status_t CameraUtils::getRotationTransform(const CameraMetadata& staticInfo,
+ 
+     int32_t mirror = 0;
+     if (mirrorMode == OutputConfiguration::MIRROR_MODE_AUTO &&
+-            entryFacing.data.u8[0] == ANDROID_LENS_FACING_FRONT) {
++            (entryFacing.data.u8[0] == ANDROID_LENS_FACING_FRONT || entryFacing.data.u8[0] == ANDROID_LENS_FACING_EXTERNAL)) {
+         mirror = NATIVE_WINDOW_TRANSFORM_FLIP_H;
+     } else if (mirrorMode == OutputConfiguration::MIRROR_MODE_H) {
+         mirror = NATIVE_WINDOW_TRANSFORM_FLIP_H;
+-- 
+2.17.1
+


### PR DESCRIPTION
The Camera Preview is not mirroring resulting
in the following test cases to fail.
-test_Camera_Preview_Capture_Video_Recording

The Camera used in CIV is external Camera, the
AOSP Code expects the cameras to be fixed, either
front or Back. So, modification is added to mirror external camera preview.

Tracked-On: OAM-104233