### PR TITLE
Fixed for Unnecessary app shortcut icon in MD Launcher.

### DIFF
--- a/aosp_diff/preliminary/packages/services/Car/0017-Fixed-for-Unnecessary-app-shortcut-icon-in-MD-Launch.patch
+++ b/aosp_diff/preliminary/packages/services/Car/0017-Fixed-for-Unnecessary-app-shortcut-icon-in-MD-Launch.patch
@@ -1,0 +1,52 @@
+From 157608e241f032994bc94d07583141ed53259ebe Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Fri, 3 Nov 2023 10:27:56 +0530
+Subject: [PATCH] Fixed for Unnecessary app shortcut icon in MD Launcher.
+
+When User try to add app shortcut from MD launcher settings in Home
+screen, some time it also add other apps shortcut app icons as well.
+
+It was adding all media services app shortcut while user try to add any
+media service app. it should add only pinned apps.
+
+Tests:
+Go to add app shortcut option in MD launcher home screen settings
+option and add app shortcut for local media app. it add app shortcut
+only for this app.
+
+Tracked-On: OAM-113019
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../launcher/PinnedAppListLiveData.java           | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/PinnedAppListLiveData.java b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/PinnedAppListLiveData.java
+index b2f4fc13c..e0d18fe83 100644
+--- a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/PinnedAppListLiveData.java
++++ b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/PinnedAppListLiveData.java
+@@ -88,12 +88,17 @@ class PinnedAppListLiveData extends LiveData<List<AppEntry>> {
+                         new Intent(MediaBrowserService.SERVICE_INTERFACE),
+                         PackageManager.GET_RESOLVED_FILTER);
+                 for (ResolveInfo info : mediaServices) {
+-                    Intent packageLaunchIntent = mPackageManager.getLaunchIntentForPackage(info.serviceInfo.packageName);
+-                    if (packageLaunchIntent != null) {
+-                        continue;
++                    String packageName = info.serviceInfo.packageName;
++                    String className = info.serviceInfo.name;
++                    ComponentName componentName = new ComponentName(packageName, className);
++                    if (pinnedAppsComponents.contains(componentName.flattenToString())) {
++                        Intent packageLaunchIntent = mPackageManager.getLaunchIntentForPackage(info.serviceInfo.packageName);
++                            if (packageLaunchIntent != null) {
++                                continue;
++                            }
++                            AppEntry entry = new AppEntry(info, mPackageManager, true);
++                            entries.add(entry);
+                     }
+-                    AppEntry entry = new AppEntry(info, mPackageManager, true);
+-                    entries.add(entry);
+                 }
+                 return entries;
+             }
+-- 
+2.17.1
+


### PR DESCRIPTION
When User try to add app shortcut from MD launcher settings in Home screen, some time it also add other apps shortcut app icons as well.

It was adding all media services app shortcut while user try to add any media service app. it should add only pinned apps.

Tests:
Go to add app shortcut option in MD launcher home screen settings option and add app shortcut for local media app. it add app shortcut only for this app.

Tracked-On: OAM-113019