### PR TITLE
Fix for default notification sound.

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/99_0198-Fix-for-default-notification-sound.patch
+++ b/aosp_diff/preliminary/frameworks/base/99_0198-Fix-for-default-notification-sound.patch
@@ -1,0 +1,35 @@
+From ff2bd4980b2d85f5c12d1fe396f30e3575ee50eb Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Mon, 16 Oct 2023 08:55:15 +0530
+Subject: [PATCH] Fix for default notification sound.
+
+"Default notification sound" value is set 'none' in Settings->Sound
+option. this was due to missing file Tethys.ogg.
+
+Added Tethys.ogg file for audio notification.
+
+Test:
+Open Settings->Sound option in Settings app and check for
+"Default notification sound" value. it should not be none.
+
+Tracked-On: OAM-112674
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ data/sounds/AllAudio.mk | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/data/sounds/AllAudio.mk b/data/sounds/AllAudio.mk
+index c6c7d3bca724..db71237cd3fe 100644
+--- a/data/sounds/AllAudio.mk
++++ b/data/sounds/AllAudio.mk
+@@ -111,6 +111,7 @@ PRODUCT_COPY_FILES += \
+     $(LOCAL_PATH)/notifications/pizzicato.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/notifications/pizzicato.ogg \
+     $(LOCAL_PATH)/notifications/regulus.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/notifications/regulus.ogg \
+     $(LOCAL_PATH)/notifications/sirius.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/notifications/sirius.ogg \
++    $(LOCAL_PATH)/notifications/ogg/Tethys.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/notifications/Tethys.ogg \
+     $(LOCAL_PATH)/notifications/tweeters.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/notifications/tweeters.ogg \
+     $(LOCAL_PATH)/notifications/vega.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/notifications/vega.ogg \
+     $(LOCAL_PATH)/ringtones/ANDROMEDA.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/ringtones/ANDROMEDA.ogg \
+-- 
+2.17.1
+


### PR DESCRIPTION
"Default notification sound" value is set 'none' in Settings->Sound option. this was due to missing file Tethys.ogg.

Added Tethys.ogg file for audio notification.

Test:
Open Settings->Sound option in Settings app and check for "Default notification sound" value. it should not be none.

Tracked-On: OAM-112674