### PR TITLE
Fix duplicated app icons on MD Launcher

### DIFF
--- a/aosp_diff/preliminary/packages/services/Car/0016-Fix-duplicated-app-icons-on-MD-Launcher.patch
+++ b/aosp_diff/preliminary/packages/services/Car/0016-Fix-duplicated-app-icons-on-MD-Launcher.patch
@@ -1,0 +1,38 @@
+From 18033713ef735ea61cfab49787150a671dc3aa89 Mon Sep 17 00:00:00 2001
+From: xubing <bing.xu@intel.com>
+Date: Thu, 19 Oct 2023 13:55:54 +0800
+Subject: [PATCH] Fix duplicated app icons on MD Launcher
+
+Some apps include media service, MD Launcher will draw
+app icon twice.
+
+Tracked-On:
+Signed-off-by: xubing <bing.xu@intel.com>
+---
+ .../car/multidisplay/launcher/AppListLiveData.java       | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppListLiveData.java b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppListLiveData.java
+index 6eaaa0746..024438e20 100644
+--- a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppListLiveData.java
++++ b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppListLiveData.java
+@@ -61,7 +61,16 @@ class AppListLiveData extends LiveData<List<AppEntry>> {
+                 List<ResolveInfo> mediaServices = mPackageManager.queryIntentServices(
+                         new Intent(MediaBrowserService.SERVICE_INTERFACE),
+                         PackageManager.GET_RESOLVED_FILTER);
++                boolean isAppIconAvailable = false;
+                 for (ResolveInfo info : mediaServices) {
++                    //Don't show the icon  as it is shown on app
++                    for (ResolveInfo app : apps) {
++                        if (info.serviceInfo.packageName.equals(app.activityInfo.packageName)) {
++                            isAppIconAvailable = true;
++                            break;
++                        }
++                    }
++                    if (isAppIconAvailable) continue;
+                     AppEntry entry = new AppEntry(info, mPackageManager, true);
+                     entries.add(entry);
+                 }
+-- 
+2.34.1
+


### PR DESCRIPTION
Some apps include media service, MD Launcher will draw app icon twice.

Tracked-On: OAM-112750