### PR TITLE
Fix for static analysis issues

### DIFF
--- a/bsp_diff/common/vendor/intel/external/project-celadon/mediasdk-omx/0008-Fix-for-static-analysis-issues.patch
+++ b/bsp_diff/common/vendor/intel/external/project-celadon/mediasdk-omx/0008-Fix-for-static-analysis-issues.patch
@@ -1,4 +1,4 @@
-From e56e55b5786aeef87b75cc519e3f5e0b14bdbd02 Mon Sep 17 00:00:00 2001
+From 00c6f7d3cad09cbf86d88499ea4921313ccae9a3 Mon Sep 17 00:00:00 2001
 From: "Singh, Sapna1" <sapna1.singh@intel.com>
 Date: Fri, 14 Jul 2023 15:55:31 +0530
 Subject: [PATCH] Fix for static analysis issues
@@ -12,20 +12,49 @@ Changes include:
 - Fix for unreachable code by removing unnecessary checks.
 - Fix for buffer overflow issue by limiting the size of dst buffer as
 minimum of the two(src and dst buffer).
+- Fix for vaMapBuffer unchecked return value
+- Add copy constructor, assignment operator an destructor
+to be complaint with three/five/zero rule.
 
 Change-Id: Ibde73107bfa5658230ebb42846dc0651fba31aa4
 Tracked-On: OAM-111171
+Tracked-On: OAM-111598
 Signed-off-by: Singh, Sapna1 <sapna1.singh@intel.com>
+Signed-off-by: Badrappan, Jeevaka <jeevaka.badrappan@intel.com>
 ---
- omx_components/src/mfx_omx_vdec_component.cpp |  9 ++---
- omx_components/src/mfx_omx_venc_component.cpp | 23 ++++++++-----
+ omx_buffers/src/mfx_omx_srf_ibuf.cpp          |  4 +-
+ omx_components/src/mfx_omx_vdec_component.cpp |  9 +++--
+ omx_components/src/mfx_omx_venc_component.cpp | 23 +++++++-----
  omx_components/src/mfx_omx_vpp_wrapp.cpp      |  1 +
- omx_core/src/mfx_omx_core.cpp                 | 17 ++++++++--
- omx_utils/include/mfx_omx_types.h             | 33 ++++++++++---------
- omx_utils/src/mfx_omx_utils.cpp               |  6 ++--
- omx_utils/src/mfx_omx_vaapi_allocator.cpp     |  2 +-
- 7 files changed, 56 insertions(+), 35 deletions(-)
+ omx_core/src/mfx_omx_core.cpp                 | 17 +++++++--
+ omx_utils/include/mfx_omx_types.h             | 37 +++++++++++--------
+ .../include/spl/mfx_omx_hevc_structures.h     |  7 ++++
+ omx_utils/src/mfx_omx_utils.cpp               |  6 ++-
+ omx_utils/src/mfx_omx_vaapi_allocator.cpp     | 17 +++------
+ 9 files changed, 74 insertions(+), 47 deletions(-)
 
+diff --git a/omx_buffers/src/mfx_omx_srf_ibuf.cpp b/omx_buffers/src/mfx_omx_srf_ibuf.cpp
+index 92d303c..09a0fb1 100755
+--- a/omx_buffers/src/mfx_omx_srf_ibuf.cpp
++++ b/omx_buffers/src/mfx_omx_srf_ibuf.cpp
+@@ -180,7 +180,7 @@ mfxStatus MfxOmxInputSurfacesPool::PrepareSurface(OMX_BUFFERHEADERTYPE* pBuffer)
+             switch(m_MfxFramesInfo.FourCC)
+             {
+                 case MFX_FOURCC_NV12:
+-                    pVideo16 = (mfxU8*)calloc(3*nPitch*m_MfxFramesInfo.Height/2, sizeof(mfxU8));
++                    pVideo16 = (mfxU8*)calloc((3*(mfxU32)(nPitch * m_MfxFramesInfo.Height))/2, sizeof(mfxU8));
+                     if (pVideo16)
+                     {
+                         pBufInfo->sSurface.Data.Y = pVideo16;
+@@ -190,7 +190,7 @@ mfxStatus MfxOmxInputSurfacesPool::PrepareSurface(OMX_BUFFERHEADERTYPE* pBuffer)
+                     else mfx_res = MFX_ERR_MEMORY_ALLOC;
+                     break;
+                 case MFX_FOURCC_YUY2:
+-                    pVideo16 = (mfxU8*)calloc(2*nPitch*m_MfxFramesInfo.Height, sizeof(mfxU8));
++                    pVideo16 = (mfxU8*)calloc(2 * (mfxU32)(nPitch * m_MfxFramesInfo.Height), sizeof(mfxU8));
+                     if (pVideo16)
+                     {
+                         pBufInfo->sSurface.Data.Y = pVideo16;
 diff --git a/omx_components/src/mfx_omx_vdec_component.cpp b/omx_components/src/mfx_omx_vdec_component.cpp
 index f3e02ec..9586385 100644
 --- a/omx_components/src/mfx_omx_vdec_component.cpp
@@ -178,10 +207,20 @@ index 8de5c43..e7e64df 100644
                      (str_flags)? strtol(str_flags, NULL, 16): (OMX_U32)MFX_OMX_COMPONENT_FLAGS_NONE;
  
 diff --git a/omx_utils/include/mfx_omx_types.h b/omx_utils/include/mfx_omx_types.h
-index 4d1b867..18291dc 100644
+index 4d1b867..d929d62 100644
 --- a/omx_utils/include/mfx_omx_types.h
 +++ b/omx_utils/include/mfx_omx_types.h
-@@ -219,22 +219,23 @@ struct MfxOmxParamsWrapper: public T
+@@ -213,28 +213,33 @@ struct MfxOmxParamsWrapper: public T
+             ext_buf_ptrs[i] = (mfxExtBuffer*)&ext_buf[i];
+         }
+     }
++
++    ~MfxOmxParamsWrapper() {
++    }
++
+     MfxOmxParamsWrapper(const MfxOmxParamsWrapper& ref)
+     {
+         *this = ref; // call to operator=
      }
      MfxOmxParamsWrapper& operator=(const MfxOmxParamsWrapper& ref)
      {
@@ -221,6 +260,24 @@ index 4d1b867..18291dc 100644
          return *this;
      }
      MfxOmxParamsWrapper(const T& ref)
+diff --git a/omx_utils/include/spl/mfx_omx_hevc_structures.h b/omx_utils/include/spl/mfx_omx_hevc_structures.h
+index e6f05f2..87a4b2c 100644
+--- a/omx_utils/include/spl/mfx_omx_hevc_structures.h
++++ b/omx_utils/include/spl/mfx_omx_hevc_structures.h
+@@ -244,6 +244,13 @@ public:
+             destroy();
+     }
+ 
++    H265ScalingList(const H265ScalingList& refList) { this->m_initialized = refList.m_initialized; }
++    H265ScalingList & operator=(const H265ScalingList& refList)
++    {
++        this->m_initialized = refList.m_initialized;
++        return *this;
++    }
++
+     int*      getScalingListAddress   (unsigned sizeId, unsigned listId)          { return m_scalingListCoef[sizeId][listId]; }
+     const int* getScalingListAddress  (unsigned sizeId, unsigned listId) const    { return m_scalingListCoef[sizeId][listId]; }
+     void     setRefMatrixId           (unsigned sizeId, unsigned listId, unsigned u)   { m_refMatrixId[sizeId][listId] = u; }
 diff --git a/omx_utils/src/mfx_omx_utils.cpp b/omx_utils/src/mfx_omx_utils.cpp
 index 87a525c..b3e1d47 100644
 --- a/omx_utils/src/mfx_omx_utils.cpp
@@ -242,18 +299,54 @@ index 87a525c..b3e1d47 100644
      return bufferSize;
  }
 diff --git a/omx_utils/src/mfx_omx_vaapi_allocator.cpp b/omx_utils/src/mfx_omx_vaapi_allocator.cpp
-index 5fae460..5f89522 100644
+index 5fae460..0938dcb 100644
 --- a/omx_utils/src/mfx_omx_vaapi_allocator.cpp
 +++ b/omx_utils/src/mfx_omx_vaapi_allocator.cpp
-@@ -277,7 +277,7 @@ mfxStatus MfxOmxVaapiFrameAllocator::RegisterSurface(VASurfaceID surface, mfxMem
+@@ -277,10 +277,7 @@ mfxStatus MfxOmxVaapiFrameAllocator::RegisterSurface(VASurfaceID surface, mfxMem
                  pmid->m_bUseBufferDirectly = bUseBufferDirectly;
                  out_mid = pmid;
                  m_extMIDs.push_back(pmid);
 -                if (out_mid)
-+                if (out_mid != NULL)
-                     *mid = out_mid;
-                 else
-                     mfx_res = MFX_ERR_UNKNOWN;
+-                    *mid = out_mid;
+-                else
+-                    mfx_res = MFX_ERR_UNKNOWN;
++                *mid = out_mid;
+             }
+             else mfx_res = MFX_ERR_NULL_PTR;
+             return mfx_res;
+@@ -808,7 +805,7 @@ mfxStatus MfxOmxVaapiFrameAllocator::AllocImpl(mfxFrameAllocRequest *request, mf
+             else
+             {
+                 VAContextID context_id = request->AllocId;
+-                mfxU32 codedbuf_size = (request->Info.Width * request->Info.Height) * 400LL / (16 * 16);
++                mfxU32 codedbuf_size = ((mfxU32)(request->Info.Width * request->Info.Height))* 400UL / (16 * 16);
+ 
+                 for (numAllocated = 0; numAllocated < surfaces_num; numAllocated++)
+                 {
+@@ -846,11 +843,7 @@ mfxStatus MfxOmxVaapiFrameAllocator::AllocImpl(mfxFrameAllocRequest *request, mf
+         {
+             response->mids = NULL;
+             response->NumFrameActual = 0;
+-            if (VA_FOURCC_P208 != va_fourcc)
+-            {
+-                if (bCreateSrfSucceeded) vaDestroySurfaces(m_dpy, surfaces, surfaces_num);
+-            }
+-            else
++            if (VA_FOURCC_P208 == va_fourcc)
+             {
+                 for (i = 0; i < numAllocated; i++)
+                     vaDestroyBuffer(m_dpy, surfaces[i]);
+@@ -1147,7 +1140,9 @@ void MfxOmxVaapiFrameAllocator::upload_yuv_to_surface(unsigned char *newImageBuf
+     int y_size = picture_width * picture_height;
+     int u_size = (picture_width >> 1) * (picture_height >> 1);
+ 
+-    vaMapBuffer(m_dpy, surface_image.buf, &surface_p);
++    va_status = vaMapBuffer(m_dpy, surface_image.buf, &surface_p);
++    if (va_status != VA_STATUS_SUCCESS) return;
++
+     y_src = newImageBuffer;
+     u_src = newImageBuffer + y_size; /* UV offset for NV12 */
+     v_src = newImageBuffer + y_size + u_size;
 -- 
 2.40.0
 


### PR DESCRIPTION
Changes include:
- Typecast the variables to appropriate type.
- Fix for unreachable code by removing unnecessary checks.
- Fix for vaMapBuffer unchecked return value
- Add copy constructor, assignment operator an destructor to be complaint with three/five/zero rule.

Change-Id: I37973107bfa5658230ebb42846dc0651fba31aa4
Tracked-On: OAM-111598