### PR TITLE
Fix sometimes wlan1 interface for Ap create failed

### DIFF
--- a/bsp_diff/common/hardware/intel/wlan/libwifihal/open/03_0003-Fix-sometimes-wlan1-interface-for-Ap-create-failed.patch
+++ b/bsp_diff/common/hardware/intel/wlan/libwifihal/open/03_0003-Fix-sometimes-wlan1-interface-for-Ap-create-failed.patch
@@ -1,0 +1,98 @@
+From ca0e92f2234fe9c8eb34c89eef2a12226509f096 Mon Sep 17 00:00:00 2001
+From: "Ye, Zhao" <zhao.ye@intel.com>
+Date: Fri, 17 Nov 2023 07:43:39 +0000
+Subject: [PATCH] Fix sometimes wlan1 interface for Ap create failed
+
+When enable 5G band for AP mode, found sometimes the wlan1
+for AP will init failed.
+Because sometimes wifi hal init before init.rc wifi interface create,
+wlan1 will init failed.
+Fix methed is when AP open, hal wifi_virtual_interface_create run,
+init wlan1 again.
+
+Tests:
+reboot 5 times, every time wifi AP can open successfully
+
+Tracked-On: OAM-113448
+Signed-off-by: Ye, Zhao <zhao.ye@intel.com>
+---
+ lib/wifi_hal.cpp | 48 +++++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 47 insertions(+), 1 deletion(-)
+
+diff --git a/lib/wifi_hal.cpp b/lib/wifi_hal.cpp
+index 332f7d4..9713567 100644
+--- a/lib/wifi_hal.cpp
++++ b/lib/wifi_hal.cpp
+@@ -27,6 +27,7 @@
+ #include "utils.h"
+ 
+ #define WIFI_INFO_MAGIC 0xDBADBADA
++#define WIFI_VIRTUAL_INTERFACE_NUM 2
+ 
+ #define WIFI_INFO_INVALID(_handle, _str) ({                                    \
+ 	int ret = !!(!_handle || _handle->magic != WIFI_INFO_MAGIC);           \
+@@ -92,7 +93,7 @@ void handle_if_init(wifi_handle handle)
+ 	}
+ 
+ 	handle->ifaces = (wifi_interface_handle *)
+-		malloc(sizeof(wifi_interface_handle) * num_ifaces);
++		malloc(sizeof(wifi_interface_handle) * (num_ifaces + WIFI_VIRTUAL_INTERFACE_NUM) );
+ 
+ 	if (!handle->ifaces) {
+ 		hal_printf(MSG_ERROR, "Failed to allocate interfaces!");
+@@ -570,7 +571,52 @@ wifi_error wifi_virtual_interface_create(wifi_handle handle, const char* ifname,
+ 	/*
+ 	 * wlan0(sta) and wlan1(ap) interface will be created in init.rc by iw add command
+ 	 */
++	struct dirent *de;
++	int num_ifaces = 0;
++	u32 i = 0;
++	const char *dir = "/sys/class/net";
++	bool virtual_created = false;
++
++	DIR *d = opendir(dir);
++
+ 	hal_printf(MSG_DEBUG, "%s", __func__);
++
++	while (i < handle->num_ifaces)
++	{
++		if(strncmp(handle->ifaces[i]->name, ifname, 5) == 0) {
++			hal_printf(MSG_DEBUG, "%s: if_nametoindex(%s) = %d already exists, skip create \n",
++				__func__, ifname, if_nametoindex(ifname));
++			return WIFI_SUCCESS;
++		}
++		i++;
++	}
++
++	if (!d) {
++		hal_printf(MSG_ERROR, "Unable to open interface directory!");
++		goto out;
++	}
++
++	while ((de = readdir(d))) {
++		if (strncmp(de->d_name, "wlan1", 5) == 0)
++			virtual_created = true;
++		if (is_wifi_iface(de->d_name))
++			num_ifaces++;
++	}
++
++	if (!num_ifaces)
++		goto out;
++
++	if (virtual_created)
++	{
++		if (if_handle_read(&handle->ifaces[handle->num_ifaces], ifname) < 0) {
++			goto out;
++		}
++		handle->ifaces[handle->num_ifaces]->handle = handle;
++		handle->num_ifaces = handle->num_ifaces + 1;
++	}
++out:
++	closedir(d);
++
+ 	return WIFI_SUCCESS;
+ }
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
When enable 5G band for AP mode, found sometimes the wlan1 for AP will init failed.
Because sometimes wifi hal init before init.rc wifi interface create, wlan1 will init failed.
Fix methed is when AP open, hal wifi_virtual_interface_create run, init wlan1 again.

Tests:
reboot 5 times, every time wifi AP can open successfully

Tracked-On: OAM-113448