### PR TITLE
Fixed for crash in webview_shell during monkey test.

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/99_0175-Fixed-for-crash-in-webview_shell-during-monkey-test.patch
+++ b/aosp_diff/preliminary/frameworks/base/99_0175-Fixed-for-crash-in-webview_shell-during-monkey-test.patch
@@ -1,0 +1,42 @@
+From b2029d82c20c17b988def49f8375ae2d8960ae6c Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Mon, 7 Aug 2023 13:42:53 +0530
+Subject: [PATCH] Fixed for crash in webview_shell during monkey test.
+
+Getting below crash when running monkey test-:
+FATAL EXCEPTION: main
+Process: org.chromium.webview_shell, PID: 22973
+java.lang.RuntimeException: StrictMode ThreadPolicy violation
+Caused by: android.os.strictmode.DiskWriteViolation
+
+Added StrictMode ThreadPolicy for disk write.
+
+Tracked-On: OAM-110732
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ core/java/android/app/ActivityThread.java | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/core/java/android/app/ActivityThread.java b/core/java/android/app/ActivityThread.java
+index 8af74edb88ff..7f0c643577cf 100644
+--- a/core/java/android/app/ActivityThread.java
++++ b/core/java/android/app/ActivityThread.java
+@@ -4633,6 +4633,7 @@ public final class ActivityThread extends ClientTransactionHandler
+     }
+ 
+     private void handleDumpGfxInfo(DumpComponentInfo info) {
++        final StrictMode.ThreadPolicy oldPolicy = StrictMode.allowThreadDiskWrites();
+         try {
+             nDumpGraphicsInfo(info.fd.getFileDescriptor());
+             WindowManagerGlobal.getInstance().dumpGfxInfo(info.fd.getFileDescriptor(), info.args);
+@@ -4640,6 +4641,7 @@ public final class ActivityThread extends ClientTransactionHandler
+             Log.w(TAG, "Caught exception from dumpGfxInfo()", e);
+         } finally {
+             IoUtils.closeQuietly(info.fd);
++            StrictMode.setThreadPolicy(oldPolicy);
+         }
+     }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
Getting below crash when running monkey test-:
FATAL EXCEPTION: main
Process: org.chromium.webview_shell, PID: 22973
java.lang.RuntimeException: StrictMode ThreadPolicy violation Caused by: android.os.strictmode.DiskWriteViolation

Added StrictMode ThreadPolicy for disk write.

Tracked-On: OAM-110732