### PR TITLE
Fix for VtsHalGraphicsComposerV2_4TargetTest Case

### DIFF
--- a/bsp_diff/common/device/intel/mixins/0005-Fix-for-VtsHalGraphicsComposerV2_4TargetTest-Case.patch
+++ b/bsp_diff/common/device/intel/mixins/0005-Fix-for-VtsHalGraphicsComposerV2_4TargetTest-Case.patch
@@ -1,0 +1,45 @@
+From 6a58e0087fda95bc729c676bf68a866365291be7 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Thu, 5 Oct 2023 16:30:34 +0530
+Subject: [PATCH] Fix for VtsHalGraphicsComposerV2_4TargetTest Case
+
+while running the vts module following fail to push error is occurring:
+Attempting to push dir 'VtsHalGraphicsComposerV2_4TargetTest' to an
+existing device file /data/local/tmp/.
+
+When it try to push directory, it always shows that dir already exists
+even if it is not there. this was checking dir using 'ls' command and
+check for 'No such file or directory' output. But 'ls' command was
+giving always 'Invalid argument' and in that case it was always
+returning showing dir exists. During 'ls' command syscall for 'prctrl'
+was assigning VMA name, but VMA feature was not enabled, so it was
+assigning default error code EINVAL. Enabling this feature by enabling
+this flag-: CONFIG_ANON_VMA_NAME
+
+Test:
+Run 'ls' command in adb shell for some file or directory which does not
+exists, it should give output "No such file or Directory" instead of
+"Invalid argument".
+
+Tracked-On: OAM-112486
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../gmin64/config-lts/linux-intel-lts2021/x86_64_defconfig      | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/groups/kernel/gmin64/config-lts/linux-intel-lts2021/x86_64_defconfig b/groups/kernel/gmin64/config-lts/linux-intel-lts2021/x86_64_defconfig
+index eba6e3f..be75ceb 100644
+--- a/groups/kernel/gmin64/config-lts/linux-intel-lts2021/x86_64_defconfig
++++ b/groups/kernel/gmin64/config-lts/linux-intel-lts2021/x86_64_defconfig
+@@ -932,7 +932,7 @@ CONFIG_ARCH_HAS_PKEYS=y
+ #
+ # CONFIG_READ_ONLY_THP_FOR_FS is not set
+ CONFIG_ARCH_HAS_PTE_SPECIAL=y
+-# CONFIG_ANON_VMA_NAME is not set
++CONFIG_ANON_VMA_NAME=y
+ # CONFIG_LRU_GEN is not set
+ 
+ #
+-- 
+2.17.1
+


### PR DESCRIPTION
while running the vts module following fail to
push error is occurring-: Attempting to push dir
'VtsHalGraphicsComposerV2_4TargetTest' to an
existing device file /data/local/tmp/.

When it try to push directory, it always shows that dir already exists even if it is not there. this
was checking dir using 'ls' command and check for
'No such file or directory' output. But 'ls' command was giving always 'Invalid argument' and in that case it was always returning showing dir exists.
During 'ls' command syscall for 'prctrl' was assiging VMA name, but VMA feature was not enabled, so it was assiging default error code EINVAL.
Enabling this feature by enabling this flag-:
CONFIG_ANON_VMA_NAME

Test:
Run 'ls' command in adb shell for some file or directory which does not exists, it should give output
"No such file or Directory" instead of "Invalid argument".

Tracked-On: OAM-112486