### PR TITLE
Modification of IVI audio HAL and kernel

### DIFF
--- a/bsp_diff/celadon_ivi/device/intel/mixins/0001-Modification-of-IVI-kernel.patch
+++ b/bsp_diff/celadon_ivi/device/intel/mixins/0001-Modification-of-IVI-kernel.patch
@@ -1,0 +1,29 @@
+From b9586667d9fc012cc48f68a79eb264a62c926704 Mon Sep 17 00:00:00 2001
+From: celadon <celadon@intel.com>
+Date: Tue, 12 Sep 2023 11:20:31 +0000
+Subject: [PATCH] Modification of IVI kernel
+
+Modified IVI kernel to work for RPL NUC
+- Modified dsp_driver flag from 4 to 1 at BoardConfig.mk
+
+Signed-off-by: Yerriswamy <yerriswamy.kt@intel.com>
+---
+ groups/kernel/BoardConfig.mk | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/groups/kernel/BoardConfig.mk b/groups/kernel/BoardConfig.mk
+index bcfa1fa..58a40a0 100644
+--- a/groups/kernel/BoardConfig.mk
++++ b/groups/kernel/BoardConfig.mk
+@@ -81,7 +81,7 @@ BOARD_KERNEL_CMDLINE += \
+ endif
+ 
+ BOARD_KERNEL_CMDLINE += \
+-      snd_intel_dspcfg.dsp_driver=4 \
++      snd_intel_dspcfg.dsp_driver=1 \
+       snd_soc_core.dyndbg==pmf \
+       snd_hda_core.dyndbg==pmf \
+       snd_hda_ext_core.dyndbg==pmf \
+-- 
+2.39.2
+

--- a/bsp_diff/celadon_ivi/vendor/intel/external/project-celadon/audio/0001-Modification-of-IVI-audio-HAL.patch
+++ b/bsp_diff/celadon_ivi/vendor/intel/external/project-celadon/audio/0001-Modification-of-IVI-audio-HAL.patch
@@ -1,0 +1,93 @@
+From 030fbf04616e4a8c6a5d148236102a8b05b11161 Mon Sep 17 00:00:00 2001
+From: celadon <celadon@intel.com>
+Date: Tue, 12 Sep 2023 10:10:54 +0000
+Subject: [PATCH] Modification of IVI audio HAL
+
+Modified IVI audio HAL to work on RPL NUC
+- Sound card name is changed from avsrt56401 to PCH
+- PCM_DEVICE_AVS macro is changed from 1 to 0
+
+Signed-off-by: Yerriswamy <yerriswamy.kt@intel.com>
+---
+ primary/audio_hw.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/primary/audio_hw.c b/primary/audio_hw.c
+index e1544de..53c9976 100644
+--- a/primary/audio_hw.c
++++ b/primary/audio_hw.c
+@@ -55,7 +55,7 @@
+ #define PCM_CARD_DEFAULT 0
+ 
+ #define PCM_DEVICE 0
+-#define PCM_DEVICE_AVS 1
++#define PCM_DEVICE_AVS 0
+ #define PCM_DEVICE_DUMMY 0
+ /*Note:Original HAL configuration in celadon for primary device*/
+ #define OUT_PERIOD_SIZE_HIFI 960
+@@ -480,7 +480,7 @@ pcm_data_t *route_out_pcm(struct stream_out *out,bus_addresses_t bus_to_device)
+                 else
+                     out->pcm_config->channels = 2;
+             } else {
+-                adev->card = get_pcm_card("avsrt56401");
++                adev->card = get_pcm_card("PCH");
+                 adev->device  = PCM_DEVICE_AVS;
+             }
+             adev->audio_zone = 0; 
+@@ -610,7 +610,7 @@ static int start_input_stream(struct stream_in *in)
+             adev->cardc = get_pcm_card("Dummy");
+             adev->device  = PCM_DEVICE_DUMMY;
+         } else {
+-            adev->cardc = get_pcm_card("avsrt56401");
++            adev->cardc = get_pcm_card("PCH");
+             adev->device  = PCM_DEVICE_AVS;
+         }
+         if (adev->cardc < 0)
+@@ -1666,7 +1666,7 @@ static int adev_set_parameters(struct audio_hw_device *dev, const char *kvpairs)
+         adev->primarycard = get_pcm_card("Dummy");
+         adev->device = PCM_DEVICE_DUMMY;
+     } else {
+-        adev->primarycard = get_pcm_card("avsrt56401");
++        adev->primarycard = get_pcm_card("PCH");
+         adev->device = PCM_DEVICE_AVS;
+         if (adev->primarycard < 0)
+             adev->primarycard = get_pcm_card("Dummy");
+@@ -1864,7 +1864,7 @@ static int adev_open_input_stream(struct audio_hw_device *dev,
+     if (adev->custom_audio)
+         adev->cardc = get_pcm_card("Dummy");
+     else
+-    adev->cardc = get_pcm_card("avsrt56401");
++    adev->cardc = get_pcm_card("PCH");
+ 
+     if (adev->cardc < 0)
+         adev->cardc = get_pcm_card("Dummy");
+@@ -2663,7 +2663,7 @@ static int mixer_setting_for_volume(float left, float right, int audio_zone)
+     struct mixer_ctl *vol_ctl;
+ 
+     ALOGV("%s enter", __func__);
+-    card = get_pcm_card("avsrt56401");
++    card = get_pcm_card("PCH");
+     if (card < 0)
+             card = PCM_CARD_DEFAULT;
+     if (audio_zone == 1) {
+@@ -2715,7 +2715,7 @@ static int adev_set_audio_port_config(struct audio_hw_device *dev ,
+     if (adev->custom_audio)
+         card = get_pcm_card("Dummy");
+     else
+-        card = get_pcm_card("avsrt56401");
++        card = get_pcm_card("PCH");
+     if (card < 0)
+         card = get_pcm_card("Dummy");
+     adev->ar = audio_route_init(card, mixer_path);
+@@ -2833,7 +2833,7 @@ static int adev_open(const hw_module_t* module, const char* name,
+         if (adev->custom_audio)
+             card = get_pcm_card("Dummy");
+         else
+-            card = get_pcm_card("avsrt56401");
++            card = get_pcm_card("PCH");
+         if (card < 0)
+             card = get_pcm_card("Dummy");
+         adev->ar = audio_route_init(card, mixer_path);
+-- 
+2.39.2
+


### PR DESCRIPTION
Modified IVI audio HAL to work for RPL NUC
- Sound card name is changed from avsrt56401 to PCH
- PCM_DEVICE_AVS macro is changed from 1 to 0
- Modified dsp_driver flag from 4 to 1 at BoardConfig.mk