### PR TITLE
Add Marvell MDIO PHY test mode registor read/write function

### DIFF
--- a/bsp_diff/common/kernel/linux-intel-lts2021/0027-Add-marvell-MDIO-phy-test-mode-register-read-write-f.patch
+++ b/bsp_diff/common/kernel/linux-intel-lts2021/0027-Add-marvell-MDIO-phy-test-mode-register-read-write-f.patch
@@ -1,0 +1,66 @@
+From 8428b3c0b22a5173bb9cf670c6b889859d548620 Mon Sep 17 00:00:00 2001
+From: Zhao Ye <zhao.ye@intel.com>
+Date: Wed, 27 Sep 2023 12:15:37 +0800
+Subject: [PATCH] Add marvell MDIO phy test mode register read/write function
+
+Tracked-On: OAM-112419
+Signed-off-by: Zhao Ye <zhao.ye@intel.com>
+---
+ drivers/net/phy/phylink.c | 14 ++++++++++++++
+ include/uapi/linux/mii.h  |  5 +++++
+ 2 files changed, 19 insertions(+)
+
+diff --git a/drivers/net/phy/phylink.c b/drivers/net/phy/phylink.c
+index 5d5c0e5e6ba7..69bc1c056aaa 100644
+--- a/drivers/net/phy/phylink.c
++++ b/drivers/net/phy/phylink.c
+@@ -1939,8 +1939,15 @@ static int phylink_phy_read(struct phylink *pl, unsigned int phy_id,
+ 		case MII_BMSR:
+ 		case MII_PHYSID1:
+ 		case MII_PHYSID2:
++		case MII_TESTMODE:
+ 			devad = __ffs(phydev->c45_ids.mmds_present);
+ 			break;
++		case MII_PCSControl1:
++		case MII_PCSControl2:
++			devad = __ffs(phydev->c45_ids.mmds_present);
++			/* subdev is 3, default subdev is 1 */
++			devad += (MDIO_MMD_PCS - MDIO_MMD_PMAPMD);
++			break;
+ 		case MII_ADVERTISE:
+ 		case MII_LPA:
+ 			if (!(phydev->c45_ids.mmds_present & MDIO_DEVS_AN))
+@@ -1979,7 +1986,14 @@ static int phylink_phy_write(struct phylink *pl, unsigned int phy_id,
+ 		case MII_BMSR:
+ 		case MII_PHYSID1:
+ 		case MII_PHYSID2:
++		case MII_TESTMODE:
++			devad = __ffs(phydev->c45_ids.mmds_present);
++			break;
++		case MII_PCSControl1:
++		case MII_PCSControl2:
+ 			devad = __ffs(phydev->c45_ids.mmds_present);
++			/* subdev is 3, default subdev is 1 */
++			devad += (MDIO_MMD_PCS - MDIO_MMD_PMAPMD);
+ 			break;
+ 		case MII_ADVERTISE:
+ 		case MII_LPA:
+diff --git a/include/uapi/linux/mii.h b/include/uapi/linux/mii.h
+index 39f7c44baf53..3e8332305251 100644
+--- a/include/uapi/linux/mii.h
++++ b/include/uapi/linux/mii.h
+@@ -174,6 +174,11 @@
+ #define MII_MMD_CTRL_INCR_RDWT	0x8000	/* post increment on reads & writes */
+ #define MII_MMD_CTRL_INCR_ON_WT	0xC000	/* post increment on writes only */
+ 
++/* MDIO PHY device test mode control register fields */
++#define MII_TESTMODE 	  	0x0904	/* Test mode setting	       */
++#define MII_PCSControl1 	0x0900	/* PCS control 1	       */
++#define MII_PCSControl2 	0xFD00	/* PCS control 2	       */
++
+ /* This structure is used in all SIOCxMIIxxx ioctl calls */
+ struct mii_ioctl_data {
+ 	__u16		phy_id;
+-- 
+2.25.1
+


### PR DESCRIPTION
Tests:
1, Download MDIO tools: https://github.com/PieVo/mdio-tool.git 2, Compile the tool to binary "mdio-tool", and adb push to system/bin 3, Open Marvell PHY test mode 1 : mdio-tool w eth1 0x904 0x2000 4, Open Marvell PHY loop back mode : mdio-tool w eth1 0x900 0x4000

Tracked-On: OAM-112419