### PR TITLE
Update BT HFP call state to audio manager

### DIFF
--- a/aosp_diff/celadon_ivi/packages/apps/Bluetooth/0001-Update-BT-HFP-call-state-to-audio-manager.patch
+++ b/aosp_diff/celadon_ivi/packages/apps/Bluetooth/0001-Update-BT-HFP-call-state-to-audio-manager.patch
@@ -1,0 +1,86 @@
+From 5c33ffe86f5688aa007ed28b1f6ba3e3fd3eceb0 Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Tue, 27 Jun 2023 12:27:19 +0530
+Subject: [PATCH] Update BT HFP call state to audio manager
+
+As we are using btusb loopback device, there is no audio output
+if we open btusb card during DIALING/RINGING call state.
+
+Audio is routed properly when btusb loopback device is opened
+after call is picked up (i.e., call state to ACTIVE).
+
+We are updating this call state to audio manager, so that
+audio manager can open/close the btusb loopback device.
+
+Voice call verified on ADL NUC.
+
+Tracked-On: OAM-111143
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ .../hfpclient/HeadsetClientStateMachine.java  | 36 +++++++++++++++++++
+ 1 file changed, 36 insertions(+)
+
+diff --git a/src/com/android/bluetooth/hfpclient/HeadsetClientStateMachine.java b/src/com/android/bluetooth/hfpclient/HeadsetClientStateMachine.java
+index 881ef3892..1a81d5ca5 100644
+--- a/src/com/android/bluetooth/hfpclient/HeadsetClientStateMachine.java
++++ b/src/com/android/bluetooth/hfpclient/HeadsetClientStateMachine.java
+@@ -136,6 +136,9 @@ public class HeadsetClientStateMachine extends StateMachine {
+     // Keep track of audio routing across all devices.
+     private static boolean sAudioIsRouted = false;
+ 
++    // Keep track of call state.
++    private static boolean sIsCallStateUpdatedToAudio = false;
++
+     private final Disconnected mDisconnected;
+     private final Connecting mConnecting;
+     private final Connected mConnected;
+@@ -357,6 +360,7 @@ public class HeadsetClientStateMachine extends StateMachine {
+         intent.addFlags(Intent.FLAG_RECEIVER_FOREGROUND);
+         intent.putExtra(BluetoothHeadsetClient.EXTRA_CALL, c);
+         mService.sendBroadcast(intent, BLUETOOTH_CONNECT, Utils.getTempAllowlistBroadcastOptions());
++        updateCallStateToAudioManager(c);
+     }
+ 
+     private boolean queryCallsStart() {
+@@ -824,6 +828,38 @@ public class HeadsetClientStateMachine extends StateMachine {
+         sAudioIsRouted = enable;
+     }
+ 
++    synchronized void updateCallStateToAudioManager(BluetoothHeadsetClientCall c) {
++        if (mAudioManager == null) {
++            Log.e(TAG, "AudioManager is null!");
++            return;
++        }
++        logD("bthfp_call_state=" + c.getState());
++        switch (c.getState()) {
++            case BluetoothHeadsetClientCall.CALL_STATE_INCOMING:
++            case BluetoothHeadsetClientCall.CALL_STATE_WAITING:
++            case BluetoothHeadsetClientCall.CALL_STATE_HELD:
++            case BluetoothHeadsetClientCall.CALL_STATE_HELD_BY_RESPONSE_AND_HOLD:
++            case BluetoothHeadsetClientCall.CALL_STATE_ALERTING:
++            case BluetoothHeadsetClientCall.CALL_STATE_DIALING:
++                /* Not handled as of now */
++                break;
++            case BluetoothHeadsetClientCall.CALL_STATE_ACTIVE:
++                if (!sIsCallStateUpdatedToAudio) {
++                    mAudioManager.setParameters("bthfp_call_state=true");
++                    sIsCallStateUpdatedToAudio = true;
++                }
++                break;
++            case BluetoothHeadsetClientCall.CALL_STATE_TERMINATED:
++                if (sIsCallStateUpdatedToAudio) {
++                    mAudioManager.setParameters("bthfp_call_state=false");
++                    sIsCallStateUpdatedToAudio = false;
++                }
++                break;
++            default:
++                break;
++        }
++    }
++
+     private AudioFocusRequest requestAudioFocus() {
+         AudioAttributes streamAttributes =
+                 new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+-- 
+2.17.1
+


### PR DESCRIPTION
As we are using btusb loopback device, there is no audio output if we open btusb card during DIALING/RINGING call state.

Audio is routed properly when btusb loopback device is opened after call is picked up (i.e., call state to ACTIVE).

We are updating this call state to audio manager, so that audio manager can open/close the btusb loopback device.

Voice call verified on ADL NUC.

Tracked-On: OAM-111143
Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>