### PR TITLE
[WA] Add a revert patch to fix a perfetto issue

### DIFF
--- a/bsp_diff/common/kernel/linux-intel-lts2021/0001-WA-Revert-f2fs-Fix-f2fs_truncate_partial_nodes-ftrac.patch
+++ b/bsp_diff/common/kernel/linux-intel-lts2021/0001-WA-Revert-f2fs-Fix-f2fs_truncate_partial_nodes-ftrac.patch
@@ -1,0 +1,30 @@
+From ca0eb8846b980f9c62226bf796dc6e1625953d3f Mon Sep 17 00:00:00 2001
+From: "Guo, Jade" <jade.guo@intel.com>
+Date: Thu, 14 Sep 2023 14:51:15 +0800
+Subject: [PATCH] [WA]Revert "f2fs: Fix f2fs_truncate_partial_nodes ftrace
+ event"
+
+This reverts commit 14bb1fb893db1d915c98fce24263c0f42c259579 to fix the Perfetto problem.
+
+Tracked-On: OAM-112068
+Signed-off-by: Guo, Jade <jade.guo@intel.com>
+---
+ include/trace/events/f2fs.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/trace/events/f2fs.h b/include/trace/events/f2fs.h
+index e6ec99ed670b..ee413941be76 100644
+--- a/include/trace/events/f2fs.h
++++ b/include/trace/events/f2fs.h
+@@ -513,7 +513,7 @@ TRACE_EVENT(f2fs_truncate_partial_nodes,
+ 	TP_STRUCT__entry(
+ 		__field(dev_t,	dev)
+ 		__field(ino_t,	ino)
+-		__array(nid_t,	nid, 3)
++		__field(nid_t,	nid[3])
+ 		__field(int,	depth)
+ 		__field(int,	err)
+ 	),
+-- 
+2.34.1
+


### PR DESCRIPTION
This commit adds a patch which revert 14bb1fb893db1d915c98fce24263c0f42c259579 to fix the Pefetto problem.

Tracked-On: OAM-112068