### PR TITLE
Fix for STS failure

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/99_0174-Strip-transition-information-from-activityoptions-when-sent-.bulletin.patch
+++ b/aosp_diff/preliminary/frameworks/base/99_0174-Strip-transition-information-from-activityoptions-when-sent-.bulletin.patch
@@ -1,0 +1,62 @@
+From 2260d53ca8cfdc58c21fc85ae7a3b7554d542e2a Mon Sep 17 00:00:00 2001
+From: Evan Rosky <erosky@google.com>
+Date: Wed, 3 Aug 2022 11:48:33 -0700
+Subject: [PATCH] Strip transition information from activityoptions when sent
+ to app
+
+The implementation of shared-element transitions takes the
+ActivityOptions from the calling activity and sends them to
+another activity. This means that any sensitive information
+passed into ActivityManager via ActivityOptions can make its
+way to an unrelated app. Recently a RemoteTransition object
+was added which includes some sensitive information.
+
+This CL strips the sensitive information from the activity
+options before sending it to anonther app.
+
+Bug: 237290578
+Test: atest ActivityManagerTest#testActivityManager_stripTransitionFromActivityOptions
+Change-Id: Ifa08fc195698f02bf70ca386178c67f6ba4a14ea
+(cherry picked from commit 0d03e6f1fc66fefb5409ac93ff49fa922f81664c)
+Merged-In: Ifa08fc195698f02bf70ca386178c67f6ba4a14ea
+---
+ core/java/android/app/ActivityOptions.java                   | 5 +++++
+ services/core/java/com/android/server/wm/ActivityRecord.java | 4 ++++
+ 2 files changed, 9 insertions(+)
+
+diff --git a/core/java/android/app/ActivityOptions.java b/core/java/android/app/ActivityOptions.java
+index 0ff9f6655b8a..e76f89ce9461 100644
+--- a/core/java/android/app/ActivityOptions.java
++++ b/core/java/android/app/ActivityOptions.java
+@@ -1352,6 +1352,11 @@ public class ActivityOptions {
+         return mRemoteTransition;
+     }
+ 
++    /** @hide */
++    public void setRemoteTransition(@Nullable RemoteTransition remoteTransition) {
++        mRemoteTransition = remoteTransition;
++    }
++
+     /** @hide */
+     public static ActivityOptions fromBundle(Bundle bOptions) {
+         return bOptions != null ? new ActivityOptions(bOptions) : null;
+diff --git a/services/core/java/com/android/server/wm/ActivityRecord.java b/services/core/java/com/android/server/wm/ActivityRecord.java
+index 49b77bc8f828..fe13d1794ecd 100644
+--- a/services/core/java/com/android/server/wm/ActivityRecord.java
++++ b/services/core/java/com/android/server/wm/ActivityRecord.java
+@@ -4630,8 +4630,12 @@ final class ActivityRecord extends WindowToken implements WindowManagerService.A
+     ActivityOptions takeOptions() {
+         if (DEBUG_TRANSITION) Slog.i(TAG, "Taking options for " + this + " callers="
+                 + Debug.getCallers(6));
++        if (mPendingOptions == null) return null;
+         final ActivityOptions opts = mPendingOptions;
+         mPendingOptions = null;
++        // Strip sensitive information from options before sending it to app.
++        opts.setRemoteTransition(null);
++        opts.setRemoteAnimationAdapter(null);
+         return opts;
+     }
+ 
+-- 
+2.37.2.789.g6183377224-goog
+


### PR DESCRIPTION
STS failed details
Module - x86_64 CtsSecurityTestCases
Test Case-  android.security.cts.ActivityManagerTest#testActivityManager_stripTransitionFromActivityOptions This patch released on ASB-OCT-2022 and missed in the 12.1 codebase . We ported the patch in 12.1 and STS failure is resolved.

Patch details
1)0001-Strip-transition-information-from-activityoptions-when-sent-.bulletin.patch

Tracked-On: OAM-111062