### PR TITLE
Fix dialer app crash during monkey test

### DIFF
--- a/aosp_diff/celadon_ivi/packages/apps/Car/Dialer/0001-Fix-dailer-app-crash-during-monkey-test.patch
+++ b/aosp_diff/celadon_ivi/packages/apps/Car/Dialer/0001-Fix-dailer-app-crash-during-monkey-test.patch
@@ -1,0 +1,31 @@
+From d982f017bb4717acbc926ddc0f205548e3bd1710 Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Thu, 14 Sep 2023 11:50:02 +0530
+Subject: [PATCH] Fix dailer app crash during monkey test
+
+Check the bluetooth device object before sending the SMS.
+
+Tracked-On: OAM-112162
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ src/com/android/car/dialer/telecom/UiCallManager.java | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/com/android/car/dialer/telecom/UiCallManager.java b/src/com/android/car/dialer/telecom/UiCallManager.java
+index b4924657..a4e1d2c3 100644
+--- a/src/com/android/car/dialer/telecom/UiCallManager.java
++++ b/src/com/android/car/dialer/telecom/UiCallManager.java
+@@ -259,8 +259,8 @@ public final class UiCallManager {
+         bundle.putString(CarVoiceInteractionSession.KEY_PHONE_NUMBER, number);
+         bundle.putString(CarVoiceInteractionSession.KEY_RECIPIENT_NAME, name);
+         bundle.putString(CarVoiceInteractionSession.KEY_RECIPIENT_UID, uid);
+-        bundle.putString(CarVoiceInteractionSession.KEY_DEVICE_ADDRESS, device.getAddress());
+-        bundle.putString(CarVoiceInteractionSession.KEY_DEVICE_NAME, device.getName());
++        bundle.putString(CarVoiceInteractionSession.KEY_DEVICE_ADDRESS, device == null ? null : device.getAddress());
++        bundle.putString(CarVoiceInteractionSession.KEY_DEVICE_NAME, device == null ? null : device.getName());
+ 
+         Context context = activity.getApplicationContext();
+         Intent intent = new Intent(context, MessagingService.class)
+-- 
+2.17.1
+


### PR DESCRIPTION
Check the bluetooth device object before sending the SMS.

Tracked-On: OAM-112162
Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
