### PR TITLE
Fixed for crash in Local media player during monkey test.

### DIFF
--- a/aosp_diff/celadon_ivi/packages/apps/Car/LocalMediaPlayer/0001-Fixed-for-crash-in-Local-media-player-during-monkey-.patch
+++ b/aosp_diff/celadon_ivi/packages/apps/Car/LocalMediaPlayer/0001-Fixed-for-crash-in-Local-media-player-during-monkey-.patch
@@ -1,0 +1,36 @@
+From 324ef5dc8508897d7b2dfb82632a3ddf27ac9b71 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Mon, 7 Aug 2023 17:39:46 +0530
+Subject: [PATCH] Fixed for crash in Local media player during monkey test.
+
+Getting below crash when running monkey test-:
+
+java.lang.RuntimeException: Unable to create service
+com.android.car.media.localmediaplayer.LocalMediaBrowserService:
+java.lang.IllegalStateException: SharedPreferences in credential
+encrypted storage are not available until after user is unlocked
+
+Use device protected storage to Access shared preference before reboot complete.
+
+Tracked-On: OAM-111435
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ src/com/android/car/media/localmediaplayer/Player.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/com/android/car/media/localmediaplayer/Player.java b/src/com/android/car/media/localmediaplayer/Player.java
+index ea47595..c408e34 100644
+--- a/src/com/android/car/media/localmediaplayer/Player.java
++++ b/src/com/android/car/media/localmediaplayer/Player.java
+@@ -100,7 +100,7 @@ public class Player extends MediaSession.Callback {
+         mDataModel = dataModel;
+         mAudioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+         mSession = session;
+-        mSharedPrefs = context.getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE);
++        mSharedPrefs = context.createDeviceProtectedStorageContext().getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE);
+ 
+         mShuffle = new CustomAction.Builder(SHUFFLE, context.getString(R.string.shuffle),
+                 R.drawable.shuffle).build();
+-- 
+2.17.1
+


### PR DESCRIPTION
Getting below crash when running monkey test-:

java.lang.RuntimeException: Unable to create service com.android.car.media.localmediaplayer.LocalMediaBrowserService: java.lang.IllegalStateException: SharedPreferences in credential encrypted storage are not available until after user is unlocked

Use device protected storage to Access shared preference before reboot complete.

Tracked-On: OAM-111435