### PR TITLE
Fix "Loading" dialog not hidden timely after user SWITCHING event

### DIFF
--- a/aosp_diff/celadon_ivi/packages/apps/Car/SystemUI/0001-Fix-Loading-dialog-not-hidden-timely-after-user-SWIT.patch
+++ b/aosp_diff/celadon_ivi/packages/apps/Car/SystemUI/0001-Fix-Loading-dialog-not-hidden-timely-after-user-SWIT.patch
@@ -1,0 +1,69 @@
+From d9e3afb3dfb60b5da7948fcbad2d971e38a1c287 Mon Sep 17 00:00:00 2001
+From: Zhou Jingyu <jingyu.zhou@intel.com>
+Date: Tue, 1 Aug 2023 13:27:14 +0800
+Subject: [PATCH] Fix "Loading" dialog not hidden timely after user SWITCHING
+ event
+
+Sometimes a "Loading" dialog is seen during boot
+for several seconds before launcher show up. Two
+problems found in Car SystemUI app may lead to
+this issue. This patch contains two fixes for it,
+and improves about 3 seconds boot time KPI.
+
+1. Fix CalledFromWrongThreadException in function
+UserNameViewController.updateUser(). This exception
+will interrupt the user SWITCHING event delivery
+and cause this issue.
+
+2. Fix the race condition when checking mShowing in
+UserSwitchTransitionViewController.handleHide(). The
+race condition may lead to skipping the actual hide
+action and cause this issue.
+
+Tracked-On: OAM-111369
+Signed-off-by: Zhou Jingyu <jingyu.zhou@intel.com>
+---
+ .../car/statusbar/UserNameViewController.java        | 12 +++++++++++-
+ .../UserSwitchTransitionViewController.java          |  2 +-
+ 2 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/src/com/android/systemui/car/statusbar/UserNameViewController.java b/src/com/android/systemui/car/statusbar/UserNameViewController.java
+index b20a8729..f60359c1 100644
+--- a/src/com/android/systemui/car/statusbar/UserNameViewController.java
++++ b/src/com/android/systemui/car/statusbar/UserNameViewController.java
+@@ -133,7 +133,17 @@ public class UserNameViewController {
+     private void updateUser(int userId) {
+         if (mUserNameView != null) {
+             UserInfo currentUserInfo = mUserManager.getUserInfo(userId);
+-            mUserNameView.setText(currentUserInfo.name);
++            if (Thread.currentThread() != mContext.getMainLooper().getThread()) {
++                mContext.getMainExecutor().execute(new Runnable() {
++
++                    @Override
++                    public void run() {
++                        mUserNameView.setText(currentUserInfo.name);
++                    }
++                });
++            } else {
++                mUserNameView.setText(currentUserInfo.name);
++            }
+         }
+     }
+ }
+diff --git a/src/com/android/systemui/car/userswitcher/UserSwitchTransitionViewController.java b/src/com/android/systemui/car/userswitcher/UserSwitchTransitionViewController.java
+index 2e73c21c..64f05141 100644
+--- a/src/com/android/systemui/car/userswitcher/UserSwitchTransitionViewController.java
++++ b/src/com/android/systemui/car/userswitcher/UserSwitchTransitionViewController.java
+@@ -129,8 +129,8 @@ public class UserSwitchTransitionViewController extends OverlayViewController {
+     }
+ 
+     void handleHide() {
+-        if (!mShowing) return;
+         mMainExecutor.execute(() -> {
++            if (!mShowing) return;
+             mShowing = false;
+             stop();
+             if (mCancelRunnable != null) {
+-- 
+2.40.1
+


### PR DESCRIPTION
Sometimes a "Loading" dialog is seen during boot for several seconds before launcher show up. Two problems found in Car SystemUI app may lead to this issue. This patch contains two fixes for it, and improves about 3 seconds boot time KPI.

1. Fix CalledFromWrongThreadException in function UserNameViewController.updateUser(). This exception will interrupt the user SWITCHING event delivery and cause this issue.

2. Fix the race condition when checking mShowing in UserSwitchTransitionViewController.handleHide(). The race condition may lead to skipping the actual hide action and cause this issue.

Tracked-On: OAM-111369