### PR TITLE
Fixed for crash in Alert Dialog Builder during monkey test.

### DIFF
--- a/aosp_diff/celadon_ivi/packages/apps/Car/libs/0002-Fixed-for-crash-in-Alert-Dialog-Builder-during-monke.patch
+++ b/aosp_diff/celadon_ivi/packages/apps/Car/libs/0002-Fixed-for-crash-in-Alert-Dialog-Builder-during-monke.patch
@@ -1,0 +1,55 @@
+From e16232cfbf2a818aed36775240b785a27989b3f1 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Mon, 7 Aug 2023 18:01:17 +0530
+Subject: [PATCH] Fixed for crash in Alert Dialog Builder during monkey test.
+
+java.lang.NullPointerException: Attempt to invoke interface method
+'java.lang.String java.lang.CharSequence.toString()' on a null object reference
+at com.android.car.ui.AlertDialogBuilder.lambda$new$0$AlertDialogBuilder(AlertDialogBuilder.java:125)
+
+Tracked-On: OAM-111429
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../src/main/java/com/android/car/ui/AlertDialogBuilder.java | 5 +++--
+ car-ui-lib/car-ui-lib/src/main/res/values/strings.xml        | 2 ++
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/car-ui-lib/car-ui-lib/src/main/java/com/android/car/ui/AlertDialogBuilder.java b/car-ui-lib/car-ui-lib/src/main/java/com/android/car/ui/AlertDialogBuilder.java
+index f40d2b396..ffa9f6d37 100644
+--- a/car-ui-lib/car-ui-lib/src/main/java/com/android/car/ui/AlertDialogBuilder.java
++++ b/car-ui-lib/car-ui-lib/src/main/java/com/android/car/ui/AlertDialogBuilder.java
+@@ -97,7 +97,7 @@ public class AlertDialogBuilder {
+             if (VERSION.SDK_INT >= VERSION_CODES.R) {
+                 Bundle bundle = new Bundle();
+                 String titleString = mWideScreenTitle != null ? mWideScreenTitle
+-                        : mTitle.toString();
++                        : (mTitle != null ? mTitle.toString() : mContext.getString(R.string.car_ui_dialog_no_title_message));
+                 bundle.putString(ADD_DESC_TITLE_TO_CONTENT_AREA, titleString);
+                 bundle.putString(ADD_DESC_TO_CONTENT_AREA, s.toString());
+                 mInputMethodManager.sendAppPrivateCommand(mCarUiEditText, WIDE_SCREEN_ACTION,
+@@ -122,7 +122,8 @@ public class AlertDialogBuilder {
+ 
+         if (insets.isVisible(ime())) {
+             Bundle bundle = new Bundle();
+-            String title = mWideScreenTitle != null ? mWideScreenTitle : mTitle.toString();
++            String title = mWideScreenTitle != null ? mWideScreenTitle
++                    : (mTitle != null ? mTitle.toString() : mContext.getString(R.string.car_ui_dialog_no_title_message));
+             bundle.putString(ADD_DESC_TITLE_TO_CONTENT_AREA, title);
+             if (mWideScreenTitleDesc != null) {
+                 bundle.putString(ADD_DESC_TO_CONTENT_AREA, mWideScreenTitleDesc);
+diff --git a/car-ui-lib/car-ui-lib/src/main/res/values/strings.xml b/car-ui-lib/car-ui-lib/src/main/res/values/strings.xml
+index d455a4bc8..2fcd6105b 100644
+--- a/car-ui-lib/car-ui-lib/src/main/res/values/strings.xml
++++ b/car-ui-lib/car-ui-lib/src/main/res/values/strings.xml
+@@ -44,6 +44,8 @@ limitations under the License.
+     <!-- Negative option for a preference dialog. [CHAR_LIMIT=30] -->
+     <string name="car_ui_dialog_preference_negative" translatable="false">@android:string/cancel
+     </string>
++    <!-- No Title for a preference dialog. [CHAR_LIMIT=30] -->
++    <string name="car_ui_dialog_no_title_message">I don\'t have a title.</string>
+     <!-- Text to show when a preference switch is on. [CHAR_LIMIT=30] -->
+     <string name="car_ui_preference_switch_on">On</string>
+     <!-- Text to show when a preference switch is off. [CHAR_LIMIT=30] -->
+-- 
+2.17.1
+


### PR DESCRIPTION
java.lang.NullPointerException: Attempt to invoke interface method 'java.lang.String java.lang.CharSequence.toString()' on a null object reference at com.android.car.ui.AlertDialogBuilder.lambda$new$0$AlertDialogBuilder(AlertDialogBuilder.java:125)

Tracked-On: OAM-111429