### PR TITLE
ftrace: Ignore f2fs/f2fs_truncate_partial_nodes.nid field

### DIFF
--- a/aosp_diff/preliminary/external/perfetto/0001-ftrace-Ignore-f2fs-f2fs_truncate_partial_nodes.nid-f.patch
+++ b/aosp_diff/preliminary/external/perfetto/0001-ftrace-Ignore-f2fs-f2fs_truncate_partial_nodes.nid-f.patch
@@ -1,0 +1,143 @@
+From 1b56651f560ac226fc1381384fd415f8129d4c46 Mon Sep 17 00:00:00 2001
+From: Daniele Di Proietto <ddiproietto@google.com>
+Date: Fri, 12 May 2023 16:42:40 +0000
+Subject: [PATCH] ftrace: Ignore f2fs/f2fs_truncate_partial_nodes.nid field
+
+The field has a different format on kernels before and after
+0b04d4c0542e("f2fs: Fix f2fs_truncate_partial_nodes ftrace event").
+Perfetto is not able to understand the new format anyway and it would
+hit a DCHECK (abort in non debug builds).
+
+This commit also adds two tests:
+* One with the event format/a page from the old kernel.
+* One with the event format/a page from the new kernel.
+
+Bug: 281660544
+Change-Id: I72d6b304b25d243db8e514294210e8229c2162a2
+Signed-off-by: ZhuChenyanX <zhucx@intel.com>
+---
+ src/traced/probes/ftrace/event_info.cc            |  3 ---
+ .../test/data/b281660544_new/available_events     |  1 +
+ .../f2fs/f2fs_truncate_partial_nodes/format       | 15 +++++++++++++++
+ .../test/data/b281660544_new/events/header_page   |  4 ++++
+ .../test/data/b281660544_old/available_events     |  1 +
+ .../f2fs/f2fs_truncate_partial_nodes/format       | 15 +++++++++++++++
+ .../test/data/b281660544_old/events/header_page   |  4 ++++
+ tools/ftrace_proto_gen/ftrace_proto_gen.cc        |  5 +++++
+ 8 files changed, 45 insertions(+), 3 deletions(-)
+ create mode 100644 src/traced/probes/ftrace/test/data/b281660544_new/available_events
+ create mode 100644 src/traced/probes/ftrace/test/data/b281660544_new/events/f2fs/f2fs_truncate_partial_nodes/format
+ create mode 100644 src/traced/probes/ftrace/test/data/b281660544_new/events/header_page
+ create mode 100644 src/traced/probes/ftrace/test/data/b281660544_old/available_events
+ create mode 100644 src/traced/probes/ftrace/test/data/b281660544_old/events/f2fs/f2fs_truncate_partial_nodes/format
+ create mode 100644 src/traced/probes/ftrace/test/data/b281660544_old/events/header_page
+
+diff --git a/src/traced/probes/ftrace/event_info.cc b/src/traced/probes/ftrace/event_info.cc
+index b8c23e2b9..5b18409c0 100644
+--- a/src/traced/probes/ftrace/event_info.cc
++++ b/src/traced/probes/ftrace/event_info.cc
+@@ -3823,9 +3823,6 @@ std::vector<Event> GetStaticEventInfo() {
+            {kUnsetOffset, kUnsetSize, FtraceFieldType::kInvalidFtraceFieldType,
+             "ino", 2, ProtoSchemaType::kUint64,
+             TranslationStrategy::kInvalidTranslationStrategy},
+-           {kUnsetOffset, kUnsetSize, FtraceFieldType::kInvalidFtraceFieldType,
+-            "nid", 3, ProtoSchemaType::kUint32,
+-            TranslationStrategy::kInvalidTranslationStrategy},
+            {kUnsetOffset, kUnsetSize, FtraceFieldType::kInvalidFtraceFieldType,
+             "depth", 4, ProtoSchemaType::kInt32,
+             TranslationStrategy::kInvalidTranslationStrategy},
+diff --git a/src/traced/probes/ftrace/test/data/b281660544_new/available_events b/src/traced/probes/ftrace/test/data/b281660544_new/available_events
+new file mode 100644
+index 000000000..5588a9606
+--- /dev/null
++++ b/src/traced/probes/ftrace/test/data/b281660544_new/available_events
+@@ -0,0 +1 @@
++f2fs:f2fs_truncate_partial_nodes
+diff --git a/src/traced/probes/ftrace/test/data/b281660544_new/events/f2fs/f2fs_truncate_partial_nodes/format b/src/traced/probes/ftrace/test/data/b281660544_new/events/f2fs/f2fs_truncate_partial_nodes/format
+new file mode 100644
+index 000000000..2f5a8ab38
+--- /dev/null
++++ b/src/traced/probes/ftrace/test/data/b281660544_new/events/f2fs/f2fs_truncate_partial_nodes/format
+@@ -0,0 +1,15 @@
++name: f2fs_truncate_partial_nodes
++ID: 637
++format:
++	field:unsigned short common_type;       offset:0;       size:2; signed:0;
++	field:unsigned char common_flags;       offset:2;       size:1; signed:0;
++	field:unsigned char common_preempt_count;       offset:3;       size:1; signed:0;
++	field:int common_pid;   offset:4;       size:4; signed:1;
++
++	field:dev_t dev;        offset:8;       size:4; signed:0;
++	field:ino_t ino;        offset:16;      size:8; signed:0;
++	field:nid_t nid[3];     offset:24;      size:12;        signed:0;
++	field:int depth;        offset:36;      size:4; signed:1;
++	field:int err;  offset:40;      size:4; signed:1;
++
++print fmt: "dev = (%d,%d), ino = %lu, nid[0] = %u, nid[1] = %u, nid[2] = %u, depth = %d, err = %d", ((unsigned int) ((REC->dev) >> 20)), ((unsigned int) ((REC->dev) & ((1U << 20) - 1))), (unsigned long)REC->ino, (unsigned int)REC->nid[0], (unsigned int)REC->nid[1], (unsigned int)REC->nid[2], REC->depth, REC->err
+diff --git a/src/traced/probes/ftrace/test/data/b281660544_new/events/header_page b/src/traced/probes/ftrace/test/data/b281660544_new/events/header_page
+new file mode 100644
+index 000000000..276dce9d5
+--- /dev/null
++++ b/src/traced/probes/ftrace/test/data/b281660544_new/events/header_page
+@@ -0,0 +1,4 @@
++	field: u64 timestamp;   offset:0;       size:8; signed:0;
++	field: local_t commit;  offset:8;       size:8; signed:1;
++	field: int overwrite;   offset:8;       size:1; signed:1;
++	field: char data;       offset:16;      size:4080;      signed:1;
+diff --git a/src/traced/probes/ftrace/test/data/b281660544_old/available_events b/src/traced/probes/ftrace/test/data/b281660544_old/available_events
+new file mode 100644
+index 000000000..5588a9606
+--- /dev/null
++++ b/src/traced/probes/ftrace/test/data/b281660544_old/available_events
+@@ -0,0 +1 @@
++f2fs:f2fs_truncate_partial_nodes
+diff --git a/src/traced/probes/ftrace/test/data/b281660544_old/events/f2fs/f2fs_truncate_partial_nodes/format b/src/traced/probes/ftrace/test/data/b281660544_old/events/f2fs/f2fs_truncate_partial_nodes/format
+new file mode 100644
+index 000000000..15f6a646b
+--- /dev/null
++++ b/src/traced/probes/ftrace/test/data/b281660544_old/events/f2fs/f2fs_truncate_partial_nodes/format
+@@ -0,0 +1,15 @@
++name: f2fs_truncate_partial_nodes
++ID: 637
++format:
++	field:unsigned short common_type;       offset:0;       size:2; signed:0;
++	field:unsigned char common_flags;       offset:2;       size:1; signed:0;
++	field:unsigned char common_preempt_count;       offset:3;       size:1; signed:0;
++	field:int common_pid;   offset:4;       size:4; signed:1;
++
++	field:dev_t dev;        offset:8;       size:4; signed:0;
++	field:ino_t ino;        offset:16;      size:8; signed:0;
++	field:nid_t nid[3];     offset:24;      size:4; signed:0;
++	field:int depth;        offset:28;      size:4; signed:1;
++	field:int err;  offset:32;      size:4; signed:1;
++
++print fmt: "dev = (%d,%d), ino = %lu, nid[0] = %u, nid[1] = %u, nid[2] = %u, depth = %d, err = %d", ((unsigned int) ((REC->dev) >> 20)), ((unsigned int) ((REC->dev) & ((1U << 20) - 1))), (unsigned long)REC->ino, (unsigned int)REC->nid[0], (unsigned int)REC->nid[1], (unsigned int)REC->nid[2], REC->depth, REC->err
+diff --git a/src/traced/probes/ftrace/test/data/b281660544_old/events/header_page b/src/traced/probes/ftrace/test/data/b281660544_old/events/header_page
+new file mode 100644
+index 000000000..276dce9d5
+--- /dev/null
++++ b/src/traced/probes/ftrace/test/data/b281660544_old/events/header_page
+@@ -0,0 +1,4 @@
++	field: u64 timestamp;   offset:0;       size:8; signed:0;
++	field: local_t commit;  offset:8;       size:8; signed:1;
++	field: int overwrite;   offset:8;       size:1; signed:1;
++	field: char data;       offset:16;      size:4080;      signed:1;
+diff --git a/tools/ftrace_proto_gen/ftrace_proto_gen.cc b/tools/ftrace_proto_gen/ftrace_proto_gen.cc
+index b372ee520..eeb67f87b 100644
+--- a/tools/ftrace_proto_gen/ftrace_proto_gen.cc
++++ b/tools/ftrace_proto_gen/ftrace_proto_gen.cc
+@@ -201,6 +201,11 @@ std::string SingleEventInfo(perfetto::Proto proto,
+     // configurations)
+     if (group == "ftrace" && proto.event_name == "print" && field->name == "ip")
+       continue;
++    // Ignore the "nid" field. On new kernels, this field has a type that we
++    // don't know how to parse. See b/281660544
++    if (group == "f2fs" && proto.event_name == "f2fs_truncate_partial_nodes" &&
++        field->name == "nid")
++      continue;
+     s += "{";
+     s += "kUnsetOffset, ";
+     s += "kUnsetSize, ";
+-- 
+2.17.1
+


### PR DESCRIPTION
The field has a different format on kernels before and after 0b04d4c0542e("f2fs: Fix f2fs_truncate_partial_nodes ftrace event"). Perfetto is not able to understand the new format anyway and it would hit a DCHECK (abort in non debug builds).

Skipped test code for it's too new to merge into current perfetto(v15.0).

Apply to aosp_diff/preliminary folder.

Tracked-On: OAM-110834