### PR TITLE
Fix fragment java crash on com.android.deskclock

### DIFF
--- a/aosp_diff/preliminary/packages/apps/DeskClock/0002-Fix-fragment-java-crash-on-com.android.deskclock.patch
+++ b/aosp_diff/preliminary/packages/apps/DeskClock/0002-Fix-fragment-java-crash-on-com.android.deskclock.patch
@@ -1,0 +1,36 @@
+From 018e6c5f5c6dd62d5d0ef56387765d10b1c844d9 Mon Sep 17 00:00:00 2001
+From: xubing <bing.xu@intel.com>
+Date: Wed, 22 Nov 2023 09:23:40 +0800
+Subject: [PATCH] Fix fragment java crash on com.android.deskclock
+
+JavaCrash happen on com.android.deskclock as Fragment
+StopwatchFragment not attach to a context
+
+Fragment StopwatchFragment don't attach to window, so we need
+check it before geting resource of the Fragment.
+
+Tests done: monkey test Pass
+
+Tracked-On: OAM-113328
+Signed-off-by: xubing <bing.xu@intel.com>
+---
+ src/com/android/deskclock/DeskClock.kt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/deskclock/DeskClock.kt b/src/com/android/deskclock/DeskClock.kt
+index 363a3da7b..076d22773 100644
+--- a/src/com/android/deskclock/DeskClock.kt
++++ b/src/com/android/deskclock/DeskClock.kt
+@@ -220,7 +220,8 @@ class DeskClock : BaseActivity(), FabContainer, AlarmLabelDialogHandler {
+ 
+         leftHideAnimation.addListener(object : AnimatorListenerAdapter() {
+             override fun onAnimationEnd(animation: Animator) {
+-                selectedDeskClockFragment.onUpdateFabButtons(mLeftButton, mRightButton)
++                if(selectedDeskClockFragment.isAdded())
++                    selectedDeskClockFragment.onUpdateFabButtons(mLeftButton, mRightButton)
+             }
+         })
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
Fragment StopwatchFragment don't attach to window, so we need check it before geting resource of the Fragment.

Tracked-On: OAM-113328