### PR TITLE
Fix javacrash on com.android.gallery3d with null object

### DIFF
--- a/aosp_diff/preliminary/packages/apps/Gallery2/0002-Fix-javaCrash-on-com.android.gallery3d-with-null-obj.patch
+++ b/aosp_diff/preliminary/packages/apps/Gallery2/0002-Fix-javaCrash-on-com.android.gallery3d-with-null-obj.patch
@@ -1,0 +1,29 @@
+From a40673990645fca41d5540bf29b020652e22fdb7 Mon Sep 17 00:00:00 2001
+From: xubing <bing.xu@intel.com>
+Date: Mon, 13 Nov 2023 13:23:37 +0800
+Subject: [PATCH] Fix javaCrash on com.android.gallery3d with null object
+
+mContainer is used but not initialized, so check it before
+it is used.
+
+Tracked-On: OAM-113169
+Signed-off-by: xubing <bing.xu@intel.com>
+---
+ src/com/android/gallery3d/filtershow/EditorPlaceHolder.java | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/com/android/gallery3d/filtershow/EditorPlaceHolder.java b/src/com/android/gallery3d/filtershow/EditorPlaceHolder.java
+index 8c447b40b..ad0466e8c 100644
+--- a/src/com/android/gallery3d/filtershow/EditorPlaceHolder.java
++++ b/src/com/android/gallery3d/filtershow/EditorPlaceHolder.java
+@@ -82,6 +82,7 @@ public class EditorPlaceHolder {
+     }
+ 
+     public void hide() {
++        if (mContainer == null) return;
+         mContainer.setVisibility(View.GONE);
+     }
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
mContainer is used but not initialized, so check it before it is used.

Tracked-On: OAM-113169