### PR TITLE
Disable mandatory memset in allocate() of scudo to improve performance

### DIFF
--- a/bsp_diff/common/device/intel/mixins/0005-Disable-mandatory-memset-in-allocate-of-scudo-to-imp.patch
+++ b/bsp_diff/common/device/intel/mixins/0005-Disable-mandatory-memset-in-allocate-of-scudo-to-imp.patch
@@ -1,0 +1,26 @@
+From 9e1d2ea605fd614f2bb93ac5dad89e525600be74 Mon Sep 17 00:00:00 2001
+From: Zhiwei Li <zhiwei.li@intel.com>
+Date: Fri, 1 Sep 2023 08:25:14 +0000
+Subject: [PATCH] Disable mandatory memset in allocate() of scudo to improve
+ performance
+
+Tracked-On: OAM-112205
+Signed-off-by: Zhiwei Li <zhiwei.li@intel.com>
+---
+ groups/device-specific/celadon_ivi/BoardConfig.mk | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/groups/device-specific/celadon_ivi/BoardConfig.mk b/groups/device-specific/celadon_ivi/BoardConfig.mk
+index f7511e9..9f4738b 100644
+--- a/groups/device-specific/celadon_ivi/BoardConfig.mk
++++ b/groups/device-specific/celadon_ivi/BoardConfig.mk
+@@ -56,3 +56,6 @@ BUILD_BROKEN_USES_BUILD_HOST_EXECUTABLE := true
+ BUILD_BROKEN_USES_BUILD_COPY_HEADERS := true
+ # PRODUCT_COPY_FILES directives.
+ BUILD_BROKEN_ELF_PREBUILT_PRODUCT_COPY_FILES := true
++
++#disable mandatory zero_content to improve performance
++MALLOC_ZERO_CONTENTS := false
+-- 
+2.34.1
+


### PR DESCRIPTION
Tracked-On: OAM-112205