### PR TITLE
Add virtio tiling mode support for SRIOV

### DIFF
--- a/bsp_diff/caas/kernel/lts2020-yocto/0001-drm-virtio-Improve-DMA-API-usage-for-shmem-BOs.patch
+++ b/bsp_diff/caas/kernel/lts2020-yocto/0001-drm-virtio-Improve-DMA-API-usage-for-shmem-BOs.patch
@@ -1,0 +1,292 @@
+From 9c1a94a600dcf7850d39741a4b34985a6dde1bdf Mon Sep 17 00:00:00 2001
+From: Dmitry Osipenko <dmitry.osipenko@collabora.com>
+Date: Thu, 30 Jun 2022 23:07:24 +0300
+Subject: [PATCH 1/8] drm/virtio: Improve DMA API usage for shmem BOs
+
+DRM API requires the DRM's driver to be backed with the device that can
+be used for generic DMA operations. The VirtIO-GPU device can't perform
+DMA operations if it uses PCI transport because PCI device driver creates
+a virtual VirtIO-GPU device that isn't associated with the PCI. Use PCI's
+GPU device for the DRM's device instead of the VirtIO-GPU device and drop
+DMA-related hacks from the VirtIO-GPU driver.
+
+Signed-off-by: Dmitry Osipenko <dmitry.osipenko@collabora.com>
+Link: http://patchwork.freedesktop.org/patch/msgid/20220630200726.1884320-8-dmitry.osipenko@collabora.com
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+Signed-off-by: ZhuChenyanX <zhucx@intel.com>
+---
+ drivers/gpu/drm/virtio/virtgpu_drv.c    | 51 ++++++-------------------
+ drivers/gpu/drm/virtio/virtgpu_drv.h    |  5 +--
+ drivers/gpu/drm/virtio/virtgpu_kms.c    |  7 ++--
+ drivers/gpu/drm/virtio/virtgpu_object.c | 49 +++++-------------------
+ drivers/gpu/drm/virtio/virtgpu_vq.c     | 13 +++----
+ 5 files changed, 30 insertions(+), 95 deletions(-)
+
+diff --git a/drivers/gpu/drm/virtio/virtgpu_drv.c b/drivers/gpu/drm/virtio/virtgpu_drv.c
+index 51a5b10bf1f4..c190bd383a29 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_drv.c
++++ b/drivers/gpu/drm/virtio/virtgpu_drv.c
+@@ -45,12 +45,11 @@ static int virtio_gpu_modeset = -1;
+ MODULE_PARM_DESC(modeset, "Disable/Enable modesetting");
+ module_param_named(modeset, virtio_gpu_modeset, int, 0400);
+ 
+-static int virtio_gpu_pci_quirk(struct drm_device *dev, struct virtio_device *vdev)
++static int virtio_gpu_pci_quirk(struct drm_device *dev)
+ {
+-	struct pci_dev *pdev = to_pci_dev(vdev->dev.parent);
++	struct pci_dev *pdev = to_pci_dev(dev->dev);
+ 	const char *pname = dev_name(&pdev->dev);
+ 	bool vga = (pdev->class >> 8) == PCI_CLASS_DISPLAY_VGA;
+-	char unique[20];
+ 	int ret;
+ 
+ 	DRM_INFO("pci: %s detected at %s\n",
+@@ -62,39 +61,7 @@ static int virtio_gpu_pci_quirk(struct drm_device *dev, struct virtio_device *vd
+ 			return ret;
+ 	}
+ 
+-	/*
+-	 * Normally the drm_dev_set_unique() call is done by core DRM.
+-	 * The following comment covers, why virtio cannot rely on it.
+-	 *
+-	 * Unlike the other virtual GPU drivers, virtio abstracts the
+-	 * underlying bus type by using struct virtio_device.
+-	 *
+-	 * Hence the dev_is_pci() check, used in core DRM, will fail
+-	 * and the unique returned will be the virtio_device "virtio0",
+-	 * while a "pci:..." one is required.
+-	 *
+-	 * A few other ideas were considered:
+-	 * - Extend the dev_is_pci() check [in drm_set_busid] to
+-	 *   consider virtio.
+-	 *   Seems like a bigger hack than what we have already.
+-	 *
+-	 * - Point drm_device::dev to the parent of the virtio_device
+-	 *   Semantic changes:
+-	 *   * Using the wrong device for i2c, framebuffer_alloc and
+-	 *     prime import.
+-	 *   Visual changes:
+-	 *   * Helpers such as DRM_DEV_ERROR, dev_info, drm_printer,
+-	 *     will print the wrong information.
+-	 *
+-	 * We could address the latter issues, by introducing
+-	 * drm_device::bus_dev, ... which would be used solely for this.
+-	 *
+-	 * So for the moment keep things as-is, with a bulky comment
+-	 * for the next person who feels like removing this
+-	 * drm_dev_set_unique() quirk.
+-	 */
+-	snprintf(unique, sizeof(unique), "pci:%s", pname);
+-	return drm_dev_set_unique(dev, unique);
++	return 0;
+ }
+ 
+ static int virtio_gpu_probe(struct virtio_device *vdev)
+@@ -108,18 +75,24 @@ static int virtio_gpu_probe(struct virtio_device *vdev)
+ 	if (virtio_gpu_modeset == 0)
+ 		return -EINVAL;
+ 
+-	dev = drm_dev_alloc(&driver, &vdev->dev);
++	/*
++	 * The virtio-gpu device is a virtual device that doesn't have DMA
++	 * ops assigned to it, nor DMA mask set and etc. Its parent device
++	 * is actual GPU device we want to use it for the DRM's device in
++	 * order to benefit from using generic DRM APIs.
++	 */
++	dev = drm_dev_alloc(&driver, vdev->dev.parent);
+ 	if (IS_ERR(dev))
+ 		return PTR_ERR(dev);
+ 	vdev->priv = dev;
+ 
+ 	if (!strcmp(vdev->dev.parent->bus->name, "pci")) {
+-		ret = virtio_gpu_pci_quirk(dev, vdev);
++		ret = virtio_gpu_pci_quirk(dev);
+ 		if (ret)
+ 			goto err_free;
+ 	}
+ 
+-	ret = virtio_gpu_init(dev);
++	ret = virtio_gpu_init(vdev, dev);
+ 	if (ret)
+ 		goto err_free;
+ 
+diff --git a/drivers/gpu/drm/virtio/virtgpu_drv.h b/drivers/gpu/drm/virtio/virtgpu_drv.h
+index 3e272d8a80e4..c1c0a7b44348 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_drv.h
++++ b/drivers/gpu/drm/virtio/virtgpu_drv.h
+@@ -96,8 +96,6 @@ struct virtio_gpu_object {
+ 
+ struct virtio_gpu_object_shmem {
+ 	struct virtio_gpu_object base;
+-	struct sg_table *pages;
+-	uint32_t mapped;
+ };
+ 
+ struct virtio_gpu_object_vram {
+@@ -207,7 +205,6 @@ struct virtio_gpu_drv_cap_cache {
+ };
+ 
+ struct virtio_gpu_device {
+-	struct device *dev;
+ 	struct drm_device *ddev;
+ 
+ 	struct virtio_device *vdev;
+@@ -270,7 +267,7 @@ extern struct drm_ioctl_desc virtio_gpu_ioctls[DRM_VIRTIO_NUM_IOCTLS];
+ void virtio_gpu_create_context(struct drm_device *dev, struct drm_file *file);
+ 
+ /* virtgpu_kms.c */
+-int virtio_gpu_init(struct drm_device *dev);
++int virtio_gpu_init(struct virtio_device *vdev, struct drm_device *dev);
+ void virtio_gpu_deinit(struct drm_device *dev);
+ void virtio_gpu_release(struct drm_device *dev);
+ int virtio_gpu_driver_open(struct drm_device *dev, struct drm_file *file);
+diff --git a/drivers/gpu/drm/virtio/virtgpu_kms.c b/drivers/gpu/drm/virtio/virtgpu_kms.c
+index ff53d6af270e..bb570235be6b 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_kms.c
++++ b/drivers/gpu/drm/virtio/virtgpu_kms.c
+@@ -118,13 +118,13 @@ int virtio_gpu_find_vqs(struct virtio_gpu_device *vgdev)
+ 	return 0;
+ }
+ 
+-int virtio_gpu_init(struct drm_device *dev)
++int virtio_gpu_init(struct virtio_device *vdev, struct drm_device *dev)
+ {
+ 	struct virtio_gpu_device *vgdev;
+ 	u32 num_scanouts, num_capsets;
+ 	int ret = 0;
+ 
+-	if (!virtio_has_feature(dev_to_virtio(dev->dev), VIRTIO_F_VERSION_1))
++	if (!virtio_has_feature(vdev, VIRTIO_F_VERSION_1))
+ 		return -ENODEV;
+ 
+ 	vgdev = kzalloc(sizeof(struct virtio_gpu_device), GFP_KERNEL);
+@@ -133,8 +133,7 @@ int virtio_gpu_init(struct drm_device *dev)
+ 
+ 	vgdev->ddev = dev;
+ 	dev->dev_private = vgdev;
+-	vgdev->vdev = dev_to_virtio(dev->dev);
+-	vgdev->dev = dev->dev;
++	vgdev->vdev = vdev;
+ 
+ 	spin_lock_init(&vgdev->display_info_lock);
+ 	spin_lock_init(&vgdev->resource_export_lock);
+diff --git a/drivers/gpu/drm/virtio/virtgpu_object.c b/drivers/gpu/drm/virtio/virtgpu_object.c
+index 91c6b3369859..41ca707f71f3 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_object.c
++++ b/drivers/gpu/drm/virtio/virtgpu_object.c
+@@ -99,21 +99,6 @@ void virtio_gpu_cleanup_object(struct virtio_gpu_object *bo)
+ 
+ 	virtio_gpu_resource_id_put(vgdev, bo->hw_res_handle);
+ 	if (virtio_gpu_is_shmem(bo)) {
+-		struct virtio_gpu_object_shmem *shmem = to_virtio_gpu_shmem(bo);
+-
+-		if (shmem->pages) {
+-			if (shmem->mapped) {
+-				dma_unmap_sgtable(vgdev->vdev->dev.parent,
+-					     shmem->pages, DMA_TO_DEVICE, 0);
+-				shmem->mapped = 0;
+-			}
+-
+-			sg_free_table(shmem->pages);
+-			kfree(shmem->pages);
+-			shmem->pages = NULL;
+-			drm_gem_shmem_unpin(&bo->base.base);
+-		}
+-
+ 		drm_gem_shmem_free_object(&bo->base.base);
+ 	} else if (virtio_gpu_is_vram(bo)) {
+ 		struct virtio_gpu_object_vram *vram = to_virtio_gpu_vram(bo);
+@@ -186,34 +171,18 @@ static int virtio_gpu_object_shmem_init(struct virtio_gpu_device *vgdev,
+ 					unsigned int *nents)
+ {
+ 	bool use_dma_api = !virtio_has_dma_quirk(vgdev->vdev);
+-	struct virtio_gpu_object_shmem *shmem = to_virtio_gpu_shmem(bo);
+ 	struct scatterlist *sg;
+-	int si, ret;
++	struct sg_table *pages;
++	int si;
+ 
+-	ret = drm_gem_shmem_pin(&bo->base.base);
+-	if (ret < 0)
+-		return -EINVAL;
+-
+-	/*
+-	 * virtio_gpu uses drm_gem_shmem_get_sg_table instead of
+-	 * drm_gem_shmem_get_pages_sgt because virtio has it's own set of
+-	 * dma-ops. This is discouraged for other drivers, but should be fine
+-	 * since virtio_gpu doesn't support dma-buf import from other devices.
+-	 */
+-	shmem->pages = drm_gem_shmem_get_sg_table(&bo->base.base);
+-	if (!shmem->pages) {
+-		drm_gem_shmem_unpin(&bo->base.base);
+-		return -EINVAL;
+-	}
++	pages = drm_gem_shmem_get_pages_sgt(&bo->base.base);
++	if (IS_ERR(pages))
++		return PTR_ERR(pages);
+ 
+ 	if (use_dma_api) {
+-		ret = dma_map_sgtable(vgdev->vdev->dev.parent,
+-				      shmem->pages, DMA_TO_DEVICE, 0);
+-		if (ret)
+-			return ret;
+-		*nents = shmem->mapped = shmem->pages->nents;
++		*nents = pages->nents;
+ 	} else {
+-		*nents = shmem->pages->orig_nents;
++		*nents = pages->orig_nents;
+ 	}
+ 
+ 	*ents = kvmalloc_array(*nents,
+@@ -225,13 +194,13 @@ static int virtio_gpu_object_shmem_init(struct virtio_gpu_device *vgdev,
+ 	}
+ 
+ 	if (use_dma_api) {
+-		for_each_sgtable_dma_sg(shmem->pages, sg, si) {
++		for_each_sgtable_dma_sg(pages, sg, si) {
+ 			(*ents)[si].addr = cpu_to_le64(sg_dma_address(sg));
+ 			(*ents)[si].length = cpu_to_le32(sg_dma_len(sg));
+ 			(*ents)[si].padding = 0;
+ 		}
+ 	} else {
+-		for_each_sgtable_sg(shmem->pages, sg, si) {
++		for_each_sgtable_sg(pages, sg, si) {
+ 			(*ents)[si].addr = cpu_to_le64(sg_phys(sg));
+ 			(*ents)[si].length = cpu_to_le32(sg->length);
+ 			(*ents)[si].padding = 0;
+diff --git a/drivers/gpu/drm/virtio/virtgpu_vq.c b/drivers/gpu/drm/virtio/virtgpu_vq.c
+index 2e71e91278b4..b832dbaf3913 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_vq.c
++++ b/drivers/gpu/drm/virtio/virtgpu_vq.c
+@@ -608,11 +608,10 @@ void virtio_gpu_cmd_transfer_to_host_2d(struct virtio_gpu_device *vgdev,
+ 	struct virtio_gpu_transfer_to_host_2d *cmd_p;
+ 	struct virtio_gpu_vbuffer *vbuf;
+ 	bool use_dma_api = !virtio_has_dma_quirk(vgdev->vdev);
+-	struct virtio_gpu_object_shmem *shmem = to_virtio_gpu_shmem(bo);
+ 
+ 	if (use_dma_api)
+-		dma_sync_sgtable_for_device(vgdev->vdev->dev.parent,
+-					    shmem->pages, DMA_TO_DEVICE);
++		dma_sync_sgtable_for_device(&vgdev->vdev->dev,
++					    bo->base.sgt, DMA_TO_DEVICE);
+ 
+ 	cmd_p = virtio_gpu_alloc_cmd(vgdev, &vbuf, sizeof(*cmd_p));
+ 	memset(cmd_p, 0, sizeof(*cmd_p));
+@@ -1030,11 +1029,9 @@ void virtio_gpu_cmd_transfer_to_host_3d(struct virtio_gpu_device *vgdev,
+ 	struct virtio_gpu_vbuffer *vbuf;
+ 	bool use_dma_api = !virtio_has_dma_quirk(vgdev->vdev);
+ 
+-	if (virtio_gpu_is_shmem(bo) && use_dma_api) {
+-		struct virtio_gpu_object_shmem *shmem = to_virtio_gpu_shmem(bo);
+-		dma_sync_sgtable_for_device(vgdev->vdev->dev.parent,
+-					    shmem->pages, DMA_TO_DEVICE);
+-	}
++	if (virtio_gpu_is_shmem(bo) && use_dma_api)
++		dma_sync_sgtable_for_device(&vgdev->vdev->dev,
++					    bo->base.sgt, DMA_TO_DEVICE);
+ 
+ 	cmd_p = virtio_gpu_alloc_cmd(vgdev, &vbuf, sizeof(*cmd_p));
+ 	memset(cmd_p, 0, sizeof(*cmd_p));
+-- 
+2.17.1
+

--- a/bsp_diff/caas/kernel/lts2020-yocto/0002-virtio-gpu-api-multiple-context-types-with-explicit-.patch
+++ b/bsp_diff/caas/kernel/lts2020-yocto/0002-virtio-gpu-api-multiple-context-types-with-explicit-.patch
@@ -1,0 +1,90 @@
+From 7ba88be0eb7162e04fb055e96bc2225b931ec28f Mon Sep 17 00:00:00 2001
+From: Gurchetan Singh <gurchetansingh@chromium.org>
+Date: Tue, 21 Sep 2021 16:20:13 -0700
+Subject: [PATCH 2/8] virtio-gpu api: multiple context types with explicit
+ initialization
+
+This feature allows for each virtio-gpu 3D context to be created
+with a "context_init" variable.  This variable can specify:
+
+ - the type of protocol used by the context via the capset id.
+   This is useful for differentiating virgl, gfxstream, and venus
+   protocols by host userspace.
+
+ - other things in the future, such as the version of the context.
+
+In addition, each different context needs one or more timelines, so
+for example a virgl context's waiting can be independent on a
+gfxstream context's waiting.
+
+VIRTIO_GPU_FLAG_INFO_RING_IDX is introduced to specific to tell the
+host which per-context command ring (or "hardware queue", distinct
+from the virtio-queue) the fence should be associated with.
+
+The new capability sets (gfxstream, venus etc.) are only defined in
+the virtio-gpu spec and not defined in the header.
+
+Signed-off-by: Gurchetan Singh <gurchetansingh@chromium.org>
+Acked-by: Lingfeng Yang <lfy@google.com>
+Link: http://patchwork.freedesktop.org/patch/msgid/20210921232024.817-2-gurchetansingh@chromium.org
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+Signed-off-by: ZhuChenyanX <zhucx@intel.com>
+---
+ include/uapi/linux/virtio_gpu.h | 18 +++++++++++++++---
+ 1 file changed, 15 insertions(+), 3 deletions(-)
+
+diff --git a/include/uapi/linux/virtio_gpu.h b/include/uapi/linux/virtio_gpu.h
+index 97523a95781d..f556fde07b76 100644
+--- a/include/uapi/linux/virtio_gpu.h
++++ b/include/uapi/linux/virtio_gpu.h
+@@ -59,6 +59,11 @@
+  * VIRTIO_GPU_CMD_RESOURCE_CREATE_BLOB
+  */
+ #define VIRTIO_GPU_F_RESOURCE_BLOB       3
++/*
++ * VIRTIO_GPU_CMD_CREATE_CONTEXT with
++ * context_init and multiple timelines
++ */
++#define VIRTIO_GPU_F_CONTEXT_INIT        4
+ 
+ enum virtio_gpu_ctrl_type {
+ 	VIRTIO_GPU_UNDEFINED = 0,
+@@ -122,14 +127,20 @@ enum virtio_gpu_shm_id {
+ 	VIRTIO_GPU_SHM_ID_HOST_VISIBLE = 1
+ };
+ 
+-#define VIRTIO_GPU_FLAG_FENCE (1 << 0)
++#define VIRTIO_GPU_FLAG_FENCE         (1 << 0)
++/*
++ * If the following flag is set, then ring_idx contains the index
++ * of the command ring that needs to used when creating the fence
++ */
++#define VIRTIO_GPU_FLAG_INFO_RING_IDX (1 << 1)
+ 
+ struct virtio_gpu_ctrl_hdr {
+ 	__le32 type;
+ 	__le32 flags;
+ 	__le64 fence_id;
+ 	__le32 ctx_id;
+-	__le32 padding;
++	__u8 ring_idx;
++	__u8 padding[3];
+ };
+ 
+ /* data passed in the cursor vq */
+@@ -269,10 +280,11 @@ struct virtio_gpu_resource_create_3d {
+ };
+ 
+ /* VIRTIO_GPU_CMD_CTX_CREATE */
++#define VIRTIO_GPU_CONTEXT_INIT_CAPSET_ID_MASK 0x000000ff
+ struct virtio_gpu_ctx_create {
+ 	struct virtio_gpu_ctrl_hdr hdr;
+ 	__le32 nlen;
+-	__le32 padding;
++	__le32 context_init;
+ 	char debug_name[64];
+ };
+ 
+-- 
+2.17.1
+

--- a/bsp_diff/caas/kernel/lts2020-yocto/0003-drm-virtio-implement-context-init-probe-for-feature.patch
+++ b/bsp_diff/caas/kernel/lts2020-yocto/0003-drm-virtio-implement-context-init-probe-for-feature.patch
@@ -1,0 +1,86 @@
+From 9f6c01f0c0ea2bd556e8c92b237a02868fbe396a Mon Sep 17 00:00:00 2001
+From: Anthoine Bourgeois <anthoine.bourgeois@gmail.com>
+Date: Tue, 21 Sep 2021 16:20:16 -0700
+Subject: [PATCH 3/8] drm/virtio: implement context init: probe for feature
+
+Let's probe for VIRTIO_GPU_F_CONTEXT_INIT.
+
+Create a new DRM_INFO(..) line since the current one is getting
+too long.
+
+Signed-off-by: Anthoine Bourgeois <anthoine.bourgeois@gmail.com>
+Acked-by: Lingfeng Yang <lfy@google.com>
+Link: http://patchwork.freedesktop.org/patch/msgid/20210921232024.817-5-gurchetansingh@chromium.org
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+Signed-off-by: ZhuChenyanX <zhucx@intel.com>
+---
+ drivers/gpu/drm/virtio/virtgpu_debugfs.c | 1 +
+ drivers/gpu/drm/virtio/virtgpu_drv.c     | 1 +
+ drivers/gpu/drm/virtio/virtgpu_drv.h     | 1 +
+ drivers/gpu/drm/virtio/virtgpu_kms.c     | 8 +++++++-
+ 4 files changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/virtio/virtgpu_debugfs.c b/drivers/gpu/drm/virtio/virtgpu_debugfs.c
+index c2b20e0ee030..b6954e2f75e6 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_debugfs.c
++++ b/drivers/gpu/drm/virtio/virtgpu_debugfs.c
+@@ -52,6 +52,7 @@ static int virtio_gpu_features(struct seq_file *m, void *data)
+ 			    vgdev->has_resource_assign_uuid);
+ 
+ 	virtio_gpu_add_bool(m, "blob resources", vgdev->has_resource_blob);
++	virtio_gpu_add_bool(m, "context init", vgdev->has_context_init);
+ 	virtio_gpu_add_int(m, "cap sets", vgdev->num_capsets);
+ 	virtio_gpu_add_int(m, "scanouts", vgdev->num_scanouts);
+ 	if (vgdev->host_visible_region.len) {
+diff --git a/drivers/gpu/drm/virtio/virtgpu_drv.c b/drivers/gpu/drm/virtio/virtgpu_drv.c
+index c190bd383a29..26bb74da5e00 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_drv.c
++++ b/drivers/gpu/drm/virtio/virtgpu_drv.c
+@@ -145,6 +145,7 @@ static unsigned int features[] = {
+ 	VIRTIO_GPU_F_EDID,
+ 	VIRTIO_GPU_F_RESOURCE_UUID,
+ 	VIRTIO_GPU_F_RESOURCE_BLOB,
++	VIRTIO_GPU_F_CONTEXT_INIT,
+ };
+ 
+ #ifdef CONFIG_PM_SLEEP
+diff --git a/drivers/gpu/drm/virtio/virtgpu_drv.h b/drivers/gpu/drm/virtio/virtgpu_drv.h
+index c1c0a7b44348..2b50af90e11d 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_drv.h
++++ b/drivers/gpu/drm/virtio/virtgpu_drv.h
+@@ -235,6 +235,7 @@ struct virtio_gpu_device {
+ 	bool has_resource_assign_uuid;
+ 	bool has_resource_blob;
+ 	bool has_host_visible;
++	bool has_context_init;
+ 	struct virtio_shm_region host_visible_region;
+ 	struct drm_mm host_visible_mm;
+ 
+diff --git a/drivers/gpu/drm/virtio/virtgpu_kms.c b/drivers/gpu/drm/virtio/virtgpu_kms.c
+index bb570235be6b..82aa20010f5f 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_kms.c
++++ b/drivers/gpu/drm/virtio/virtgpu_kms.c
+@@ -196,13 +196,19 @@ int virtio_gpu_init(struct virtio_device *vdev, struct drm_device *dev)
+ 			    (unsigned long)vgdev->host_visible_region.addr,
+ 			    (unsigned long)vgdev->host_visible_region.len);
+ 	}
++	if (virtio_has_feature(vgdev->vdev, VIRTIO_GPU_F_CONTEXT_INIT)) {
++		vgdev->has_context_init = true;
++	}
+ 
+-	DRM_INFO("features: %cvirgl %cedid %cresource_blob %chost_visible\n",
++	DRM_INFO("features: %cvirgl %cedid %cresource_blob %chost_visible",
+ 		 vgdev->has_virgl_3d    ? '+' : '-',
+ 		 vgdev->has_edid        ? '+' : '-',
+ 		 vgdev->has_resource_blob ? '+' : '-',
+ 		 vgdev->has_host_visible ? '+' : '-');
+ 
++	DRM_INFO("features: %ccontext_init\n",
++		 vgdev->has_context_init ? '+' : '-');
++
+ 	ret = virtio_gpu_find_vqs(vgdev);
+ 	if (ret) {
+ 		DRM_ERROR("failed to find virt queues\n");
+-- 
+2.17.1
+

--- a/bsp_diff/caas/kernel/lts2020-yocto/0004-drm-introduce-fb_modifiers_not_supported-flag-in-mod.patch
+++ b/bsp_diff/caas/kernel/lts2020-yocto/0004-drm-introduce-fb_modifiers_not_supported-flag-in-mod.patch
@@ -1,0 +1,235 @@
+From 71c6f5ff46c2d7b963829da107f5c18b8c1da7ac Mon Sep 17 00:00:00 2001
+From: Tomohito Esaki <etom@igel.co.jp>
+Date: Fri, 28 Jan 2022 15:08:34 +0900
+Subject: [PATCH 4/8] drm: introduce fb_modifiers_not_supported flag in
+ mode_config
+
+If only linear modifier is advertised, since there are many drivers that
+only linear supported, the DRM core should handle this rather than
+open-coding in every driver. However, there are legacy drivers such as
+radeon that do not support modifiers but infer the actual layout of the
+underlying buffer. Therefore, a new flag fb_modifiers_not_supported is
+introduced for these legacy drivers, and allow_fb_modifiers is replaced
+with this new flag.
+
+v3:
+ - change the order as follows:
+   1. add fb_modifiers_not_supported flag
+   2. add default modifiers
+   3. remove allow_fb_modifiers flag
+ - add a conditional disable in amdgpu_dm_plane_init()
+
+v4:
+ - modify kernel docs
+
+v5:
+ - modify kernel docs
+
+Signed-off-by: Tomohito Esaki <etom@igel.co.jp>
+Acked-by: Harry Wentland <harry.wentland@amd.com>
+Reviewed-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Reviewed-by: Laurent Pinchart <laurent.pinchart@ideasonboard.com>
+Signed-off-by: Daniel Vetter <daniel.vetter@ffwll.ch>
+Link: https://patchwork.freedesktop.org/patch/msgid/20220128060836.11216-2-etom@igel.co.jp
+Signed-off-by: ZhuChenyanX <zhucx@intel.com>
+---
+ drivers/gpu/drm/amd/amdgpu/amdgpu_display.c       |  4 ++--
+ drivers/gpu/drm/amd/amdgpu/dce_v10_0.c            |  2 ++
+ drivers/gpu/drm/amd/amdgpu/dce_v11_0.c            |  2 ++
+ drivers/gpu/drm/amd/amdgpu/dce_v6_0.c             |  1 +
+ drivers/gpu/drm/amd/amdgpu/dce_v8_0.c             |  2 ++
+ drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c |  3 +++
+ drivers/gpu/drm/drm_framebuffer.c                 |  6 +++---
+ drivers/gpu/drm/drm_ioctl.c                       |  2 +-
+ drivers/gpu/drm/nouveau/nouveau_display.c         |  6 ++++--
+ drivers/gpu/drm/radeon/radeon_display.c           |  2 ++
+ include/drm/drm_mode_config.h                     | 10 ++++++++++
+ 11 files changed, 32 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_display.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_display.c
+index dc50c05f23fc..b7655d8aaa59 100644
+--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_display.c
++++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_display.c
+@@ -958,7 +958,7 @@ static int amdgpu_display_verify_sizes(struct amdgpu_framebuffer *rfb)
+ 	int ret;
+ 	unsigned int i, block_width, block_height, block_size_log2;
+ 
+-	if (!rfb->base.dev->mode_config.allow_fb_modifiers)
++	if (rfb->base.dev->mode_config.fb_modifiers_not_supported)
+ 		return 0;
+ 
+ 	for (i = 0; i < format_info->num_planes; ++i) {
+@@ -1153,7 +1153,7 @@ int amdgpu_display_framebuffer_init(struct drm_device *dev,
+ 			return ret;
+ 	}
+ 
+-	if (dev->mode_config.allow_fb_modifiers &&
++	if (!dev->mode_config.fb_modifiers_not_supported &&
+ 	    !(rfb->base.flags & DRM_MODE_FB_MODIFIERS)) {
+ 		ret = convert_tiling_flags_to_modifier(rfb);
+ 		if (ret) {
+diff --git a/drivers/gpu/drm/amd/amdgpu/dce_v10_0.c b/drivers/gpu/drm/amd/amdgpu/dce_v10_0.c
+index d1570a462a51..fb61c0814115 100644
+--- a/drivers/gpu/drm/amd/amdgpu/dce_v10_0.c
++++ b/drivers/gpu/drm/amd/amdgpu/dce_v10_0.c
+@@ -2798,6 +2798,8 @@ static int dce_v10_0_sw_init(void *handle)
+ 	adev_to_drm(adev)->mode_config.preferred_depth = 24;
+ 	adev_to_drm(adev)->mode_config.prefer_shadow = 1;
+ 
++	adev_to_drm(adev)->mode_config.fb_modifiers_not_supported = true;
++
+ 	adev_to_drm(adev)->mode_config.fb_base = adev->gmc.aper_base;
+ 
+ 	r = amdgpu_display_modeset_create_props(adev);
+diff --git a/drivers/gpu/drm/amd/amdgpu/dce_v11_0.c b/drivers/gpu/drm/amd/amdgpu/dce_v11_0.c
+index 18a7b3bd633b..17942a11366d 100644
+--- a/drivers/gpu/drm/amd/amdgpu/dce_v11_0.c
++++ b/drivers/gpu/drm/amd/amdgpu/dce_v11_0.c
+@@ -2916,6 +2916,8 @@ static int dce_v11_0_sw_init(void *handle)
+ 	adev_to_drm(adev)->mode_config.preferred_depth = 24;
+ 	adev_to_drm(adev)->mode_config.prefer_shadow = 1;
+ 
++	adev_to_drm(adev)->mode_config.fb_modifiers_not_supported = true;
++
+ 	adev_to_drm(adev)->mode_config.fb_base = adev->gmc.aper_base;
+ 
+ 	r = amdgpu_display_modeset_create_props(adev);
+diff --git a/drivers/gpu/drm/amd/amdgpu/dce_v6_0.c b/drivers/gpu/drm/amd/amdgpu/dce_v6_0.c
+index c7803dc2b2d5..2ec99ec8e1a3 100644
+--- a/drivers/gpu/drm/amd/amdgpu/dce_v6_0.c
++++ b/drivers/gpu/drm/amd/amdgpu/dce_v6_0.c
+@@ -2674,6 +2674,7 @@ static int dce_v6_0_sw_init(void *handle)
+ 	adev_to_drm(adev)->mode_config.max_height = 16384;
+ 	adev_to_drm(adev)->mode_config.preferred_depth = 24;
+ 	adev_to_drm(adev)->mode_config.prefer_shadow = 1;
++	adev_to_drm(adev)->mode_config.fb_modifiers_not_supported = true;
+ 	adev_to_drm(adev)->mode_config.fb_base = adev->gmc.aper_base;
+ 
+ 	r = amdgpu_display_modeset_create_props(adev);
+diff --git a/drivers/gpu/drm/amd/amdgpu/dce_v8_0.c b/drivers/gpu/drm/amd/amdgpu/dce_v8_0.c
+index b200b9e722d9..8369336cec90 100644
+--- a/drivers/gpu/drm/amd/amdgpu/dce_v8_0.c
++++ b/drivers/gpu/drm/amd/amdgpu/dce_v8_0.c
+@@ -2699,6 +2699,8 @@ static int dce_v8_0_sw_init(void *handle)
+ 	adev_to_drm(adev)->mode_config.preferred_depth = 24;
+ 	adev_to_drm(adev)->mode_config.prefer_shadow = 1;
+ 
++	adev_to_drm(adev)->mode_config.fb_modifiers_not_supported = true;
++
+ 	adev_to_drm(adev)->mode_config.fb_base = adev->gmc.aper_base;
+ 
+ 	r = amdgpu_display_modeset_create_props(adev);
+diff --git a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+index 380ae6a38f95..b63fcf3b94e8 100644
+--- a/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
++++ b/drivers/gpu/drm/amd/display/amdgpu_dm/amdgpu_dm.c
+@@ -7279,6 +7279,9 @@ static int amdgpu_dm_plane_init(struct amdgpu_display_manager *dm,
+ 	if (res)
+ 		return res;
+ 
++	if (modifiers == NULL)
++		adev_to_drm(dm->adev)->mode_config.fb_modifiers_not_supported = true;
++
+ 	res = drm_universal_plane_init(adev_to_drm(dm->adev), plane, possible_crtcs,
+ 				       &dm_plane_funcs, formats, num_formats,
+ 				       modifiers, plane->type, NULL);
+diff --git a/drivers/gpu/drm/drm_framebuffer.c b/drivers/gpu/drm/drm_framebuffer.c
+index 07f5abc875e9..4562a8b86579 100644
+--- a/drivers/gpu/drm/drm_framebuffer.c
++++ b/drivers/gpu/drm/drm_framebuffer.c
+@@ -309,7 +309,7 @@ drm_internal_framebuffer_create(struct drm_device *dev,
+ 	}
+ 
+ 	if (r->flags & DRM_MODE_FB_MODIFIERS &&
+-	    !dev->mode_config.allow_fb_modifiers) {
++	    dev->mode_config.fb_modifiers_not_supported) {
+ 		DRM_DEBUG_KMS("driver does not support fb modifiers\n");
+ 		return ERR_PTR(-EINVAL);
+ 	}
+@@ -594,7 +594,7 @@ int drm_mode_getfb2_ioctl(struct drm_device *dev,
+ 	r->pixel_format = fb->format->format;
+ 
+ 	r->flags = 0;
+-	if (dev->mode_config.allow_fb_modifiers)
++	if (!dev->mode_config.fb_modifiers_not_supported)
+ 		r->flags |= DRM_MODE_FB_MODIFIERS;
+ 
+ 	for (i = 0; i < ARRAY_SIZE(r->handles); i++) {
+@@ -607,7 +607,7 @@ int drm_mode_getfb2_ioctl(struct drm_device *dev,
+ 	for (i = 0; i < fb->format->num_planes; i++) {
+ 		r->pitches[i] = fb->pitches[i];
+ 		r->offsets[i] = fb->offsets[i];
+-		if (dev->mode_config.allow_fb_modifiers)
++		if (!dev->mode_config.fb_modifiers_not_supported)
+ 			r->modifier[i] = fb->modifier;
+ 	}
+ 
+diff --git a/drivers/gpu/drm/drm_ioctl.c b/drivers/gpu/drm/drm_ioctl.c
+index 0a6de5b41e4c..675061d67a07 100644
+--- a/drivers/gpu/drm/drm_ioctl.c
++++ b/drivers/gpu/drm/drm_ioctl.c
+@@ -297,7 +297,7 @@ static int drm_getcap(struct drm_device *dev, void *data, struct drm_file *file_
+ 			req->value = 64;
+ 		break;
+ 	case DRM_CAP_ADDFB2_MODIFIERS:
+-		req->value = dev->mode_config.allow_fb_modifiers;
++		req->value = !dev->mode_config.fb_modifiers_not_supported;
+ 		break;
+ 	case DRM_CAP_CRTC_IN_VBLANK_EVENT:
+ 		req->value = 1;
+diff --git a/drivers/gpu/drm/nouveau/nouveau_display.c b/drivers/gpu/drm/nouveau/nouveau_display.c
+index 929de41c281f..1ecad7fa3e8a 100644
+--- a/drivers/gpu/drm/nouveau/nouveau_display.c
++++ b/drivers/gpu/drm/nouveau/nouveau_display.c
+@@ -711,10 +711,12 @@ nouveau_display_create(struct drm_device *dev)
+ 				     &disp->disp);
+ 		if (ret == 0) {
+ 			nouveau_display_create_properties(dev);
+-			if (disp->disp.object.oclass < NV50_DISP)
++			if (disp->disp.object.oclass < NV50_DISP) {
++				dev->mode_config.fb_modifiers_not_supported = true;
+ 				ret = nv04_display_create(dev);
+-			else
++			} else {
+ 				ret = nv50_display_create(dev);
++			}
+ 		}
+ 	} else {
+ 		ret = 0;
+diff --git a/drivers/gpu/drm/radeon/radeon_display.c b/drivers/gpu/drm/radeon/radeon_display.c
+index 573154268d43..b9a07677a71e 100644
+--- a/drivers/gpu/drm/radeon/radeon_display.c
++++ b/drivers/gpu/drm/radeon/radeon_display.c
+@@ -1596,6 +1596,8 @@ int radeon_modeset_init(struct radeon_device *rdev)
+ 	rdev->ddev->mode_config.preferred_depth = 24;
+ 	rdev->ddev->mode_config.prefer_shadow = 1;
+ 
++	rdev->ddev->mode_config.fb_modifiers_not_supported = true;
++
+ 	rdev->ddev->mode_config.fb_base = rdev->mc.aper_base;
+ 
+ 	ret = radeon_modeset_create_props(rdev);
+diff --git a/include/drm/drm_mode_config.h b/include/drm/drm_mode_config.h
+index 1ddf7783fdf7..9ba493288d6b 100644
+--- a/include/drm/drm_mode_config.h
++++ b/include/drm/drm_mode_config.h
+@@ -921,6 +921,16 @@ struct drm_mode_config {
+ 	 */
+ 	bool allow_fb_modifiers;
+ 
++	/**
++	 * @fb_modifiers_not_supported:
++	 *
++	 * When this flag is set, the DRM device will not expose modifier
++	 * support to userspace. This is only used by legacy drivers that infer
++	 * the buffer layout through heuristics without using modifiers. New
++	 * drivers shall not set fhis flag.
++	 */
++	bool fb_modifiers_not_supported;
++
+ 	/**
+ 	 * @normalize_zpos:
+ 	 *
+-- 
+2.17.1
+

--- a/bsp_diff/caas/kernel/lts2020-yocto/0005-drm-virtio-set-fb_modifiers_not_supported.patch
+++ b/bsp_diff/caas/kernel/lts2020-yocto/0005-drm-virtio-set-fb_modifiers_not_supported.patch
@@ -1,0 +1,37 @@
+From 30cab6d947bcd37feffd291392d91c12f4b898ae Mon Sep 17 00:00:00 2001
+From: Chia-I Wu <olvaffe@gmail.com>
+Date: Wed, 31 Aug 2022 12:06:01 -0700
+Subject: [PATCH 5/8] drm/virtio: set fb_modifiers_not_supported
+
+Without this, the drm core advertises LINEAR modifier which is
+incorrect.
+
+Also userspace virgl does not support modifiers.  For example, it causes
+chrome on ozone/drm to fail with "Failed to create scanout buffer".
+
+Fixes: 2af104290da5 ("drm: introduce fb_modifiers_not_supported flag in mode_config")
+Suggested-by: Shao-Chuan Lee <shaochuan@chromium.org>
+Signed-off-by: Chia-I Wu <olvaffe@gmail.com>
+Link: http://patchwork.freedesktop.org/patch/msgid/20220831190601.1295129-1-olvaffe@gmail.com
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+Signed-off-by: ZhuChenyanX <zhucx@intel.com>
+---
+ drivers/gpu/drm/virtio/virtgpu_display.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/gpu/drm/virtio/virtgpu_display.c b/drivers/gpu/drm/virtio/virtgpu_display.c
+index bb955dfaca14..8bf65c6c4369 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_display.c
++++ b/drivers/gpu/drm/virtio/virtgpu_display.c
+@@ -339,6 +339,8 @@ int virtio_gpu_modeset_init(struct virtio_gpu_device *vgdev)
+ 	vgdev->ddev->mode_config.max_width = XRES_MAX;
+ 	vgdev->ddev->mode_config.max_height = YRES_MAX;
+ 
++	vgdev->ddev->mode_config.fb_modifiers_not_supported = true;
++
+ 	for (i = 0 ; i < vgdev->num_scanouts; ++i)
+ 		vgdev_output_init(vgdev, i);
+ 
+-- 
+2.17.1
+

--- a/bsp_diff/caas/kernel/lts2020-yocto/0006-drivers-virtgpu-Add-support-for-gem-buffer-import.patch
+++ b/bsp_diff/caas/kernel/lts2020-yocto/0006-drivers-virtgpu-Add-support-for-gem-buffer-import.patch
@@ -1,0 +1,157 @@
+From af4d0a62faea8618d739a2040548ba58708df50c Mon Sep 17 00:00:00 2001
+From: hangliu1 <hang1.liu@linux.intel.com>
+Date: Mon, 3 Jul 2023 08:31:56 -0400
+Subject: [PATCH 6/8] drivers: virtgpu: Add support for gem buffer import
+
+Scatter gather gem buffer created from i915 could
+be imported to virtio gpu driver and make it as
+a framebuffer later directly.
+
+Tracked-On: OAM-110757
+Signed-off-by: hangliu1 <hang1.liu@linux.intel.com>
+Signed-off-by: ZhuChenyanX <zhucx@intel.com>
+---
+ drivers/gpu/drm/virtio/virtgpu_drv.h    |  6 ++
+ drivers/gpu/drm/virtio/virtgpu_object.c |  4 +-
+ drivers/gpu/drm/virtio/virtgpu_prime.c  | 85 ++++++++++++++++++++++++-
+ 3 files changed, 92 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/gpu/drm/virtio/virtgpu_drv.h b/drivers/gpu/drm/virtio/virtgpu_drv.h
+index 2b50af90e11d..41c3333c9195 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_drv.h
++++ b/drivers/gpu/drm/virtio/virtgpu_drv.h
+@@ -445,6 +445,12 @@ bool virtio_gpu_is_shmem(struct virtio_gpu_object *bo);
+ int virtio_gpu_resource_id_get(struct virtio_gpu_device *vgdev,
+ 			       uint32_t *resid);
+ 
++void virtio_gpu_resource_id_put(struct virtio_gpu_device *vgdev, uint32_t id);
++
++void virtio_gpu_object_save_restore_list(struct virtio_gpu_device *vgdev,
++					 struct virtio_gpu_object *bo,
++					 struct virtio_gpu_object_params *params);
++
+ int virtio_gpu_object_restore_all(struct virtio_gpu_device *vgdev);
+ 
+ /* virtgpu_prime.c */
+diff --git a/drivers/gpu/drm/virtio/virtgpu_object.c b/drivers/gpu/drm/virtio/virtgpu_object.c
+index 41ca707f71f3..ef8fd5363811 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_object.c
++++ b/drivers/gpu/drm/virtio/virtgpu_object.c
+@@ -54,14 +54,14 @@ int virtio_gpu_resource_id_get(struct virtio_gpu_device *vgdev, uint32_t *resid)
+ 	return 0;
+ }
+ 
+-static void virtio_gpu_resource_id_put(struct virtio_gpu_device *vgdev, uint32_t id)
++void virtio_gpu_resource_id_put(struct virtio_gpu_device *vgdev, uint32_t id)
+ {
+ 	if (!virtio_gpu_virglrenderer_workaround) {
+ 		ida_free(&vgdev->resource_ida, id - 1);
+ 	}
+ }
+ 
+-static void virtio_gpu_object_save_restore_list(struct virtio_gpu_device *vgdev,
++void virtio_gpu_object_save_restore_list(struct virtio_gpu_device *vgdev,
+ 						struct virtio_gpu_object *bo,
+ 						struct virtio_gpu_object_params *params)
+ {
+diff --git a/drivers/gpu/drm/virtio/virtgpu_prime.c b/drivers/gpu/drm/virtio/virtgpu_prime.c
+index e45dbf14b307..169482767b69 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_prime.c
++++ b/drivers/gpu/drm/virtio/virtgpu_prime.c
+@@ -138,9 +138,92 @@ struct drm_gem_object *virtgpu_gem_prime_import(struct drm_device *dev,
+ 	return drm_gem_prime_import(dev, buf);
+ }
+ 
++static int virtio_gpu_sgt_to_mem_entry(struct virtio_gpu_device *vgdev,
++				       struct sg_table *table,
++				       struct virtio_gpu_mem_entry **ents,
++				       unsigned int *nents)
++{
++	struct scatterlist *sg;
++	int si;
++
++	bool use_dma_api = !virtio_has_dma_quirk(vgdev->vdev);
++	if (use_dma_api)
++		*nents = table->nents;
++	else
++		*nents = table->orig_nents;
++
++	*ents = kvmalloc_array(*nents,
++			       sizeof(struct virtio_gpu_mem_entry),
++			       GFP_KERNEL);
++	if (!(*ents)) {
++		DRM_ERROR("failed to allocate ent list\n");
++		return -ENOMEM;
++	}
++
++	if (use_dma_api) {
++		for_each_sgtable_dma_sg(table, sg, si) {
++			(*ents)[si].addr = cpu_to_le64(sg_dma_address(sg));
++			(*ents)[si].length = cpu_to_le32(sg_dma_len(sg));
++			(*ents)[si].padding = 0;
++		}
++	} else {
++		for_each_sgtable_sg(table, sg, si) {
++			(*ents)[si].addr = cpu_to_le64(sg_phys(sg));
++			(*ents)[si].length = cpu_to_le32(sg->length);
++			(*ents)[si].padding = 0;
++		}
++	}
++
++	return 0;
++
++}
++
+ struct drm_gem_object *virtgpu_gem_prime_import_sg_table(
+ 	struct drm_device *dev, struct dma_buf_attachment *attach,
+ 	struct sg_table *table)
+ {
+-	return ERR_PTR(-ENODEV);
++	size_t size = PAGE_ALIGN(attach->dmabuf->size);
++	struct virtio_gpu_device *vgdev = dev->dev_private;
++	struct virtio_gpu_object_params params = { 0 };
++	struct virtio_gpu_object *bo;
++	struct drm_gem_object *obj;
++	struct virtio_gpu_mem_entry *ents;
++	unsigned int nents;
++	int ret;
++
++	if (!vgdev->has_resource_blob || vgdev->has_virgl_3d) {
++		return ERR_PTR(-ENODEV);
++	}
++
++	obj = drm_gem_shmem_prime_import_sg_table(dev, attach, table);
++	if (IS_ERR(obj)) {
++		return ERR_CAST(obj);
++	}
++
++	bo = gem_to_virtio_gpu_obj(obj);
++	ret = virtio_gpu_resource_id_get(vgdev, &bo->hw_res_handle);
++	if (ret < 0) {
++		return ret;
++	}
++
++	ret = virtio_gpu_sgt_to_mem_entry(vgdev, table, &ents, &nents);
++	if (ret != 0) {
++		goto err_put_id;
++	}
++
++	bo->guest_blob = true;
++	params.blob_mem = VIRTGPU_BLOB_MEM_GUEST;
++	params.blob_flags = VIRTGPU_BLOB_FLAG_USE_SHAREABLE;
++	params.blob = true;
++	params.size = size;
++
++	virtio_gpu_cmd_resource_create_blob(vgdev, bo, &params,
++					    ents, nents);
++	virtio_gpu_object_save_restore_list(vgdev, bo, &params);
++
++	return obj;
++
++err_put_id:
++	virtio_gpu_resource_id_put(vgdev, bo->hw_res_handle);
++	return ret;
+ }
+-- 
+2.17.1
+

--- a/bsp_diff/caas/kernel/lts2020-yocto/0007-drivers-virtgpu-Add-virtio-gpu-tiling-format-support.patch
+++ b/bsp_diff/caas/kernel/lts2020-yocto/0007-drivers-virtgpu-Add-virtio-gpu-tiling-format-support.patch
@@ -1,0 +1,226 @@
+From a8f9ed1cbb03f62b37ef3ba8ffd4ff3b675dc538 Mon Sep 17 00:00:00 2001
+From: Yifan Liu <yifan1.liu@intel.com>
+Date: Sat, 22 Jul 2023 03:13:52 +0000
+Subject: [PATCH 7/8] drivers: virtgpu: Add virtio-gpu tiling format support
+
+Add tiling support featured with feature bit VIRTIO_GPU_F_MODIFIER,
+so buffer created by virtio gpu with intel_x_tiling
+and intel_y_tiling format could be rendered directly by i915.
+
+Tracked-On: OAM-110757
+Signed-off-by: hangliu1 <hang1.liu@linux.intel.com>
+Signed-off-by: Yifan Liu <yifan1.liu@intel.com>
+Signed-off-by: ZhuChenyanX <zhucx@intel.com>
+---
+ drivers/gpu/drm/virtio/virtgpu_display.c |  3 +-
+ drivers/gpu/drm/virtio/virtgpu_drv.c     |  1 +
+ drivers/gpu/drm/virtio/virtgpu_drv.h     |  5 ++-
+ drivers/gpu/drm/virtio/virtgpu_kms.c     |  3 ++
+ drivers/gpu/drm/virtio/virtgpu_plane.c   | 45 +++++++++++++++++++++---
+ drivers/gpu/drm/virtio/virtgpu_vq.c      | 15 ++++++++
+ include/uapi/linux/virtio_gpu.h          | 12 +++++++
+ 7 files changed, 77 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/gpu/drm/virtio/virtgpu_display.c b/drivers/gpu/drm/virtio/virtgpu_display.c
+index 8bf65c6c4369..fbf9b194c33a 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_display.c
++++ b/drivers/gpu/drm/virtio/virtgpu_display.c
+@@ -339,7 +339,8 @@ int virtio_gpu_modeset_init(struct virtio_gpu_device *vgdev)
+ 	vgdev->ddev->mode_config.max_width = XRES_MAX;
+ 	vgdev->ddev->mode_config.max_height = YRES_MAX;
+ 
+-	vgdev->ddev->mode_config.fb_modifiers_not_supported = true;
++	if (!vgdev->has_modifier)
++		vgdev->ddev->mode_config.fb_modifiers_not_supported = true;
+ 
+ 	for (i = 0 ; i < vgdev->num_scanouts; ++i)
+ 		vgdev_output_init(vgdev, i);
+diff --git a/drivers/gpu/drm/virtio/virtgpu_drv.c b/drivers/gpu/drm/virtio/virtgpu_drv.c
+index 26bb74da5e00..624c12277c20 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_drv.c
++++ b/drivers/gpu/drm/virtio/virtgpu_drv.c
+@@ -146,6 +146,7 @@ static unsigned int features[] = {
+ 	VIRTIO_GPU_F_RESOURCE_UUID,
+ 	VIRTIO_GPU_F_RESOURCE_BLOB,
+ 	VIRTIO_GPU_F_CONTEXT_INIT,
++	VIRTIO_GPU_F_MODIFIER,
+ };
+ 
+ #ifdef CONFIG_PM_SLEEP
+diff --git a/drivers/gpu/drm/virtio/virtgpu_drv.h b/drivers/gpu/drm/virtio/virtgpu_drv.h
+index 41c3333c9195..504f8cf39302 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_drv.h
++++ b/drivers/gpu/drm/virtio/virtgpu_drv.h
+@@ -231,6 +231,7 @@ struct virtio_gpu_device {
+ 
+ 	bool has_virgl_3d;
+ 	bool has_edid;
++	bool has_modifier;
+ 	bool has_indirect;
+ 	bool has_resource_assign_uuid;
+ 	bool has_resource_blob;
+@@ -410,7 +411,9 @@ virtio_gpu_cmd_set_scanout_blob(struct virtio_gpu_device *vgdev,
+ 				struct drm_framebuffer *fb,
+ 				uint32_t width, uint32_t height,
+ 				uint32_t x, uint32_t y);
+-
++void virtio_gpu_cmd_set_modifier(struct virtio_gpu_device *vgdev,
++				 uint32_t scanout_id,
++				 struct drm_framebuffer *fb);
+ /* virtgpu_display.c */
+ int virtio_gpu_modeset_init(struct virtio_gpu_device *vgdev);
+ void virtio_gpu_modeset_fini(struct virtio_gpu_device *vgdev);
+diff --git a/drivers/gpu/drm/virtio/virtgpu_kms.c b/drivers/gpu/drm/virtio/virtgpu_kms.c
+index 82aa20010f5f..e5e02238298a 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_kms.c
++++ b/drivers/gpu/drm/virtio/virtgpu_kms.c
+@@ -176,6 +176,9 @@ int virtio_gpu_init(struct virtio_device *vdev, struct drm_device *dev)
+ 	}
+ 	if (virtio_has_feature(vgdev->vdev, VIRTIO_GPU_F_RESOURCE_BLOB)) {
+ 		vgdev->has_resource_blob = true;
++		if (virtio_has_feature(vgdev->vdev, VIRTIO_GPU_F_MODIFIER)) {
++			vgdev->has_modifier = true;
++		}
+ 	}
+ 	if (virtio_get_shm_region(vgdev->vdev, &vgdev->host_visible_region,
+ 				  VIRTIO_GPU_SHM_ID_HOST_VISIBLE)) {
+diff --git a/drivers/gpu/drm/virtio/virtgpu_plane.c b/drivers/gpu/drm/virtio/virtgpu_plane.c
+index e6b32f1b560c..3f5258ee9d41 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_plane.c
++++ b/drivers/gpu/drm/virtio/virtgpu_plane.c
+@@ -119,7 +119,7 @@ static void virtio_gpu_plane_destroy(struct drm_plane *plane)
+ 	kfree(plane);
+ }
+ 
+-static const struct drm_plane_funcs virtio_gpu_plane_funcs = {
++static struct drm_plane_funcs virtio_gpu_plane_funcs = {
+ 	.update_plane		= drm_atomic_helper_update_plane,
+ 	.disable_plane		= drm_atomic_helper_disable_plane,
+ 	.destroy		= virtio_gpu_plane_destroy,
+@@ -268,6 +268,9 @@ static void virtio_gpu_primary_plane_update(struct drm_plane *plane,
+ 						 plane->state->src_h >> 16,
+ 						 plane->state->src_x >> 16,
+ 						 plane->state->src_y >> 16);
++			if (vgdev->has_modifier)
++				virtio_gpu_cmd_set_modifier(vgdev, output->index, plane->state->fb);
++
+ 		} else {
+ 			virtio_gpu_cmd_set_scanout(vgdev, output->index,
+ 						   bo->hw_res_handle,
+@@ -379,6 +382,27 @@ static const struct drm_plane_helper_funcs virtio_gpu_cursor_helper_funcs = {
+ 	.atomic_update		= virtio_gpu_cursor_plane_update,
+ };
+ 
++static const uint64_t virtio_gpu_format_modifiers[] = {
++	DRM_FORMAT_MOD_LINEAR,
++	I915_FORMAT_MOD_X_TILED,
++	I915_FORMAT_MOD_Y_TILED,
++	DRM_FORMAT_MOD_INVALID
++};
++
++
++static bool virtio_gpu_plane_format_mod_supported(struct drm_plane *_plane,
++						  u32 format, u64 modifier)
++{
++	switch (modifier) {
++	case DRM_FORMAT_MOD_LINEAR:
++	case I915_FORMAT_MOD_X_TILED:
++	case I915_FORMAT_MOD_Y_TILED:
++		return true;
++	default:
++		return false;
++        }
++}
++
+ struct drm_plane *virtio_gpu_plane_init(struct virtio_gpu_device *vgdev,
+ 					enum drm_plane_type type,
+ 					int index)
+@@ -402,10 +426,21 @@ struct drm_plane *virtio_gpu_plane_init(struct virtio_gpu_device *vgdev,
+ 		nformats = ARRAY_SIZE(virtio_gpu_formats);
+ 		funcs = &virtio_gpu_primary_helper_funcs;
+ 	}
+-	ret = drm_universal_plane_init(dev, plane, 1 << index,
+-				       &virtio_gpu_plane_funcs,
+-				       formats, nformats,
+-				       NULL, type, NULL);
++
++	if (vgdev->has_modifier) {
++		const uint64_t *modifiers = virtio_gpu_format_modifiers;
++		virtio_gpu_plane_funcs.format_mod_supported = virtio_gpu_plane_format_mod_supported;
++		ret = drm_universal_plane_init(dev, plane, 1 << index,
++						&virtio_gpu_plane_funcs,
++						formats, nformats,
++						modifiers, type, NULL);
++	} else {
++		ret = drm_universal_plane_init(dev, plane, 1 << index,
++						&virtio_gpu_plane_funcs,
++						formats, nformats,
++						NULL, type, NULL);
++	}
++
+ 	if (ret)
+ 		goto err_plane_init;
+ 
+diff --git a/drivers/gpu/drm/virtio/virtgpu_vq.c b/drivers/gpu/drm/virtio/virtgpu_vq.c
+index b832dbaf3913..6303c7c5473a 100644
+--- a/drivers/gpu/drm/virtio/virtgpu_vq.c
++++ b/drivers/gpu/drm/virtio/virtgpu_vq.c
+@@ -1307,3 +1307,18 @@ void virtio_gpu_cmd_set_scanout_blob(struct virtio_gpu_device *vgdev,
+ 
+ 	virtio_gpu_queue_ctrl_buffer(vgdev, vbuf);
+ }
++
++void virtio_gpu_cmd_set_modifier(struct virtio_gpu_device *vgdev,
++				     uint32_t scanout_id,
++				     struct drm_framebuffer *fb)
++{
++	struct virtio_gpu_set_modifier *cmd_p;
++	struct virtio_gpu_vbuffer *vbuf;
++
++	cmd_p = virtio_gpu_alloc_cmd(vgdev, &vbuf, sizeof(*cmd_p));
++	memset(cmd_p, 0, sizeof(*cmd_p));
++	cmd_p->hdr.type = cpu_to_le32(VIRTIO_GPU_CMD_SET_MODIFIER);
++	cmd_p->modifier = cpu_to_le64(fb->modifier);
++	cmd_p->scanout_id = cpu_to_le32(scanout_id);
++	virtio_gpu_queue_ctrl_buffer(vgdev, vbuf);
++}
+diff --git a/include/uapi/linux/virtio_gpu.h b/include/uapi/linux/virtio_gpu.h
+index f556fde07b76..3a251301395b 100644
+--- a/include/uapi/linux/virtio_gpu.h
++++ b/include/uapi/linux/virtio_gpu.h
+@@ -64,6 +64,10 @@
+  * context_init and multiple timelines
+  */
+ #define VIRTIO_GPU_F_CONTEXT_INIT        4
++/*
++ *VIRTIO_GPU_CMD_SET_MODIFIER
++ */
++#define VIRTIO_GPU_F_MODIFIER            5
+ 
+ enum virtio_gpu_ctrl_type {
+ 	VIRTIO_GPU_UNDEFINED = 0,
+@@ -83,6 +87,7 @@ enum virtio_gpu_ctrl_type {
+ 	VIRTIO_GPU_CMD_RESOURCE_ASSIGN_UUID,
+ 	VIRTIO_GPU_CMD_RESOURCE_CREATE_BLOB,
+ 	VIRTIO_GPU_CMD_SET_SCANOUT_BLOB,
++	VIRTIO_GPU_CMD_SET_MODIFIER,
+ 
+ 	/* 3d commands */
+ 	VIRTIO_GPU_CMD_CTX_CREATE = 0x0200,
+@@ -425,6 +430,13 @@ struct virtio_gpu_set_scanout_blob {
+ 	__le32 strides[4];
+ 	__le32 offsets[4];
+ };
++/* VIRTIO_GPU_CMD_SET_MODIFIER */
++struct virtio_gpu_set_modifier {
++	struct virtio_gpu_ctrl_hdr hdr;
++	__le64 modifier;
++	__le32 scanout_id;
++	__le32 padding;
++};
+ 
+ /* VIRTIO_GPU_CMD_RESOURCE_MAP_BLOB */
+ struct virtio_gpu_resource_map_blob {
+-- 
+2.17.1
+

--- a/host/qemu/0036-dm-virtio-gpu-Add-virtio-gpu-plane-format-modifier-s.patch
+++ b/host/qemu/0036-dm-virtio-gpu-Add-virtio-gpu-plane-format-modifier-s.patch
@@ -1,0 +1,188 @@
+From 4831dc1e286ceccef1f4cf136fa689c9baf31121 Mon Sep 17 00:00:00 2001
+From: "Zhu, ChenyanX" <zhucx@intel.com>
+Date: Wed, 9 Aug 2023 19:19:07 +0800
+Subject: [PATCH] dm: virtio-gpu: Add virtio-gpu plane format modifier support
+
+This patch adds a new virtio-gpu cmd to support tiling format.
+
+Signed-off-by: Yifan Liu <yifan1.liu@intel.com>
+Signed-off-by: Zhu, ChenyanX <zhucx@intel.com>
+---
+ hw/display/trace-events                     |  1 +
+ hw/display/virtio-gpu-base.c                |  1 +
+ hw/display/virtio-gpu-udmabuf.c             |  7 +++++++
+ hw/display/virtio-gpu.c                     | 21 +++++++++++++++++++++
+ include/hw/virtio/virtio-gpu-bswap.h        |  9 +++++++++
+ include/hw/virtio/virtio-gpu.h              |  1 +
+ include/standard-headers/linux/virtio_gpu.h | 20 ++++++++++++++++++++
+ 7 files changed, 60 insertions(+)
+
+diff --git a/hw/display/trace-events b/hw/display/trace-events
+index 96fe1ea3d..6b4345376 100644
+--- a/hw/display/trace-events
++++ b/hw/display/trace-events
+@@ -41,6 +41,7 @@ virtio_gpu_cmd_get_display_info(void) ""
+ virtio_gpu_cmd_get_edid(uint32_t scanout) "scanout %d"
+ virtio_gpu_cmd_set_scanout(uint32_t id, uint32_t res, uint32_t w, uint32_t h, uint32_t x, uint32_t y) "id %d, res 0x%x, w %d, h %d, x %d, y %d"
+ virtio_gpu_cmd_set_scanout_blob(uint32_t id, uint32_t res, uint32_t w, uint32_t h, uint32_t x, uint32_t y) "id %d, res 0x%x, w %d, h %d, x %d, y %d"
++virtio_gpu_cmd_set_modifier(uint32_t id, uint64_t mdf) "id %d, mdf 0x%x"
+ virtio_gpu_cmd_res_create_2d(uint32_t res, uint32_t fmt, uint32_t w, uint32_t h) "res 0x%x, fmt 0x%x, w %d, h %d"
+ virtio_gpu_cmd_res_create_3d(uint32_t res, uint32_t fmt, uint32_t w, uint32_t h, uint32_t d) "res 0x%x, fmt 0x%x, w %d, h %d, d %d"
+ virtio_gpu_cmd_res_create_blob(uint32_t res, uint64_t size) "res 0x%x, size %" PRId64
+diff --git a/hw/display/virtio-gpu-base.c b/hw/display/virtio-gpu-base.c
+index dd294276c..33c6835f4 100644
+--- a/hw/display/virtio-gpu-base.c
++++ b/hw/display/virtio-gpu-base.c
+@@ -210,6 +210,7 @@ virtio_gpu_base_get_features(VirtIODevice *vdev, uint64_t features,
+     }
+     if (virtio_gpu_blob_enabled(g->conf)) {
+         features |= (1 << VIRTIO_GPU_F_RESOURCE_BLOB);
++        features |= (1 << VIRTIO_GPU_F_MODIFIER);
+     }
+ 
+     return features;
+diff --git a/hw/display/virtio-gpu-udmabuf.c b/hw/display/virtio-gpu-udmabuf.c
+index b11ac5bc6..b0445e418 100644
+--- a/hw/display/virtio-gpu-udmabuf.c
++++ b/hw/display/virtio-gpu-udmabuf.c
+@@ -174,16 +174,23 @@ static VGPUDMABuf
+                           struct virtio_gpu_framebuffer *fb,
+                           struct virtio_gpu_rect *r)
+ {
++    struct virtio_gpu_scanout *scanout;
+     VGPUDMABuf *dmabuf;
+ 
+     if (res->dmabuf_fd < 0) {
+         return NULL;
+     }
+ 
++    if (scanout_id >= VIRTIO_GPU_MAX_SCANOUTS) {
++        return NULL;
++    }
++
++    scanout = &g->parent_obj.scanout[scanout_id];
+     dmabuf = g_new0(VGPUDMABuf, 1);
+     dmabuf->buf.width = fb->width;
+     dmabuf->buf.height = fb->height;
+     dmabuf->buf.stride = fb->stride;
++    dmabuf->buf.modifier = scanout->modifier;
+     dmabuf->buf.x = r->x;
+     dmabuf->buf.y = r->y;
+     dmabuf->buf.scanout_width = r->width;
+diff --git a/hw/display/virtio-gpu.c b/hw/display/virtio-gpu.c
+index a8c46f6d8..5ff482edc 100644
+--- a/hw/display/virtio-gpu.c
++++ b/hw/display/virtio-gpu.c
+@@ -775,6 +775,24 @@ static void virtio_gpu_set_scanout_blob(VirtIOGPU *g,
+                               &fb, res, &ss.r, &cmd->error);
+ }
+ 
++static void
++virtio_gpu_set_modifier(VirtIOGPU *g,
++                        struct virtio_gpu_ctrl_command *cmd)
++{
++    struct virtio_gpu_scanout *scanout;
++    struct virtio_gpu_set_modifier sm;
++
++    VIRTIO_GPU_FILL_CMD(sm);
++    virtio_gpu_set_modifier_bswap(&sm);
++    trace_virtio_gpu_cmd_set_modifier(sm.scanout_id, sm.modifier);
++    if (sm.scanout_id >= VIRTIO_GPU_MAX_SCANOUTS) {
++        cmd->error = VIRTIO_GPU_RESP_ERR_INVALID_PARAMETER;
++        return;
++    }
++    scanout = &g->parent_obj.scanout[sm.scanout_id];
++    scanout->modifier = sm.modifier;
++}
++
+ int virtio_gpu_create_mapping_iov(VirtIOGPU *g,
+                                   uint32_t nr_entries, uint32_t offset,
+                                   struct virtio_gpu_ctrl_command *cmd,
+@@ -976,6 +994,9 @@ void virtio_gpu_simple_process_cmd(VirtIOGPU *g,
+         }
+         virtio_gpu_set_scanout_blob(g, cmd);
+         break;
++    case VIRTIO_GPU_CMD_SET_MODIFIER:
++        virtio_gpu_set_modifier(g, cmd);
++        break;
+     case VIRTIO_GPU_CMD_RESOURCE_ATTACH_BACKING:
+         virtio_gpu_resource_attach_backing(g, cmd);
+         break;
+diff --git a/include/hw/virtio/virtio-gpu-bswap.h b/include/hw/virtio/virtio-gpu-bswap.h
+index e2bee8f59..13cfd37fe 100644
+--- a/include/hw/virtio/virtio-gpu-bswap.h
++++ b/include/hw/virtio/virtio-gpu-bswap.h
+@@ -75,4 +75,13 @@ virtio_gpu_scanout_blob_bswap(struct virtio_gpu_set_scanout_blob *ssb)
+     le32_to_cpus(&ssb->offsets[3]);
+ }
+ 
++static inline void
++virtio_gpu_set_modifier_bswap(struct virtio_gpu_set_modifier *sm)
++{
++    virtio_gpu_ctrl_hdr_bswap(&sm->hdr);
++    le64_to_cpus(&sm->modifier);
++    le32_to_cpus(&sm->scanout_id);
++    le32_to_cpus(&sm->padding);
++}
++
+ #endif
+diff --git a/include/hw/virtio/virtio-gpu.h b/include/hw/virtio/virtio-gpu.h
+index da6e4a415..c21864b19 100644
+--- a/include/hw/virtio/virtio-gpu.h
++++ b/include/hw/virtio/virtio-gpu.h
+@@ -76,6 +76,7 @@ struct virtio_gpu_scanout {
+     uint32_t resource_id;
+     struct virtio_gpu_update_cursor cursor;
+     QEMUCursor *current_cursor;
++    uint64_t modifier;
+ };
+ 
+ struct virtio_gpu_requested_state {
+diff --git a/include/standard-headers/linux/virtio_gpu.h b/include/standard-headers/linux/virtio_gpu.h
+index 1357e4774..0856b3bac 100644
+--- a/include/standard-headers/linux/virtio_gpu.h
++++ b/include/standard-headers/linux/virtio_gpu.h
+@@ -60,6 +60,17 @@
+  */
+ #define VIRTIO_GPU_F_RESOURCE_BLOB       3
+ 
++/*
++ * VIRTIO_GPU_CMD_CREATE_CONTEXT with
++ * context_init and multiple timelines
++ */
++#define VIRTIO_GPU_F_CONTEXT_INIT        4
++
++/*
++ * VIRTIO_GPU_CMD_SET_MODIFIER
++ */
++#define VIRTIO_GPU_F_MODIFIER		5
++
+ enum virtio_gpu_ctrl_type {
+ 	VIRTIO_GPU_UNDEFINED = 0,
+ 
+@@ -78,6 +89,7 @@ enum virtio_gpu_ctrl_type {
+ 	VIRTIO_GPU_CMD_RESOURCE_ASSIGN_UUID,
+ 	VIRTIO_GPU_CMD_RESOURCE_CREATE_BLOB,
+ 	VIRTIO_GPU_CMD_SET_SCANOUT_BLOB,
++	VIRTIO_GPU_CMD_SET_MODIFIER,
+ 
+ 	/* 3d commands */
+ 	VIRTIO_GPU_CMD_CTX_CREATE = 0x0200,
+@@ -414,6 +426,14 @@ struct virtio_gpu_set_scanout_blob {
+ 	uint32_t offsets[4];
+ };
+ 
++/* VIRTIO_GPU_CMD_SET_MODIFIER */
++struct virtio_gpu_set_modifier {
++	struct virtio_gpu_ctrl_hdr hdr;
++	uint64_t modifier;
++	uint32_t scanout_id;
++	uint32_t padding;
++};
++
+ /* VIRTIO_GPU_CMD_RESOURCE_MAP_BLOB */
+ struct virtio_gpu_resource_map_blob {
+ 	struct virtio_gpu_ctrl_hdr hdr;
+-- 
+2.25.1
+


### PR DESCRIPTION
Porting patches from celadon_ivi(lts2021 kernel)/ACRN to caas(lts2020 kernel)/QEMU. Add missing patches from lts2021 to lts2020, to make tiling patch work.