### PR TITLE
Fix random crash on Ximalaya app.

### DIFF
--- a/aosp_diff/celadon_ivi/frameworks/base/0003-Fix-random-crash-on-Ximalaya-app.patch
+++ b/aosp_diff/celadon_ivi/frameworks/base/0003-Fix-random-crash-on-Ximalaya-app.patch
@@ -1,0 +1,79 @@
+From 6cf3f702b7577e1e8deb4f573cfd89474f22e775 Mon Sep 17 00:00:00 2001
+From: xubing <bing.xu@intel.com>
+Date: Thu, 31 Aug 2023 09:24:40 +0800
+Subject: [PATCH] Fix random crash on Ximalaya app.
+
+When zooming in/out on main screen of Ximalaya app, it will crash if
+the point index is invalid, so check it before using.
+
+Tracked-On: OAM-111908
+Signed-off-by: xubing <bing.xu@intel.com>
+---
+ .../android/internal/widget/ViewPager.java    | 23 ++++++++++++++++++-
+ 1 file changed, 22 insertions(+), 1 deletion(-)
+
+diff --git a/core/java/com/android/internal/widget/ViewPager.java b/core/java/com/android/internal/widget/ViewPager.java
+index 1174db5b2cf7..5a6b5f336ff7 100644
+--- a/core/java/com/android/internal/widget/ViewPager.java
++++ b/core/java/com/android/internal/widget/ViewPager.java
+@@ -1857,6 +1857,10 @@ public class ViewPager extends ViewGroup {
+                 }
+ 
+                 final int pointerIndex = ev.findPointerIndex(activePointerId);
++                //Validate pointerIndex before get X value
++                if(pointerIndex < 0 || pointerIndex >= ev.getPointerCount()){
++                    break;
++                }
+                 final float x = ev.getX(pointerIndex);
+                 final float dx = x - mLastMotionX;
+                 final float xDiff = Math.abs(dx);
+@@ -1993,6 +1997,10 @@ public class ViewPager extends ViewGroup {
+             case MotionEvent.ACTION_MOVE:
+                 if (!mIsBeingDragged) {
+                     final int pointerIndex = ev.findPointerIndex(mActivePointerId);
++                    //Validate pointerIndex before get X value
++                    if(pointerIndex < 0 || pointerIndex >= ev.getPointerCount()){
++                        break;
++                    }
+                     final float x = ev.getX(pointerIndex);
+                     final float xDiff = Math.abs(x - mLastMotionX);
+                     final float y = ev.getY(pointerIndex);
+@@ -2019,6 +2027,10 @@ public class ViewPager extends ViewGroup {
+                 if (mIsBeingDragged) {
+                     // Scroll to follow the motion event
+                     final int activePointerIndex = ev.findPointerIndex(mActivePointerId);
++                    //Validate activePointerIndex before get X value
++                    if(activePointerIndex < 0 || activePointerIndex >= ev.getPointerCount()){
++                        break;
++                    }
+                     final float x = ev.getX(activePointerIndex);
+                     needsInvalidate |= performDrag(x, ev.getY(activePointerIndex));
+                 }
+@@ -2043,6 +2055,10 @@ public class ViewPager extends ViewGroup {
+                     }
+ 
+                     final int activePointerIndex = ev.findPointerIndex(mActivePointerId);
++                    //Validate activePointerIndex before get X value
++                    if(activePointerIndex < 0 || activePointerIndex >= ev.getPointerCount()){
++                        break;
++                    }
+                     final float x = ev.getX(activePointerIndex);
+                     final int totalDelta = (int) (x - mInitialMotionX);
+                     final int nextPage = determineTargetPage(
+@@ -2075,7 +2091,12 @@ public class ViewPager extends ViewGroup {
+             }
+             case MotionEvent.ACTION_POINTER_UP:
+                 onSecondaryPointerUp(ev);
+-                mLastMotionX = ev.getX(ev.findPointerIndex(mActivePointerId));
++                final int activePointerIndex = ev.findPointerIndex(mActivePointerId);
++                //Validate activePointerIndex before get X value
++                if(activePointerIndex < 0 || activePointerIndex >= ev.getPointerCount()){
++                    break;
++                }
++                mLastMotionX = ev.getX(activePointerIndex);
+                 break;
+         }
+         if (needsInvalidate) {
+-- 
+2.34.1
+


### PR DESCRIPTION
When zooming in/out on main screen of Ximalaya app, it will crash if the point index is invalid, so check it before using.

Tracked-On: OAM-111908