### PR TITLE
Fixed for AAOS Hardware Form factor.

### DIFF
--- a/aosp_diff/preliminary/packages/services/Car/0018-Fixed-for-AAOS-Hardware-Form-factor.patch
+++ b/aosp_diff/preliminary/packages/services/Car/0018-Fixed-for-AAOS-Hardware-Form-factor.patch
@@ -1,0 +1,43 @@
+From 73bfe56afc4b85ea51d7ce94a0d991872a856f78 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Fri, 3 Nov 2023 10:46:02 +0530
+Subject: [PATCH] Fixed for AAOS Hardware Form factor.
+
+When running ATS bfg performance test, we were seeing following issue
+java.lang.RuntimeException: Failed to determine the current device.
+MANUFACTURER="Intel" BRAND="intel" MODEL="AOSP at
+com.google.android.apps.gsa.testing.ui.support.AndroidPlatform
+.getCurrentDevice(AndroidPlatform.java:154)
+at com.google.android.apps.gsa.testing.ui.support.AppFlowEventMonitor
+.isAutoDevice(AppFlowEventMonitor.java:50)
+
+Above error we were seeing due to missing below property
+ro.hardware.type=automotive
+
+Tests:
+Run ATS bfg test. Above error should not come.
+
+Tracked-On: OAM-112883
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ car_product/build/car.mk | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/car_product/build/car.mk b/car_product/build/car.mk
+index 7223d01b0..7c42b6862 100644
+--- a/car_product/build/car.mk
++++ b/car_product/build/car.mk
+@@ -66,7 +66,9 @@ PRODUCT_COPY_FILES += \
+ 
+ PRODUCT_PROPERTY_OVERRIDES += \
+     persist.bluetooth.enablenewavrcp=false \
+-    ro.carrier=unknown
++    ro.carrier=unknown \
++    ro.hardware.type=automotive \
++
+ 
+ PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
+     config.disable_systemtextclassifier=true
+-- 
+2.17.1
+


### PR DESCRIPTION
When running ATS bfg performance test, we were seeing following issue java.lang.RuntimeException: Failed to determine the current device. MANUFACTURER="Intel" BRAND="intel" MODEL="AOSP at
com.google.android.apps.gsa.testing.ui.support.AndroidPlatform .getCurrentDevice(AndroidPlatform.java:154)
at com.google.android.apps.gsa.testing.ui.support.AppFlowEventMonitor .isAutoDevice(AppFlowEventMonitor.java:50)

Above error we were seeing due to missing below property ro.hardware.type=automotive

Tests:
Run ATS bfg test. Above error should not come.

Tracked-On: OAM-112883