### PR TITLE
Fix for com.android.car.dialer monkey test.

### DIFF
--- a/aosp_diff/celadon_ivi/packages/apps/Car/Dialer/0001-Fix-for-com.android.car.dialer-start-activity-Compon.patch
+++ b/aosp_diff/celadon_ivi/packages/apps/Car/Dialer/0001-Fix-for-com.android.car.dialer-start-activity-Compon.patch
@@ -1,0 +1,29 @@
+From 4eea70596c6d34e3d26a7343f3b46f2a6c6dc0d5 Mon Sep 17 00:00:00 2001
+From: "Reddy, Alavala Srinivasa" <alavala.srinivasa.reddy@intel.com>
+Date: Wed, 6 Sep 2023 11:41:10 +0530
+Subject: [PATCH] Fix for com.android.car.dialer start activity ComponentInfo.
+
+JavaCrash happen on com.android.car.dialer in Monkey Test
+as unable to start activity ComponentInfo
+
+Signed-off-by: Reddy, Alavala Srinivasa <alavala.srinivasa.reddy@intel.com>
+---
+ src/com/android/car/dialer/inject/DialerModules.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/com/android/car/dialer/inject/DialerModules.java b/src/com/android/car/dialer/inject/DialerModules.java
+index ed1682f6..b9ca3506 100644
+--- a/src/com/android/car/dialer/inject/DialerModules.java
++++ b/src/com/android/car/dialer/inject/DialerModules.java
+@@ -53,7 +53,7 @@ public final class DialerModules {
+         @Singleton
+         @Provides
+         static SharedPreferences provideSharedPreferences(@ApplicationContext Context context) {
+-            return PreferenceManager.getDefaultSharedPreferences(context);
++            return PreferenceManager.getDefaultSharedPreferences(context.createDeviceProtectedStorageContext());
+         }
+     }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
Fix for com.android.car.dialer monkey test.

JavaCrash happen on com.android.car.dialer in Monkey Test 
as unable to start activity ComponentInfo

Tracked-On: OAM-111740