### PR TITLE
Fixed for crash in Media component.

### DIFF
--- a/aosp_diff/celadon_ivi/packages/apps/Car/Media/0001-Fixed-for-crash-in-Media-component.patch
+++ b/aosp_diff/celadon_ivi/packages/apps/Car/Media/0001-Fixed-for-crash-in-Media-component.patch
@@ -1,0 +1,41 @@
+From 577215a41ed05cda8b50772d456551b4316599d2 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Fri, 4 Aug 2023 17:20:18 +0530
+Subject: [PATCH] Fixed for crash in Media component.
+
+Getting following error while running monkey test-:
+java.lang.IllegalArgumentException: Tab position is invalid: 0
+at com.android.car.ui.toolbar.TabLayout.selectTab(TabLayout.java:121)
+at com.android.car.ui.toolbar.ToolbarControllerImpl.selectTab(ToolbarControllerImpl.java:353)
+at com.android.car.media.widgets.AppBarController.setActiveItem(AppBarController.java:234)
+
+it should show tab only when navigation bar is not present.
+But here it is trying to show tab, even navigation bar is present
+and which get crash due to tab size 0.
+
+Tracked-On: OAM-111149
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ src/com/android/car/media/widgets/AppBarController.java | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/car/media/widgets/AppBarController.java b/src/com/android/car/media/widgets/AppBarController.java
+index 38eccdf..b7c2a7b 100644
+--- a/src/com/android/car/media/widgets/AppBarController.java
++++ b/src/com/android/car/media/widgets/AppBarController.java
+@@ -231,7 +231,11 @@ public class AppBarController {
+                     item.getId(),
+                     mediaItemMetadata.getId());
+             if (match) {
+-                mToolbarController.selectTab(i);
++                mSelectedTab = i;
++                // Only select a tab when the tabs are shown.
++                if (mToolbarController.getNavButtonMode() == NavButtonMode.DISABLED) {
++                    mToolbarController.selectTab(mSelectedTab);
++                }
+                 return;
+             }
+         }
+-- 
+2.17.1
+


### PR DESCRIPTION
Getting following error while running monkey test-: java.lang.IllegalArgumentException: Tab position is invalid: 0 at com.android.car.ui.toolbar.TabLayout.selectTab(TabLayout.java:121) at com.android.car.ui.toolbar.ToolbarControllerImpl.selectTab(ToolbarControllerImpl.java:353) at com.android.car.media.widgets.AppBarController.setActiveItem(AppBarController.java:234)

it should show tab only when navigation bar is not present. But here it is trying to show tab, even navigation bar is present and which get crash due to tab size 0.

Tracked-On: OAM-111149