### PR TITLE
Update utils commit hash in host kernel build script

### DIFF
--- a/host/kernel/lts2022-chromium/build_weekly.sh
+++ b/host/kernel/lts2022-chromium/build_weekly.sh
@@ -23,7 +23,7 @@ cd host_kernel
 
 git clone https://github.com/projectceladon/vendor-intel-utils.git
 cd vendor-intel-utils
-git checkout 4326c028f778b15717d6475670165f4d281fbb9c
+git checkout aeb4d524537887af5dc1af8a7ac4f4953e24f606
 cd ../
 
 git clone https://github.com/projectceladon/linux-intel-lts2022-chromium.git


### PR DESCRIPTION
Updated utils commit hash in host kernel build script for v6.1.61 rebase.

Tests done:
- Host kernel build and boot.

Tracked-On: OAM-114109