### PR TITLE
Fixed crash in DeskClock during monkey test.

### DIFF
--- a/aosp_diff/preliminary/packages/apps/DeskClock/0001-Fixed-crash-in-DeskClock-during-monkey-test.patch
+++ b/aosp_diff/preliminary/packages/apps/DeskClock/0001-Fixed-crash-in-DeskClock-during-monkey-test.patch
@@ -1,0 +1,42 @@
+From dd87cd19c9923bb47eeeee379d7627d3a1029bf0 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Tue, 8 Aug 2023 11:18:16 +0530
+Subject: [PATCH] Fixed crash in DeskClock during monkey test.
+
+Getting below crash when running monkey test-:
+java.lang.NullPointerException: Parameter specified as non-null is null:
+method kotlin.jvm.internal.Intrinsics.checkNotNullParameter, parameter event
+at com.android.deskclock.LabelDialogFragment$ImeDoneListener.onEditorAction(Unknown Source:7)
+
+event parameter is currently declared as non null. it can be null also,
+So declaring it as null parameter.
+
+Tracked-On: OAM-111432
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ src/com/android/deskclock/LabelDialogFragment.kt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/com/android/deskclock/LabelDialogFragment.kt b/src/com/android/deskclock/LabelDialogFragment.kt
+index 77f0b7b35..811e47ade 100644
+--- a/src/com/android/deskclock/LabelDialogFragment.kt
++++ b/src/com/android/deskclock/LabelDialogFragment.kt
+@@ -150,7 +150,7 @@ class LabelDialogFragment : DialogFragment() {
+      * Handles completing the label edit from the IME keyboard.
+      */
+     private inner class ImeDoneListener : OnEditorActionListener {
+-        override fun onEditorAction(v: TextView, actionId: Int, event: KeyEvent): Boolean {
++        override fun onEditorAction(v: TextView, actionId: Int, event: KeyEvent?): Boolean {
+             if (actionId == EditorInfo.IME_ACTION_DONE) {
+                 setLabel()
+                 dismissAllowingStateLoss()
+@@ -227,4 +227,4 @@ class LabelDialogFragment : DialogFragment() {
+             fragment.show(tx, TAG)
+         }
+     }
+-}
+\ No newline at end of file
++}
+-- 
+2.17.1
+


### PR DESCRIPTION
Getting below crash when running monkey test-:
java.lang.NullPointerException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkNotNullParameter, parameter event at com.android.deskclock.LabelDialogFragment$ImeDoneListener.onEditorAction(Unknown Source:7)

event parameter is currently declared as non null. it can be null also, So declaring it as null parameter.

Tracked-On: OAM-111432