### PR TITLE
[WA] Add a patch which remove some code to fix a reboot bug

### DIFF
--- a/aosp_diff/celadon_ivi/system/core/0001-WA-remove-some-code-to-fix-a-reboot-bug.patch
+++ b/aosp_diff/celadon_ivi/system/core/0001-WA-remove-some-code-to-fix-a-reboot-bug.patch
@@ -1,0 +1,50 @@
+From e1e7681d21c695518c91476b7ede185c91445baf Mon Sep 17 00:00:00 2001
+From: "Guo, Jade" <jade.guo@intel.com>
+Date: Thu, 7 Sep 2023 16:44:54 +0800
+Subject: [PATCH] [WA] remove some code to fix a reboot bug
+
+System will boot twice after flashing images if we keep this piece of code. Safely remove it to bypass
+the bug.
+
+The code removed is part of the commit a7635718 "Pass wiped and fs_type to vold to format encrypted partition".
+
+Tracked-On: OAM-111863
+Signed-off-by: Guo, Jade <jade.guo@intel.com>
+---
+ fs_mgr/fs_mgr.cpp | 20 --------------------
+ 1 file changed, 20 deletions(-)
+
+diff --git a/fs_mgr/fs_mgr.cpp b/fs_mgr/fs_mgr.cpp
+index 8896ec33c..4f5cdf8f1 100644
+--- a/fs_mgr/fs_mgr.cpp
++++ b/fs_mgr/fs_mgr.cpp
+@@ -1550,26 +1550,6 @@ MountAllResult fs_mgr_mount_all(Fstab* fstab, int mount_mode) {
+                 crypt_footer = true;
+             }
+ 
+-            // EncryptInplace will be used when vdc gives an error or needs to format partitions
+-            // other than /data
+-            if (should_use_metadata_encryption(current_entry) &&
+-                current_entry.mount_point == "/data") {
+-
+-                // vdc->Format requires "ro.crypto.type" to set an encryption flag
+-                encryptable = FS_MGR_MNTALL_DEV_IS_METADATA_ENCRYPTED;
+-                set_type_property(encryptable);
+-
+-                if (!call_vdc({"cryptfs", "encryptFstab", current_entry.blk_device,
+-                               current_entry.mount_point, "true" /* shouldFormat */,
+-                               current_entry.fs_type},
+-                              nullptr)) {
+-                    LERROR << "Encryption failed";
+-                } else {
+-                    userdata_mounted = true;
+-                    continue;
+-                }
+-            }
+-
+             if (fs_mgr_do_format(current_entry, crypt_footer) == 0) {
+                 // Let's replay the mount actions.
+                 i = top_idx - 1;
+-- 
+2.34.1
+


### PR DESCRIPTION
This WA aims to solve the problem that [IVI_BM]The first boot after flashing will reboot twice.
This deletes some code belongs to commit a7635718c459b95c45a09c409460570e564037dc "Pass wiped and fs_type to vold to format encrypted partition".

Tracked-On: OAM-111863