### PR TITLE
Fixed for crash in Multidisplay launcher.

### DIFF
--- a/aosp_diff/celadon_ivi/packages/services/Car/0013-Fixed-for-crash-in-Multidisplay-launcher.patch
+++ b/aosp_diff/celadon_ivi/packages/services/Car/0013-Fixed-for-crash-in-Multidisplay-launcher.patch
@@ -1,0 +1,64 @@
+From 33f9cb4cba3e0a7830703f3107ddad2e92c869b1 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Fri, 4 Aug 2023 17:28:04 +0530
+Subject: [PATCH] Fixed for crash in Multidisplay launcher.
+
+Getting below crash when running monkey test-:
+java.lang.NullPointerException: Attempt to invoke virtual method
+'java.lang.String android.content.ComponentName.flattenToString()' on a null object reference
+at com.android.car.multidisplay.launcher.LauncherActivity.onAppPicked(LauncherActivity.java:382)
+
+When try pinning any media app in launcher home screen, then it try to
+fetch component name, but for media apps component name was not set.
+
+Tracked-On: OAM-111351
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../android/car/multidisplay/launcher/AppEntry.java  | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppEntry.java b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppEntry.java
+index 873190605..fc0637648 100644
+--- a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppEntry.java
++++ b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppEntry.java
+@@ -29,6 +29,7 @@ public  class AppEntry {
+     private String mLabel;
+     private Drawable mIcon;
+     private Intent mLaunchIntent;
++    private ComponentName mComponentName;
+ 
+     AppEntry(ResolveInfo info, PackageManager packageManager, boolean mediaApp) {
+         if(mediaApp) {
+@@ -36,15 +37,16 @@ public  class AppEntry {
+             mIcon = info.serviceInfo.loadIcon(packageManager);
+             String packageName = info.serviceInfo.packageName;
+             String className = info.serviceInfo.name;
+-            ComponentName componentName = new ComponentName(packageName, className);
++            mComponentName = new ComponentName(packageName, className);
+             mLaunchIntent = new Intent(Car.CAR_INTENT_ACTION_MEDIA_TEMPLATE);
+-            mLaunchIntent.putExtra(Car.CAR_EXTRA_MEDIA_COMPONENT, componentName.flattenToString());
++            mLaunchIntent.putExtra(Car.CAR_EXTRA_MEDIA_COMPONENT, mComponentName.flattenToString());
+         } else {
+             mLabel = info.loadLabel(packageManager).toString();
+             mIcon = info.loadIcon(packageManager);
+             mLaunchIntent = new Intent();
+-            mLaunchIntent.setComponent(new ComponentName(info.activityInfo.packageName,
+-                    info.activityInfo.name));
++            mComponentName = new ComponentName(info.activityInfo.packageName,
++                    info.activityInfo.name);
++            mLaunchIntent.setComponent(mComponentName);
+         }
+     }
+ 
+@@ -61,7 +63,7 @@ public  class AppEntry {
+     }
+ 
+     ComponentName getComponentName() {
+-        return mLaunchIntent.getComponent();
++	return mComponentName;
+     }
+ 
+     @Override
+-- 
+2.17.1
+


### PR DESCRIPTION
Getting below crash when running monkey test-:
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.content.ComponentName.flattenToString()' on a null object reference at com.android.car.multidisplay.launcher.LauncherActivity.onAppPicked(LauncherActivity.java:382)

When try pinning any media app in launcher home screen, then it try to fetch component name, but for media apps component name was not set.

Tracked-On: OAM-111351