### PR TITLE
Fix IndexOutOfBoundsException on com.android.car.media.localmediaplayer

### DIFF
--- a/aosp_diff/preliminary/packages/apps/Car/LocalMediaPlayer/0002-Fix-IndexOutOfBoundsException-on-LocalMediaPlayer.patch
+++ b/aosp_diff/preliminary/packages/apps/Car/LocalMediaPlayer/0002-Fix-IndexOutOfBoundsException-on-LocalMediaPlayer.patch
@@ -1,0 +1,73 @@
+From 7b743cabc6b18e1ab6996fcb5c66a57662a51e87 Mon Sep 17 00:00:00 2001
+From: xubing <bing.xu@intel.com>
+Date: Wed, 22 Nov 2023 12:58:10 +0800
+Subject: [PATCH] Fix IndexOutOfBoundsException on LocalMediaPlayer
+
+JavaCrash happen on com.android.car.media.localmediaplayer
+as IndexOutOfBoundsException
+
+Playlist is changed when the media is playing, so we should rebuild
+queue before we play or pause the media.
+
+Tests done: monkey test Pass
+
+Tracked-On: OAM-113421
+Signed-off-by: xubing <bing.xu@intel.com>
+---
+ .../car/media/localmediaplayer/Player.java    | 33 +++++++++++++++++--
+ 1 file changed, 31 insertions(+), 2 deletions(-)
+
+diff --git a/src/com/android/car/media/localmediaplayer/Player.java b/src/com/android/car/media/localmediaplayer/Player.java
+index 5ef1c7a..4508c30 100644
+--- a/src/com/android/car/media/localmediaplayer/Player.java
++++ b/src/com/android/car/media/localmediaplayer/Player.java
+@@ -416,6 +416,23 @@ public class Player extends MediaSession.Callback {
+             Log.d(TAG, "pausePlayback()");
+         }
+ 
++        if (mCurrentQueueIdx > (mQueue.size() - 1)) {
++            try {
++                Log.d(TAG, "pausePlayback, rebuild queue");
++                String serialized = mSharedPrefs.getString(CURRENT_PLAYLIST_KEY, null);
++                if (serialized == null) {
++                    return;
++                }
++                Playlist playlist = Playlist.parseFrom(Base64.getDecoder().decode(serialized));
++                if (!maybeRebuildQueue(playlist)) {
++                    return;
++                }
++            } catch (IllegalArgumentException | InvalidProtocolBufferNanoException e) {
++                // Couldn't restore the playlist. Not the end of the world.
++                return;
++            }
++        }
++
+         long currentPosition = 0;
+         if (mMediaPlayer.isPlaying()) {
+             currentPosition = mMediaPlayer.getCurrentPosition();
+@@ -492,8 +509,20 @@ public class Player extends MediaSession.Callback {
+     private void playCurrentQueueIndex() throws IOException {
+         //Check the index to avoid OutOfBoundsException
+         if (mCurrentQueueIdx > (mQueue.size() - 1)) {
+-            stopPlayback();
+-            return;
++            try {
++                Log.d(TAG, "playCurrentQueueIndex, rebuild queue");
++                String serialized = mSharedPrefs.getString(CURRENT_PLAYLIST_KEY, null);
++                if (serialized == null) {
++                    return;
++                }
++                Playlist playlist = Playlist.parseFrom(Base64.getDecoder().decode(serialized));
++                if (!maybeRebuildQueue(playlist)) {
++                    return;
++                }
++            } catch (IllegalArgumentException | InvalidProtocolBufferNanoException e) {
++                // Couldn't restore the playlist. Not the end of the world.
++                return;
++            }
+         }
+         MediaDescription next = mQueue.get(mCurrentQueueIdx).getDescription();
+         String path = next.getExtras().getString(DataModel.PATH_KEY);
+-- 
+2.34.1
+


### PR DESCRIPTION
Playlist is changed when the media is playing, so we should rebuild queue before we play or pause the media.

Tracked-On: OAM-113421