### PR TITLE
updating dummy cpufreq_frequency_table

### DIFF
--- a/bsp_diff/common/kernel/linux-intel-lts2021/0019-updating-dummy-cpufreq_frequency_table.patch
+++ b/bsp_diff/common/kernel/linux-intel-lts2021/0019-updating-dummy-cpufreq_frequency_table.patch
@@ -1,0 +1,40 @@
+From c7fea08eedfe57b5f546376d53c5cf958145604c Mon Sep 17 00:00:00 2001
+From: raju <raju.mallikarjun.chegaraddi@intel.com>
+Date: Mon, 24 Jul 2023 06:39:53 +0000
+Subject: [PATCH] updating dummy cpufreq_frequency_table
+
+updating frequency tables that represent the available
+CPU frequencies from ADL for scaling the CPU's clock
+frequency dynamically. This structure allows the kernel
+to manage the CPU's operating frequency based on the system's
+workload and power-saving requirements.
+
+Reference platform (ADL-NUC):
+Model name: 12th Gen Intel(R) Core(TM) i7-1260P
+CPU min MHz: 400MHz
+CPU max MHz: 4700MHz
+
+Tracked-On: OAM-111324
+Signed-off-by: raju <raju.mallikarjun.chegaraddi@intel.com>
+---
+ drivers/cpufreq/dummy-cpufreq.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/cpufreq/dummy-cpufreq.c b/drivers/cpufreq/dummy-cpufreq.c
+index e74ef6782e5a..9637280e5f8d 100644
+--- a/drivers/cpufreq/dummy-cpufreq.c
++++ b/drivers/cpufreq/dummy-cpufreq.c
+@@ -6,8 +6,8 @@
+ #include <linux/module.h>
+ 
+ static struct cpufreq_frequency_table freq_table[] = {
+-	{ .frequency = 1 },
+-	{ .frequency = 2 },
++	{ .frequency = 400000 },
++	{ .frequency = 4700000 },
+ 	{ .frequency = CPUFREQ_TABLE_END },
+ };
+ 
+-- 
+2.39.2
+

--- a/bsp_diff/common/kernel/lts2021-chromium/0023-updating-dummy-cpufreq_frequency_table.patch
+++ b/bsp_diff/common/kernel/lts2021-chromium/0023-updating-dummy-cpufreq_frequency_table.patch
@@ -1,0 +1,40 @@
+From f6738fa8d2e8fcbc814d58fc713a148f35995107 Mon Sep 17 00:00:00 2001
+From: raju <raju.mallikarjun.chegaraddi@intel.com>
+Date: Mon, 24 Jul 2023 06:49:43 +0000
+Subject: [PATCH] updating dummy cpufreq_frequency_table
+
+updating frequency tables that represent the available
+CPU frequencies from ADL for scaling the CPU's clock
+frequency dynamically. This structure allows the kernel
+to manage the CPU's operating frequency based on the system's
+workload and power-saving requirements.
+
+Reference platform (ADL-NUC):
+Model name: 12th Gen Intel(R) Core(TM) i7-1260P
+CPU min MHz: 400MHz
+CPU max MHz: 4700MHz
+
+Tracked-On: OAM-111324
+Signed-off-by: raju <raju.mallikarjun.chegaraddi@intel.com>
+---
+ drivers/cpufreq/dummy-cpufreq.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/cpufreq/dummy-cpufreq.c b/drivers/cpufreq/dummy-cpufreq.c
+index e74ef6782e5a..9637280e5f8d 100644
+--- a/drivers/cpufreq/dummy-cpufreq.c
++++ b/drivers/cpufreq/dummy-cpufreq.c
+@@ -6,8 +6,8 @@
+ #include <linux/module.h>
+ 
+ static struct cpufreq_frequency_table freq_table[] = {
+-	{ .frequency = 1 },
+-	{ .frequency = 2 },
++	{ .frequency = 400000 },
++	{ .frequency = 4700000 },
+ 	{ .frequency = CPUFREQ_TABLE_END },
+ };
+ 
+-- 
+2.39.2
+


### PR DESCRIPTION
updating frequency tables that represent the available CPU frequencies from ADL for scaling the CPU's clock frequency dynamically. This structure allows the kernel to manage the CPU's operating frequency based on the system's workload and power-saving requirements.

Reference platform (ADL-NUC):
Model name: 12th Gen Intel(R) Core(TM) i7-1260P
CPU min MHz: 400MHz
CPU max MHz: 4700MHz

Tracked-On: OAM-111324