### PR TITLE
update media stack to media 23.2.4 release (devel-682)

### DIFF
--- a/bsp_diff/common/hardware/intel/gmmlib/0001-Enable-compilation-on-android.patch
+++ b/bsp_diff/common/hardware/intel/gmmlib/0001-Enable-compilation-on-android.patch
@@ -1,15 +1,20 @@
-From 52c6b08ba82c2e852cf91fc1849d32d7dddecd98 Mon Sep 17 00:00:00 2001
+From 016e273425381e13653ea3cdea318d9329639c80 Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Fri, 15 Jul 2022 22:02:24 +0530
-Subject: [PATCH] Add Android.mk
+Subject: [PATCH] Enable compilation on android
 
-Change-Id: I134da0c5e6a9cc9d281e313f7ea68d45ef8b1d70
-Tracked-On: OAM-106860
+- resolved compilation error
+- added Android.mk
+
+Change-Id: I134da07ce6ad4c9d281e313f7ea68d45ef8b1d70
+Tracked-On: OAM-111192
 Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Signed-off-by: Yerriswamy <yerriswamy.kt@intel.com>
+Signed-off-by: Ratnesh Kumar Rai <ratnesh.kumar.rai@intel.com>
 ---
- Android.mk | 126 +++++++++++++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 126 insertions(+)
+ Android.mk                           | 126 +++++++++++++++++++++++++++
+ Source/GmmLib/GlobalInfo/GmmInfo.cpp |   8 +-
+ 2 files changed, 130 insertions(+), 4 deletions(-)
  create mode 100644 Android.mk
 
 diff --git a/Android.mk b/Android.mk
@@ -144,6 +149,46 @@ index 0000000..c388889
 +    $(LOCAL_PATH)/Source/inc/common \
 +
 +include $(BUILD_STATIC_LIBRARY)
+diff --git a/Source/GmmLib/GlobalInfo/GmmInfo.cpp b/Source/GmmLib/GlobalInfo/GmmInfo.cpp
+index ec2be20..1530c4f 100644
+--- a/Source/GmmLib/GlobalInfo/GmmInfo.cpp
++++ b/Source/GmmLib/GlobalInfo/GmmInfo.cpp
+@@ -585,7 +585,7 @@ uint32_t GMM_STDCALL GmmLib::GmmMultiAdapterContext::GetNumAdapters()
+ ///
+ /// @return     GMM_STATUS.
+ /////////////////////////////////////////////////////////////////////////////////////
+-GMM_STATUS GMM_STDCALL GmmLib::GmmMultiAdapterContext::LockMAContextSyncMutex()
++GMM_STATUS GmmLib::GmmMultiAdapterContext::LockMAContextSyncMutex()
+ {
+     if(MAContextSyncMutex)
+     {
+@@ -605,7 +605,7 @@ GMM_STATUS GMM_STDCALL GmmLib::GmmMultiAdapterContext::LockMAContextSyncMutex()
+ ///
+ /// @return     GMM_STATUS.
+ /////////////////////////////////////////////////////////////////////////////////////
+-GMM_STATUS GMM_STDCALL GmmLib::GmmMultiAdapterContext::UnLockMAContextSyncMutex()
++GMM_STATUS GmmLib::GmmMultiAdapterContext::UnLockMAContextSyncMutex()
+ {
+     if(MAContextSyncMutex)
+     {
+@@ -625,7 +625,7 @@ GMM_STATUS GMM_STDCALL GmmLib::GmmMultiAdapterContext::UnLockMAContextSyncMutex(
+ ///
+ /// @return     GMM_STATUS.
+ /////////////////////////////////////////////////////////////////////////////////////
+-GMM_STATUS GMM_STDCALL GmmLib::GmmMultiAdapterContext::LockMAContextSyncMutex()
++GMM_STATUS GmmLib::GmmMultiAdapterContext::LockMAContextSyncMutex()
+ {
+     pthread_mutex_lock(&MAContextSyncMutex);
+     return GMM_SUCCESS;
+@@ -636,7 +636,7 @@ GMM_STATUS GMM_STDCALL GmmLib::GmmMultiAdapterContext::LockMAContextSyncMutex()
+ ///
+ /// @return     GMM_STATUS.
+ /////////////////////////////////////////////////////////////////////////////////////
+-GMM_STATUS GMM_STDCALL GmmLib::GmmMultiAdapterContext::UnLockMAContextSyncMutex()
++GMM_STATUS GmmLib::GmmMultiAdapterContext::UnLockMAContextSyncMutex()
+ {
+     pthread_mutex_unlock(&MAContextSyncMutex);
+     return GMM_SUCCESS;
 -- 
-2.40.1
+2.17.1
 

--- a/bsp_diff/common/hardware/intel/libva/0001-Update-Android.mk-for-libva-2.19.0.patch
+++ b/bsp_diff/common/hardware/intel/libva/0001-Update-Android.mk-for-libva-2.19.0.patch
@@ -1,7 +1,7 @@
-From a6f82fc72b4a8ed6f777a6539558a22b69192cda Mon Sep 17 00:00:00 2001
+From ad43348cc5c4a47702a15a0fcc3a65950b4ee492 Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
 Date: Thu, 30 Mar 2023 16:23:14 +0530
-Subject: [PATCH] Update Android.mk for libva 2.18.0
+Subject: [PATCH] Update Android.mk for libva 2.19.0
 
 added va_version.h
 updated the va/Android.mk
@@ -136,7 +136,7 @@ index a8f05f1..75334db 100644
  include $(BUILD_SHARED_LIBRARY)
 diff --git a/va/va_version.h b/va/va_version.h
 new file mode 100644
-index 0000000..80077d5
+index 0000000..af6afc9
 --- /dev/null
 +++ b/va/va_version.h
 @@ -0,0 +1,87 @@
@@ -179,7 +179,7 @@ index 0000000..80077d5
 + *
 + * The minor version of VA-API (2, if %VA_VERSION is 1.2.3)
 + */
-+#define VA_MINOR_VERSION    18
++#define VA_MINOR_VERSION    19
 +
 +/**
 + * VA_MICRO_VERSION:
@@ -193,7 +193,7 @@ index 0000000..80077d5
 + *
 + * The full version of VA-API, like 1.2.3
 + */
-+#define VA_VERSION          2.18.0
++#define VA_VERSION          2.19.0
 +
 +/**
 + * VA_VERSION_S:
@@ -201,7 +201,7 @@ index 0000000..80077d5
 + * The full version of VA-API, in string form (suited for string
 + * concatenation)
 + */
-+#define VA_VERSION_S       "2.18.0"
++#define VA_VERSION_S       "2.19.0"
 +
 +/**
 + * VA_VERSION_HEX:
@@ -228,5 +228,5 @@ index 0000000..80077d5
 +
 +#endif /* VA_VERSION_H */
 -- 
-2.40.1
+2.17.1
 

--- a/bsp_diff/common/hardware/intel/libva/0002-Support-media-stack-on-specified-render-node.patch
+++ b/bsp_diff/common/hardware/intel/libva/0002-Support-media-stack-on-specified-render-node.patch
@@ -1,4 +1,4 @@
-From 6e24121953512c064bacce19f18a6b3362e43358 Mon Sep 17 00:00:00 2001
+From 23cd22b5ec04b93df0178f85f84548958dbd526f Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
 Date: Fri, 28 Oct 2022 14:32:50 +0530
 Subject: [PATCH] Support media stack on specified render node
@@ -56,5 +56,5 @@ index f103d15..d2c167f 100644
      }
      drm_state->auth_type = VA_DRM_AUTH_CUSTOM;
 -- 
-2.40.1
+2.17.1
 

--- a/bsp_diff/common/hardware/intel/libva/0003-Fixed-crashes-due-to-wrong-environment-name.patch
+++ b/bsp_diff/common/hardware/intel/libva/0003-Fixed-crashes-due-to-wrong-environment-name.patch
@@ -1,0 +1,47 @@
+From 08a2a88421cb76505ee3ba4d5c271041729335c1 Mon Sep 17 00:00:00 2001
+From: Ratnesh Kumar Rai <ratnesh.kumar.rai@intel.com>
+Date: Fri, 14 Jul 2023 21:45:27 +0530
+Subject: [PATCH] Fixed crashes due to wrong environment name
+
+Signed-off-by: Ratnesh Kumar Rai <ratnesh.kumar.rai@intel.com>
+---
+ va/Android.mk | 2 ++
+ va/va.c       | 2 +-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/va/Android.mk b/va/Android.mk
+index 75334db..5359364 100644
+--- a/va/Android.mk
++++ b/va/Android.mk
+@@ -58,6 +58,7 @@ LOCAL_CFLAGS := \
+ 	$(IGNORED_WARNNING) \
+         -DLOG_TAG=\"libva\" \
+         -DSYSCONFDIR="\"$(LIBVA_CONFIG_DIR)\""
++        -DANDROID=1 \
+ 
+ LOCAL_C_INCLUDES := \
+ 	$(LOCAL_PATH)/..
+@@ -123,6 +124,7 @@ LOCAL_SRC_FILES := \
+ 
+ LOCAL_CFLAGS += \
+ 	-DLOG_TAG=\"libva-android\" \
++        -DANDROID=1 \
+ 	$(IGNORED_WARNNING)
+ 
+ LOCAL_C_INCLUDES += \
+diff --git a/va/va.c b/va/va.c
+index fb62442..25f1d7c 100644
+--- a/va/va.c
++++ b/va/va.c
+@@ -60,7 +60,7 @@
+ #ifndef HAVE_SECURE_GETENV
+ static char * secure_getenv(const char *name)
+ {
+-#if defined(__MINGW32__) || defined(__MINGW64__)
++#if defined(__MINGW32__) || defined(__MINGW64__) || defined(ANDROID)
+     if (getuid() == geteuid())
+ #else
+     if (getuid() == geteuid() && getgid() == getegid())
+-- 
+2.17.1
+

--- a/bsp_diff/common/hardware/intel/media-driver/0001-Add-changes-to-build-latest-media-driver-in-Android.patch
+++ b/bsp_diff/common/hardware/intel/media-driver/0001-Add-changes-to-build-latest-media-driver-in-Android.patch
@@ -1,4 +1,4 @@
-From dfc364a8294357abfe7089297c75902aec7ff66f Mon Sep 17 00:00:00 2001
+From 660587c413d3417b53a057191170d35a566b5cc7 Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
 Date: Tue, 11 Apr 2023 15:01:20 +0530
 Subject: [PATCH] Add changes to build latest media driver in Android
@@ -40,7 +40,7 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  .../linux/common/cp/ddi/media_srcs.cmake      |    2 +
  .../linux/common/cp/os/media_srcs.cmake       |    1 +
  media_common/linux/common/os/media_srcs.cmake |    1 +
- media_driver/Android.mk                       | 1988 +++++++++++++++++
+ media_driver/Android.mk                       | 1991 +++++++++++++++++
  .../agnostic/Xe_M/Xe_HPM/hw/media_srcs.cmake  |    1 +
  .../Xe_M/Xe_HPM/hw/vdbox/media_srcs.cmake     |    1 +
  .../Xe_M/Xe_HPM/vp/hal/media_srcs.cmake       |    2 +
@@ -388,7 +388,7 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  .../encode/vp9/ddi/media_srcs.cmake           |    4 +-
  .../xe_lpm_plus_r0/vp/ddi/media_srcs.cmake    |    4 +-
  .../media_interfaces_mtl/media_srcs.cmake     |    5 +-
- 371 files changed, 3207 insertions(+), 246 deletions(-)
+ 371 files changed, 3210 insertions(+), 246 deletions(-)
  create mode 100644 cmrtlib/Android.mk
  create mode 100644 media_driver/Android.mk
  create mode 100644 media_driver/agnostic/gen12_tgllp/vp/kernel/swsb/media_srcs.cmake
@@ -404,7 +404,7 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  create mode 100644 media_softlet/agnostic/Xe_R/Xe_HPG/vp/kernel_free/Source/media_srcs.cmake
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 9adc2dc4c..e9c2611e2 100755
+index 3c16b3369..2ebde9e67 100755
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -53,9 +53,9 @@ cmake_dependent_option( ENABLE_NONFREE_KERNELS
@@ -897,10 +897,10 @@ index e117b5e8d..828fa2060 100644
  endif() # CMAKE_WDDM_LINUX
 diff --git a/media_driver/Android.mk b/media_driver/Android.mk
 new file mode 100644
-index 000000000..4bb53a2ae
+index 000000000..8f6a618b5
 --- /dev/null
 +++ b/media_driver/Android.mk
-@@ -0,0 +1,1988 @@
+@@ -0,0 +1,1991 @@
 +
 +# Copyright(c) 2018 Intel Corporation
 +
@@ -1188,6 +1188,7 @@ index 000000000..4bb53a2ae
 +    ../media_softlet/agnostic/common/codec/hal/enc/av1/features/encode_av1_vdenc_lpla_enc.cpp \
 +    ../media_softlet/agnostic/common/codec/hal/enc/av1/packet/encode_av1_brc_init_packet.cpp \
 +    ../media_softlet/agnostic/common/codec/hal/enc/av1/packet/encode_av1_brc_update_packet.cpp \
++    ../media_softlet/agnostic/common/codec/hal/enc/av1/packet/encode_av1_pak_integrate_packet.cpp \
 +    ../media_softlet/agnostic/common/codec/hal/enc/av1/packet/encode_av1_vdenc_packet.cpp \
 +    ../media_softlet/agnostic/common/codec/hal/enc/av1/packet/encode_back_annotation_packet.cpp \
 +    ../media_softlet/agnostic/common/codec/hal/enc/av1/pipeline/encode_av1_pipeline.cpp \
@@ -1216,6 +1217,7 @@ index 000000000..4bb53a2ae
 +    ../media_softlet/agnostic/common/codec/hal/enc/avc/pipeline/encode_avc_vdenc_pipeline.cpp \
 +    ../media_softlet/agnostic/common/codec/hal/enc/avc/pipeline/encode_avc_vdenc_pipeline_adapter.cpp \
 +    ../media_softlet/agnostic/common/codec/hal/enc/hevc/features/encode_hevc_basic_feature.cpp \
++    ../media_softlet/agnostic/common/codec/hal/enc/hevc/features/encode_hevc_basic_feature_422.cpp \
 +    ../media_softlet/agnostic/common/codec/hal/enc/hevc/features/encode_hevc_brc.cpp \
 +    ../media_softlet/agnostic/common/codec/hal/enc/hevc/features/encode_hevc_cqp.cpp \
 +    ../media_softlet/agnostic/common/codec/hal/enc/hevc/features/encode_hevc_dss.cpp \
@@ -1238,6 +1240,7 @@ index 000000000..4bb53a2ae
 +    ../media_softlet/agnostic/common/codec/hal/enc/hevc/features/roi/encode_hevc_vdenc_roi_qpmap.cpp \
 +    ../media_softlet/agnostic/common/codec/hal/enc/hevc/features/roi/encode_hevc_vdenc_roi_strategy.cpp \
 +    ../media_softlet/agnostic/common/codec/hal/enc/hevc/packet/encode_hevc_tile_replay_packet.cpp \
++    ../media_softlet/agnostic/common/codec/hal/enc/hevc/packet/encode_hevc_vdenc_422_packet.cpp \
 +    ../media_softlet/agnostic/common/codec/hal/enc/hevc/packet/encode_hevc_vdenc_packet.cpp \
 +    ../media_softlet/agnostic/common/codec/hal/enc/hevc/packet/encode_huc_brc_init_packet.cpp \
 +    ../media_softlet/agnostic/common/codec/hal/enc/hevc/packet/encode_huc_brc_update_packet.cpp \
@@ -2397,8 +2400,8 @@ index 000000000..4bb53a2ae
 +    -DIGFX_XEHP_SDV_SUPPORTED \
 +    -DIGFX_XE_HPG_CMFCPATCH_SUPPORTED \
 +    -DIGFX_XE_HPG_SUPPORTED \
-+    -DMEDIA_VERSION=\"23.2.1\" \
-+    -DMEDIA_VERSION_DETAILS=\"169aa0eed\" \
++    -DMEDIA_VERSION=\"23.2.4\" \
++    -DMEDIA_VERSION_DETAILS=\"b9e4af8d4\" \
 +    -DVEBOX_AUTO_DENOISE_SUPPORTED=1 \
 +    -DX11_FOUND \
 +    -D_AV1_DECODE_SUPPORTED \
@@ -4144,7 +4147,7 @@ index 8fdb07865..04f8b4739 100644
 +media_add_curr_to_include_path()
  endif() #NOT CMAKE_WDDM_LINUX
 diff --git a/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp b/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
-index 3372db61a..86296468e 100644
+index 362f2d9bc..946f26d51 100644
 --- a/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
 +++ b/media_driver/linux/gen12/ddi/media_libva_caps_g12.cpp
 @@ -38,6 +38,9 @@
@@ -6747,10 +6750,10 @@ index 149e2bb16..e0b0ca5b3 100644
 \ No newline at end of file
 +)
 diff --git a/media_softlet/agnostic/common/codec/hal/enc/av1/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/av1/packet/media_srcs.cmake
-index e6906854b..15ff451b4 100644
+index fcfbccc12..2ac5d9eb8 100644
 --- a/media_softlet/agnostic/common/codec/hal/enc/av1/packet/media_srcs.cmake
 +++ b/media_softlet/agnostic/common/codec/hal/enc/av1/packet/media_srcs.cmake
-@@ -48,9 +48,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+@@ -50,9 +50,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
  set(TMP_SOURCES_ "")
  set(TMP_HEADERS_ "")
  
@@ -6835,10 +6838,10 @@ index ecf63fd3a..6dbd09e18 100644
  
  set(SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_
 diff --git a/media_softlet/agnostic/common/codec/hal/enc/hevc/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/hevc/features/media_srcs.cmake
-index 7d3b89c5a..3c4ff8dac 100644
+index 63b983255..1d2159033 100644
 --- a/media_softlet/agnostic/common/codec/hal/enc/hevc/features/media_srcs.cmake
 +++ b/media_softlet/agnostic/common/codec/hal/enc/hevc/features/media_srcs.cmake
-@@ -65,6 +65,8 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+@@ -67,6 +67,8 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
  set(TMP_SOURCES_ "")
  set(TMP_HEADERS_ "")
  
@@ -6861,10 +6864,10 @@ index 9c8e34da2..545ed1187 100644
  
  set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
 diff --git a/media_softlet/agnostic/common/codec/hal/enc/hevc/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/hevc/packet/media_srcs.cmake
-index 0ca0e943b..ba555276e 100644
+index 536e0a541..b31b97741 100644
 --- a/media_softlet/agnostic/common/codec/hal/enc/hevc/packet/media_srcs.cmake
 +++ b/media_softlet/agnostic/common/codec/hal/enc/hevc/packet/media_srcs.cmake
-@@ -54,9 +54,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
+@@ -56,9 +56,11 @@ source_group( CodecHalNext\\Shared\\Encode FILES ${TMP_SOURCES_} ${TMP_HEADERS_}
  set(TMP_SOURCES_ "")
  set(TMP_HEADERS_ "")
  
@@ -7551,10 +7554,10 @@ index 5ac1ca5ae..a1e4b5488 100644
 +
 +media_add_curr_to_include_path()
 diff --git a/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_allocator.cpp b/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_allocator.cpp
-index 2273915bf..4902c78a5 100644
+index d355951ab..0855f649f 100644
 --- a/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_allocator.cpp
 +++ b/media_softlet/agnostic/common/vp/hal/bufferMgr/vp_allocator.cpp
-@@ -710,7 +710,7 @@ MOS_STATUS VpAllocator::AllocParamsInitType(
+@@ -733,7 +733,7 @@ MOS_STATUS VpAllocator::AllocParamsInitType(
      VP_FUNC_CALL();
      VP_PUBLIC_CHK_NULL_RETURN(surface);
  
@@ -8058,5 +8061,5 @@ index 15c3d1e36..5ff007de8 100644
 +media_add_curr_to_include_path()
 +
 -- 
-2.40.1
+2.17.1
 

--- a/bsp_diff/common/hardware/intel/media-driver/0002-Resolved-compilation-issue-for-media-driver.patch
+++ b/bsp_diff/common/hardware/intel/media-driver/0002-Resolved-compilation-issue-for-media-driver.patch
@@ -1,4 +1,4 @@
-From 5af20ebc58c0cde441e63e15ddf832491ceb1a98 Mon Sep 17 00:00:00 2001
+From 8a073cdd39b10cb6b21aebea2554749d98c87195 Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Tue, 30 May 2023 22:01:00 +0530
 Subject: [PATCH] Resolved compilation issue for media driver
@@ -40,10 +40,10 @@ index 36b98c13a..d63221f8f 100644
  
      // New Surface Manager
 diff --git a/media_driver/Android.mk b/media_driver/Android.mk
-index 4bb53a2ae..e43b85c36 100644
+index 8f6a618b5..463fae17f 100644
 --- a/media_driver/Android.mk
 +++ b/media_driver/Android.mk
-@@ -427,7 +427,6 @@ LOCAL_SRC_FILES := \
+@@ -430,7 +430,6 @@ LOCAL_SRC_FILES := \
      ../media_softlet/agnostic/common/os/mos_util_debug.cpp \
      ../media_softlet/agnostic/common/os/mos_utilities_inner.cpp \
      ../media_softlet/agnostic/common/os/mos_utilities_next.cpp \
@@ -51,7 +51,7 @@ index 4bb53a2ae..e43b85c36 100644
      ../media_softlet/agnostic/common/os/share/mos_oca_util_debug.cpp \
      ../media_softlet/agnostic/common/os/user_setting/media_user_setting.cpp \
      ../media_softlet/agnostic/common/os/user_setting/media_user_setting_configure.cpp \
-@@ -596,10 +595,6 @@ LOCAL_SRC_FILES := \
+@@ -599,10 +598,6 @@ LOCAL_SRC_FILES := \
      ../media_softlet/linux/common/os/mos_vma.c \
      ../media_softlet/linux/common/os/osservice/mos_util_debug_specific.cpp \
      ../media_softlet/linux/common/os/osservice/mos_utilities_specific.cpp \
@@ -62,7 +62,7 @@ index 4bb53a2ae..e43b85c36 100644
      ../media_softlet/linux/common/os/user_setting/media_user_setting_configure_specific.cpp \
      ../media_softlet/linux/common/shared/hal_oca_interface_next.cpp \
      ../media_softlet/linux/common/shared/skuwa_dumper_specific.c \
-@@ -1978,7 +1973,8 @@ LOCAL_C_INCLUDES  = \
+@@ -1981,7 +1976,8 @@ LOCAL_C_INCLUDES  = \
      $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/decode/vp8/ddi \
      $(LOCAL_PATH)/../media_softlet/linux/xe_lpm_plus_r0/decode/vp9/ddi \
      $(LOCAL_PATH)/../media_softlet/media_interface/media_interfaces_mtl \
@@ -73,10 +73,10 @@ index 4bb53a2ae..e43b85c36 100644
  #LOCAL_CPP_FEATURES := rtti exceptions
  
 diff --git a/media_softlet/agnostic/common/vp/kdll/hal_kerneldll_next.c b/media_softlet/agnostic/common/vp/kdll/hal_kerneldll_next.c
-index 4f6e97798..28c5db050 100644
+index d8f7d429a..7d5ea5b7c 100644
 --- a/media_softlet/agnostic/common/vp/kdll/hal_kerneldll_next.c
 +++ b/media_softlet/agnostic/common/vp/kdll/hal_kerneldll_next.c
-@@ -3864,6 +3864,7 @@ bool KernelDll_BuildKernel_CmFc(Kdll_State *pState, Kdll_SearchState *pSearchSta
+@@ -3918,6 +3918,7 @@ bool KernelDll_BuildKernel_CmFc(Kdll_State *pState, Kdll_SearchState *pSearchSta
      VP_RENDER_FUNCTION_ENTER;
  
      // Disable pop-up box window for STL assertion to avoid VM hang in auto test.
@@ -84,7 +84,7 @@ index 4f6e97798..28c5db050 100644
  #if (!LINUX)
      uint32_t prevErrorMode = ::SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
  #if defined(_MSC_VER)
-@@ -3876,7 +3877,7 @@ bool KernelDll_BuildKernel_CmFc(Kdll_State *pState, Kdll_SearchState *pSearchSta
+@@ -3930,7 +3931,7 @@ bool KernelDll_BuildKernel_CmFc(Kdll_State *pState, Kdll_SearchState *pSearchSta
      _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
  #endif
  #endif
@@ -93,7 +93,7 @@ index 4f6e97798..28c5db050 100644
      pSearchState->KernelLink.dwSize  = DL_MAX_SYMBOLS;
      pSearchState->KernelLink.dwCount = 0;
      pSearchState->KernelLink.pLink   = pSearchState->LinkArray;
-@@ -3994,7 +3995,7 @@ bool KernelDll_BuildKernel_CmFc(Kdll_State *pState, Kdll_SearchState *pSearchSta
+@@ -4048,7 +4049,7 @@ bool KernelDll_BuildKernel_CmFc(Kdll_State *pState, Kdll_SearchState *pSearchSta
      res = true;
  
  finish:
@@ -102,7 +102,7 @@ index 4f6e97798..28c5db050 100644
      ::SetErrorMode(prevErrorMode);
  #endif
      return res;
-@@ -4400,4 +4401,4 @@ bool KernelDll_SetupFunctionPointers_Ext(
+@@ -4454,4 +4455,4 @@ bool KernelDll_SetupFunctionPointers_Ext(
  
  #ifdef __cplusplus
  }
@@ -110,7 +110,7 @@ index 4f6e97798..28c5db050 100644
 \ No newline at end of file
 +#endif  // __cplusplus
 diff --git a/media_softlet/linux/Xe_M_plus/ddi/media_libva_caps_mtl_base.cpp b/media_softlet/linux/Xe_M_plus/ddi/media_libva_caps_mtl_base.cpp
-index e488e8fc0..0a6cde6d9 100644
+index 3949d5b55..715305585 100644
 --- a/media_softlet/linux/Xe_M_plus/ddi/media_libva_caps_mtl_base.cpp
 +++ b/media_softlet/linux/Xe_M_plus/ddi/media_libva_caps_mtl_base.cpp
 @@ -37,6 +37,7 @@
@@ -122,7 +122,7 @@ index e488e8fc0..0a6cde6d9 100644
  const VAImageFormat m_supportedImageformatsXe_Lpm_Plus_Base[] =
  {   {VA_FOURCC_BGRA,           VA_LSB_FIRST,   32, 32, 0x0000ff00, 0x00ff0000, 0xff000000,  0x000000ff}, /* [31:0] B:G:R:A 8:8:8:8 little endian */
 diff --git a/media_softlet/linux/common/os/i915/include/mos_bufmgr.h b/media_softlet/linux/common/os/i915/include/mos_bufmgr.h
-index 9c96dff44..5b08067a9 100644
+index 9f2fd36ad..41fba3033 100644
 --- a/media_softlet/linux/common/os/i915/include/mos_bufmgr.h
 +++ b/media_softlet/linux/common/os/i915/include/mos_bufmgr.h
 @@ -34,6 +34,7 @@
@@ -154,5 +154,5 @@ index 97ad15c62..6090a49aa 100644
      }
      return;
 -- 
-2.40.1
+2.17.1
 

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0001-Changes-for-OneVPL-integration.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0001-Changes-for-OneVPL-integration.patch
@@ -1,4 +1,4 @@
-From 2a2f7b0c18aecdaa930c4bfe43a8669fd2da3c7b Mon Sep 17 00:00:00 2001
+From e63009228757ee2f302ce281c656538e694f5706 Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
 Date: Fri, 28 Oct 2022 23:23:43 +0530
 Subject: [PATCH] Changes for OneVPL integration
@@ -394,7 +394,7 @@ index 00000000..ccd2ea14
 +
 +include $(BUILD_SHARED_LIBRARY)
 diff --git a/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h b/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
-index c87443a8..f23d3826 100644
+index 329cfa52..149f1283 100644
 --- a/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
 +++ b/_studio/mfx_lib/encode_hw/h264/include/mfx_h264_encode_hw_utils.h
 @@ -35,9 +35,9 @@
@@ -409,7 +409,7 @@ index c87443a8..f23d3826 100644
  #include "asc.h"
  #endif
 diff --git a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
-index 4ab28697..aa53f750 100644
+index d0235af4..01b082d7 100644
 --- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
 +++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
 @@ -974,8 +974,10 @@ mfxStatus ImplementationAvc::InitScd(mfxFrameAllocRequest& request)
@@ -581,10 +581,10 @@ index 5b23cd6c..0911951e 100644
  #if defined (MFX_ENABLE_FOURCC_RGB565)
      case MFX_FOURCC_RGB565:
 diff --git a/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp b/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
-index 863d38e0..2075476e 100644
+index de2f0f91..910cdbb7 100644
 --- a/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
 +++ b/_studio/mfx_lib/vpp/src/mfx_vpp_sw_core.cpp
-@@ -952,7 +952,9 @@ mfxStatus VideoVPPBase::Query(VideoCORE * core, mfxVideoParam *in, mfxVideoParam
+@@ -922,7 +922,9 @@ mfxStatus VideoVPPBase::Query(VideoCORE * core, mfxVideoParam *in, mfxVideoParam
  #endif // MFX_ENABLE_FOURCC_RGB565
              out->vpp.In.FourCC != MFX_FOURCC_RGB4 &&
              out->vpp.In.FourCC != MFX_FOURCC_BGR4 &&
@@ -593,7 +593,7 @@ index 863d38e0..2075476e 100644
 +#endif
              out->vpp.In.FourCC != MFX_FOURCC_P010 &&
              out->vpp.In.FourCC != MFX_FOURCC_UYVY &&
-             out->vpp.In.FourCC != MFX_FOURCC_P210 &&
+             out->vpp.In.FourCC != MFX_FOURCC_I420 &&
 diff --git a/_studio/mfx_lib/vpp/src/mfx_vpp_utils.cpp b/_studio/mfx_lib/vpp/src/mfx_vpp_utils.cpp
 index 20249928..5ea9c994 100644
 --- a/_studio/mfx_lib/vpp/src/mfx_vpp_utils.cpp
@@ -752,7 +752,7 @@ index 97e8db29..a7609116 100644
      m_dataIn->accuracy = 1;
  
 diff --git a/_studio/shared/include/mfx_config.h b/_studio/shared/include/mfx_config.h
-index de69ca7e..dfa860ae 100644
+index 95fe11ca..8c5a11ec 100644
 --- a/_studio/shared/include/mfx_config.h
 +++ b/_studio/shared/include/mfx_config.h
 @@ -28,9 +28,15 @@
@@ -775,7 +775,7 @@ index de69ca7e..dfa860ae 100644
  #define SYNCHRONIZATION_BY_VA_MAP_BUFFER
  #if !defined(SYNCHRONIZATION_BY_VA_SYNC_SURFACE)
 diff --git a/_studio/shared/include/mfx_utils.h b/_studio/shared/include/mfx_utils.h
-index 6455f38c..7b1d4662 100644
+index b7a37ae1..decbf20e 100644
 --- a/_studio/shared/include/mfx_utils.h
 +++ b/_studio/shared/include/mfx_utils.h
 @@ -24,6 +24,7 @@
@@ -786,7 +786,7 @@ index 6455f38c..7b1d4662 100644
  
  #include "mfxdeprecated.h"
  #include "mfxplugin.h"
-@@ -800,6 +801,7 @@ struct mfxRefCountable
+@@ -821,6 +822,7 @@ struct mfxRefCountable
      virtual mfxU32    GetRefCounter() const = 0;
      virtual void      AddRef()              = 0;
      virtual mfxStatus Release()             = 0;
@@ -794,7 +794,7 @@ index 6455f38c..7b1d4662 100644
  };
  
  template <typename T>
-@@ -824,9 +826,11 @@ protected:
+@@ -845,9 +847,11 @@ protected:
      template <typename X, typename std::enable_if<HasRefInterface<X>::value, bool>::type = true>
      void AssignFunctionPointers()
      {
@@ -806,7 +806,7 @@ index 6455f38c..7b1d4662 100644
      }
  
      template <typename X, typename std::enable_if<!HasRefInterface<X>::value, bool>::type = true>
-@@ -919,6 +923,7 @@ public:
+@@ -940,6 +944,7 @@ public:
          return MFX_ERR_NONE;
      }
  
@@ -814,7 +814,7 @@ index 6455f38c..7b1d4662 100644
      static mfxStatus _AddRef2(mfxRefInterface* object)
      {
          MFX_CHECK_NULL_PTR1(object);
-@@ -949,6 +954,7 @@ public:
+@@ -970,6 +975,7 @@ public:
          *counter = instance->GetRefCounter();
          return MFX_ERR_NONE;
      }
@@ -1389,5 +1389,5 @@ index 00000000..0de07f85
 +    $(MFX_INCLUDES_LIBVA)
 \ No newline at end of file
 -- 
-2.40.1
+2.17.1
 

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0002-Restore-SG1-as-a-VPL-platform.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0002-Restore-SG1-as-a-VPL-platform.patch
@@ -1,4 +1,4 @@
-From 5ad6991d899f1f0d98b9579709bdd3f3e62992f4 Mon Sep 17 00:00:00 2001
+From 26cc2a424fc224ad39a13c86a3e2b50265967d8d Mon Sep 17 00:00:00 2001
 From: Ratnesh Kumar Rai <ratnesh.kumar.rai@intel.com>
 Date: Sat, 9 Apr 2022 09:57:38 +0530
 Subject: [PATCH] Restore SG1 as a VPL platform
@@ -16,10 +16,10 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/_studio/mfx_lib/shared/include/mfx_platform_caps.h b/_studio/mfx_lib/shared/include/mfx_platform_caps.h
-index 94fa0040..975f580f 100644
+index fb6bbbec..384c225f 100644
 --- a/_studio/mfx_lib/shared/include/mfx_platform_caps.h
 +++ b/_studio/mfx_lib/shared/include/mfx_platform_caps.h
-@@ -53,7 +53,7 @@ namespace CommonCaps {
+@@ -46,7 +46,7 @@ namespace CommonCaps {
  
      inline bool IsVplHW(eMFXHWType hw, mfxU32 deviceId)
      {
@@ -29,5 +29,5 @@ index 94fa0040..975f580f 100644
  
      inline bool CapsQueryOptimizationSupport(eMFXHWType platform)
 -- 
-2.40.1
+2.17.1
 

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0003-Resolved-runtime-error-for-onevpl.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0003-Resolved-runtime-error-for-onevpl.patch
@@ -1,4 +1,4 @@
-From a7d252f9d4495a0695e8d0ae9aefaac7fcd67f45 Mon Sep 17 00:00:00 2001
+From d278285e8cad955c1c81573685d41203761d9255 Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
 Date: Fri, 3 Feb 2023 11:50:32 +0530
 Subject: [PATCH] Resolved runtime error for onevpl
@@ -327,5 +327,5 @@ index 0de07f85..8d5ef227 100644
 \ No newline at end of file
 +    $(MFX_INCLUDES_LIBVA)
 -- 
-2.40.1
+2.17.1
 

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0004-Remove-ITT-vtune-support.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0004-Remove-ITT-vtune-support.patch
@@ -1,4 +1,4 @@
-From 3498576d4dd3be2f98446d2cb43a9174aac0a860 Mon Sep 17 00:00:00 2001
+From 0d686294de6283e5b9479e8fded57c949a689088 Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Thu, 10 Nov 2022 00:23:21 +0530
 Subject: [PATCH] Remove ITT (vtune) support
@@ -33,7 +33,7 @@ Signed-off-by: yerriswamy <yerriswamy.kt@intel.com>
  delete mode 100644 builder/FindVTune.cmake
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 49a129a8..12c6fd60 100644
+index 7cc941c6..5d839a8b 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -74,7 +74,6 @@ include( ${BUILDER_ROOT}/FindOpenCL.cmake )
@@ -197,7 +197,7 @@ index d6b520bb..de9e0af3 100644
      /*ColorFill is always present*/
      list.push_back(MFX_EXTBUFF_VPP_COLORFILL);
 diff --git a/_studio/shared/include/mfx_config.h b/_studio/shared/include/mfx_config.h
-index dfa860ae..7f5aa468 100644
+index 8c5a11ec..a5e44742 100644
 --- a/_studio/shared/include/mfx_config.h
 +++ b/_studio/shared/include/mfx_config.h
 @@ -77,17 +77,12 @@
@@ -359,7 +359,7 @@ index cc59b617..00000000
 -#endif // #ifdef MFX_TRACE_ENABLE_TEXTLOG
 -#endif // #ifndef __MFX_TRACE_ITT_LOG_H__
 diff --git a/_studio/shared/mfx_trace/src/mfx_trace.cpp b/_studio/shared/mfx_trace/src/mfx_trace.cpp
-index c30824d3..a34bea0b 100644
+index c0ce8ab2..a87d0668 100644
 --- a/_studio/shared/mfx_trace/src/mfx_trace.cpp
 +++ b/_studio/shared/mfx_trace/src/mfx_trace.cpp
 @@ -40,7 +40,6 @@ extern "C"
@@ -775,5 +775,5 @@ index 4a9418be..00000000
 -
 -endif()
 -- 
-2.40.1
+2.17.1
 

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0005-Fix-for-HEVC-rendering-failing-with-usptream-ffmpeg.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0005-Fix-for-HEVC-rendering-failing-with-usptream-ffmpeg.patch
@@ -1,4 +1,4 @@
-From 96dffbe66f6614200e68effee7d1870c098352b6 Mon Sep 17 00:00:00 2001
+From 220715f8dae5f2f9a9234c7d450184ffe05f73e8 Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Wed, 8 Mar 2023 15:42:09 +0530
 Subject: [PATCH] Fix for HEVC rendering failing with usptream ffmpeg
@@ -42,5 +42,5 @@ index b3f7c039..465408cd 100644
  # Enable feature with output decoded frames without latency regarding
  # SPS.VUI.max_num_reorder_frames
 -- 
-2.40.1
+2.17.1
 

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0006-Changes-to-be-in-sync-with-features-enabled-in-linux.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0006-Changes-to-be-in-sync-with-features-enabled-in-linux.patch
@@ -1,4 +1,4 @@
-From 6dbce949606d6606571075f66ebaa8a003135ad4 Mon Sep 17 00:00:00 2001
+From f7e877881ac2053116cea2a9db04a7c05d1c169d Mon Sep 17 00:00:00 2001
 From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
 Date: Wed, 8 Mar 2023 15:46:04 +0530
 Subject: [PATCH] Changes to be in sync with features enabled in linux variant
@@ -147,5 +147,5 @@ index 465408cd..fe5bc2be 100644
  
  # Android version preference:
 -- 
-2.40.1
+2.17.1
 

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0007-Enable-avx2.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0007-Enable-avx2.patch
@@ -1,4 +1,4 @@
-From e1f50396a06e7c0dd2489091d3c992c6e8346c4a Mon Sep 17 00:00:00 2001
+From 87164f54be781f08e9f088bfb1b0b52c6c1bd0c4 Mon Sep 17 00:00:00 2001
 From: yerriswamy <yerriswamy.kt@intel.com>
 Date: Wed, 29 Mar 2023 15:42:03 +0530
 Subject: [PATCH] Enable avx2
@@ -25,5 +25,5 @@ index fe5bc2be..6cd24900 100644
  # Enable feature with output decoded frames without latency regarding
  # SPS.VUI.max_num_reorder_frames
 -- 
-2.40.1
+2.17.1
 

--- a/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0008-Fix-crash-seen-during-unloading-of-oneVPL-GPU-runtim.patch
+++ b/bsp_diff/common/hardware/intel/onevpl-intel-gpu/0008-Fix-crash-seen-during-unloading-of-oneVPL-GPU-runtim.patch
@@ -1,6 +1,6 @@
-From 3dabcc8463066b5cf5ac1b1eff3f5c3f04784d9c Mon Sep 17 00:00:00 2001
-From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
-Date: Wed, 28 Jun 2023 00:25:38 +0530
+From 18381a8a05a9cdae94e1fe3874935151ea61a7a3 Mon Sep 17 00:00:00 2001
+From: Yerriswamy <yerriswamy.kt@intel.com>
+Date: Fri, 14 Jul 2023 14:38:58 +0530
 Subject: [PATCH] Fix crash seen during unloading of oneVPL GPU runtime
 
 While VPL dispatch tries to unload all libaries, crash seen
@@ -15,16 +15,17 @@ Fix the issue by initializing member variables of PerfUtility to
 
 Change-Id: I146a4907bfa5658230ebb42846dc0651fba31aa4
 Tracked-On: OAM-110789
-Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com
+Signed-off-by: Yerriswamy <yerriswamy.kt@intel.com>
 ---
- _studio/shared/mfx_logging/src/mfx_utils_perf.cpp | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ _studio/shared/mfx_logging/src/mfx_utils_perf.cpp | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
 
 diff --git a/_studio/shared/mfx_logging/src/mfx_utils_perf.cpp b/_studio/shared/mfx_logging/src/mfx_utils_perf.cpp
-index 2f4cf642..657c4a28 100644
+index 41b1f8c7..9abde6b7 100644
 --- a/_studio/shared/mfx_logging/src/mfx_utils_perf.cpp
 +++ b/_studio/shared/mfx_logging/src/mfx_utils_perf.cpp
-@@ -85,8 +85,8 @@ PerfUtility* PerfUtility::getInstance()
+@@ -133,8 +133,8 @@ PerfUtility* PerfUtility::getInstance()
  
  PerfUtility::PerfUtility()
  {
@@ -35,13 +36,14 @@ index 2f4cf642..657c4a28 100644
  }
  
  PerfUtility::~PerfUtility()
-@@ -193,4 +193,4 @@ void PerfUtility::printPerfTimeStamp(Tick *newTick, const std::vector<uint32_t>&
+@@ -253,4 +253,5 @@ void PerfUtility::printPerfTimeStamp(Tick *newTick, const std::vector<uint32_t>&
          }
      }
-     log_buffer[current_tid].append("\n");
+     it->second.append("\n");
 -}
 \ No newline at end of file
++    log_buffer[current_tid].append("\n");
 +}
 -- 
-2.41.0
+2.17.1
 


### PR DESCRIPTION
Included versions:
* libva: 2.19.0 (was 2.18.0)
* gmmlib: 22.3.7 (was 22.3.5)
* media-driver: 23.2.4 (was 23.2.1)
* onevpl-gpu: 23.2.4 (was 23.2.1)
* oneVPL: v2023.3.0 (was v2023.2.1)

Tracked-On: OAM-111192