### PR TITLE
Fix 88Q2122 eth phy remote wakeup disable failed issue

### DIFF
--- a/bsp_diff/common/kernel/linux-intel-lts2021/0033-Fix-88Q2122-eth-phy-remote-wakeup-disable-failed-issue.patch
+++ b/bsp_diff/common/kernel/linux-intel-lts2021/0033-Fix-88Q2122-eth-phy-remote-wakeup-disable-failed-issue.patch
@@ -1,0 +1,34 @@
+From b8dc4dce0e5c73afdfaa7a09abbb86605fe1d93c Mon Sep 17 00:00:00 2001
+From: Zhao Ye <zhao.ye@intel.com>
+Date: Tue, 28 Nov 2023 14:58:49 +0800
+Subject: [PATCH] Fix 88Q2122 eth phy remote wakeup disable failed issue
+
+when remote FDHU do not suspend, RDHU can
+not suspend success.
+
+Test:
+Connect FDHU and RDHU, keep FDHU alive,
+suspend RDHU, RDHU can suspend success
+
+Tracked-On: OAM-113634
+Signed-off-by: Zhao Ye <zhao.ye@intel.com>
+---
+ drivers/net/phy/marvell-88q2xxx.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/phy/marvell-88q2xxx.c b/drivers/net/phy/marvell-88q2xxx.c
+index a8344e61a5ca..5ac33861d44a 100644
+--- a/drivers/net/phy/marvell-88q2xxx.c
++++ b/drivers/net/phy/marvell-88q2xxx.c
+@@ -220,7 +220,7 @@ static int mv88q2xxx_config_init(struct phy_device *phydev)
+ 	mv88q2xxx_soft_reset(phydev);
+ 
+ 	// disable remote wake up
+-	phy_set_bits_mmd(phydev, 3 ,0x801d, 0x800);
++	phy_set_bits_mmd(phydev, 3 ,0x801d, 0x8800);
+ 
+ 	return 0;
+ }
+-- 
+2.25.1
+


### PR DESCRIPTION
when remote FDHU do not suspend, RDHU can
not suspend success.

Test:
Connect FDHU and RDHU, keep FDHU alive,
suspend RDHU, RDHU can suspend success

Tracked-On: OAM-113634