### PR TITLE
Fix crash on EmbeddedKitchenSink.

### DIFF
--- a/aosp_diff/celadon_ivi/packages/services/Car/0014-Fix-crash-on-EmbeddedKitchenSink.patch
+++ b/aosp_diff/celadon_ivi/packages/services/Car/0014-Fix-crash-on-EmbeddedKitchenSink.patch
@@ -1,0 +1,45 @@
+From 97d29819488122e5954db2797902e162865584e1 Mon Sep 17 00:00:00 2001
+From: xubing <bing.xu@intel.com>
+Date: Thu, 10 Aug 2023 10:23:18 +0800
+Subject: [PATCH] Fix crash on EmbeddedKitchenSink.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Getting following error while running monkey test-:
+android.view.WindowManager$BadTokenException: Unable to
+add window android.view.ViewRootImpl$W@fa52119 – permission
+denied for window type 2038
+at android.view.ViewRootImpl.setView(ViewRootImpl.java:1213)
+at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:400)
+
+Permission isn't set before app add dialog, we check it first
+and set it by hand
+
+Tracked-On: OAM-111431
+Signed-off-by: xubing <bing.xu@intel.com>
+---
+ .../android/car/kitchensink/UserNoiticeDemoUiService.java  | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/tests/EmbeddedKitchenSinkApp/src/com/google/android/car/kitchensink/UserNoiticeDemoUiService.java b/tests/EmbeddedKitchenSinkApp/src/com/google/android/car/kitchensink/UserNoiticeDemoUiService.java
+index dfe18dca0..502c9bca9 100644
+--- a/tests/EmbeddedKitchenSinkApp/src/com/google/android/car/kitchensink/UserNoiticeDemoUiService.java
++++ b/tests/EmbeddedKitchenSinkApp/src/com/google/android/car/kitchensink/UserNoiticeDemoUiService.java
+@@ -115,6 +115,13 @@ public class UserNoiticeDemoUiService extends Service {
+                 Log.wtf(TAG, "Dialog already created", new RuntimeException());
+                 return;
+             }
++            //if permission isn't set, set by hand
++            if (!Settings.canDrawOverlays(this)) {
++                Intent intent = new Intent();
++                intent.setAction(Settings.ACTION_MANAGE_OVERLAY_PERMISSION);
++                startActivity(intent);
++                return;
++            }
+             mDialog = createDialog();
+             // Necessary permission is auto-granted by car service before starting this.
+             mDialog.getWindow().setType(WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY);
+-- 
+2.34.1
+


### PR DESCRIPTION
Getting following error while running monkey test-: android.view.WindowManager$BadTokenException: Unable to add window android.view.ViewRootImpl$W@fa52119 – permission denied for window type 2038
at android.view.ViewRootImpl.setView(ViewRootImpl.java:1213)

Permission isn't set before app add dialog, we check it first and set it by hand

Tracked-On: OAM-111431