### PR TITLE
Don't let SystemUpdater app access files on Udisk

### DIFF
--- a/aosp_diff/preliminary/bootable/recovery/03_0003-Modify-systemupdatersample-to-support-OTA-from-U-dis.patch
+++ b/aosp_diff/preliminary/bootable/recovery/03_0003-Modify-systemupdatersample-to-support-OTA-from-U-dis.patch
@@ -1,4 +1,4 @@
-From 0fa7a32281e4fe2db871835a1b47263f030ba121 Mon Sep 17 00:00:00 2001
+From 42d3e9ed001fd4cc92720ee7e16c82d040fdab5b Mon Sep 17 00:00:00 2001
 From: jizhenlo <zhenlong.z.ji@intel.com>
 Date: Thu, 9 Nov 2023 16:59:53 +0800
 Subject: [PATCH] Modify systemupdatersample to support OTA from U disk
@@ -18,8 +18,8 @@ Signed-off-by: jizhenlo <zhenlong.z.ji@intel.com>
  .../systemupdatersample/UpdaterState.java     |  15 +-
  .../services/PrepareUpdateService.java        |  10 ++
  .../systemupdatersample/ui/MainActivity.java  | 163 +++++++++++-------
- .../util/UpdateConfigs.java                   |  71 +++++---
- 11 files changed, 332 insertions(+), 159 deletions(-)
+ .../util/UpdateConfigs.java                   |  55 +++---
+ 11 files changed, 316 insertions(+), 159 deletions(-)
  create mode 100644 updater_sample/res/values-zh-rCN/strings.xml
 
 diff --git a/updater_sample/Android.bp b/updater_sample/Android.bp
@@ -859,7 +859,7 @@ index 6d1e4c35..e99f39f6 100644
  
  }
 diff --git a/updater_sample/src/com/example/android/systemupdatersample/util/UpdateConfigs.java b/updater_sample/src/com/example/android/systemupdatersample/util/UpdateConfigs.java
-index bbefcaf1..f816de98 100644
+index bbefcaf1..4701f5a0 100644
 --- a/updater_sample/src/com/example/android/systemupdatersample/util/UpdateConfigs.java
 +++ b/updater_sample/src/com/example/android/systemupdatersample/util/UpdateConfigs.java
 @@ -22,6 +22,9 @@ import android.util.Log;
@@ -884,12 +884,12 @@ index bbefcaf1..f816de98 100644
  
      public static final String UPDATE_CONFIGS_ROOT = "configs/";
 +    public static final String UPDATE_MEDIA_ROOT = "/mnt/media_rw";
-+    public static final String UPDATE_INFO_FILE = "ota_info.txt";
-+    public static final String ZEEKR_OTA_META = "OTA PACKAGE NAME";
++    public static final String ZEEKR_OTA_PACK = "zeekr_ota_package.zip";
++    public static final String ZEEKR_OTA_NONE = "Udisk Not Found";
  
      /**
       * @param configs update configs
-@@ -60,34 +67,54 @@ public final class UpdateConfigs {
+@@ -60,34 +67,38 @@ public final class UpdateConfigs {
       * @return list of configs from directory {@link UpdateConfigs#getConfigsRoot}
       */
      public static List<UpdateConfig> getUpdateConfigs(Context context) {
@@ -897,6 +897,7 @@ index bbefcaf1..f816de98 100644
 +        File root = new File(UPDATE_MEDIA_ROOT);
          ArrayList<UpdateConfig> configs = new ArrayList<>();
 +		boolean findConfig = false;
++		String packName, packUrl;
          if (!root.exists()) {
              return configs;
          }
@@ -917,12 +918,20 @@ index bbefcaf1..f816de98 100644
 -    }
 +			findConfig = false;
 +			if (f.isDirectory()) {
-+				for (final File f2: f.listFiles()) {
-+					if (!f2.isDirectory() && f2.getName().equals(UPDATE_INFO_FILE)) {
-+						try {
-+							FileInputStream inputStream = new FileInputStream(f2);
-+							BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
-+							String line;
++				packName = f.getName() + "/" + ZEEKR_OTA_PACK;
++				packUrl = "file://" + UPDATE_MEDIA_ROOT + "/" + packName;
++				configs.add(new UpdateConfig(packName, packUrl, UpdateConfig.AB_INSTALL_TYPE_NON_STREAMING));
++				findConfig = true;
++				break;
++			}
++		}
++		if (!findConfig) {
++			packName = ZEEKR_OTA_NONE;
++			packUrl = "file://" + UPDATE_MEDIA_ROOT + "/" + packName;
++			configs.add(new UpdateConfig(packName, packUrl, UpdateConfig.AB_INSTALL_TYPE_NON_STREAMING));
++		}
++		return configs;
++	}
  
 -    /**
 -     * @param filename searches by given filename
@@ -931,31 +940,6 @@ index bbefcaf1..f816de98 100644
 -     *         stored as {@link UpdateConfig.PackageFile}.
 -     */
 -    public static Optional<UpdateConfig.PackageFile> getPropertyFile(
-+							if ((line = reader.readLine()) != null && line.equals(ZEEKR_OTA_META)) {
-+								if ((line = reader.readLine()) != null) {
-+									File pack = new File(UPDATE_MEDIA_ROOT+"/"+ f.getName() + "/" + line);
-+									if (pack.exists()) {
-+										Log.d("### updater", pack.getName() + " exists");
-+										String packName = f.getName() + "/" + line;
-+										String packUrl = "file://" + UPDATE_MEDIA_ROOT + "/" + packName;
-+										configs.add(new UpdateConfig(packName, packUrl, UpdateConfig.AB_INSTALL_TYPE_NON_STREAMING));
-+									}
-+									findConfig = true;
-+								}
-+							}
-+							reader.close();
-+						} catch (Exception e) {
-+							e.printStackTrace();
-+						}
-+						if (findConfig)
-+							break;
-+					}
-+				}
-+			}
-+		}
-+		return configs;
-+	}
-+
 +	/**
 +	 * @param filename searches by given filename
 +	 * @param config searches in {@link UpdateConfig#getAbConfig()}


### PR DESCRIPTION
Udisk will be mounted as adoptable storage, and SystemUpdater will have no permissions to access the files on Udisk directly.

Test done: SystemUpdater won't crash when Udisk is mounted as
adoptable storage

Tracked-On: OAM-113511