### PR TITLE
Set 5G band as default for Wifi AP mode

### DIFF
--- a/aosp_diff/preliminary/packages/modules/Wifi/0011-Set-5G-band-as-default-for-Wifi-AP-mode.patch
+++ b/aosp_diff/preliminary/packages/modules/Wifi/0011-Set-5G-band-as-default-for-Wifi-AP-mode.patch
@@ -1,0 +1,82 @@
+From 24375112be93df261b09699fd29134760251ee5e Mon Sep 17 00:00:00 2001
+From: "Ye, Zhao" <zhao.ye@intel.com>
+Date: Fri, 17 Nov 2023 07:12:32 +0000
+Subject: [PATCH] Set 5G band as default for Wifi AP mode
+
+Set 5G band as default for Wifi AP mode
+
+Tests:
+open wifi hotspots on android setting,
+use "iw wlan1 info" command.
+it will show log as below, 5785MHz means AP run on 5G Interface wlan1
+	ifindex 12
+	wdev 0x2
+	addr e2:6f:96:66:ae:ae
+	ssid AndroidAP_6776
+	type AP
+	wiphy 0
+	channel 157 (5785 MHz), width: 20 MHz, center1: 5785 MHz
+
+Tracked-On: OAM-113448
+Signed-off-by: Ye, Zhao <zhao.ye@intel.com>
+---
+ framework/java/android/net/wifi/SoftApConfiguration.java    | 3 ++-
+ service/ServiceWifiResources/res/values/config.xml          | 4 ++--
+ service/java/com/android/server/wifi/WifiApConfigStore.java | 4 ++++
+ 3 files changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/framework/java/android/net/wifi/SoftApConfiguration.java b/framework/java/android/net/wifi/SoftApConfiguration.java
+index b1aa97bd99..55518070f1 100644
+--- a/framework/java/android/net/wifi/SoftApConfiguration.java
++++ b/framework/java/android/net/wifi/SoftApConfiguration.java
+@@ -879,8 +879,9 @@ public final class SoftApConfiguration implements Parcelable {
+             mBssid = null;
+             mPassphrase = null;
+             mHiddenSsid = false;
+-            mChannels = new SparseIntArray(1);
++            mChannels = new SparseIntArray(2);
+             mChannels.put(BAND_2GHZ, 0);
++            mChannels.put(BAND_5GHZ, 0);
+             mMaxNumberOfClients = 0;
+             mSecurityType = SECURITY_TYPE_OPEN;
+             mAutoShutdownEnabled = true; // enabled by default.
+diff --git a/service/ServiceWifiResources/res/values/config.xml b/service/ServiceWifiResources/res/values/config.xml
+index a35036e404..2077852727 100644
+--- a/service/ServiceWifiResources/res/values/config.xml
++++ b/service/ServiceWifiResources/res/values/config.xml
+@@ -28,7 +28,7 @@
+          Note: This config is replacing the config_wifi_dual_band_support
+          since more bands may now be supported (such as 6GHz), the naming dual_band
+          is no longer indicative, and a separate config now exists for each band -->
+-    <bool translatable="false" name ="config_wifi5ghzSupport">false</bool>
++    <bool translatable="false" name ="config_wifi5ghzSupport">true</bool>
+ 
+     <!-- boolean indicating whether the WiFi chipset has 6GHz band support -->
+     <bool translatable="false" name ="config_wifi6ghzSupport">false</bool>
+@@ -171,7 +171,7 @@
+     <!-- List of allowed channels in 5GHz band for softap. If the device doesn't want to restrict
+          channels this should be empty. Values is a comma separated channel string and/or channel
+          range string like '36-48,149'. -->
+-    <string  translatable="false" name="config_wifiSoftap5gChannelList"></string>
++    <string  translatable="false" name="config_wifiSoftap5gChannelList">149,153,157</string>
+ 
+     <!-- List of allowed channels in 6GHz band for softap. If the device doesn't want to restrict
+          channels this should be empty. Values is a comma separated channel string and/or channel
+diff --git a/service/java/com/android/server/wifi/WifiApConfigStore.java b/service/java/com/android/server/wifi/WifiApConfigStore.java
+index 17ebe5ff76..b38e699502 100644
+--- a/service/java/com/android/server/wifi/WifiApConfigStore.java
++++ b/service/java/com/android/server/wifi/WifiApConfigStore.java
+@@ -604,6 +604,10 @@ public class WifiApConfigStore {
+      * @return A band which will be used for a default band in default configuration.
+      */
+     public static @BandType int generateDefaultBand(Context context) {
++	// make 5G as first priority
++	if (ApConfigUtil.isBandSupported(SoftApConfiguration.BAND_5GHZ, context))
++		return SoftApConfiguration.BAND_5GHZ;
++
+         for (int band : SoftApConfiguration.BAND_TYPES) {
+             if (ApConfigUtil.isBandSupported(band, context)) {
+                 return band;
+-- 
+2.34.1
+


### PR DESCRIPTION
Set 5G band as default for Wifi AP mode

Tests:
open wifi hotspots on android setting,
use "iw wlan1 info" command.
it will show log as below, 5785MHz means AP run on 5G Interface wlan1
        ifindex 12
        wdev 0x2
        addr e2:6f:96:66:ae:ae
        ssid AndroidAP_6776
        type AP
        wiphy 0
        channel 157 (5785 MHz), width: 20 MHz, center1: 5785 MHz

Tracked-On: OAM-113448