### PR TITLE
Disable thermal daemon excessive logs.

### DIFF
--- a/aosp_diff/preliminary/external/thermal_daemon/0001-Disable-Thermal-Daemon-logs.patch
+++ b/aosp_diff/preliminary/external/thermal_daemon/0001-Disable-Thermal-Daemon-logs.patch
@@ -1,0 +1,947 @@
+From 18107484c68910fb61465d8517d23586ebe2f0f2 Mon Sep 17 00:00:00 2001
+From: Vilas R K <vilas.r.k@intel.com>
+Date: Mon, 16 Oct 2023 22:52:36 +0530
+Subject: [PATCH] Disable Thermal Daemon logs.
+
+This commit disables the logging of Thermal Daemon to reduce log
+clutter and improve system performance.
+
+By Default logs will be disabled it can be enabled by setting the
+following the below mentioned procedure.
+Steps:
+1. adb shell
+2. setprop persist.vendor.disable.thermal.logs true
+
+Tracked-On: OAM-112768
+
+Signed-off-by: Vilas R K <vilas.r.k@intel.com>
+---
+ src/thd_cdev.cpp              |  4 ++-
+ src/thd_cdev.h                |  4 ++-
+ src/thd_cdev_rapl.cpp         |  4 ++-
+ src/thd_cdev_therm_sys_fs.cpp |  5 ++--
+ src/thd_engine.cpp            | 31 +++++++++++++++------
+ src/thd_engine_default.cpp    |  9 ++++--
+ src/thd_parse.cpp             | 14 +++++++---
+ src/thd_rapl_power_meter.cpp  | 24 ++++++++++------
+ src/thd_sensor.cpp            | 18 ++++++++----
+ src/thd_sensor.h              |  4 ++-
+ src/thd_trip_point.cpp        | 52 ++++++++++++++++++++++++-----------
+ src/thd_trip_point.h          | 28 +++++++++++++------
+ src/thd_zone.cpp              | 17 ++++++++----
+ src/thd_zone.h                | 21 +++++++++-----
+ src/thd_zone_cpu.cpp          |  5 +++-
+ src/thd_zone_therm_sys_fs.cpp | 41 ++++++++++++++++++---------
+ 16 files changed, 196 insertions(+), 85 deletions(-)
+
+diff --git a/src/thd_cdev.cpp b/src/thd_cdev.cpp
+index 87170a9..e0d0e6a 100644
+--- a/src/thd_cdev.cpp
++++ b/src/thd_cdev.cpp
+@@ -155,6 +155,7 @@ int cthd_cdev::thd_cdev_set_state(int set_point, int target_temp,
+ 
+ 	time_t tm;
+ 	int ret;
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 
+ 	time(&tm);
+ 	thd_log_info(
+@@ -190,7 +191,8 @@ int cthd_cdev::thd_cdev_set_state(int set_point, int target_temp,
+ 			limit.trip = trip_id;
+ 			limit.target_state_valid = target_state_valid;
+ 			limit.target_value = target_value;
+-			thd_log_info("Added zone %d trip %d clamp_valid %d clamp %d\n",
++			if (DEBUG_THERMAL)
++			    thd_log_info("Added zone %d trip %d clamp_valid %d clamp %d\n",
+ 					limit.zone, limit.trip, limit.target_state_valid,
+ 					limit.target_value);
+ 			zone_trip_limits.push_back(limit);
+diff --git a/src/thd_cdev.h b/src/thd_cdev.h
+index bda1999..af264d5 100644
+--- a/src/thd_cdev.h
++++ b/src/thd_cdev.h
+@@ -227,10 +227,12 @@ public:
+ 		alias_str = _alias_str;
+ 	}
+ 	void set_pid_param(double kp, double ki, double kd) {
++		bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 		pid_ctrl.kp = kp;
+ 		pid_ctrl.ki = ki;
+ 		pid_ctrl.kd = kd;
+-		thd_log_info("set_pid_param %d [%g.%g,%g]\n", index, kp, ki, kd);
++		if (DEBUG_THERMAL)
++		    thd_log_info("set_pid_param %d [%g.%g,%g]\n", index, kp, ki, kd);
+ 	}
+ 	void enable_pid() {
+ 		thd_log_info("PID control enabled %d\n", index);
+diff --git a/src/thd_cdev_rapl.cpp b/src/thd_cdev_rapl.cpp
+index 7eaea44..75f3d25 100644
+--- a/src/thd_cdev_rapl.cpp
++++ b/src/thd_cdev_rapl.cpp
+@@ -263,6 +263,7 @@ int cthd_sysfs_cdev_rapl::update() {
+ 
+ bool cthd_sysfs_cdev_rapl::read_ppcc_power_limits() {
+ 	csys_fs sys_fs;
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 
+ 	if (sys_fs.exists("/sys/bus/pci/devices/0000:00:04.0/power_limits/"))
+ 		sys_fs.update_path("/sys/bus/pci/devices/0000:00:04.0/power_limits/");
+@@ -296,7 +297,8 @@ bool cthd_sysfs_cdev_rapl::read_ppcc_power_limits() {
+ 	}
+ 
+ 	if (pl0_max_pwr && pl0_min_pwr && pl0_min_window && pl0_step_pwr) {
+-		thd_log_debug("ppcc limits max:%u min:%u  min_win:%u step:%u\n",
++		if (DEBUG_THERMAL)
++		    thd_log_debug("ppcc limits max:%u min:%u  min_win:%u step:%u\n",
+ 				pl0_max_pwr, pl0_min_pwr, pl0_min_window, pl0_step_pwr);
+ 		return true;
+ 	}
+diff --git a/src/thd_cdev_therm_sys_fs.cpp b/src/thd_cdev_therm_sys_fs.cpp
+index a01d608..a5fae26 100644
+--- a/src/thd_cdev_therm_sys_fs.cpp
++++ b/src/thd_cdev_therm_sys_fs.cpp
+@@ -33,6 +33,7 @@
+ int cthd_sysfs_cdev::update() {
+ 
+ 	std::stringstream tc_state_dev;
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 	tc_state_dev << "cooling_device" << index << "/cur_state";
+ 	if (cdev_sysfs.exists(tc_state_dev.str())) {
+ 		std::string state_str;
+@@ -62,8 +63,8 @@ int cthd_sysfs_cdev::update() {
+ 				read_back = false;
+ 		}
+ 	}
+-
+-	thd_log_debug("cooling dev %d:%d:%d:%s\n", index, curr_state, max_state,
++	if (DEBUG_THERMAL)
++	    thd_log_debug("cooling dev %d:%d:%d:%s\n", index, curr_state, max_state,
+ 			type_str.c_str());
+ 
+ 	return THD_SUCCESS;
+diff --git a/src/thd_engine.cpp b/src/thd_engine.cpp
+index 53930ef..2f09524 100644
+--- a/src/thd_engine.cpp
++++ b/src/thd_engine.cpp
+@@ -94,9 +94,11 @@ void cthd_engine::thd_engine_thread() {
+ 	for (;;) {
+ 		if (terminate)
+ 			break;
++		bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 
+ 		n = poll(poll_fds, poll_fd_cnt, poll_timeout_msec);
+-		thd_log_debug("poll exit %d polls_fd event %d %d\n", n,
++		if (DEBUG_THERMAL)
++		    thd_log_debug("poll exit %d polls_fd event %d %d\n", n,
+ 				poll_fds[0].revents, poll_fds[1].revents);
+ 		if (n < 0) {
+ 			thd_log_warn("Write to pipe failed \n");
+@@ -166,18 +168,21 @@ bool cthd_engine::set_preference(const int pref) {
+ int cthd_engine::thd_engine_start(bool ignore_cpuid_check) {
+ 	int ret;
+ 	int wake_fds[2];
+-
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 	if (ignore_cpuid_check) {
+-		thd_log_debug("Ignore CPU ID check for MSRs \n");
++		if (DEBUG_THERMAL)
++		    thd_log_debug("Ignore CPU ID check for MSRs \n");
+ 		proc_list_matched = true;
+ 	} else {
+ 		check_cpu_id();
+ 
+ 		if (!proc_list_matched) {
+ 			if ((parser_init() == THD_SUCCESS) && parser.platform_matched()) {
+-				thd_log_warn("Unsupported cpu model, using thermal-conf.xml only \n");
++				if (DEBUG_THERMAL)
++				    thd_log_warn("Unsupported cpu model, using thermal-conf.xml only \n");
+ 			} else {
+-				thd_log_warn("Unsupported cpu model, use thermal-conf.xml file or run with --ignore-cpuid-check \n");
++				if (DEBUG_THERMAL)
++				    thd_log_warn("Unsupported cpu model, use thermal-conf.xml file or run with --ignore-cpuid-check \n");
+ 				return THD_FATAL_ERROR;
+ 			}
+ 		}
+@@ -710,8 +715,10 @@ void cthd_engine::thd_read_default_thermal_sensors() {
+ 	struct dirent *entry;
+ 	const std::string base_path = "/sys/class/thermal/";
+ 	int max_index = 0;
++	bool DEBUG_THERMAL=property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 
+-	thd_log_debug("thd_read_default_thermal_sensors \n");
++	if (DEBUG_THERMAL)
++	    thd_log_debug("thd_read_default_thermal_sensors \n");
+ 	if ((dir = opendir(base_path.c_str())) != NULL) {
+ 		while ((entry = readdir(dir)) != NULL) {
+ 			if (!strncmp(entry->d_name, "thermal_zone",
+@@ -778,8 +785,10 @@ void cthd_engine::thd_read_default_cooling_devices() {
+ 	struct dirent *entry;
+ 	const std::string base_path = "/sys/class/thermal/";
+ 	int max_index = 0;
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 
+-	thd_log_debug("thd_read_default_cooling devices \n");
++	if (DEBUG_THERMAL)
++	    thd_log_debug("thd_read_default_cooling devices \n");
+ 	if ((dir = opendir(base_path.c_str())) != NULL) {
+ 		while ((entry = readdir(dir)) != NULL) {
+ 			if (!strncmp(entry->d_name, "cooling_device",
+@@ -1139,6 +1148,7 @@ int cthd_engine::user_delete_zone(std::string name) {
+ int cthd_engine::user_add_cdev(std::string cdev_name, std::string cdev_path,
+ 		int min_state, int max_state, int step) {
+ 	cthd_cdev *cdev;
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 
+ 	pthread_mutex_lock(&thd_engine_mutex);
+ 	// Check if there is existing cdev with this name and path
+@@ -1167,18 +1177,21 @@ int cthd_engine::user_add_cdev(std::string cdev_name, std::string cdev_path,
+ 	pthread_mutex_unlock(&thd_engine_mutex);
+ 
+ 	for (unsigned int i = 0; i < cdevs.size(); ++i) {
+-		cdevs[i]->cdev_dump();
++		if (DEBUG_THERMAL)
++		    cdevs[i]->cdev_dump();
+ 	}
+ 
+ 	return THD_SUCCESS;
+ }
+ 
+ int cthd_engine::parser_init() {
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 	if (parser_init_done)
+ 		return THD_SUCCESS;
+ 	if (parser.parser_init(get_config_file()) == THD_SUCCESS) {
+ 		if (parser.start_parse() == THD_SUCCESS) {
+-			parser.dump_thermal_conf();
++			if (DEBUG_THERMAL)
++			    parser.dump_thermal_conf();
+ 			parser_init_done = true;
+ 			return THD_SUCCESS;
+ 		}
+diff --git a/src/thd_engine_default.cpp b/src/thd_engine_default.cpp
+index 5040462..2e1658c 100644
+--- a/src/thd_engine_default.cpp
++++ b/src/thd_engine_default.cpp
+@@ -641,6 +641,7 @@ int cthd_engine_default::add_replace_cdev(cooling_dev_t *config) {
+ int cthd_engine_default::read_cooling_devices() {
+ 	int size;
+ 	int i;
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 
+ 	// Read first all the default cooling devices added by kernel
+ 	thd_read_default_cooling_devices();
+@@ -726,7 +727,8 @@ int cthd_engine_default::read_cooling_devices() {
+ 
+ 	// Dump all cooling devices
+ 	for (unsigned i = 0; i < cdevs.size(); ++i) {
+-		cdevs[i]->cdev_dump();
++		if (DEBUG_THERMAL)
++		    cdevs[i]->cdev_dump();
+ 	}
+ 
+ 	return THD_SUCCESS;
+@@ -737,6 +739,7 @@ cthd_engine *thd_engine;
+ 
+ int thd_engine_create_default_engine(bool ignore_cpuid_check,
+ 		bool exclusive_control, const char *conf_file) {
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 	thd_engine = new cthd_engine_default();
+ 	if (exclusive_control)
+ 		thd_engine->set_control_mode(EXCLUSIVE);
+@@ -747,7 +750,9 @@ int thd_engine_create_default_engine(bool ignore_cpuid_check,
+ 		thd_engine->set_config_file(conf_file);
+ 
+ 	if (thd_engine->thd_engine_start(ignore_cpuid_check) != THD_SUCCESS) {
+-		thd_log_error("THD engine start failed\n");
++		property_set("persist.vendor.thermal.daemon.supported", "0");
++		if (DEBUG_THERMAL)
++		    thd_log_error("THD engine start failed\n");
+ 		return THD_ERROR;
+ 	}
+ 
+diff --git a/src/thd_parse.cpp b/src/thd_parse.cpp
+index 3bff092..d6a2d38 100644
+--- a/src/thd_parse.cpp
++++ b/src/thd_parse.cpp
+@@ -29,6 +29,7 @@
+ #include "thd_parse.h"
+ #include <stdlib.h>
+ #include <algorithm>
++#include <cutils/properties.h>
+ #include "thd_sys_fs.h"
+ #include "thd_trt_art_reader.h"
+ 
+@@ -766,6 +767,7 @@ bool cthd_parse::platform_matched() {
+ 	std::string line;
+ 
+ 	std::ifstream product_uuid("/sys/class/dmi/id/product_uuid");
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 
+ 	if (product_uuid.is_open() && getline(product_uuid, line)) {
+ 		for (unsigned int i = 0; i < thermal_info_list.size(); ++i) {
+@@ -794,16 +796,19 @@ bool cthd_parse::platform_matched() {
+ 			if (!thermal_info_list[i].product_name.size())
+ 				continue;
+ 			string_trim(line);
+-			thd_log_debug("config product name [%s] match with [%s]\n",
++			if (DEBUG_THERMAL)
++			    thd_log_debug("config product name [%s] match with [%s]\n",
+ 					thermal_info_list[i].product_name.c_str(), line.c_str());
+ 			if (thermal_info_list[i].product_name == "*") {
+ 				matched_thermal_info_index = i;
+-				thd_log_info("Product Name matched [wildcard]\n");
++				if (DEBUG_THERMAL)
++				    thd_log_info("Product Name matched [wildcard]\n");
+ 				return true;
+ 			}
+ 			if (line == thermal_info_list[i].product_name) {
+ 				matched_thermal_info_index = i;
+-				thd_log_info("Product Name matched \n");
++				if (DEBUG_THERMAL)
++				    thd_log_info("Product Name matched \n");
+ 				return true;
+ 			}
+ 		}
+@@ -813,7 +818,8 @@ bool cthd_parse::platform_matched() {
+ 			continue;
+ 		if (!thermal_info_list[i].product_name.compare(0, 1, "*")) {
+ 			matched_thermal_info_index = i;
+-			thd_log_info("Product Name matched \n");
++			if (DEBUG_THERMAL)
++			    thd_log_info("Product Name matched \n");
+ 			return true;
+ 		}
+ 	}
+diff --git a/src/thd_rapl_power_meter.cpp b/src/thd_rapl_power_meter.cpp
+index 204a15f..b14d628 100644
+--- a/src/thd_rapl_power_meter.cpp
++++ b/src/thd_rapl_power_meter.cpp
+@@ -43,15 +43,18 @@ cthd_rapl_power_meter::cthd_rapl_power_meter(unsigned int mask) :
+ 		rapl_present(true), rapl_sysfs("/sys/class/powercap/intel-rapl/"), domain_list(
+ 				0), last_time(0), poll_thread(0), measure_mask(mask), enable_measurement(
+ 				false) {
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 	thd_attr = pthread_attr_t();
+ 
+ 	if (rapl_sysfs.exists()) {
+-		thd_log_debug("RAPL sysfs present \n");
++		if (DEBUG_THERMAL)
++		    thd_log_debug("RAPL sysfs present \n");
+ 		rapl_present = true;
+ 		last_time = time(NULL);
+ 		rapl_read_domains(rapl_sysfs.get_base_path());
+ 	} else {
+-		thd_log_warn("NO RAPL sysfs present \n");
++		if (DEBUG_THERMAL)
++		    thd_log_warn("NO RAPL sysfs present \n");
+ 		rapl_present = false;
+ 	}
+ }
+@@ -59,11 +62,12 @@ cthd_rapl_power_meter::cthd_rapl_power_meter(unsigned int mask) :
+ void cthd_rapl_power_meter::rapl_read_domains(const char *dir_name) {
+ 	int count = 0;
+ 	csys_fs sys_fs;
+-
++    bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 	if (rapl_present) {
+ 		DIR *dir;
+ 		struct dirent *dir_entry;
+-		thd_log_debug("RAPL base path %s\n", dir_name);
++		if (DEBUG_THERMAL)
++		    thd_log_debug("RAPL base path %s\n", dir_name);
+ 		if ((dir = opendir(dir_name)) != NULL) {
+ 			while ((dir_entry = readdir(dir)) != NULL) {
+ 				std::string buffer;
+@@ -84,16 +88,19 @@ void cthd_rapl_power_meter::rapl_read_domains(const char *dir_name) {
+ 				if (!strcmp(dir_entry->d_name, ".")
+ 						|| !strcmp(dir_entry->d_name, ".."))
+ 					continue;
+-				thd_log_debug("RAPL domain dir %s\n", dir_entry->d_name);
++				if (DEBUG_THERMAL)
++				    thd_log_debug("RAPL domain dir %s\n", dir_entry->d_name);
+ 				path << dir_name << dir_entry->d_name << "/" << "name";
+ 				if (!sys_fs.exists(path.str())) {
+-					thd_log_debug(" %s doesn't exist\n", path.str().c_str());
++					if (DEBUG_THERMAL)
++					    thd_log_debug(" %s doesn't exist\n", path.str().c_str());
+ 					continue;
+ 				}
+ 				status = sys_fs.read(path.str(), buffer);
+ 				if (status < 0)
+ 					continue;
+-				thd_log_debug("name %s\n", buffer.c_str());
++				if (DEBUG_THERMAL)
++				    thd_log_debug("name %s\n", buffer.c_str());
+ 				if (fnmatch("package-*", buffer.c_str(), 0) == 0) {
+ 					domain.type = PACKAGE;
+ 					std::stringstream path;
+@@ -121,7 +128,8 @@ void cthd_rapl_power_meter::rapl_read_domains(const char *dir_name) {
+ 		}
+ 	}
+ 
+-	thd_log_info("RAPL domain count %d\n", count);
++	if (DEBUG_THERMAL)
++	    thd_log_info("RAPL domain count %d\n", count);
+ }
+ 
+ void cthd_rapl_power_meter::rapl_enable_periodic_timer() {
+diff --git a/src/thd_sensor.cpp b/src/thd_sensor.cpp
+index 8d9604c..630c101 100644
+--- a/src/thd_sensor.cpp
++++ b/src/thd_sensor.cpp
+@@ -34,17 +34,20 @@ cthd_sensor::cthd_sensor(int _index, std::string control_path,
+ }
+ 
+ int cthd_sensor::sensor_update() {
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 	if (type == SENSOR_TYPE_THERMAL_SYSFS) {
+ 		if (sensor_sysfs.exists("type")) {
+ 			sensor_sysfs.read("type", type_str);
+-			thd_log_info("sensor_update: type %s\n", type_str.c_str());
++			if (DEBUG_THERMAL)
++			    thd_log_info("sensor_update: type %s\n", type_str.c_str());
+ 		} else
+ 			return THD_ERROR;
+ 
+ 		if (sensor_sysfs.exists("temp")) {
+ 			return THD_SUCCESS;
+ 		} else {
+-			thd_log_warn("sensor id %d: No temp sysfs for reading temp\n",
++			if (DEBUG_THERMAL)
++			    thd_log_warn("sensor id %d: No temp sysfs for reading temp\n",
+ 					index);
+ 			return THD_ERROR;
+ 		}
+@@ -53,7 +56,8 @@ int cthd_sensor::sensor_update() {
+ 		if (sensor_sysfs.exists("")) {
+ 			return THD_SUCCESS;
+ 		} else {
+-			thd_log_warn("sensor id %d %s: No temp sysfs for reading raw temp\n",
++			if (DEBUG_THERMAL)
++			    thd_log_warn("sensor id %d %s: No temp sysfs for reading raw temp\n",
+ 					index, sensor_sysfs.get_base_path());
+ 			return THD_ERROR;
+ 		}
+@@ -65,8 +69,10 @@ unsigned int cthd_sensor::read_temperature() {
+ 	csys_fs sysfs;
+ 	std::string buffer;
+ 	int temp;
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 
+-	thd_log_debug("read_temperature sensor ID %d\n", index);
++	if (DEBUG_THERMAL)
++	    thd_log_debug("read_temperature sensor ID %d\n", index);
+ 	if (type == SENSOR_TYPE_THERMAL_SYSFS)
+ 		sensor_sysfs.read("temp", buffer);
+ 	else
+@@ -74,7 +80,9 @@ unsigned int cthd_sensor::read_temperature() {
+ 	std::istringstream(buffer) >> temp;
+ 	if (temp < 0)
+ 		temp = 0;
+-	thd_log_debug("Sensor %s :temp %u \n", type_str.c_str(), temp);
++
++	if (DEBUG_THERMAL)
++	    thd_log_debug("Sensor %s :temp %u \n", type_str.c_str(), temp);
+ 	return (unsigned int)temp / scale;
+ }
+ 
+diff --git a/src/thd_sensor.h b/src/thd_sensor.h
+index df84d05..63ef798 100644
+--- a/src/thd_sensor.h
++++ b/src/thd_sensor.h
+@@ -81,7 +81,9 @@ public:
+ 		scale = _scale;
+ 	}
+ 	virtual void sensor_dump() {
+-		thd_log_info("sensor index:%d %s %s Async:%d \n", index,
++		bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
++		if (DEBUG_THERMAL)
++		    thd_log_info("sensor index:%d %s %s Async:%d \n", index,
+ 				type_str.c_str(), sensor_sysfs.get_base_path(), async_capable);
+ 	}
+ 	// Even if sensors are capable of async, it is possible that it is not reliable enough
+diff --git a/src/thd_trip_point.cpp b/src/thd_trip_point.cpp
+index 58b09bb..bfe70a2 100644
+--- a/src/thd_trip_point.cpp
++++ b/src/thd_trip_point.cpp
+@@ -26,6 +26,7 @@
+ #include <string.h>
+ #include <errno.h>
+ #include <sys/reboot.h>
++#include <cutils/properties.h>
+ #include "thd_trip_point.h"
+ #include "thd_engine.h"
+ 
+@@ -36,7 +37,9 @@ int _temp, unsigned int _hyst, int _zone_id, int _sensor_id,
+ 				_control_type), zone_id(_zone_id), sensor_id(_sensor_id), trip_on(
+ 				false), poll_on(false), depend_cdev(NULL), depend_cdev_state(0), depend_cdev_state_rel(
+ 				EQUAL) {
+-	thd_log_debug("Add trip pt %d:%d:0x%x:%d:%d\n", type, zone_id, sensor_id,
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
++	if (DEBUG_THERMAL)
++	    thd_log_debug("Add trip pt %d:%d:0x%x:%d:%d\n", type, zone_id, sensor_id,
+ 			temp, hyst);
+ }
+ 
+@@ -91,6 +94,7 @@ bool cthd_trip_point::thd_trip_point_check(int id, unsigned int read_temp,
+ 	int on = -1;
+ 	int off = -1;
+ 	bool apply = false;
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 
+ 	*reset = false;
+ 
+@@ -124,7 +128,8 @@ bool cthd_trip_point::thd_trip_point_check(int id, unsigned int read_temp,
+ 		}
+ 
+ 		if (!valid) {
+-			thd_log_info("constraint failed %s:%d:%d:%d \n",
++			if (DEBUG_THERMAL)
++			    thd_log_info("constraint failed %s:%d:%d:%d \n",
+ 					depend_cdev->get_cdev_type().c_str(), _state, depend_cdev_state_rel,
+ 					depend_cdev_state);
+ 			return false;
+@@ -135,7 +140,8 @@ bool cthd_trip_point::thd_trip_point_check(int id, unsigned int read_temp,
+ 		return false;
+ 
+ 	if (read_temp == 0) {
+-		thd_log_debug("TEMP == 0 pref: %d\n", pref);
++		if (DEBUG_THERMAL)
++		    thd_log_debug("TEMP == 0 pref: %d\n", pref);
+ 	}
+ 
+ 	if (type == CRITICAL) {
+@@ -171,7 +177,8 @@ bool cthd_trip_point::thd_trip_point_check(int id, unsigned int read_temp,
+ 		cthd_sensor *sensor = thd_engine->get_sensor(sensor_id);
+ 		if (sensor) {
+ 			if (!poll_on && read_temp >= temp) {
+-				thd_log_debug("polling trip reached, on \n");
++				if (DEBUG_THERMAL)
++				    thd_log_debug("polling trip reached, on \n");
+ 				sensor->sensor_poll_trip(true);
+ 				poll_on = true;
+ 				sensor->sensor_fast_poll(true);
+@@ -179,7 +186,8 @@ bool cthd_trip_point::thd_trip_point_check(int id, unsigned int read_temp,
+ 					sensor->set_threshold(0, temp);
+ 			} else if (poll_on && read_temp < temp) {
+ 				sensor->sensor_poll_trip(false);
+-				thd_log_debug("Dropped below poll threshold \n");
++				if (DEBUG_THERMAL)
++				    thd_log_debug("Dropped below poll threshold \n");
+ 				*reset = true;
+ 				poll_on = false;
+ 				sensor->sensor_fast_poll(false);
+@@ -189,7 +197,8 @@ bool cthd_trip_point::thd_trip_point_check(int id, unsigned int read_temp,
+ 		}
+ 		return true;
+ 	}
+-	thd_log_debug("pref %d type %d temp %d trip %d \n", pref, type, read_temp,
++	if (DEBUG_THERMAL)
++	    thd_log_debug("pref %d type %d temp %d trip %d \n", pref, type, read_temp,
+ 			temp);
+ 	switch (pref) {
+ 	case PREF_DISABLED:
+@@ -199,14 +208,16 @@ bool cthd_trip_point::thd_trip_point_check(int id, unsigned int read_temp,
+ 	case PREF_PERFORMANCE:
+ 		if (type == ACTIVE || type == MAX) {
+ 			apply = true;
+-			thd_log_debug("Active Trip point applicable \n");
++			if (DEBUG_THERMAL)
++			    thd_log_debug("Active Trip point applicable \n");
+ 		}
+ 		break;
+ 
+ 	case PREF_ENERGY_CONSERVE:
+ 		if (type == PASSIVE || type == MAX) {
+ 			apply = true;
+-			thd_log_debug("Passive Trip point applicable \n");
++			if (DEBUG_THERMAL)
++			    thd_log_debug("Passive Trip point applicable \n");
+ 		}
+ 		break;
+ 
+@@ -216,12 +227,14 @@ bool cthd_trip_point::thd_trip_point_check(int id, unsigned int read_temp,
+ 
+ 	if (apply) {
+ 		if (read_temp >= temp) {
+-			thd_log_debug("Trip point applicable >  %d:%d \n", index, temp);
++			if (DEBUG_THERMAL)
++			    thd_log_debug("Trip point applicable >  %d:%d \n", index, temp);
+ 			on = 1;
+ 			trip_on = true;
+ 		} else if ((trip_on && (read_temp + hyst) < temp)
+ 				|| (!trip_on && read_temp < temp)) {
+-			thd_log_debug("Trip point applicable <  %d:%d \n", index, temp);
++			if (DEBUG_THERMAL)
++			    thd_log_debug("Trip point applicable <  %d:%d \n", index, temp);
+ 			off = 1;
+ 			trip_on = false;
+ 		}
+@@ -232,7 +245,8 @@ bool cthd_trip_point::thd_trip_point_check(int id, unsigned int read_temp,
+ 		return true;
+ 
+ 	int i, ret;
+-	thd_log_debug("cdev size for this trippoint %lu\n",
++	if (DEBUG_THERMAL)
++	    thd_log_debug("cdev size for this trippoint %lu\n",
+ 			(unsigned long) cdevs.size());
+ 	if (on > 0) {
+ 		for (unsigned i = 0; i < cdevs.size(); ++i) {
+@@ -255,7 +269,8 @@ bool cthd_trip_point::thd_trip_point_check(int id, unsigned int read_temp,
+ 				}
+ 				cdevs[i].last_op_time = tm;
+ 			}
+-			thd_log_debug("cdev at index %d:%s\n", cdev->thd_cdev_get_index(),
++			if (DEBUG_THERMAL)
++			    thd_log_debug("cdev at index %d:%s\n", cdev->thd_cdev_get_index(),
+ 					cdev->get_cdev_type().c_str());
+ 			/*
+ 			 * When the cdev is already in max state, we skip this cdev.
+@@ -268,7 +283,8 @@ bool cthd_trip_point::thd_trip_point_check(int id, unsigned int read_temp,
+ 									cdev->map_target_state(
+ 											cdevs[i].target_state_valid,
+ 											cdevs[i].target_state)) <= 0)) {
+-				thd_log_debug("Need to switch to next cdev target %d \n",
++				if (DEBUG_THERMAL)
++				    thd_log_debug("Need to switch to next cdev target %d \n",
+ 						cdev->map_target_state(cdevs[i].target_state_valid,
+ 								cdevs[i].target_state));
+ 				// No scope of control with this cdev
+@@ -294,10 +310,12 @@ bool cthd_trip_point::thd_trip_point_check(int id, unsigned int read_temp,
+ 		for (i = cdevs.size() - 1; i >= 0; --i) {
+ 
+ 			cthd_cdev *cdev = cdevs[i].cdev;
+-			thd_log_debug("cdev at index %d:%s\n", cdev->thd_cdev_get_index(),
++			if (DEBUG_THERMAL)
++			    thd_log_debug("cdev at index %d:%s\n", cdev->thd_cdev_get_index(),
+ 					cdev->get_cdev_type().c_str());
+ 			if (cdev->in_min_state()) {
+-				thd_log_debug("Need to switch to next cdev \n");
++				if (DEBUG_THERMAL)
++				    thd_log_debug("Need to switch to next cdev \n");
+ 				// No scope of control with this cdev
+ 				continue;
+ 			}
+@@ -359,10 +377,12 @@ int cthd_trip_point::thd_trip_point_add_cdev_index(int _index, int influence) {
+ }
+ 
+ void cthd_trip_point::thd_trip_cdev_state_reset() {
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 	thd_log_info("thd_trip_cdev_state_reset \n");
+ 	for (int i = cdevs.size() - 1; i >= 0; --i) {
+ 		cthd_cdev *cdev = cdevs[i].cdev;
+-		thd_log_info("thd_trip_cdev_state_reset index %d:%s\n",
++		if (DEBUG_THERMAL)
++		    thd_log_info("thd_trip_cdev_state_reset index %d:%s\n",
+ 				cdev->thd_cdev_get_index(), cdev->get_cdev_type().c_str());
+ 		if (cdev->in_min_state()) {
+ 			thd_log_debug("Need to switch to next cdev \n");
+diff --git a/src/thd_trip_point.h b/src/thd_trip_point.h
+index 89eb083..072ae63 100644
+--- a/src/thd_trip_point.h
++++ b/src/thd_trip_point.h
+@@ -168,6 +168,7 @@ public:
+ 		std::sort(cdevs.begin(), cdevs.end(), trip_cdev_sort);
+ 	}
+ 	void trip_dump() {
++		bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 		std::string _type_str;
+ 		if (type == CRITICAL)
+ 			_type_str = "critical";
+@@ -183,30 +184,39 @@ public:
+ 			_type_str = "hot";
+ 		else
+ 			_type_str = "invalid";
+-		thd_log_info(
++		if (DEBUG_THERMAL)
++		    thd_log_info(
+ 				"index %d: type:%s temp:%u hyst:%u zone id:%d sensor id:%d control_type:%d cdev size:%lu\n",
+ 				index, _type_str.c_str(), temp, hyst, zone_id, sensor_id,
+ 				control_type, (unsigned long) cdevs.size());
+ 
+ 		if (depend_cdev) {
+-			thd_log_info("Depends on cdev %s:%d:%d\n",
++			if (DEBUG_THERMAL)
++			    thd_log_info("Depends on cdev %s:%d:%d\n",
+ 					depend_cdev->get_cdev_type().c_str(), depend_cdev_state_rel,
+ 					depend_cdev_state);
+ 		}
+ 
+ 		for (unsigned int i = 0; i < cdevs.size(); ++i) {
+-			thd_log_info("cdev[%u] %s, Sampling period: %d\n", i,
++			if (DEBUG_THERMAL)
++			    thd_log_info("cdev[%u] %s, Sampling period: %d\n", i,
+ 					cdevs[i].cdev->get_cdev_type().c_str(),
+ 					cdevs[i].sampling_priod);
+-			if (cdevs[i].target_state_valid)
+-				thd_log_info("\t target_state:%d\n", cdevs[i].target_state);
+-			else
+-				thd_log_info("\t target_state:not defined\n");
++			if (cdevs[i].target_state_valid) {
++			    if (DEBUG_THERMAL)
++				    thd_log_info("\t target_state:%d\n", cdevs[i].target_state);
++			}
++			else {
++				if (DEBUG_THERMAL)
++				    thd_log_info("\t target_state:not defined\n");
++			}
+ 
+-			if (cdevs[i].pid_param.valid)
+-				thd_log_info("\t pid: kp=%g ki=%g kd=%g\n",
++			if (cdevs[i].pid_param.valid) {
++				if (DEBUG_THERMAL)
++				    thd_log_info("\t pid: kp=%g ki=%g kd=%g\n",
+ 						cdevs[i].pid_param.kp, cdevs[i].pid_param.ki,
+ 						cdevs[i].pid_param.kd);
++			}
+ 		}
+ 	}
+ };
+diff --git a/src/thd_zone.cpp b/src/thd_zone.cpp
+index cb7b8e8..ef17443 100644
+--- a/src/thd_zone.cpp
++++ b/src/thd_zone.cpp
+@@ -38,7 +38,9 @@ cthd_zone::cthd_zone(int _index, std::string control_path, sensor_relate_t rel)
+ 		index(_index), zone_sysfs(control_path.c_str()), zone_temp(0), zone_active(
+ 				false), zone_cdev_binded_status(false), type_str(), sensor_rel(
+ 				rel) {
+-	thd_log_debug("Added zone index:%d \n", index);
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
++	if (DEBUG_THERMAL)
++	    thd_log_debug("Added zone index:%d \n", index);
+ }
+ 
+ cthd_zone::~cthd_zone() {
+@@ -103,13 +105,16 @@ int cthd_zone::read_user_set_psv_temp() {
+ }
+ 
+ void cthd_zone::sort_and_update_poll_trip() {
+-	thd_log_debug("sort_and_update_poll_trip: trip_points_size =%zu\n",
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
++	if (DEBUG_THERMAL)
++	    thd_log_debug("sort_and_update_poll_trip: trip_points_size =%zu\n",
+ 			trip_points.size());
+ 	if (trip_points.size()) {
+ 		unsigned int polling_trip = 0;
+ 
+ 		std::sort(trip_points.begin(), trip_points.end(), trip_sort);
+-		thd_log_info("Sorted trip dump zone index:%d type:%s:\n", index,
++		if (DEBUG_THERMAL)
++		    thd_log_info("Sorted trip dump zone index:%d type:%s:\n", index,
+ 				type_str.c_str());
+ 		for (unsigned int i = 0; i < trip_points.size(); ++i) {
+ 			trip_points[i].trip_dump();
+@@ -124,13 +129,15 @@ void cthd_zone::sort_and_update_poll_trip() {
+ 		int poll_trip_index = 0;
+ 		for (unsigned int i = 0; i < trip_points.size(); ++i) {
+ 			if (trip_points[i].get_trip_type() == POLLING) {
+-				thd_log_debug("polling trip already present\n");
++				if (DEBUG_THERMAL)
++				    thd_log_debug("polling trip already present\n");
+ 				poll_trip_present = 1;
+ 				poll_trip_index = i;
+ 			}
+ 			if (polling_trip > trip_points[i].get_trip_temp())
+ 				polling_trip = trip_points[i].get_trip_temp();
+-			thd_log_info("trip type: %d temp: %d \n",
++			if (DEBUG_THERMAL)
++			    thd_log_info("trip type: %d temp: %d \n",
+ 					trip_points[i].get_trip_type(),
+ 					trip_points[i].get_trip_temp());
+ 		}
+diff --git a/src/thd_zone.h b/src/thd_zone.h
+index 9bf5259..eb70560 100644
+--- a/src/thd_zone.h
++++ b/src/thd_zone.h
+@@ -105,7 +105,9 @@ public:
+ 	}
+ 
+ 	void zone_cdev_set_binded() {
+-		thd_log_info("zone %s bounded \n", type_str.c_str());
++		bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
++		if (DEBUG_THERMAL)
++		    thd_log_info("zone %s bounded \n", type_str.c_str());
+ 		zone_cdev_binded_status = true;
+ 	}
+ 
+@@ -173,22 +175,27 @@ public:
+ 	}
+ 
+ 	void zone_dump() {
++		bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 		if (!zone_active)
+ 			return;
+-
+-		thd_log_info("\n");
+-		thd_log_info("Zone %d: %s, Active:%d Bind:%d Sensor_cnt:%lu\n", index,
++		if (DEBUG_THERMAL) {
++		    thd_log_info("\n");
++		    thd_log_info("Zone %d: %s, Active:%d Bind:%d Sensor_cnt:%lu\n", index,
+ 				type_str.c_str(), zone_active, zone_cdev_binded_status,
+ 				(unsigned long) sensors.size());
+-		thd_log_info("..sensors.. \n");
++		    thd_log_info("..sensors.. \n");
++		}
+ 		for (unsigned int i = 0; i < sensors.size(); ++i) {
+ 			sensors[i]->sensor_dump();
+ 		}
+-		thd_log_info("..trips.. \n");
++
++		if (DEBUG_THERMAL)
++		    thd_log_info("..trips.. \n");
+ 		for (unsigned int i = 0; i < trip_points.size(); ++i) {
+ 			trip_points[i].trip_dump();
+ 		}
+-		thd_log_info("\n");
++		if (DEBUG_THERMAL)
++		    thd_log_info("\n");
+ 
+ 	}
+ 
+diff --git a/src/thd_zone_cpu.cpp b/src/thd_zone_cpu.cpp
+index 051cbf8..1182e54 100644
+--- a/src/thd_zone_cpu.cpp
++++ b/src/thd_zone_cpu.cpp
+@@ -46,7 +46,10 @@ cthd_zone_cpu::cthd_zone_cpu(int index, std::string path, int package_id) :
+ 				package_id), pkg_thres_th_zone(-1), pkg_temp_poll_enable(false) {
+ 
+ 	type_str = "cpu";
+-	thd_log_debug("zone dts syfs: %s, package id %d \n", path.c_str(),
++
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
++	if (DEBUG_THERMAL)
++	    thd_log_debug("zone dts syfs: %s, package id %d \n", path.c_str(),
+ 			package_id);
+ }
+ 
+diff --git a/src/thd_zone_therm_sys_fs.cpp b/src/thd_zone_therm_sys_fs.cpp
+index 0e3c25e..0171213 100644
+--- a/src/thd_zone_therm_sys_fs.cpp
++++ b/src/thd_zone_therm_sys_fs.cpp
+@@ -28,17 +28,19 @@
+ 
+ cthd_sysfs_zone::cthd_sysfs_zone(int count, std::string path) :
+ 		cthd_zone(count, path), trip_point_cnt(0) {
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 
+ 	std::stringstream tc_type_dev;
+ 	tc_type_dev << index << "/type";
+-
+-	thd_log_debug("Thermal Zone look for %s\n", tc_type_dev.str().c_str());
++	if (DEBUG_THERMAL)
++	    thd_log_debug("Thermal Zone look for %s\n", tc_type_dev.str().c_str());
+ 
+ 	if (zone_sysfs.exists(tc_type_dev.str())) {
+ 		zone_sysfs.read(tc_type_dev.str(), type_str);
+ 	}
+ 
+-	thd_log_debug("Thermal Zone %d:%s\n", index, type_str.c_str());
++	if (DEBUG_THERMAL)
++	    thd_log_debug("Thermal Zone %d:%s\n", index, type_str.c_str());
+ }
+ 
+ cthd_sysfs_zone::~cthd_sysfs_zone() {
+@@ -72,6 +74,7 @@ int cthd_sysfs_zone::read_trip_points() {
+ 	// Gather all trip points
+ 	std::stringstream trip_sysfs;
+ 	trip_sysfs << index << "/" << "trip_point_";
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
+ 	for (int i = 0; i < max_trip_points; ++i) {
+ 		std::stringstream type_stream;
+ 		std::stringstream temp_stream;
+@@ -88,7 +91,8 @@ int cthd_sysfs_zone::read_trip_points() {
+ 		type_stream << trip_sysfs.str() << i << "_type";
+ 		if (zone_sysfs.exists(type_stream.str())) {
+ 			zone_sysfs.read(type_stream.str(), _type_str);
+-			thd_log_debug("read_trip_points %s:%s \n",
++			if (DEBUG_THERMAL)
++			    thd_log_debug("read_trip_points %s:%s \n",
+ 					type_stream.str().c_str(), _type_str.c_str());
+ 		}
+ 		temp_stream << trip_sysfs.str() << i << "_temp";
+@@ -96,7 +100,8 @@ int cthd_sysfs_zone::read_trip_points() {
+ 			mode = zone_sysfs.get_mode(temp_stream.str());
+ 			zone_sysfs.read(temp_stream.str(), _temp_str);
+ 			std::istringstream(_temp_str) >> temp;
+-			thd_log_debug("read_trip_points %s:%s \n",
++			if (DEBUG_THERMAL)
++			    thd_log_debug("read_trip_points %s:%s \n",
+ 					temp_stream.str().c_str(), _temp_str.c_str());
+ 		}
+ 
+@@ -106,7 +111,8 @@ int cthd_sysfs_zone::read_trip_points() {
+ 			std::istringstream(_hist_str) >> hyst;
+ 			if (hyst < 1000 || hyst > 5000)
+ 				hyst = 1000;
+-			thd_log_debug("read_trip_points %s:%s \n",
++			if (DEBUG_THERMAL)
++			    thd_log_debug("read_trip_points %s:%s \n",
+ 					hist_stream.str().c_str(), _hist_str.c_str());
+ 		}
+ 
+@@ -138,7 +144,8 @@ int cthd_sysfs_zone::read_trip_points() {
+ 			++trip_point_cnt;
+ 		}
+ 	}
+-	thd_log_debug("read_trip_points Added %d trips \n", trip_point_cnt);
++	if (DEBUG_THERMAL)
++	    thd_log_debug("read_trip_points Added %d trips \n", trip_point_cnt);
+ 	if (trip_point_cnt == 0)
+ 		return THD_ERROR;
+ 	else
+@@ -146,7 +153,9 @@ int cthd_sysfs_zone::read_trip_points() {
+ }
+ 
+ int cthd_sysfs_zone::read_cdev_trip_points() {
+-	thd_log_debug(" >> read_cdev_trip_points for \n");
++	bool DEBUG_THERMAL = property_get_bool("persist.vendor.disable.thermal.logs", false);
++	if (DEBUG_THERMAL)
++	    thd_log_debug(" >> read_cdev_trip_points for \n");
+ 
+ 	// Gather all Cdevs
+ 	// Gather all trip points
+@@ -164,30 +173,36 @@ int cthd_sysfs_zone::read_cdev_trip_points() {
+ 			std::istringstream(trip_pt_str) >> trip_cnt;
+ 		} else
+ 			continue;
+-		thd_log_debug("cdev trip point: %s contains %d\n", trip_pt_str.c_str(),
++
++		if (DEBUG_THERMAL)
++		    thd_log_debug("cdev trip point: %s contains %d\n", trip_pt_str.c_str(),
+ 				trip_cnt);
+ 		cdev_stream << cdev_sysfs.str() << i;
+ 		if (zone_sysfs.exists(cdev_stream.str())) {
+-			thd_log_debug("cdev%d present\n", i);
++			if (DEBUG_THERMAL)
++			    thd_log_debug("cdev%d present\n", i);
+ 			int ret = zone_sysfs.read_symbolic_link_value(cdev_stream.str(),
+ 					buf, sizeof(buf) - 1);
+ 			if (ret == 0) {
+ 				ptr = strstr(buf, "cooling_device");
+ 				if (ptr) {
+ 					ptr += strlen("cooling_device");
+-					thd_log_debug("symbolic name %s:%s\n", buf, ptr);
++					if (DEBUG_THERMAL)
++					    thd_log_debug("symbolic name %s:%s\n", buf, ptr);
+ 					if (trip_cnt >= 0 && trip_cnt < trip_point_cnt) {
+ 						trip_points[trip_cnt].thd_trip_point_add_cdev_index(
+ 								atoi(ptr), cthd_trip_point::default_influence);
+ 						zone_cdev_set_binded();
+ 					} else {
+-						thd_log_debug("Invalid trip_cnt\n");
++						if (DEBUG_THERMAL)
++						    thd_log_debug("Invalid trip_cnt\n");
+ 					}
+ 				}
+ 			}
+ 		}
+ 	}
+-	thd_log_debug(
++	if (DEBUG_THERMAL)
++	    thd_log_debug(
+ 			"cthd_sysfs_zone::read_cdev_trip_points: ZONE bound to CDEV status %d \n",
+ 			zone_cdev_binded_status);
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
This commit disables the logging of Thermal Daemon to reduce log clutter and improve system performance.

By Default logs will be disabled it can be enabled by setting the following the below mentioned procedure.

Steps:
1. adb shell
2. setprop persist.vendor.disable.thermal.logs true

Tracked-On: OAM-113302