### PR TITLE
Update bthfp call state to audio manager

### DIFF
--- a/aosp_diff/preliminary/packages/apps/Bluetooth/05_0005-Update-BT-HFP-call-state-to-audio-manager.patch
+++ b/aosp_diff/preliminary/packages/apps/Bluetooth/05_0005-Update-BT-HFP-call-state-to-audio-manager.patch
@@ -1,0 +1,115 @@
+From 73589ef8ff996260b33d203527d8cd602c51636e Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Tue, 27 Jun 2023 12:27:19 +0530
+Subject: [PATCH] Update BT HFP call state to audio manager
+
+---
+ .../hfpclient/HeadsetClientStateMachine.java  | 39 ++++++++++++++++++-
+ .../VendorCommandResponseProcessor.java       |  2 +-
+ 2 files changed, 39 insertions(+), 2 deletions(-)
+
+diff --git a/src/com/android/bluetooth/hfpclient/HeadsetClientStateMachine.java b/src/com/android/bluetooth/hfpclient/HeadsetClientStateMachine.java
+index 881ef3892..896aa7abe 100644
+--- a/src/com/android/bluetooth/hfpclient/HeadsetClientStateMachine.java
++++ b/src/com/android/bluetooth/hfpclient/HeadsetClientStateMachine.java
+@@ -85,7 +85,7 @@ import java.util.Set;
+ 
+ public class HeadsetClientStateMachine extends StateMachine {
+     private static final String TAG = "HeadsetClientStateMachine";
+-    private static final boolean DBG = Log.isLoggable(TAG, Log.DEBUG);
++    private static final boolean DBG = true;//Log.isLoggable(TAG, Log.DEBUG);
+ 
+     static final int NO_ACTION = 0;
+     static final int IN_BAND_RING_ENABLED = 1;
+@@ -135,6 +135,7 @@ public class HeadsetClientStateMachine extends StateMachine {
+ 
+     // Keep track of audio routing across all devices.
+     private static boolean sAudioIsRouted = false;
++    private static boolean sIsCallStateUpdatedToAudio = false;
+ 
+     private final Disconnected mDisconnected;
+     private final Connecting mConnecting;
+@@ -357,6 +358,7 @@ public class HeadsetClientStateMachine extends StateMachine {
+         intent.addFlags(Intent.FLAG_RECEIVER_FOREGROUND);
+         intent.putExtra(BluetoothHeadsetClient.EXTRA_CALL, c);
+         mService.sendBroadcast(intent, BLUETOOTH_CONNECT, Utils.getTempAllowlistBroadcastOptions());
++        updateCallStateToAudioManager(c);
+     }
+ 
+     private boolean queryCallsStart() {
+@@ -513,6 +515,7 @@ public class HeadsetClientStateMachine extends StateMachine {
+         int action = -1;
+ 
+         logD("acceptCall: (" + flag + ")");
++        Log.w(TAG, "acceptCall ( " + flag + ")");
+ 
+         BluetoothHeadsetClientCall c = getCall(BluetoothHeadsetClientCall.CALL_STATE_INCOMING,
+                 BluetoothHeadsetClientCall.CALL_STATE_WAITING);
+@@ -528,10 +531,12 @@ public class HeadsetClientStateMachine extends StateMachine {
+         logD("Call to accept: " + c);
+         switch (c.getState()) {
+             case BluetoothHeadsetClientCall.CALL_STATE_INCOMING:
++                Log.w(TAG, "acceptCall 1");
+                 if (flag != BluetoothHeadsetClient.CALL_ACCEPT_NONE) {
+                     return;
+                 }
+                 action = HeadsetClientHalConstants.CALL_ACTION_ATA;
++                Log.w(TAG, "acceptCall 2");
+                 break;
+             case BluetoothHeadsetClientCall.CALL_STATE_WAITING:
+                 if (callsInState(BluetoothHeadsetClientCall.CALL_STATE_ACTIVE) == 0) {
+@@ -824,6 +829,38 @@ public class HeadsetClientStateMachine extends StateMachine {
+         sAudioIsRouted = enable;
+     }
+ 
++    synchronized void updateCallStateToAudioManager(BluetoothHeadsetClientCall c) {
++        if (mAudioManager == null) {
++            Log.e(TAG, "AudioManager is null!");
++            return;
++        }
++        logD("bthfp_call_state=" + c.getState());
++        switch (c.getState()) {
++            case BluetoothHeadsetClientCall.CALL_STATE_INCOMING:
++            case BluetoothHeadsetClientCall.CALL_STATE_WAITING:
++            case BluetoothHeadsetClientCall.CALL_STATE_HELD:
++            case BluetoothHeadsetClientCall.CALL_STATE_HELD_BY_RESPONSE_AND_HOLD:
++            case BluetoothHeadsetClientCall.CALL_STATE_ALERTING:
++            case BluetoothHeadsetClientCall.CALL_STATE_DIALING:
++                /* Not handled as of now */
++                break;
++            case BluetoothHeadsetClientCall.CALL_STATE_ACTIVE:
++		if (!sIsCallStateUpdatedToAudio) {
++                    mAudioManager.setParameters("bthfp_call_state=true");
++		    sIsCallStateUpdatedToAudio = true;
++                }
++		break;
++            case BluetoothHeadsetClientCall.CALL_STATE_TERMINATED:
++		if (sIsCallStateUpdatedToAudio) {
++                    mAudioManager.setParameters("bthfp_call_state=false");
++		    sIsCallStateUpdatedToAudio = false;
++                }
++		break;
++            default:
++                break;
++        }
++    }
++
+     private AudioFocusRequest requestAudioFocus() {
+         AudioAttributes streamAttributes =
+                 new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+diff --git a/src/com/android/bluetooth/hfpclient/VendorCommandResponseProcessor.java b/src/com/android/bluetooth/hfpclient/VendorCommandResponseProcessor.java
+index 74ecadf20..e9f326286 100644
+--- a/src/com/android/bluetooth/hfpclient/VendorCommandResponseProcessor.java
++++ b/src/com/android/bluetooth/hfpclient/VendorCommandResponseProcessor.java
+@@ -36,7 +36,7 @@ import java.util.Map;
+ class VendorCommandResponseProcessor {
+ 
+     private static final String TAG = "VendorCommandResponseProcessor";
+-    private static final boolean DBG = Log.isLoggable(TAG, Log.DEBUG);
++    private static final boolean DBG = true;//Log.isLoggable(TAG, Log.DEBUG);
+ 
+     private final HeadsetClientService mService;
+     private final NativeInterface mNativeInterface;
+-- 
+2.17.1
+


### PR DESCRIPTION
As we are using btusb loopback device, there is no audio output if we open btusb card during DAILING/RINGING call state. Audio is routed properly when btusb card is opened after call is picked up (i.e., call state to ACTIVE).

We are updating the same to audio manager.