### PR TITLE
Fix duplicated app icons & navigation keys issues on MD Launcher.

### DIFF
--- a/aosp_diff/preliminary/packages/services/Car/0016-Fix-duplicated-app-icons-navigation-keys-issues-on-M.patch
+++ b/aosp_diff/preliminary/packages/services/Car/0016-Fix-duplicated-app-icons-navigation-keys-issues-on-M.patch
@@ -1,0 +1,79 @@
+From 12174fdc665d6ee615381cae447297774942eeed Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Fri, 20 Oct 2023 10:43:43 +0530
+Subject: [PATCH] Fix duplicated app icons & navigation keys issues on MD
+ Launcher.
+
+MultiDisplay launcher is having following 2 issues:
+1) Some apps include media service, in those few apps do not have
+launcher activity. these apps are getting included in launcher
+by querying all MediaBrowsingService apps. Now some apps are getting
+included two times, one based on MediaBrowsingService & second based
+on launcher category.
+2) Navigation keys are showing in MD Launcher app for driver user.
+Driver user uses Car Launcher and it already is having navigation bar.
+
+Include apps based on only launcher category, if it have launcher
+activity. Also Hide navigation keys in MD launcher for driver user.
+
+Tests:
+Install some media app ex. prime video and open MD launcher.
+it should show prime video app only one time and also MD launcher
+should not show navigation keys.
+
+Tracked-On: OAM-112750 OAM-112847
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../android/car/multidisplay/launcher/AppListLiveData.java    | 4 ++++
+ .../android/car/multidisplay/launcher/LauncherActivity.java   | 4 +++-
+ .../car/multidisplay/launcher/PinnedAppListLiveData.java      | 4 ++++
+ 3 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppListLiveData.java b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppListLiveData.java
+index 6eaaa0746..a31ec458b 100644
+--- a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppListLiveData.java
++++ b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppListLiveData.java
+@@ -62,6 +62,10 @@ class AppListLiveData extends LiveData<List<AppEntry>> {
+                         new Intent(MediaBrowserService.SERVICE_INTERFACE),
+                         PackageManager.GET_RESOLVED_FILTER);
+                 for (ResolveInfo info : mediaServices) {
++                    Intent packageLaunchIntent = mPackageManager.getLaunchIntentForPackage(info.serviceInfo.packageName);
++                    if (packageLaunchIntent != null) {
++                        continue;
++                    }
+                     AppEntry entry = new AppEntry(info, mPackageManager, true);
+                     entries.add(entry);
+                 }
+diff --git a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/LauncherActivity.java b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/LauncherActivity.java
+index 04a5e40ee..a14e2594f 100644
+--- a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/LauncherActivity.java
++++ b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/LauncherActivity.java
+@@ -116,7 +116,9 @@ public class LauncherActivity extends FragmentActivity implements AppPickedCallb
+         mCar = Car.createCar(getApplicationContext());
+ 	mZoneManager = (CarOccupantZoneManager) mCar.getCarManager(Car.CAR_OCCUPANT_ZONE_SERVICE);
+         mDisplayId = getLauncherDisplayId();
+-        createNavigationKeysOverlay(mOverlay != null);
++        if (android.os.Process.myUserHandle().getIdentifier() != ActivityManager.getCurrentUser()) {
++            createNavigationKeysOverlay(mOverlay != null);
++        }
+ 
+         mRootView.setOnApplyWindowInsetsListener((view, insets) -> {
+             mRootView.setPadding(0, 0, 0, insets.getSystemWindowInsetBottom());
+diff --git a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/PinnedAppListLiveData.java b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/PinnedAppListLiveData.java
+index ec966b86b..b2f4fc13c 100644
+--- a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/PinnedAppListLiveData.java
++++ b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/PinnedAppListLiveData.java
+@@ -88,6 +88,10 @@ class PinnedAppListLiveData extends LiveData<List<AppEntry>> {
+                         new Intent(MediaBrowserService.SERVICE_INTERFACE),
+                         PackageManager.GET_RESOLVED_FILTER);
+                 for (ResolveInfo info : mediaServices) {
++                    Intent packageLaunchIntent = mPackageManager.getLaunchIntentForPackage(info.serviceInfo.packageName);
++                    if (packageLaunchIntent != null) {
++                        continue;
++                    }
+                     AppEntry entry = new AppEntry(info, mPackageManager, true);
+                     entries.add(entry);
+                 }
+-- 
+2.17.1
+


### PR DESCRIPTION
MultiDisplay launcher is having following 2 issues: 1) Some apps include media service, in those few apps do not have launcher activity. these apps are getting included in launcher by querying all MediaBrowsingService apps. Now some apps are getting included two times, one based on MediaBrowsingService & second based on launcher category.
2) Navigation keys are showing in MD Launcher app for driver user. Driver user uses Car Launcher and it already is having navigation bar.

Include apps based on only launcher category, if it have launcher activity. Also Hide navigation keys in MD launcher for driver user.

Tests:
Install some media app ex. prime video and open MD launcher. it should show prime video app only one time and also MD launcher should not show navigation keys.

Tracked-On: OAM-112750 OAM-112847