### PR TITLE
Add 88Q2122 eth phy suspend resume code

### DIFF
--- a/bsp_diff/common/kernel/linux-intel-lts2021/0028-Add-88q2122-eth-phy-suspend-resume-code.patch
+++ b/bsp_diff/common/kernel/linux-intel-lts2021/0028-Add-88q2122-eth-phy-suspend-resume-code.patch
@@ -1,0 +1,83 @@
+From 28ef34c1de96bf6996bfca15928d3e2627c3a9bd Mon Sep 17 00:00:00 2001
+From: Zhao Ye <zhao.ye@intel.com>
+Date: Wed, 22 Nov 2023 12:55:41 +0800
+Subject: [PATCH] Add 88Q2122 eth phy suspend resume code
+
+Add 88Q2122 eth phy suspend resume code,
+Delete some useless warning.
+
+Tests:
+on A1 board, ethernet can suspend/resume
+success, ethernet power go down when it suspend.
+
+Tracked-On: OAM-113125
+Signed-off-by: Zhao Ye <zhao.ye@intel.com>
+---
+ drivers/net/phy/marvell-88q2xxx.c | 18 ++++++++++++++++--
+ drivers/net/phy/phy_device.c      |  5 +++--
+ 2 files changed, 19 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/phy/marvell-88q2xxx.c b/drivers/net/phy/marvell-88q2xxx.c
+index c853b72ec856..a8344e61a5ca 100644
+--- a/drivers/net/phy/marvell-88q2xxx.c
++++ b/drivers/net/phy/marvell-88q2xxx.c
+@@ -52,17 +52,28 @@ static int mv88q2xxx_tx_enable(struct phy_device *phydev)
+ 
+ static int mv88q2xxx_tx_disable(struct phy_device *phydev)
+ {
+-	return phy_clear_bits_mmd(phydev, 3 ,0x8000, 0x8);
++	return phy_set_bits_mmd(phydev, 3 ,0x8000, 0x8);
+ }
+ 
+ static int mv88q2xxx_resume(struct phy_device *phydev)
+ {
++	phy_clear_bits_mmd(phydev, 3 ,0x801c, 0x1);
++	phy_clear_bits_mmd(phydev, 1 ,0x0, 0x800);
++	phy_clear_bits_mmd(phydev, 1 ,0x900, 0x800);
++	phy_clear_bits_mmd(phydev, 3 ,0x0, 0x800);
++
+ 	return mv88q2xxx_tx_enable(phydev);
+ }
+ 
+ static int mv88q2xxx_suspend(struct phy_device *phydev)
+ {
+-	return mv88q2xxx_tx_disable(phydev);
++	int ret = mv88q2xxx_tx_disable(phydev);
++	phy_set_bits_mmd(phydev, 3 ,0x0, 0x800);
++	phy_set_bits_mmd(phydev, 1 ,0x900, 0x800);
++	phy_set_bits_mmd(phydev, 1 ,0x0, 0x800);
++	phy_set_bits_mmd(phydev, 3 ,0x801c, 0x1);
++
++	return ret;
+ }
+ static int mv88q2xxx_soft_reset(struct phy_device *phydev)
+ {
+@@ -208,6 +219,9 @@ static int mv88q2xxx_config_init(struct phy_device *phydev)
+ 	//reset
+ 	mv88q2xxx_soft_reset(phydev);
+ 
++	// disable remote wake up
++	phy_set_bits_mmd(phydev, 3 ,0x801d, 0x800);
++
+ 	return 0;
+ }
+ 
+diff --git a/drivers/net/phy/phy_device.c b/drivers/net/phy/phy_device.c
+index 76d7c4de7e23..179c616a87e4 100644
+--- a/drivers/net/phy/phy_device.c
++++ b/drivers/net/phy/phy_device.c
+@@ -316,8 +316,9 @@ static __maybe_unused int mdio_bus_phy_resume(struct device *dev)
+ 	 * that something went wrong and we should most likely be using
+ 	 * MAC managed PM, but we are not.
+ 	 */
+-	WARN_ON(phydev->state != PHY_HALTED && phydev->state != PHY_READY &&
+-		phydev->state != PHY_UP);
++	// As marvell phy resume register setting delay, this warning happened always
++	//WARN_ON(phydev->state != PHY_HALTED && phydev->state != PHY_READY &&
++	//	phydev->state != PHY_UP);
+ 
+ 	ret = phy_init_hw(phydev);
+ 	if (ret < 0)
+-- 
+2.25.1
+


### PR DESCRIPTION
Add 88Q2122 eth phy suspend resume code,
Delete some useless warning.

Tests:
on A1 board, ethernet can suspend/resume
success, ethernet power go down when it suspend.

Tracked-On: OAM-113125