### PR TITLE
Fix for Local Media Player in Passenger zone.

### DIFF
--- a/aosp_diff/celadon_ivi/packages/apps/Car/libs/0001-Fix-for-Local-Media-Player-in-Passenger-Zone.patch
+++ b/aosp_diff/celadon_ivi/packages/apps/Car/libs/0001-Fix-for-Local-Media-Player-in-Passenger-Zone.patch
@@ -1,0 +1,91 @@
+From 17b4d87853f9f20c2bc124da6594f760b4f2a927 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Tue, 27 Jun 2023 10:57:32 +0530
+Subject: [PATCH] Fix for Local Media Player in Passenger Zone.
+
+Currently MultiDisplay launcher does not have capability
+to show launcher icons for media services app, as these apps
+does not have any launcher category, So it does not show icon in
+launcher app.
+
+Querying all MediaBrowsingService apps and adding them in launcher.
+
+Tracked-On: OAM-106796
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../common/source/MediaSourceViewModel.java      | 16 ++++++++++++----
+ .../common/source/MediaSourceViewModelTest.java  |  3 ++-
+ 2 files changed, 14 insertions(+), 5 deletions(-)
+
+diff --git a/car-media-common/src/com/android/car/media/common/source/MediaSourceViewModel.java b/car-media-common/src/com/android/car/media/common/source/MediaSourceViewModel.java
+index 0b297fea6..00fb22b57 100644
+--- a/car-media-common/src/com/android/car/media/common/source/MediaSourceViewModel.java
++++ b/car-media-common/src/com/android/car/media/common/source/MediaSourceViewModel.java
+@@ -20,6 +20,7 @@ import static com.android.car.apps.common.util.LiveDataFunctions.dataOf;
+ 
+ import android.app.Application;
+ import android.car.Car;
++import android.car.Car.CarServiceLifecycleListener;
+ import android.car.CarNotConnectedException;
+ import android.car.media.CarMediaManager;
+ import android.content.ComponentName;
+@@ -64,7 +65,7 @@ public class MediaSourceViewModel extends AndroidViewModel {
+         MediaBrowserConnector createMediaBrowserConnector(@NonNull Application application,
+                 @NonNull MediaBrowserConnector.Callback connectedBrowserCallback);
+ 
+-        Car getCarApi();
++        Car getCarApi(CarServiceLifecycleListener mCarServiceLifecycleListener);
+ 
+         CarMediaManager getCarMediaManager(Car carApi) throws CarNotConnectedException;
+ 
+@@ -94,8 +95,9 @@ public class MediaSourceViewModel extends AndroidViewModel {
+             }
+ 
+             @Override
+-            public Car getCarApi() {
+-                return Car.createCar(application);
++            public Car getCarApi(CarServiceLifecycleListener mCarServiceLifecycleListener) {
++                return Car.createCar(application, /* handler= */ null,
++                Car.CAR_WAIT_TIMEOUT_WAIT_FOREVER, mCarServiceLifecycleListener);
+             }
+ 
+             @Override
+@@ -123,7 +125,13 @@ public class MediaSourceViewModel extends AndroidViewModel {
+ 
+         mMode = mode;
+         mInputFactory = inputFactory;
+-        mCar = inputFactory.getCarApi();
++        mCar = inputFactory.getCarApi((car, ready) -> {
++            if (!ready) {
++                Log.d(TAG, "Disconnected from Car Service");
++                return;
++            }
++            Log.d(TAG, "Connected to Car Service");
++        });
+ 
+         mBrowserConnector = inputFactory.createMediaBrowserConnector(application, mBrowserCallback);
+ 
+diff --git a/car-media-common/tests/robotests/src/com/android/car/media/common/source/MediaSourceViewModelTest.java b/car-media-common/tests/robotests/src/com/android/car/media/common/source/MediaSourceViewModelTest.java
+index 196553fcd..3403a0602 100644
+--- a/car-media-common/tests/robotests/src/com/android/car/media/common/source/MediaSourceViewModelTest.java
++++ b/car-media-common/tests/robotests/src/com/android/car/media/common/source/MediaSourceViewModelTest.java
+@@ -28,6 +28,7 @@ import static org.robolectric.RuntimeEnvironment.application;
+ 
+ import android.app.Application;
+ import android.car.Car;
++import android.car.Car.CarServiceLifecycleListener;
+ import android.car.media.CarMediaManager;
+ import android.content.ComponentName;
+ import android.support.v4.media.MediaBrowserCompat;
+@@ -102,7 +103,7 @@ public class MediaSourceViewModelTest {
+             }
+ 
+             @Override
+-            public Car getCarApi() {
++            public Car getCarApi(CarServiceLifecycleListener mCarServiceLifecycleListener) {
+                 return mCar;
+             }
+ 
+-- 
+2.17.1
+

--- a/aosp_diff/celadon_ivi/packages/services/Car/0011-Fix-for-Local-Media-Player-in-Passenger-Zone.patch
+++ b/aosp_diff/celadon_ivi/packages/services/Car/0011-Fix-for-Local-Media-Player-in-Passenger-Zone.patch
@@ -1,0 +1,142 @@
+From 5028d9dffc8f28d33afa6201c03ba6ba1b093812 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Tue, 27 Jun 2023 10:48:38 +0530
+Subject: [PATCH] Fix for Local Media Player in Passenger Zone.
+
+Currently MultiDisplay launcher does not have capability
+to show launcher icons for media services app, as these apps
+does not have any launcher category, So it does not show icon in
+launcher app.
+
+Querying all MediaBrowsingService apps and adding them in launcher.
+
+Tracked-On: OAM-106796
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ ...preinstalled-packages-product-car-base.xml |  1 +
+ .../car/multidisplay/launcher/AppEntry.java   | 23 ++++++++++++++-----
+ .../launcher/AppListLiveData.java             | 11 ++++++++-
+ .../launcher/PinnedAppListLiveData.java       | 10 +++++++-
+ 4 files changed, 37 insertions(+), 8 deletions(-)
+
+diff --git a/car_product/build/preinstalled-packages-product-car-base.xml b/car_product/build/preinstalled-packages-product-car-base.xml
+index dcd93a843..73e09432b 100644
+--- a/car_product/build/preinstalled-packages-product-car-base.xml
++++ b/car_product/build/preinstalled-packages-product-car-base.xml
+@@ -66,6 +66,7 @@
+     <install-in-user-type package="com.android.car">
+         <install-in user-type="FULL" />
+         <install-in user-type="SYSTEM" />
++        <install-in user-type="PROFILE" />
+     </install-in-user-type>
+         <install-in-user-type package="com.android.car.shell">
+         <install-in user-type="FULL" />
+diff --git a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppEntry.java b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppEntry.java
+index 3bc5b647a..873190605 100644
+--- a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppEntry.java
++++ b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppEntry.java
+@@ -16,6 +16,7 @@
+ 
+ package com.android.car.multidisplay.launcher;
+ 
++import android.car.Car;
+ import android.content.ComponentName;
+ import android.content.Intent;
+ import android.content.pm.PackageManager;
+@@ -29,12 +30,22 @@ public  class AppEntry {
+     private Drawable mIcon;
+     private Intent mLaunchIntent;
+ 
+-    AppEntry(ResolveInfo info, PackageManager packageManager) {
+-        mLabel = info.loadLabel(packageManager).toString();
+-        mIcon = info.loadIcon(packageManager);
+-        mLaunchIntent = new Intent();
+-        mLaunchIntent.setComponent(new ComponentName(info.activityInfo.packageName,
+-                info.activityInfo.name));
++    AppEntry(ResolveInfo info, PackageManager packageManager, boolean mediaApp) {
++        if(mediaApp) {
++            mLabel = info.serviceInfo.loadLabel(packageManager).toString();
++            mIcon = info.serviceInfo.loadIcon(packageManager);
++            String packageName = info.serviceInfo.packageName;
++            String className = info.serviceInfo.name;
++            ComponentName componentName = new ComponentName(packageName, className);
++            mLaunchIntent = new Intent(Car.CAR_INTENT_ACTION_MEDIA_TEMPLATE);
++            mLaunchIntent.putExtra(Car.CAR_EXTRA_MEDIA_COMPONENT, componentName.flattenToString());
++        } else {
++            mLabel = info.loadLabel(packageManager).toString();
++            mIcon = info.loadIcon(packageManager);
++            mLaunchIntent = new Intent();
++            mLaunchIntent.setComponent(new ComponentName(info.activityInfo.packageName,
++                    info.activityInfo.name));
++        }
+     }
+ 
+     String getLabel() {
+diff --git a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppListLiveData.java b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppListLiveData.java
+index 8e2e34e3e..6eaaa0746 100644
+--- a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppListLiveData.java
++++ b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppListLiveData.java
+@@ -21,6 +21,7 @@ import android.content.Intent;
+ import android.content.pm.PackageManager;
+ import android.content.pm.ResolveInfo;
+ import android.os.AsyncTask;
++import android.service.media.MediaBrowserService;
+ 
+ import androidx.lifecycle.LiveData;
+ 
+@@ -52,10 +53,18 @@ class AppListLiveData extends LiveData<List<AppEntry>> {
+                 List<AppEntry> entries = new ArrayList<>();
+                 if (apps != null) {
+                     for (ResolveInfo app : apps) {
+-                        AppEntry entry = new AppEntry(app, mPackageManager);
++                        AppEntry entry = new AppEntry(app, mPackageManager, false);
+                         entries.add(entry);
+                     }
+                 }
++
++                List<ResolveInfo> mediaServices = mPackageManager.queryIntentServices(
++                        new Intent(MediaBrowserService.SERVICE_INTERFACE),
++                        PackageManager.GET_RESOLVED_FILTER);
++                for (ResolveInfo info : mediaServices) {
++                    AppEntry entry = new AppEntry(info, mPackageManager, true);
++                    entries.add(entry);
++                }
+                 return entries;
+             }
+ 
+diff --git a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/PinnedAppListLiveData.java b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/PinnedAppListLiveData.java
+index 1425ea129..ec966b86b 100644
+--- a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/PinnedAppListLiveData.java
++++ b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/PinnedAppListLiveData.java
+@@ -23,6 +23,7 @@ import android.content.SharedPreferences;
+ import android.content.pm.PackageManager;
+ import android.content.pm.ResolveInfo;
+ import android.os.AsyncTask;
++import android.service.media.MediaBrowserService;
+ 
+ import androidx.lifecycle.LiveData;
+ 
+@@ -77,12 +78,19 @@ class PinnedAppListLiveData extends LiveData<List<AppEntry>> {
+ 
+                     if (apps != null) {
+                         for (ResolveInfo app : apps) {
+-                            final AppEntry entry = new AppEntry(app, mPackageManager);
++                            final AppEntry entry = new AppEntry(app, mPackageManager, false);
+                             entries.add(entry);
+                         }
+                     }
+                 }
+ 
++                List<ResolveInfo> mediaServices = mPackageManager.queryIntentServices(
++                        new Intent(MediaBrowserService.SERVICE_INTERFACE),
++                        PackageManager.GET_RESOLVED_FILTER);
++                for (ResolveInfo info : mediaServices) {
++                    AppEntry entry = new AppEntry(info, mPackageManager, true);
++                    entries.add(entry);
++                }
+                 return entries;
+             }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
Currently MultiDisplay launcher does not have capability to show launcher icons for media services app, as these apps does not have any launcher category, So it does not show icon in launcher app.

Querying all MediaBrowsingService apps and adding them in launcher.

Tracked-On: OAM-106796