### PR TITLE
Enable dynamic cache config

### DIFF
--- a/aosp_diff/preliminary/bionic/0004-Enable-dynamic-cache-configuration.patch
+++ b/aosp_diff/preliminary/bionic/0004-Enable-dynamic-cache-configuration.patch
@@ -1,0 +1,919 @@
+From 8835a1d843dc045a129248e47bdb1c5b37f9829c Mon Sep 17 00:00:00 2001
+From: "Soni, Ravi Kumar" <ravi.kumar.soni@intel.com>
+Date: Fri, 10 Nov 2023 10:43:42 +0530
+Subject: [PATCH] Enable dynamic cache configuration
+
+This patch enables bionic to read cache config from the x86/64 CPU.
+Cache config will be used in memory and string functions
+
+Improvements seen on RPL, for various sizes
+
+memmove_non_overlapping
+1.25M - 12%
+1.5M - 20%
+1.75M - 25%
+
+memcpy
+1.25M - 14%
+1.5M - 25%
+1.75M - 28%
+
+Test: bionic/tests/run-on-host.sh 64 && bionic/tests/run-on-host.sh 32
+Signed-off-by: Vinay Prasad Kompella <vinay.kompella@intel.com>
+Signed-off-by: Soni, Ravi Kumar <ravi.kumar.soni@intel.com>
+--
+ libc/Android.bp                               | 26 +++++++++-
+ libc/arch-arm/bionic/cacheinfo.cpp            |  5 ++
+ libc/arch-arm64/bionic/cacheinfo.cpp          |  5 ++
+ libc/arch-x86/bionic/cacheinfo.cpp            | 48 +++++++++++++++++++
+ libc/arch-x86/cache.h                         | 15 ++++++
+ libc/arch-x86/string/cache.h                  | 41 ----------------
+ libc/arch-x86/string/sse2-memmove-slm.S       | 35 ++++++++++++--
+ libc/arch-x86/string/sse2-memset-atom.S       | 31 ++++++++++--
+ libc/arch-x86/string/sse2-memset-slm.S        | 28 +++++++++--
+ libc/arch-x86/string/ssse3-memcpy-atom.S      |  1 -
+ .../kabylake/string/avx2-memmove-kbl.S        | 15 ++++--
+ .../kabylake/string/avx2-memset-kbl.S         |  3 +-
+ libc/arch-x86_64/kabylake/string/cache.h      | 36 --------------
+ libc/arch-x86_64/silvermont/string/cache.h    | 36 --------------
+ .../silvermont/string/sse2-memmove-slm.S      | 15 ++++--
+ .../silvermont/string/sse2-memset-slm.S       |  4 +-
+ .../silvermont/string/sse4-memcmp-slm.S       |  5 +-
+ libc/bionic/libc_init_common.cpp              |  2 +
+ libc/private/bionic_cpuinfo.h                 |  9 ++++
+ 19 files changed, 221 insertions(+), 139 deletions(-)
+ create mode 100644 libc/arch-arm/bionic/cacheinfo.cpp
+ create mode 100644 libc/arch-arm64/bionic/cacheinfo.cpp
+ create mode 100644 libc/arch-x86/bionic/cacheinfo.cpp
+ create mode 100644 libc/arch-x86/cache.h
+ delete mode 100644 libc/arch-x86/string/cache.h
+ delete mode 100644 libc/arch-x86_64/kabylake/string/cache.h
+ delete mode 100644 libc/arch-x86_64/silvermont/string/cache.h
+ create mode 100644 libc/private/bionic_cpuinfo.h
+---
+ libc/Android.bp                               | 26 ++++++++-
+ libc/arch-arm/bionic/cacheinfo.cpp            | 21 ++++++++
+ libc/arch-arm64/bionic/cacheinfo.cpp          | 21 ++++++++
+ libc/arch-x86/bionic/cacheinfo.cpp            | 53 +++++++++++++++++++
+ libc/arch-x86/cache.h                         | 30 +++++++++++
+ libc/arch-x86/string/cache.h                  | 41 --------------
+ libc/arch-x86/string/sse2-memmove-slm.S       | 35 ++++++++++--
+ libc/arch-x86/string/sse2-memset-atom.S       | 31 +++++++++--
+ libc/arch-x86/string/sse2-memset-slm.S        | 28 ++++++++--
+ libc/arch-x86/string/ssse3-memcpy-atom.S      |  1 -
+ .../kabylake/string/avx2-memmove-kbl.S        | 41 ++++++++++++--
+ .../kabylake/string/avx2-memset-kbl.S         |  3 +-
+ libc/arch-x86_64/kabylake/string/cache.h      | 36 -------------
+ libc/arch-x86_64/silvermont/string/cache.h    | 36 -------------
+ .../silvermont/string/sse2-memmove-slm.S      | 42 +++++++++++++--
+ .../silvermont/string/sse2-memset-slm.S       |  4 +-
+ .../silvermont/string/sse4-memcmp-slm.S       |  5 +-
+ libc/bionic/libc_init_common.cpp              |  2 +
+ libc/private/bionic_cacheinfo.h               | 24 +++++++++
+ 19 files changed, 337 insertions(+), 143 deletions(-)
+ create mode 100644 libc/arch-arm/bionic/cacheinfo.cpp
+ create mode 100644 libc/arch-arm64/bionic/cacheinfo.cpp
+ create mode 100644 libc/arch-x86/bionic/cacheinfo.cpp
+ create mode 100644 libc/arch-x86/cache.h
+ delete mode 100644 libc/arch-x86/string/cache.h
+ delete mode 100644 libc/arch-x86_64/kabylake/string/cache.h
+ delete mode 100644 libc/arch-x86_64/silvermont/string/cache.h
+ create mode 100644 libc/private/bionic_cacheinfo.h
+
+diff --git a/libc/Android.bp b/libc/Android.bp
+index 6d1b65b86..2c4c65686 100644
+--- a/libc/Android.bp
++++ b/libc/Android.bp
+@@ -847,12 +847,30 @@ cc_library_static {
+     },
+ }
+ 
++cc_defaults {
++    name: "libcpu_features_dependencies",
++    include_dirs: ["external/cpu_features/include"],
++    cflags: [
++        // Reserve 1024 bytes on the stack when reading from `/proc/cpuinfo`.
++        "-DSTACK_LINE_READER_BUFFER_SIZE=1024",
++        "-Wno-gnu-designator",
++    ],
++    arch: {
++        x86: {
++            srcs: [":libcpu_features_x86_sources"],
++        },
++        x86_64: {
++            srcs: [":libcpu_features_x86_sources"],
++        }
++    }
++}
++
+ // ========================================================
+ // libc_bionic.a - home-grown C library code
+ // ========================================================
+ 
+ cc_library_static {
+-    defaults: ["libc_defaults"],
++    defaults: ["libc_defaults", "libcpu_features_dependencies"],
+     srcs: [
+         // These require getauxval, which isn't available on older platforms.
+         "bionic/sysconf.cpp",
+@@ -893,6 +911,7 @@ cc_library_static {
+                 "arch-arm/bionic/setjmp.S",
+                 "arch-arm/bionic/syscall.S",
+                 "arch-arm/bionic/vfork.S",
++                "arch-arm/bionic/cacheinfo.cpp",
+ 
+                 "arch-arm/cortex-a15/bionic/memcpy.S",
+                 "arch-arm/cortex-a15/bionic/memmove.S",
+@@ -930,6 +949,7 @@ cc_library_static {
+                 "arch-arm64/bionic/setjmp.S",
+                 "arch-arm64/bionic/syscall.S",
+                 "arch-arm64/bionic/vfork.S",
++                "arch-arm64/bionic/cacheinfo.cpp",
+             ],
+             exclude_srcs: [
+                 "bionic/strchr.cpp",
+@@ -1007,6 +1027,7 @@ cc_library_static {
+                 "arch-x86/bionic/syscall.S",
+                 "arch-x86/bionic/vfork.S",
+                 "arch-x86/bionic/__x86.get_pc_thunk.S",
++                "arch-x86/bionic/cacheinfo.cpp",
+             ],
+ 
+             exclude_srcs: [
+@@ -1078,6 +1099,9 @@ cc_library_static {
+                 "arch-x86_64/bionic/setjmp.S",
+                 "arch-x86_64/bionic/syscall.S",
+                 "arch-x86_64/bionic/vfork.S",
++                
++                // Common source for both x86/x86_64
++                "arch-x86/bionic/cacheinfo.cpp",
+             ],
+             exclude_srcs: [
+                 "bionic/strchr.cpp",
+diff --git a/libc/arch-arm/bionic/cacheinfo.cpp b/libc/arch-arm/bionic/cacheinfo.cpp
+new file mode 100644
+index 000000000..18c739ddc
+--- /dev/null
++++ b/libc/arch-arm/bionic/cacheinfo.cpp
+@@ -0,0 +1,21 @@
++/*
++Copyright (C) 2023 Intel Corporation.
++
++This software and the related documents are Intel copyrighted materials,
++and your use of them is governed by the express license under which they
++were provided to you (End User License Agreement for the Intel(R) Software
++Development Products). Unless the License provides
++otherwise, you may not use, modify, copy, publish, distribute, disclose or
++transmit this software or the related documents without Intel's prior
++written permission.
++
++This software and the related documents are provided as is, with no
++express or implied warranties, other than those that are expressly
++stated in the License.
++*/
++
++#include "private/bionic_cacheinfo.h"
++
++void __libc_init_cacheinfo() {
++    UNIMPLEMENTED();
++}
+diff --git a/libc/arch-arm64/bionic/cacheinfo.cpp b/libc/arch-arm64/bionic/cacheinfo.cpp
+new file mode 100644
+index 000000000..18c739ddc
+--- /dev/null
++++ b/libc/arch-arm64/bionic/cacheinfo.cpp
+@@ -0,0 +1,21 @@
++/*
++Copyright (C) 2023 Intel Corporation.
++
++This software and the related documents are Intel copyrighted materials,
++and your use of them is governed by the express license under which they
++were provided to you (End User License Agreement for the Intel(R) Software
++Development Products). Unless the License provides
++otherwise, you may not use, modify, copy, publish, distribute, disclose or
++transmit this software or the related documents without Intel's prior
++written permission.
++
++This software and the related documents are provided as is, with no
++express or implied warranties, other than those that are expressly
++stated in the License.
++*/
++
++#include "private/bionic_cacheinfo.h"
++
++void __libc_init_cacheinfo() {
++    UNIMPLEMENTED();
++}
+diff --git a/libc/arch-x86/bionic/cacheinfo.cpp b/libc/arch-x86/bionic/cacheinfo.cpp
+new file mode 100644
+index 000000000..c90054323
+--- /dev/null
++++ b/libc/arch-x86/bionic/cacheinfo.cpp
+@@ -0,0 +1,53 @@
++/*
++Copyright (C) 2023 Intel Corporation.
++
++This software and the related documents are Intel copyrighted materials,
++and your use of them is governed by the express license under which they
++were provided to you (End User License Agreement for the Intel(R) Software
++Development Products). Unless the License provides
++otherwise, you may not use, modify, copy, publish, distribute, disclose or
++transmit this software or the related documents without Intel's prior
++written permission.
++
++This software and the related documents are provided as is, with no
++express or implied warranties, other than those that are expressly
++stated in the License.
++*/
++
++#include "private/bionic_cacheinfo.h"
++#include "cpuinfo_x86.h"
++#include <async_safe/log.h>
++#include "../cache.h"
++
++/* Data cache size for use in memory and string routines, typically
++   L1 size, rounded to multiple of 256 bytes.  */
++unsigned long int __x86_data_cache_size = 24 * 1024;
++unsigned long int __x86_data_cache_size_half = __x86_data_cache_size / 2;
++/* Shared cache size for use in memory and string routines, typically
++   L2 or L3 size, rounded to multiple of 256 bytes.  */
++unsigned long int __x86_shared_cache_size = 1024 * 1024;
++unsigned long int __x86_shared_cache_size_half = __x86_shared_cache_size / 2;
++/* Shared cache size for memset routines*/
++unsigned long int __x86_shared_cache_size_memset = 1024 * 1024;
++
++using namespace cpu_features;
++
++void __libc_init_cacheinfo() {
++    CacheInfo info = GetX86CacheInfo();
++    for (int count = 0, i = 0; count < info.size && i < CPU_FEATURES_MAX_CACHE_LEVEL; ++i) {
++        if (info.levels[i].level == 1 &&
++            info.levels[i].cache_type == CPU_FEATURE_CACHE_DATA) {
++            // L1D
++            __x86_data_cache_size = info.levels[i].cache_size;
++            __x86_data_cache_size_half = __x86_data_cache_size / 2;
++        }  else if (info.levels[i].level == 2 &&
++                   (info.levels[i].cache_type == CPU_FEATURE_CACHE_UNIFIED ||
++                   info.levels[i].cache_type == CPU_FEATURE_CACHE_DATA)) {
++            /* Shared cache size */
++            __x86_shared_cache_size = info.levels[i].cache_size;
++            __x86_shared_cache_size_half = __x86_shared_cache_size / 2;
++
++            __x86_shared_cache_size_memset = __x86_shared_cache_size * 2;
++        }
++    }
++}
+diff --git a/libc/arch-x86/cache.h b/libc/arch-x86/cache.h
+new file mode 100644
+index 000000000..f5ce15d9a
+--- /dev/null
++++ b/libc/arch-x86/cache.h
+@@ -0,0 +1,30 @@
++/*
++Copyright (C) 2023 Intel Corporation.
++
++This software and the related documents are Intel copyrighted materials,
++and your use of them is governed by the express license under which they
++were provided to you (End User License Agreement for the Intel(R) Software
++Development Products). Unless the License provides
++otherwise, you may not use, modify, copy, publish, distribute, disclose or
++transmit this software or the related documents without Intel's prior
++written permission.
++
++This software and the related documents are provided as is, with no
++express or implied warranties, other than those that are expressly
++stated in the License.
++*/
++
++#ifndef __PRIVATE_ARCH_CACHE_H__
++#define __PRIVATE_ARCH_CACHE_H__
++
++/* Data cache size for use in memory and string routines, typically
++   L1 size, rounded to multiple of 256 bytes.  */
++ extern unsigned long int __x86_data_cache_size_half;
++ extern unsigned long int __x86_data_cache_size ;
++/* Shared cache size for use in memory and string routines, 
++   rounded to multiple of 256 bytes.  */
++ extern unsigned long int __x86_shared_cache_size_half ;
++ extern unsigned long int __x86_shared_cache_size ;
++/* Shared cache size for memset routines*/
++ extern unsigned long int __x86_shared_cache_size_memset ;
++#endif
+diff --git a/libc/arch-x86/string/cache.h b/libc/arch-x86/string/cache.h
+deleted file mode 100644
+index 33719a0cb..000000000
+--- a/libc/arch-x86/string/cache.h
++++ /dev/null
+@@ -1,41 +0,0 @@
+-/*
+-Copyright (c) 2010, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-#ifdef FOR_ATOM
+-#define SHARED_CACHE_SIZE (512 * 1024) /* Atom L2 Cache */
+-#endif
+-#ifdef FOR_SILVERMONT
+-#define SHARED_CACHE_SIZE (1024 * 1024) /* Silvermont L2 Cache */
+-#endif
+-
+-#define DATA_CACHE_SIZE (24 * 1024) /* Atom and Silvermont L1 Data Cache */
+-
+-#define SHARED_CACHE_SIZE_HALF (SHARED_CACHE_SIZE / 2)
+-#define DATA_CACHE_SIZE_HALF (DATA_CACHE_SIZE / 2)
+diff --git a/libc/arch-x86/string/sse2-memmove-slm.S b/libc/arch-x86/string/sse2-memmove-slm.S
+index 79b5d1b7e..8afe6fa47 100644
+--- a/libc/arch-x86/string/sse2-memmove-slm.S
++++ b/libc/arch-x86/string/sse2-memmove-slm.S
+@@ -29,7 +29,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+ #define FOR_SILVERMONT
+-#include "cache.h"
+ 
+ #ifndef MEMMOVE
+ # define MEMMOVE	memmove_generic
+@@ -94,6 +93,8 @@ name:		\
+ #define RETURN_END	POP (%ebx); ret
+ #define RETURN		RETURN_END; CFI_PUSH (%ebx)
+ 
++# define SETUP_PIC_REG(x)	call	__x86.get_pc_thunk.x
++
+ 	.section .text.sse2,"ax",@progbits
+ ENTRY (MEMMOVE)
+ 	ENTRANCE
+@@ -193,7 +194,21 @@ L(mm_len_128_or_more_forward):
+ 	cmp	%edi, %ebx
+ 	jbe	L(mm_copy_remaining_forward)
+ 
+-	cmp	$SHARED_CACHE_SIZE_HALF, %ecx
++	#ifdef SHARED_CACHE_SIZE_HALF
++		cmp	$SHARED_CACHE_SIZE_HALF, %ecx
++	#else
++	# if (defined SHARED || defined __PIC__)
++		PUSH(%ebx)
++		SETUP_PIC_REG(bx)
++		add	$_GLOBAL_OFFSET_TABLE_, %ebx
++		cmp	__x86_shared_cache_size_half@GOTOFF(%ebx), %ecx
++		/* Restore ebx. We can place a pop before jump as it doesnt effect any flags */
++		POP(%ebx)
++	# else
++		cmp	__x86_shared_cache_size_half, %ecx
++	# endif
++	#endif
++
+ 	jae	L(mm_large_page_loop_forward)
+ 
+ 	.p2align 4
+@@ -424,7 +439,21 @@ L(mm_len_128_or_more_backward):
+ 	cmp	%edi, %ebx
+ 	jae	L(mm_main_loop_backward_end)
+ 
+-	cmp	$SHARED_CACHE_SIZE_HALF, %ecx
++	#ifdef SHARED_CACHE_SIZE_HALF
++		cmp	$SHARED_CACHE_SIZE_HALF, %ecx
++	#else
++	# if (defined SHARED || defined __PIC__)
++		PUSH(%ebx)
++		SETUP_PIC_REG(bx)
++		add	$_GLOBAL_OFFSET_TABLE_, %ebx
++		cmp	__x86_shared_cache_size_half@GOTOFF(%ebx), %ecx
++		/* Restore ebx. We can place a pop before jump as it doesnt effect any flags */
++		POP(%ebx)
++	# else
++		cmp	__x86_shared_cache_size_half, %ecx
++	# endif
++	#endif
++	
+ 	jae	L(mm_large_page_loop_backward)
+ 
+ 	.p2align 4
+diff --git a/libc/arch-x86/string/sse2-memset-atom.S b/libc/arch-x86/string/sse2-memset-atom.S
+index 320afec11..a0424264d 100644
+--- a/libc/arch-x86/string/sse2-memset-atom.S
++++ b/libc/arch-x86/string/sse2-memset-atom.S
+@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include <private/bionic_asm.h>
+ 
+ #define FOR_ATOM
+-#include "cache.h"
++
+ 
+ #ifndef L
+ # define L(label)	.L##label
+@@ -64,6 +64,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #define RETURN		RETURN_END; CFI_PUSH(%ebx)
+ #define JMPTBL(I, B)	I - B
+ 
++# define SETUP_PIC_REG(x)	call	__x86.get_pc_thunk.x
++
+ /* Load an entry in a jump table into EBX and branch to it.  TABLE is a
+    jump table with relative offsets.   */
+ # define BRANCH_TO_JMPTBL_ENTRY(TABLE)				\
+@@ -256,15 +258,36 @@ L(aligned_16_less128bytes):
+ 	ALIGN(4)
+ L(128bytesormore):
+ 	PUSH(%ebx)
+-	mov	$SHARED_CACHE_SIZE, %ebx
++	#ifdef SHARED_CACHE_SIZE
++		mov	$SHARED_CACHE_SIZE, %ebx
++	#else
++	# if (defined SHARED || defined __PIC__)
++		SETUP_PIC_REG(bx)
++		add	$_GLOBAL_OFFSET_TABLE_, %ebx
++		mov	__x86_shared_cache_size_memset@GOTOFF(%ebx), %ebx
++	# else
++		mov	__x86_shared_cache_size_memset, %ebx
++	# endif
++	#endif
+ 	cmp	%ebx, %ecx
+ 	jae	L(128bytesormore_nt_start)
+ 
+ 
+ 	POP(%ebx)
+ # define RESTORE_EBX_STATE CFI_PUSH(%ebx)
+-	cmp	$DATA_CACHE_SIZE, %ecx
+-
++	#ifdef DATA_CACHE_SIZE
++		cmp	$DATA_CACHE_SIZE, %ecx
++	#else
++	# if (defined SHARED || defined __PIC__)
++		PUSH(%ebx)
++		SETUP_PIC_REG(bx)
++		add	$_GLOBAL_OFFSET_TABLE_, %ebx
++		cmp	__x86_data_cache_size@GOTOFF(%ebx), %ecx
++		POP(%ebx)
++	# else
++		cmp	__x86_data_cache_size, %ecx
++	# endif
++	#endif
+ 	jae	L(128bytes_L2_normal)
+ 	subl	$128, %ecx
+ L(128bytesormore_normal):
+diff --git a/libc/arch-x86/string/sse2-memset-slm.S b/libc/arch-x86/string/sse2-memset-slm.S
+index 5cff141ad..d3422c994 100644
+--- a/libc/arch-x86/string/sse2-memset-slm.S
++++ b/libc/arch-x86/string/sse2-memset-slm.S
+@@ -31,7 +31,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include <private/bionic_asm.h>
+ 
+ #define FOR_SILVERMONT
+-#include "cache.h"
+ 
+ #ifndef L
+ # define L(label)	.L##label
+@@ -64,6 +63,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ # define RETURN		RETURN_END; CFI_PUSH(%ebx)
+ # define JMPTBL(I, B)	I - B
+ 
++# define SETUP_PIC_REG(x)	call	__x86.get_pc_thunk.x
++
+ /* Load an entry in a jump table into EBX and branch to it.  TABLE is a
+    jump table with relative offsets.   */
+ # define BRANCH_TO_JMPTBL_ENTRY(TABLE)				\
+@@ -177,14 +178,35 @@ L(aligned_16_less128bytes):
+ 	ALIGN(4)
+ L(128bytesormore):
+ 	PUSH(%ebx)
+-	mov	$SHARED_CACHE_SIZE, %ebx
++	#ifdef SHARED_CACHE_SIZE
++		mov	$SHARED_CACHE_SIZE, %ebx
++	#else
++	# if (defined SHARED || defined __PIC__)
++		SETUP_PIC_REG(bx)
++		add	$_GLOBAL_OFFSET_TABLE_, %ebx
++		mov	__x86_shared_cache_size_memset@GOTOFF(%ebx), %ebx
++	# else
++		mov	__x86_shared_cache_size_memset, %ebx
++	# endif
++	#endif
++
+ 	cmp	%ebx, %ecx
+ 	jae	L(128bytesormore_nt_start)
+ 
+ 	POP(%ebx)
+ 
+ 	PUSH(%ebx)
+-	mov	$DATA_CACHE_SIZE, %ebx
++	#ifdef DATA_CACHE_SIZE
++		mov	$DATA_CACHE_SIZE, %ebx
++	#else
++	# if (defined SHARED || defined __PIC__)
++		SETUP_PIC_REG(bx)
++		add	$_GLOBAL_OFFSET_TABLE_, %ebx
++		mov	__x86_data_cache_size@GOTOFF(%ebx), %ebx
++	# else
++		mov	__x86_data_cache_size, %ebx
++	# endif
++	#endif
+ 
+ 	cmp	%ebx, %ecx
+ 	jae	L(128bytes_L2_normal)
+diff --git a/libc/arch-x86/string/ssse3-memcpy-atom.S b/libc/arch-x86/string/ssse3-memcpy-atom.S
+index fe3082ee7..83e198504 100644
+--- a/libc/arch-x86/string/ssse3-memcpy-atom.S
++++ b/libc/arch-x86/string/ssse3-memcpy-atom.S
+@@ -29,7 +29,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+ #define FOR_ATOM
+-#include "cache.h"
+ 
+ #ifndef MEMCPY
+ # define MEMCPY	memcpy_atom
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-memmove-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-memmove-kbl.S
+index 02e9ec1d2..16f2880ef 100644
+--- a/libc/arch-x86_64/kabylake/string/avx2-memmove-kbl.S
++++ b/libc/arch-x86_64/kabylake/string/avx2-memmove-kbl.S
+@@ -28,7 +28,6 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+-#include "cache.h"
+ 
+ #ifndef MEMMOVE
+ # define MEMMOVE		memmove_avx2
+@@ -228,8 +227,13 @@ L(mm_len_256_or_more_forward):
+         cmp     %r8, %rbx
+         jbe     L(mm_copy_remaining_forward)
+ 
+-        cmp     $SHARED_CACHE_SIZE_HALF, %rdx
+-        jae     L(mm_large_page_loop_forward)
++	#ifdef SHARED_CACHE_SIZE_HALF
++	 cmp	$SHARED_CACHE_SIZE_HALF, %rdx
++	#else
++	 cmp     __x86_shared_cache_size_half(%rip), %rdx
++	#endif
++
++        ja      L(mm_overlapping_check_forward)
+ 
+         .p2align 4
+ L(mm_main_loop_forward):
+@@ -497,8 +501,13 @@ L(mm_len_256_or_more_backward):
+ 	cmp	%r9, %rbx
+ 	jae	L(mm_recalc_len)
+ 
+-	cmp	$SHARED_CACHE_SIZE_HALF, %rdx
+-	jae	L(mm_large_page_loop_backward)
++	#ifdef SHARED_CACHE_SIZE_HALF
++	 cmp	$SHARED_CACHE_SIZE_HALF, %rdx
++	#else
++	 cmp    __x86_shared_cache_size_half(%rip), %rdx
++	#endif
++
++	ja	L(mm_overlapping_check_backward)
+ 
+ 	.p2align 4
+ L(mm_main_loop_backward):
+@@ -560,6 +569,16 @@ L(mm_return):
+ /* Big length copy forward part.  */
+ 
+ 	.p2align 4
++L(mm_overlapping_check_forward):
++	mov	%rsi, %r9
++	add 	%rdx, %r9
++	#ifdef SHARED_CACHE_SIZE
++	  cmp	$SHARED_CACHE_SIZE, %r9
++	#else
++	  cmp   __x86_shared_cache_size(%rip), %r9
++	#endif
++	jbe L(mm_main_loop_forward)
++
+ L(mm_large_page_loop_forward):
+ 	vmovdqu	  (%r8, %rsi), %ymm0
+ 	vmovdqu	  32(%r8, %rsi), %ymm1
+@@ -577,6 +596,18 @@ L(mm_large_page_loop_forward):
+ 
+ /* Big length copy backward part.  */
+ 	.p2align 4
++
++L(mm_overlapping_check_backward):
++	mov       %rdi, %r11
++	sub       %rsi, %r11 /* r11 = dst - src, diff */
++	add       %rdx, %r11
++	#ifdef SHARED_CACHE_SIZE
++	  cmp     $SHARED_CACHE_SIZE, %r11
++	#else
++	  cmp     __x86_shared_cache_size(%rip), %r11
++	#endif
++	jbe L(mm_main_loop_backward)
++
+ L(mm_large_page_loop_backward):
+ 	vmovdqu	  -64(%r9, %r8), %ymm0
+ 	vmovdqu	  -32(%r9, %r8), %ymm1
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-memset-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-memset-kbl.S
+index 09dd07dd1..05f2b8c75 100644
+--- a/libc/arch-x86_64/kabylake/string/avx2-memset-kbl.S
++++ b/libc/arch-x86_64/kabylake/string/avx2-memset-kbl.S
+@@ -30,7 +30,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ 
+-#include "cache.h"
+ 
+ #ifndef L
+ # define L(label)	.L##label
+@@ -126,7 +125,7 @@ L(256bytesmore):
+ #ifdef SHARED_CACHE_SIZE
+ 	cmp	$SHARED_CACHE_SIZE, %r8
+ #else
+-	cmp	__x86_64_shared_cache_size(%rip), %r8
++	cmp	__x86_shared_cache_size_memset(%rip), %r8
+ #endif
+ 	ja	L(256bytesmore_nt)
+ 
+diff --git a/libc/arch-x86_64/kabylake/string/cache.h b/libc/arch-x86_64/kabylake/string/cache.h
+deleted file mode 100644
+index 4131509fb..000000000
+--- a/libc/arch-x86_64/kabylake/string/cache.h
++++ /dev/null
+@@ -1,36 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-/* Values are optimized for Core Architecture */
+-#define SHARED_CACHE_SIZE (4096*1024)  /* Core Architecture L2 Cache */
+-#define DATA_CACHE_SIZE   (24*1024)    /* Core Architecture L1 Data Cache */
+-
+-#define SHARED_CACHE_SIZE_HALF (SHARED_CACHE_SIZE / 2)
+-#define DATA_CACHE_SIZE_HALF   (DATA_CACHE_SIZE / 2)
+diff --git a/libc/arch-x86_64/silvermont/string/cache.h b/libc/arch-x86_64/silvermont/string/cache.h
+deleted file mode 100644
+index 3606d2a1a..000000000
+--- a/libc/arch-x86_64/silvermont/string/cache.h
++++ /dev/null
+@@ -1,36 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-/* Values are optimized for Silvermont */
+-#define SHARED_CACHE_SIZE (1024*1024)  /* Silvermont L2 Cache */
+-#define DATA_CACHE_SIZE   (24*1024)    /* Silvermont L1 Data Cache */
+-
+-#define SHARED_CACHE_SIZE_HALF (SHARED_CACHE_SIZE / 2)
+-#define DATA_CACHE_SIZE_HALF   (DATA_CACHE_SIZE / 2)
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-memmove-slm.S b/libc/arch-x86_64/silvermont/string/sse2-memmove-slm.S
+index 7024f4950..63839035d 100644
+--- a/libc/arch-x86_64/silvermont/string/sse2-memmove-slm.S
++++ b/libc/arch-x86_64/silvermont/string/sse2-memmove-slm.S
+@@ -28,7 +28,6 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+-#include "cache.h"
+ 
+ #ifndef MEMMOVE
+ # define MEMMOVE		memmove_generic
+@@ -189,8 +188,13 @@ L(mm_len_128_or_more_forward):
+ 	cmp	%r8, %rbx
+ 	jbe	L(mm_copy_remaining_forward)
+ 
+-	cmp	$SHARED_CACHE_SIZE_HALF, %rdx
+-	jae	L(mm_large_page_loop_forward)
++	#ifdef SHARED_CACHE_SIZE_HALF
++		cmp	$SHARED_CACHE_SIZE_HALF, %rdx
++	#else
++		cmp	__x86_shared_cache_size_half(%rip), %rdx
++	#endif
++
++	ja	L(mm_overlapping_check_forward)
+ 
+ 	.p2align 4
+ L(mm_main_loop_forward):
+@@ -414,8 +418,13 @@ L(mm_len_128_or_more_backward):
+ 	cmp	%r9, %rbx
+ 	jae	L(mm_recalc_len)
+ 
+-	cmp	$SHARED_CACHE_SIZE_HALF, %rdx
+-	jae	L(mm_large_page_loop_backward)
++	#ifdef SHARED_CACHE_SIZE_HALF
++		cmp	$SHARED_CACHE_SIZE_HALF, %rdx
++	#else
++		cmp __x86_shared_cache_size_half(%rip), %rdx
++	#endif
++	
++	ja	L(mm_overlapping_check_backward)
+ 
+ 	.p2align 4
+ L(mm_main_loop_backward):
+@@ -481,6 +490,17 @@ L(mm_return):
+ /* Big length copy forward part.  */
+ 
+ 	.p2align 4
++
++L(mm_overlapping_check_forward):
++	mov     %rsi, %r9
++	add     %rdx, %r9
++	#ifdef  SHARED_CACHE_SIZE
++	  cmp   $SHARED_CACHE_SIZE, %r9
++	#else
++	  cmp   __x86_shared_cache_size(%rip), %r9
++	#endif
++	jbe     L(mm_main_loop_forward)
++
+ L(mm_large_page_loop_forward):
+ 	movdqu	(%r8, %rsi), %xmm0
+ 	movdqu	16(%r8, %rsi), %xmm1
+@@ -498,6 +518,18 @@ L(mm_large_page_loop_forward):
+ 
+ /* Big length copy backward part.  */
+ 	.p2align 4
++
++L(mm_overlapping_check_backward):
++	mov     %rdi, %r11
++	sub     %rsi, %r11    /* r11 = dst - src, diff */
++	add     %rdx, %r11
++	#ifdef SHARED_CACHE_SIZE
++	  cmp   $SHARED_CACHE_SIZE, %r11
++	#else
++	  cmp   __x86_shared_cache_size(%rip), %r11
++	#endif
++	jbe     L(mm_main_loop_backward)
++
+ L(mm_large_page_loop_backward):
+ 	movdqu	-64(%r9, %r8), %xmm0
+ 	movdqu	-48(%r9, %r8), %xmm1
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-memset-slm.S b/libc/arch-x86_64/silvermont/string/sse2-memset-slm.S
+index cceadd297..b94e94d3c 100644
+--- a/libc/arch-x86_64/silvermont/string/sse2-memset-slm.S
++++ b/libc/arch-x86_64/silvermont/string/sse2-memset-slm.S
+@@ -30,8 +30,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ 
+-#include "cache.h"
+-
+ #ifndef L
+ # define L(label)	.L##label
+ #endif
+@@ -119,7 +117,7 @@ L(128bytesmore):
+ #ifdef SHARED_CACHE_SIZE
+ 	cmp	$SHARED_CACHE_SIZE, %r8
+ #else
+-	cmp	__x86_64_shared_cache_size(%rip), %r8
++	cmp	__x86_shared_cache_size_memset(%rip), %r8
+ #endif
+ 	ja	L(128bytesmore_nt)
+ 
+diff --git a/libc/arch-x86_64/silvermont/string/sse4-memcmp-slm.S b/libc/arch-x86_64/silvermont/string/sse4-memcmp-slm.S
+index 6cfcd767f..c6db137eb 100644
+--- a/libc/arch-x86_64/silvermont/string/sse4-memcmp-slm.S
++++ b/libc/arch-x86_64/silvermont/string/sse4-memcmp-slm.S
+@@ -28,7 +28,6 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+-#include "cache.h"
+ 
+ #ifndef MEMCMP
+ # define MEMCMP		memcmp_generic
+@@ -356,7 +355,7 @@ L(512bytesormore):
+ #ifdef DATA_CACHE_SIZE_HALF
+ 	mov	$DATA_CACHE_SIZE_HALF, %r8
+ #else
+-	mov	__x86_64_data_cache_size_half(%rip), %r8
++	mov	__x86_data_cache_size_half(%rip), %r8
+ #endif
+ 	mov	%r8, %r9
+ 	shr	$1, %r8
+@@ -672,7 +671,7 @@ L(512bytesormorein2aligned):
+ #ifdef DATA_CACHE_SIZE_HALF
+ 	mov	$DATA_CACHE_SIZE_HALF, %r8
+ #else
+-	mov	__x86_64_data_cache_size_half(%rip), %r8
++	mov	__x86_data_cache_size_half(%rip), %r8
+ #endif
+ 	mov	%r8, %r9
+ 	shr	$1, %r8
+diff --git a/libc/bionic/libc_init_common.cpp b/libc/bionic/libc_init_common.cpp
+index 59b2ddb33..9d4ea5d2a 100644
+--- a/libc/bionic/libc_init_common.cpp
++++ b/libc/bionic/libc_init_common.cpp
+@@ -51,6 +51,7 @@
+ #include "private/bionic_tls.h"
+ #include "private/thread_private.h"
+ #include "pthread_internal.h"
++#include "private/bionic_cacheinfo.h"
+ 
+ extern "C" int __system_properties_init(void);
+ extern "C" void scudo_malloc_set_zero_contents(int);
+@@ -171,6 +172,7 @@ void __libc_init_common() {
+   __system_properties_init(); // Requires 'environ'.
+   __libc_init_fdsan(); // Requires system properties (for debug.fdsan).
+   __libc_init_fdtrack();
++  __libc_init_cacheinfo();
+ }
+ 
+ void __libc_init_fork_handler() {
+diff --git a/libc/private/bionic_cacheinfo.h b/libc/private/bionic_cacheinfo.h
+new file mode 100644
+index 000000000..b339e0973
+--- /dev/null
++++ b/libc/private/bionic_cacheinfo.h
+@@ -0,0 +1,24 @@
++/*
++Copyright (C) 2023 Intel Corporation.
++
++This software and the related documents are Intel copyrighted materials,
++and your use of them is governed by the express license under which they
++were provided to you (End User License Agreement for the Intel(R) Software
++Development Products). Unless the License provides
++otherwise, you may not use, modify, copy, publish, distribute, disclose or
++transmit this software or the related documents without Intel's prior
++written permission.
++
++This software and the related documents are provided as is, with no
++express or implied warranties, other than those that are expressly
++stated in the License.
++*/
++
++#ifndef _PRIVATE_BIONIC_CPUINFO_H
++#define _PRIVATE_BIONIC_CPUINFO_H
++
++#include <sys/cdefs.h>
++
++__LIBC_HIDDEN__ void __libc_init_cacheinfo ();
++
++#endif
+-- 
+2.42.0
+

--- a/aosp_diff/preliminary/build/soong/0008-Add-external-cpu_features-to-bazel-allowlist.patch
+++ b/aosp_diff/preliminary/build/soong/0008-Add-external-cpu_features-to-bazel-allowlist.patch
@@ -1,0 +1,27 @@
+From 8b16465b0564cbce71426fe2ca5f87c31f22a6fb Mon Sep 17 00:00:00 2001
+From: "Soni, Ravi Kumar" <ravi.kumar.soni@intel.com>
+Date: Thu, 9 Nov 2023 12:22:09 +0000
+Subject: [PATCH] Add external/cpu_features to bazel allowlist
+
+Change-Id: I7e079ff1729758334a94dd2009f445ab0b1cfaf7
+Signed-off-by: Vinay Prasad Kompella <vinay.kompella@intel.com>
+Signed-off-by: Soni, Ravi Kumar <ravi.kumar.soni@intel.com>
+---
+ android/allowlists/allowlists.go | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/android/allowlists/allowlists.go b/android/allowlists/allowlists.go
+index 63d4e11e0..3144530f6 100644
+--- a/android/allowlists/allowlists.go
++++ b/android/allowlists/allowlists.go
+@@ -125,6 +125,7 @@ var (
+ 		"external/bsdiff":                        Bp2BuildDefaultTrueRecursively,
+ 		"external/bzip2":                         Bp2BuildDefaultTrueRecursively,
+ 		"external/conscrypt":                     Bp2BuildDefaultTrue,
++		"external/cpu_features":                  Bp2BuildDefaultTrueRecursively,
+ 		"external/e2fsprogs":                     Bp2BuildDefaultTrueRecursively,
+ 		"external/eigen":                         Bp2BuildDefaultTrueRecursively,
+ 		"external/erofs-utils":                   Bp2BuildDefaultTrueRecursively,
+-- 
+2.42.0
+

--- a/aosp_diff/preliminary/external/cpu_features/0001-Expose-sources-for-usage-in-libc.patch
+++ b/aosp_diff/preliminary/external/cpu_features/0001-Expose-sources-for-usage-in-libc.patch
@@ -1,0 +1,31 @@
+From 2a0e28d2e0df24d6b00546e739c2161be1022d78 Mon Sep 17 00:00:00 2001
+From: "Soni, Ravi Kumar" <ravi.kumar.soni@intel.com>
+Date: Tue, 17 May 2022 10:44:31 +0000
+Subject: [PATCH] Expose sources for usage in libc
+
+Change-Id: Id30b1c77fd4990ae05a9d7e12fffe9aaeadb843c
+Signed-off-by: Vinay Prasad Kompella <vinay.kompella@intel.com>
+Signed-off-by: Soni, Ravi Kumar <ravi.kumar.soni@intel.com>
+---
+ Android.bp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/Android.bp b/Android.bp
+index 57e3804..38a6470 100644
+--- a/Android.bp
++++ b/Android.bp
+@@ -89,6 +89,11 @@ cc_library {
+     ],
+ }
+ 
++filegroup {
++    name: "libcpu_features_x86_sources",
++    srcs: ["src/impl_x86_linux_or_android.c",],
++}
++
+ cc_library {
+     name: "libcpu_features",
+     defaults: [
+-- 
+2.42.0
+


### PR DESCRIPTION
This patch reads cache info from CPU.
Cache info is used in memory and string functions.

Change-Id: Ia1934fd4054a00b10ab3e7c6de85e0d3fd86567e