### PR TITLE
Set selinux to permissive mode in user build

### DIFF
--- a/aosp_diff/celadon_ivi/system/core/0001-Set-selinux-to-permissive-mode-in-user-build.patch
+++ b/aosp_diff/celadon_ivi/system/core/0001-Set-selinux-to-permissive-mode-in-user-build.patch
@@ -1,0 +1,37 @@
+From 7bbae82ea89000d77281593b0accacc2625216ce Mon Sep 17 00:00:00 2001
+From: jizhenlo <zhenlong.z.ji@intel.com>
+Date: Tue, 27 Jun 2023 09:57:25 +0800
+Subject: [PATCH] Set selinux to permissive mode in user build
+
+Currently there are some SELinux issues blocking the boot of
+IVI user build. Set SELinux to permissive mode in user build
+temporarily, will revert this patch once resolving the issues.
+
+Tracked-On: OAM-111194
+Signed-off-by: jizhenlo <zhenlong.z.ji@intel.com>
+---
+ init/selinux.cpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/init/selinux.cpp b/init/selinux.cpp
+index 29c0ff3ba..899e829a5 100644
+--- a/init/selinux.cpp
++++ b/init/selinux.cpp
+@@ -114,10 +114,10 @@ EnforcingStatus StatusFromProperty() {
+ }
+ 
+ bool IsEnforcing() {
+-    if (ALLOW_PERMISSIVE_SELINUX) {
+-        return StatusFromProperty() == SELINUX_ENFORCING;
+-    }
+-    return true;
++    if (StatusFromProperty() == SELINUX_ENFORCING)
++        LOG(INFO) << "SELinux is in enforcing mode ";
++
++    return false;
+ }
+ 
+ // Forks, executes the provided program in the child, and waits for the completion in the parent.
+-- 
+2.25.1
+


### PR DESCRIPTION
Currently there are some SELinux issues blocking the boot of
IVI user build. Set SELinux to permissive mode in user build
temporarily, will revert this patch once resolving the issues.

Tracked-On: OAM-111194