### PR TITLE
Add null check for intent in KeyguardManager

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/99_0141-Add-null-check-for-intent-in-KeyguardManager.patch
+++ b/aosp_diff/preliminary/frameworks/base/99_0141-Add-null-check-for-intent-in-KeyguardManager.patch
@@ -1,0 +1,33 @@
+From f64670b5a1c2e017ef0bcd50b6dbf67239a42d8d Mon Sep 17 00:00:00 2001
+From: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+Date: Wed, 28 Jun 2023 09:49:53 +0530
+Subject: [PATCH] Add null check for intent in KeyguardManager
+
+The null check is not present, thus causing NPE when
+intent is null and tried to startActivity with that
+
+Tracked-On: OAM-110935
+Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+---
+ core/java/android/app/KeyguardManager.java | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/core/java/android/app/KeyguardManager.java b/core/java/android/app/KeyguardManager.java
+index dc71a3237b0b..713981cf1ba7 100644
+--- a/core/java/android/app/KeyguardManager.java
++++ b/core/java/android/app/KeyguardManager.java
+@@ -236,8 +236,10 @@ public class KeyguardManager {
+             CharSequence title, CharSequence description, int userId,
+             boolean disallowBiometricsIfPolicyExists) {
+         Intent intent = this.createConfirmDeviceCredentialIntent(title, description, userId);
+-        intent.putExtra(EXTRA_DISALLOW_BIOMETRICS_IF_POLICY_EXISTS,
++        if (intent != null) {
++	    intent.putExtra(EXTRA_DISALLOW_BIOMETRICS_IF_POLICY_EXISTS,
+                 disallowBiometricsIfPolicyExists);
++	}
+         return intent;
+     }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
intent should not be null before starting the activity. This null check will avoid that.

Tracked-On: NA