### PR TITLE
Enable Bluetooth on AX210 Typ2

### DIFF
--- a/aosp_diff/celadon_ivi/frameworks/base/0002-Enable-Bluetooth-on-AX210-Typ2.patch
+++ b/aosp_diff/celadon_ivi/frameworks/base/0002-Enable-Bluetooth-on-AX210-Typ2.patch
@@ -1,0 +1,39 @@
+From 79827dedc4748de66661c927568dab4e4d7c0535 Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Thu, 22 Jun 2023 15:03:35 +0530
+Subject: [PATCH] Enable Bluetooth on AX210 Typ2
+
+Allow hci0 interface for Bluetooth initialization.
+
+AX210 Typ2 <8087:0032>  btusb interface is initialized
+by USBHostManager. So, Bluetooth HAL is denied access
+to the card.
+
+Added patch to deny Typ2 from USB initialization, so that
+Bluetooth HAL takes control of it and does the Bluetooth
+initialization.
+
+Verified the BT on/off functionality on RPL board with
+AX210.
+
+Tracked-On: OAM-111142
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ core/res/res/values/config.xml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/core/res/res/values/config.xml b/core/res/res/values/config.xml
+index f9b951e92736..ba99ffd766c9 100644
+--- a/core/res/res/values/config.xml
++++ b/core/res/res/values/config.xml
+@@ -1052,6 +1052,7 @@
+          to this list.  If this is empty, no parts of the host USB bus will be excluded.
+     -->
+     <string-array name="config_usbHostDenylist" translatable="false">
++        <item>"8087:0032"</item>
+         <item>"8087:0033"</item>
+         <item>"8087:0026"</item>
+     </string-array>
+-- 
+2.17.1
+


### PR DESCRIPTION
Allow hci0 interface for Bluetooth initialization.

AX210 Typ2 <8087:0032>  btusb interface is initialized by USBHostManager. So, Bluetooth HAL is denied access to the card.

Added patch to deny Typ2 from USB initialization, so that Bluetooth HAL takes control of it and does the Bluetooth initialization.

Verified the BT on/off functionality on RPL board with AX210.

Tracked-On: OAM-111142
Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>