### PR TITLE
REVERTME: Increase number of patches limit  for apply_patch

### DIFF
--- a/apply_patch.sh
+++ b/apply_patch.sh
@@ -33,8 +33,8 @@ function apply()
             echo "Applying ${name}"
             patch=${root}/${proj}/${name}
             change_id=`grep -w "^Change-Id:" ${patch} | awk '{print $2}'`
-            # we limit the log to 200 commits, or it can be very slow
-            applied=`git log -200 | grep -w "^    Change-Id: ${change_id}" 2>/dev/null`
+            # we limit the log to 250 commits, or it can be very slow
+            applied=`git log -250 | grep -w "^    Change-Id: ${change_id}" 2>/dev/null`
             if [[ -z "${applied}" ]]; then
                 git am -k -3 --ignore-space-change --ignore-whitespace ${patch}
                 if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
Increase number of patches limit  for apply_patch

As of now apply_patch only checks for 200 patches in a folder to apply "Already applied" tag. 
Increasing the same to 250 as the number of Patches in framework-base folder is more than 200.
This will enable Lunch to not try and apply already applied patches till the number of Patches in a folder reaches 250+.

Tracked-On: OAM-112678