### PR TITLE
Remove NetworkPreferenceApp and CarRadioApp from default installed APP

### DIFF
--- a/aosp_diff/preliminary/packages/services/Car/0001-Remove-NetworkPreferenceApp-and-CarRadioApp-from-def.patch
+++ b/aosp_diff/preliminary/packages/services/Car/0001-Remove-NetworkPreferenceApp-and-CarRadioApp-from-def.patch
@@ -1,0 +1,37 @@
+From fd5ffa9f766dcfcaad02e04cc67e20018e3bfea3 Mon Sep 17 00:00:00 2001
+From: "Guo, Jade" <jade.guo@intel.com>
+Date: Thu, 19 Oct 2023 09:41:52 +0800
+Subject: [PATCH] Remove NetworkPreferenceApp and CarRadioApp from default
+ installed APP
+
+Remove NetworkPreferenceAPP and CarRadioApp for now since they are not used.
+
+Tracked-On: OAM-112837
+Signed-off-by: Guo, Jade <jade.guo@intel.com>
+---
+ car_product/build/car.mk | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/car_product/build/car.mk b/car_product/build/car.mk
+index f24aaa7d3..7223d01b0 100644
+--- a/car_product/build/car.mk
++++ b/car_product/build/car.mk
+@@ -44,7 +44,6 @@ PRODUCT_PACKAGES += \
+     GarageModeTestApp \
+     ExperimentalCarService \
+     BugReportApp \
+-    NetworkPreferenceApp \
+     SampleCustomInputService \
+     AdasLocationTestApp \
+     curl \
+@@ -125,7 +124,6 @@ PRODUCT_PACKAGES += \
+     CarService \
+     CarShell \
+     CarDialerApp \
+-    CarRadioApp \
+     OverviewApp \
+     CarLauncher \
+     CarSystemUI \
+-- 
+2.34.1
+


### PR DESCRIPTION
Remove NetworkPreferenceAPP and CarRadioApp for now since they are not used.

Tests done: Verified device boot to UI. Verified the mentioned apps are removed.

Tracked-On: OAM-112837