### PR TITLE
Fix for green overlay during video playback with SG1

### DIFF
--- a/bsp_diff/cic_cloud/vendor/intel/external/project-celadon/minigbm/0007-Fix-for-green-overlay-during-video-playback-with-SG1.patch
+++ b/bsp_diff/cic_cloud/vendor/intel/external/project-celadon/minigbm/0007-Fix-for-green-overlay-during-video-playback-with-SG1.patch
@@ -1,0 +1,70 @@
+From ee92befcabe5f746b35bbd9b234be5fb4f27fa3a Mon Sep 17 00:00:00 2001
+From: Marc Mao <marc.mao@intel.com>
+Date: Thu, 19 Oct 2023 13:39:07 +0000
+Subject: [PATCH] Fix for green overlay during video playback with SG1
+
+Buffer is created with 32 lines alignment for SG1 whereas the omx uses
+64 lines alignment which causes the green bar in top.
+
+Fix the issue by modifying the alignment to 64 while creating the
+buffer for all platforms.
+
+Change-Id: I89346107bfa5658230ebb42846dc0651fba31aa4
+Tracked-On: OAM-112867
+Signed-off-by: Marc Mao <marc.mao@intel.com>
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ i915.c | 34 ++++++++++++++++------------------
+ 1 file changed, 16 insertions(+), 18 deletions(-)
+
+diff --git a/i915.c b/i915.c
+index 685db70..b458e87 100644
+--- a/i915.c
++++ b/i915.c
+@@ -322,27 +322,25 @@ static int i915_align_dimensions(struct bo *bo, uint32_t tiling, uint32_t *strid
+ 		}
+ 		break;
+ 	}
+-	if (i915->genx10 >= 125) {
+-		/*
+-		 * The alignment calculated above is based on the full size luma plane and to have
+-		 * chroma
+-		 * planes properly aligned with subsampled formats, we need to multiply luma
+-		 * alignment by
+-		 * subsampling factor.
+-		 */
+-		switch (bo->meta.format) {
+-		case DRM_FORMAT_YVU420_ANDROID:
+-		case DRM_FORMAT_YVU420:
+-			horizontal_alignment *= 2;
++	/*
++	 * The alignment calculated above is based on the full size luma plane and to have
++	 * chroma
++	 * planes properly aligned with subsampled formats, we need to multiply luma
++	 * alignment by
++	 * subsampling factor.
++	 */
++	switch (bo->meta.format) {
++	case DRM_FORMAT_YVU420_ANDROID:
++	case DRM_FORMAT_YVU420:
++		horizontal_alignment *= 2;
+ 
+-		/* Fall through */
++	/* Fall through */
+ 
+-		case DRM_FORMAT_NV12:
+-			vertical_alignment *= 2;
+-			break;
+-		}
+-		i915_private_align_dimensions(bo->meta.format, &vertical_alignment);
++	case DRM_FORMAT_NV12:
++		vertical_alignment *= 2;
++		break;
+ 	}
++	i915_private_align_dimensions(bo->meta.format, &vertical_alignment);
+ 	*aligned_height = ALIGN(*aligned_height, vertical_alignment);
+ 
+ #ifdef USE_GRALLOC1
+-- 
+2.39.2
+


### PR DESCRIPTION
Buffer is created with 32 lines alignment for SG1 whereas the omx uses 64 lines alignment which causes the green bar in top.

Fix the issue by modifying the alignment to 64 while creating the buffer for all platforms.

Change-Id: I89346107bfa5658230ebb42846dc0651fba31aa4
Tracked-On: OAM-112867