### PR TITLE
Fix Automotive Ethernet can not boot up success

### DIFF
--- a/bsp_diff/common/kernel/linux-intel-lts2021/0025-Fix-Automotive-Ethernet-can-not-boot-up-success.patch
+++ b/bsp_diff/common/kernel/linux-intel-lts2021/0025-Fix-Automotive-Ethernet-can-not-boot-up-success.patch
@@ -1,0 +1,37 @@
+From 0200313e7ef921ba204cb53d50d8fbd3e7005ce9 Mon Sep 17 00:00:00 2001
+From: "Ye, Zhao" <zhao.ye@intel.com>
+Date: Wed, 27 Sep 2023 08:42:36 +0000
+Subject: [PATCH] Fix Automotive Ethernet can not boot up success
+
+Add some delay after tx_enable.
+TODO: this may needs to be fixed for a better way.
+
+Test:
+after add this patch, Automotive ethernet can
+boot up success, adb connect through this interface
+success
+
+Tracked-On: OAM-112426
+Signed-off-by: Ye, Zhao <zhao.ye@intel.com>
+---
+ drivers/net/phy/marvell-88q2xxx.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/phy/marvell-88q2xxx.c b/drivers/net/phy/marvell-88q2xxx.c
+index f5071d6cebf0..31f0a022fc8e 100644
+--- a/drivers/net/phy/marvell-88q2xxx.c
++++ b/drivers/net/phy/marvell-88q2xxx.c
+@@ -45,7 +45,9 @@ struct mv2122_data {
+ 
+ static int mv88q2xxx_tx_enable(struct phy_device *phydev)
+ {
+-	return phy_clear_bits_mmd(phydev, 3 ,0x8000, 0x8);
++	int ret = phy_clear_bits_mmd(phydev, 3 ,0x8000, 0x8);
++	msleep(10);
++	return ret;
+ }
+ 
+ static int mv88q2xxx_tx_disable(struct phy_device *phydev)
+-- 
+2.34.1
+


### PR DESCRIPTION
Add some delay after tx_enable.
TODO: this may needs to be fixed for a better way.

Test:
after add this patch, Automotive ethernet can
boot up success, adb connect through this interface success

Tracked-On: OAM-112426