### PR TITLE
Enable COREAVX2 flag for libhwui

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/99_0114-Add-COREAVX2-enable-flag-for-libhwui.patch
+++ b/aosp_diff/preliminary/frameworks/base/99_0114-Add-COREAVX2-enable-flag-for-libhwui.patch
@@ -1,0 +1,28 @@
+From ea76aa3bb8b57be4882233087b0496f031b61c82 Mon Sep 17 00:00:00 2001
+From: vraghavulu <venkat.raghavulu@intel.com>
+Date: Wed, 4 Oct 2023 10:52:07 +0000
+Subject: [PATCH] Add AVX2 enable flag for libhwui
+
+ Adding CORE-AVX2 as CFLAGs so as to generate AVX2
+instructions for libhwui library
+
+Signed-off-by: vraghavulu <venkat.raghavulu@intel.com>
+---
+ libs/hwui/Android.bp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libs/hwui/Android.bp b/libs/hwui/Android.bp
+index ad9aa6cdd3d9..413c5917c85d 100644
+--- a/libs/hwui/Android.bp
++++ b/libs/hwui/Android.bp
+@@ -55,6 +55,7 @@ cc_defaults {
+         // GCC false-positives on this warning, and since we -Werror that's
+         // a problem
+         "-Wno-free-nonheap-object",
++        "-march=core-avx2",
+     ],
+ 
+     include_dirs: [
+-- 
+2.39.2
+


### PR DESCRIPTION
Android libhwui library is built with with COREAVX2
 instructions for improved performance.