### PR TITLE
Fix javacrash on com.android.gallery3d as CursorIndexOutOfBoundsExcep…

### DIFF
--- a/aosp_diff/preliminary/packages/apps/Gallery2/0003-Fix-javacrash-on-com.android.gallery3d-as-CursorInde.patch
+++ b/aosp_diff/preliminary/packages/apps/Gallery2/0003-Fix-javacrash-on-com.android.gallery3d-as-CursorInde.patch
@@ -1,0 +1,31 @@
+From 03de6a42e24d30b2b99d0b5c3127b77448af8d94 Mon Sep 17 00:00:00 2001
+From: xubing <bing.xu@intel.com>
+Date: Mon, 13 Nov 2023 13:35:15 +0800
+Subject: [PATCH] Fix javacrash on com.android.gallery3d as
+ CursorIndexOutOfBoundsException
+
+Media file is not exist on the path, so the cursor of the path is not
+null but the size is zero, so need check both.
+
+Tracked-On: OAM-113164
+Signed-off-by: xubing <bing.xu@intel.com>
+---
+ src/com/android/gallery3d/filtershow/cache/ImageLoader.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/com/android/gallery3d/filtershow/cache/ImageLoader.java b/src/com/android/gallery3d/filtershow/cache/ImageLoader.java
+index 003ff482f..24a99ba4b 100644
+--- a/src/com/android/gallery3d/filtershow/cache/ImageLoader.java
++++ b/src/com/android/gallery3d/filtershow/cache/ImageLoader.java
+@@ -84,7 +84,7 @@ public final class ImageLoader {
+     public static String getLocalPathFromUri(Context context, Uri uri) {
+         Cursor cursor = context.getContentResolver().query(uri,
+                 new String[]{MediaStore.Images.Media.DATA}, null, null, null);
+-        if (cursor == null) {
++        if (cursor == null  || cursor.getCount() == 0) {
+             return null;
+         }
+         int index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
+-- 
+2.34.1
+


### PR DESCRIPTION
…tion

Media file is not exist on the path, so the cursor of the path is not null but the size is zero, so need check both.

Tracked-On: OAM-113164