### PR TITLE
Fix for STS failure -CVE-2023-21128

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/99_0182-Support-test-skipping-when-power-save-modes-aren-t-e.patch
+++ b/aosp_diff/preliminary/frameworks/base/99_0182-Support-test-skipping-when-power-save-modes-aren-t-e.patch
@@ -1,0 +1,187 @@
+From 0da2704f1e1d9ec54d2b9ee22286924bc260ac47 Mon Sep 17 00:00:00 2001
+From: "Reddy, Alavala Srinivasa" <alavala.srinivasa.reddy@intel.com>
+Date: Tue, 8 Aug 2023 21:50:59 +0530
+Subject: [PATCH] Support test skipping when power save modes aren't enabled.
+
+Some classes of devices will not have auto power save modes enabled. On
+those devices, we should skip tests that require the modes be enabled.
+
+Bug: 240108412
+Bug: 240630396
+Test: Manually go through CTS-V "Ignore Battery Optimizations Test"
+Test: atest CtsUsageStatsTestCases:UsageStatsTest
+Change-Id: Icc64fbe75213386a1f41fae258e50c4032920b0a
+(cherry picked from commit ba3b5d7e53428b8259abe22e7b3f86ed43e8fe33)
+Merged-In: Icc64fbe75213386a1f41fae258e50c4032920b0a
+author Kweku Adams <kwekua@google.com>	Fri Jul 29 18:05:16 2022 +0000
+
+Ported the above patch, Resloved the STS-CVE-2023-2118 Testcase issue .
+Failed details
+STS Module -x86_64 CtsSecurityBulletinHostTestCases
+STS Testcase -android.security.cts.CVE_2023_21128#testPocCVE_2023_21128
+After porting this patch , The STS testcase was Passed.
+
+Signed-off-by: Reddy, Alavala Srinivasa <alavala.srinivasa.reddy@intel.com>
+---
+ .../server/usage/AppStandbyController.java        |  6 ++++--
+ core/api/test-current.txt                         |  2 ++
+ .../android/app/usage/IUsageStatsManager.aidl     |  1 +
+ .../java/android/app/usage/UsageStatsManager.java | 13 +++++++++++++
+ core/java/android/os/IPowerManager.aidl           |  1 +
+ core/java/android/os/PowerManager.java            | 15 +++++++++++++++
+ .../android/server/power/PowerManagerService.java | 11 +++++++++++
+ .../android/server/usage/UsageStatsService.java   |  5 +++++
+ 8 files changed, 52 insertions(+), 2 deletions(-)
+
+diff --git a/apex/jobscheduler/service/java/com/android/server/usage/AppStandbyController.java b/apex/jobscheduler/service/java/com/android/server/usage/AppStandbyController.java
+index d23bef487685..5992da69e2ce 100644
+--- a/apex/jobscheduler/service/java/com/android/server/usage/AppStandbyController.java
++++ b/apex/jobscheduler/service/java/com/android/server/usage/AppStandbyController.java
+@@ -1322,8 +1322,10 @@ public class AppStandbyController
+     @Override
+     @StandbyBuckets public int getAppStandbyBucket(String packageName, int userId,
+             long elapsedRealtime, boolean shouldObfuscateInstantApps) {
+-        if (!mAppIdleEnabled || (shouldObfuscateInstantApps
+-                && mInjector.isPackageEphemeral(userId, packageName))) {
++	if (!mAppIdleEnabled) {
++            return STANDBY_BUCKET_EXEMPTED;
++        }
++        if (shouldObfuscateInstantApps && mInjector.isPackageEphemeral(userId, packageName)) {	
+             return STANDBY_BUCKET_ACTIVE;
+         }
+ 
+diff --git a/core/api/test-current.txt b/core/api/test-current.txt
+index 3c95afa9acd3..617394640bf5 100644
+--- a/core/api/test-current.txt
++++ b/core/api/test-current.txt
+@@ -657,6 +657,7 @@ package android.app.usage {
+ 
+   public final class UsageStatsManager {
+     method public void forceUsageSourceSettingRead();
++    method public boolean isAppStandbyEnabled();
+   }
+ 
+ }
+@@ -1719,6 +1720,7 @@ package android.os {
+   }
+ 
+   public final class PowerManager {
++    method public boolean areAutoPowerSaveModesEnabled();
+     field public static final String ACTION_ENHANCED_DISCHARGE_PREDICTION_CHANGED = "android.os.action.ENHANCED_DISCHARGE_PREDICTION_CHANGED";
+   }
+ 
+diff --git a/core/java/android/app/usage/IUsageStatsManager.aidl b/core/java/android/app/usage/IUsageStatsManager.aidl
+index 585eb61b6f57..376ed20ce7c9 100644
+--- a/core/java/android/app/usage/IUsageStatsManager.aidl
++++ b/core/java/android/app/usage/IUsageStatsManager.aidl
+@@ -42,6 +42,7 @@ interface IUsageStatsManager {
+     UsageEvents queryEventsForPackageForUser(long beginTime, long endTime, int userId, String pkg, String callingPackage);
+     @UnsupportedAppUsage(maxTargetSdk = 30, trackingBug = 170729553)
+     void setAppInactive(String packageName, boolean inactive, int userId);
++    boolean isAppStandbyEnabled();
+     @UnsupportedAppUsage(maxTargetSdk = 30, trackingBug = 170729553)
+     boolean isAppInactive(String packageName, int userId, String callingPackage);
+     void onCarrierPrivilegedAppsChanged();
+diff --git a/core/java/android/app/usage/UsageStatsManager.java b/core/java/android/app/usage/UsageStatsManager.java
+index ac7a31874682..9a841b9e6a81 100644
+--- a/core/java/android/app/usage/UsageStatsManager.java
++++ b/core/java/android/app/usage/UsageStatsManager.java
+@@ -621,6 +621,19 @@ public final class UsageStatsManager {
+     }
+ 
+     /**
++     * Returns whether the app standby bucket feature is enabled.
++     * @hide
++     */
++    @TestApi
++    public boolean isAppStandbyEnabled() {
++	try {
++	    return mService.isAppStandbyEnabled();
++        } catch (RemoteException e) {
++            throw e.rethrowFromSystemServer();
++        }
++    }
++
++    /**    
+      * Returns whether the specified app is currently considered inactive. This will be true if the
+      * app hasn't been used directly or indirectly for a period of time defined by the system. This
+      * could be of the order of several hours or days. Apps are not considered inactive when the
+diff --git a/core/java/android/os/IPowerManager.aidl b/core/java/android/os/IPowerManager.aidl
+index 425e797a9e0e..06ac780a2197 100644
+--- a/core/java/android/os/IPowerManager.aidl
++++ b/core/java/android/os/IPowerManager.aidl
+@@ -51,6 +51,7 @@ interface IPowerManager
+     float getBrightnessConstraint(int constraint);
+     @UnsupportedAppUsage
+     boolean isInteractive();
++    boolean areAutoPowerSaveModesEnabled();
+     boolean isPowerSaveMode();
+     PowerSaveState getPowerSaveState(int serviceType);
+     boolean setPowerSaveModeEnabled(boolean mode);
+diff --git a/core/java/android/os/PowerManager.java b/core/java/android/os/PowerManager.java
+index 3aa0bcb6abee..19b1f2268648 100644
+--- a/core/java/android/os/PowerManager.java
++++ b/core/java/android/os/PowerManager.java
+@@ -1710,6 +1710,21 @@ public final class PowerManager {
+     }
+ 
+     /**
++     * Returns true if the platform has auto power save modes (eg. Doze & app standby) enabled.
++     * This doesn't necessarily mean that the individual features are enabled. For example, if this
++     * returns true, Doze might be enabled while app standby buckets remain disabled.
++     * @hide
++     */
++    @TestApi
++    public boolean areAutoPowerSaveModesEnabled() {
++	try {
++            return mService.areAutoPowerSaveModesEnabled();
++        } catch (RemoteException e) {
++            throw e.rethrowFromSystemServer();
++        }
++    }
++    
++    /** 
+      * Returns true if the device is currently in power save mode.  When in this mode,
+      * applications should reduce their functionality in order to conserve battery as
+      * much as possible.  You can monitor for changes to this state with
+diff --git a/services/core/java/com/android/server/power/PowerManagerService.java b/services/core/java/com/android/server/power/PowerManagerService.java
+index 688a3b2f1d59..b2351cb1ad35 100644
+--- a/services/core/java/com/android/server/power/PowerManagerService.java
++++ b/services/core/java/com/android/server/power/PowerManagerService.java
+@@ -5378,6 +5378,17 @@ public final class PowerManagerService extends SystemService
+         }
+ 
+         @Override // Binder call
++	public boolean areAutoPowerSaveModesEnabled() {
++	    final long ident = Binder.clearCallingIdentity();
++            try {
++	        return mContext.getResources().getBoolean(
++		        com.android.internal.R.bool.config_enableAutoPowerModes);
++            } finally {
++                Binder.restoreCallingIdentity(ident);
++            }
++        }
++
++        @Override // Binder call	
+         public boolean isPowerSaveMode() {
+             final long ident = Binder.clearCallingIdentity();
+             try {
+diff --git a/services/usage/java/com/android/server/usage/UsageStatsService.java b/services/usage/java/com/android/server/usage/UsageStatsService.java
+index 8872e1a1bcbd..7d7657df70e5 100644
+--- a/services/usage/java/com/android/server/usage/UsageStatsService.java
++++ b/services/usage/java/com/android/server/usage/UsageStatsService.java
+@@ -1835,6 +1835,11 @@ public class UsageStatsService extends SystemService implements
+         }
+ 
+         @Override
++	public boolean isAppStandbyEnabled() {
++            return mAppStandby.isAppIdleEnabled();
++        }
++
++        @Override	
+         public boolean isAppInactive(String packageName, int userId, String callingPackage) {
+             final int callingUid = Binder.getCallingUid();
+             try {
+-- 
+2.17.1
+


### PR DESCRIPTION
STS failed details
Module -x86_64 CtsSecurityBulletinHostTestCases
Test Case- android.security.cts.CVE_2023_21128#testPocCVE_2023 As below patch was resolved the STS issue.

Patch details
1)99_0182-Support-test-skipping-when-power-save-modes-aren-t-e.patch

Tracked-On: OAM-111684