### PR TITLE
Fix for Pointer location in Developer options.

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/99_0197-Fix-for-Pointer-location-in-Developer-options.patch
+++ b/aosp_diff/preliminary/frameworks/base/99_0197-Fix-for-Pointer-location-in-Developer-options.patch
@@ -1,0 +1,31 @@
+From 34e612f8abf367769b9baf8c9bb4d36d8374534d Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Thu, 21 Sep 2023 11:47:30 +0530
+Subject: [PATCH] Fix for Pointer location in Developer options.
+
+Add SYSTEM_FLAG_SHOW_FOR_ALL_USERS to show
+pointer_location for all users.
+
+Reference-: https://cs.android.com/android/_/android/platform/frameworks/base/+/9762753c0a05fecf7d75d2253929225f0f8474cb
+
+Tracked-On: OAM-110075
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ services/core/java/com/android/server/wm/DisplayPolicy.java | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/services/core/java/com/android/server/wm/DisplayPolicy.java b/services/core/java/com/android/server/wm/DisplayPolicy.java
+index b64be7ce9e94..48c4515cb61f 100644
+--- a/services/core/java/com/android/server/wm/DisplayPolicy.java
++++ b/services/core/java/com/android/server/wm/DisplayPolicy.java
+@@ -3320,6 +3320,7 @@ public class DisplayPolicy {
+         lp.flags = WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
+                 | WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+                 | WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN;
++        lp.privateFlags |= LayoutParams.SYSTEM_FLAG_SHOW_FOR_ALL_USERS;
+         lp.setFitInsetsTypes(0);
+         lp.layoutInDisplayCutoutMode = LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS;
+         if (ActivityManager.isHighEndGfx()) {
+-- 
+2.17.1
+


### PR DESCRIPTION
Add SYSTEM_FLAG_SHOW_FOR_ALL_USERS to show
pointer_location for all users.

Reference-: https://cs.android.com/android/_/android/platform/frameworks/base/+/9762753c0a05fecf7d75d2253929225f0f8474cb

Tracked-On: OAM-110075