### PR TITLE
Fixing lunch issue with the patch

### DIFF
--- a/bsp_diff/caas/device/intel/mixins/0001-Upgrading-API-to-34-for-android-U.patch
+++ b/bsp_diff/caas/device/intel/mixins/0001-Upgrading-API-to-34-for-android-U.patch
@@ -1,5 +1,5 @@
-From 68dd80a591752dea593745c7c7b9c1937df864b9 Mon Sep 17 00:00:00 2001
-From: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+From 0509250af66125bc80b166cbbd82a3fe76c6f581 Mon Sep 17 00:00:00 2001
+From: "Tekriwal, Tanuj" <tanuj.tekriwal@intel.com>
 Date: Sun, 27 Aug 2023 15:09:49 +0000
 Subject: [PATCH] Upgrading API to 34 for android U
 
@@ -20,12 +20,12 @@ Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
  5 files changed, 11 insertions(+), 30 deletions(-)
 
 diff --git a/groups/device-specific/caas/caas.mk b/groups/device-specific/caas/caas.mk
-index aad059a..c48f86e 100644
+index 7a1b952..c4139fe 100644
 --- a/groups/device-specific/caas/caas.mk
 +++ b/groups/device-specific/caas/caas.mk
-@@ -64,7 +64,7 @@ PRODUCT_AAPT_PREF_CONFIG := mdpi
- PRODUCT_RESTRICT_VENDOR_FILES := false
- PRODUCT_SET_DEBUGFS_RESTRICTIONS := false
+@@ -71,7 +71,7 @@ else
+ PRODUCT_SET_DEBUGFS_RESTRICTIONS := true
+ endif
  {{^ota-update}}
 -PRODUCT_SHIPPING_API_LEVEL := 33
 +PRODUCT_SHIPPING_API_LEVEL := 34
@@ -117,7 +117,7 @@ index ae957fb..4877255 100644
 +    </sepolicy>
  </manifest>
 diff --git a/groups/device-specific/caas/product.mk b/groups/device-specific/caas/product.mk
-index 0e8ecaa..434eda5 100755
+index eb717cd..65296ad 100755
 --- a/groups/device-specific/caas/product.mk
 +++ b/groups/device-specific/caas/product.mk
 @@ -29,7 +29,6 @@ PRODUCT_PACKAGES +=  \


### PR DESCRIPTION
for r2 build local lunch is failing for caas.
This patch will rebase the patch causing conflict.

Test:
$lunch caas-userdebug
on local workspace.

Tracked-On: OAM-112925