### PR TITLE
Let shell have the permission to access syslog

### DIFF
--- a/aosp_diff/preliminary/system/sepolicy/13_0013-Let-shell-have-the-permission-to-access-syslog.patch
+++ b/aosp_diff/preliminary/system/sepolicy/13_0013-Let-shell-have-the-permission-to-access-syslog.patch
@@ -1,0 +1,70 @@
+From c7e5d852efb1b091cbb485328f4c10a3c59f1bc6 Mon Sep 17 00:00:00 2001
+From: jizhenlo <zhenlong.z.ji@intel.com>
+Date: Tue, 7 Nov 2023 10:38:06 +0800
+Subject: [PATCH] Let shell have the permission to access syslog
+
+Some PnP tools need infomation provided by 'adb shell dmesg'.
+
+Signed-off-by: jizhenlo <zhenlong.z.ji@intel.com>
+---
+ prebuilts/api/32.0/public/app.te   | 2 +-
+ prebuilts/api/32.0/public/shell.te | 2 ++
+ public/app.te                      | 2 +-
+ public/shell.te                    | 2 ++
+ 4 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/prebuilts/api/32.0/public/app.te b/prebuilts/api/32.0/public/app.te
+index 5527f9994..302013eb5 100644
+--- a/prebuilts/api/32.0/public/app.te
++++ b/prebuilts/api/32.0/public/app.te
+@@ -534,7 +534,7 @@ neverallow appdomain
+     proc:dir_file_class_set write;
+ 
+ # Access to syslog(2) or /proc/kmsg.
+-neverallow appdomain kernel:system { syslog_read syslog_mod syslog_console };
++neverallow { appdomain -shell } kernel:system { syslog_read syslog_mod syslog_console };
+ 
+ # SELinux is not an API for apps to use
+ neverallow { appdomain -shell } *:security { compute_av check_context };
+diff --git a/prebuilts/api/32.0/public/shell.te b/prebuilts/api/32.0/public/shell.te
+index 70a7fb484..6f416d951 100644
+--- a/prebuilts/api/32.0/public/shell.te
++++ b/prebuilts/api/32.0/public/shell.te
+@@ -190,6 +190,8 @@ allow shell sepolicy_file:file r_file_perms;
+ # Allow shell to start up vendor shell
+ allow shell vendor_shell_exec:file rx_file_perms;
+ 
++allow shell kernel:system syslog_read;
++
+ # Everything is labeled as rootfs in recovery mode. Allow shell to
+ # execute them.
+ recovery_only(`
+diff --git a/public/app.te b/public/app.te
+index 5527f9994..302013eb5 100644
+--- a/public/app.te
++++ b/public/app.te
+@@ -534,7 +534,7 @@ neverallow appdomain
+     proc:dir_file_class_set write;
+ 
+ # Access to syslog(2) or /proc/kmsg.
+-neverallow appdomain kernel:system { syslog_read syslog_mod syslog_console };
++neverallow { appdomain -shell } kernel:system { syslog_read syslog_mod syslog_console };
+ 
+ # SELinux is not an API for apps to use
+ neverallow { appdomain -shell } *:security { compute_av check_context };
+diff --git a/public/shell.te b/public/shell.te
+index 70a7fb484..6f416d951 100644
+--- a/public/shell.te
++++ b/public/shell.te
+@@ -190,6 +190,8 @@ allow shell sepolicy_file:file r_file_perms;
+ # Allow shell to start up vendor shell
+ allow shell vendor_shell_exec:file rx_file_perms;
+ 
++allow shell kernel:system syslog_read;
++
+ # Everything is labeled as rootfs in recovery mode. Allow shell to
+ # execute them.
+ recovery_only(`
+-- 
+2.25.1
+


### PR DESCRIPTION
Some PnP tools need the information provided by 'adb shell dmesg'.