### PR TITLE
Fix phoneInterfaceManager java crash in monkey test

### DIFF
--- a/aosp_diff/preliminary/packages/services/Telephony/0003-Fix-phoneInterfaceManager-java-crash-in-monkey-test.patch
+++ b/aosp_diff/preliminary/packages/services/Telephony/0003-Fix-phoneInterfaceManager-java-crash-in-monkey-test.patch
@@ -1,0 +1,36 @@
+From 4b792cf786d13b581615f148c749deaeb639de51 Mon Sep 17 00:00:00 2001
+From: maozhong1 <roger.mao@intel.com>
+Date: Tue, 28 Nov 2023 21:34:29 +0800
+Subject: [PATCH] Fix phoneInterfaceManager java crash in monkey test
+
+JavaCrash happen on com.android.phone when performing Map Navigation with audio A2DP on back
+a null object reference at com.android.phone.PhoneInterfaceManager
+
+Fix: add protection if phone is null
+
+Tracked-On: OAM-113415
+Signed-off-by: maozhong1 roger.mao@intel.com
+---
+ src/com/android/phone/PhoneInterfaceManager.java | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/phone/PhoneInterfaceManager.java b/src/com/android/phone/PhoneInterfaceManager.java
+index d96c0c59b..722d0a59e 100755
+--- a/src/com/android/phone/PhoneInterfaceManager.java
++++ b/src/com/android/phone/PhoneInterfaceManager.java
+@@ -1623,7 +1623,11 @@ public class PhoneInterfaceManager extends ITelephony.Stub {
+                     request = (MainThreadRequest) msg.obj;
+                     WorkSource ws = (WorkSource) request.argument;
+                     Phone phone = getPhoneFromRequest(request);
+-                    phone.getCellIdentity(ws, obtainMessage(EVENT_GET_CELL_LOCATION_DONE, request));
++                    if (phone != null) {
++                         phone.getCellIdentity(ws, obtainMessage(EVENT_GET_CELL_LOCATION_DONE, request));
++                    } else {
++                        loge("Get cell location failed: No phone object");
++		    }
+                     break;
+                 }
+                 case EVENT_GET_CELL_LOCATION_DONE: {
+-- 
+2.25.1
+


### PR DESCRIPTION
    JavaCrash happen on com.android.phone when performing Map Navigation with audio A2DP on back
    a null object reference at com.android.phone.PhoneInterfaceManager

    Fix: add protection if phone is null

    Tracked-On: OAM-113415
    Signed-off-by: maozhong1 roger.mao@intel.com