### PR TITLE
Update the Security patch level string

### DIFF
--- a/aosp_diff/preliminary/build/make/0004-Update-security_patch_level-string.patch
+++ b/aosp_diff/preliminary/build/make/0004-Update-security_patch_level-string.patch
@@ -1,0 +1,29 @@
+From 1146a0bdfed2a8d3f9acd7fe422da1c31bdc4d6d Mon Sep 17 00:00:00 2001
+From: "Reddy, Alavala Srinivasa" <alavala.srinivasa.reddy@intel.com>
+Date: Mon, 7 Aug 2023 20:19:29 +0530
+Subject: [PATCH] Update security_patch_level string
+
+Security_patch_level needs to be updated.
+When ASB patches are integrated.
+
+Signed-off-by: Reddy, Alavala Srinivasa <alavala.srinivasa.reddy@intel.com>
+---
+ core/version_defaults.mk | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/core/version_defaults.mk b/core/version_defaults.mk
+index 0daae6bdcb..f7bb875463 100644
+--- a/core/version_defaults.mk
++++ b/core/version_defaults.mk
+@@ -240,7 +240,7 @@ ifndef PLATFORM_SECURITY_PATCH
+     #  It must be of the form "YYYY-MM-DD" on production devices.
+     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
+     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
+-    PLATFORM_SECURITY_PATCH := 2022-06-05
++    PLATFORM_SECURITY_PATCH := 2023-07-01
+ endif
+ .KATI_READONLY := PLATFORM_SECURITY_PATCH
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
Update the Security patch level string
PLATFORM_SECURITY_PATCH from 2022-06-05 to 2023-07-01.
Ported the ASB Patches from 2022-07-01 to 2023-07-01.
Fix all STS issues and merge till 2023-07-01
Tested Suite details.
STS Suite -android-sts-12.1_sts-r17-linux-x86_64.zip

Tracked-On: OAM-111660