### PR TITLE
Fixed for Crashes in Gallery App.

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Gallery2/0005-Fixed-for-Crashes-in-Gallery-App.patch
+++ b/aosp_diff/base_aaos/packages/apps/Gallery2/0005-Fixed-for-Crashes-in-Gallery-App.patch
@@ -1,0 +1,101 @@
+From 1c5264e91400c115a8b48300921f3579711eb6fc Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Mon, 11 Dec 2023 19:26:31 +0530
+Subject: [PATCH] Fixed for Crashes in Gallery App.
+
+During monkey test run, observing following crash
+1) java.lang.RuntimeException: Unable to destroy activity
+{com.android.gallery3d/com.android.gallery3d.filtershow
+.FilterShowActivity}
+2) ava.lang.NullPointerException: Attempt to invoke virtual method
+'void com.android.gallery3d.filtershow.data.UserPresetsManager.close()'
+on a null object reference
+3) com.android.gallery3d java.lang.NullPointerException: Attempt to
+invoke virtual method 'boolean com.android.gallery3d.filtershow
+.pipeline.ImagePreset.contains(byte)' on a null object reference
+4) com.android.gallery3d java.lang.NullPointerException: Attempt to
+invoke virtual method 'void android.view.View.setVisibility(int)' on a
+null object reference
+5) com.android.gallery3d java.lang.NullPointerException: Attempt to
+invoke interface method 'void com.android.gallery3d.filtershow.controller
+.Control.updateUI()' on a null object reference
+6) java.lang.IllegalStateException: Can not perform this action after
+onSaveInstanceState.
+
+Tests:
+Run monkey test and observe.
+
+Tracked-On: OAM-113637
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../gallery3d/filtershow/FilterShowActivity.java       | 10 +++++++---
+ .../gallery3d/filtershow/category/MainPanel.java       |  2 +-
+ .../filtershow/editors/EditorColorBorder.java          |  4 +++-
+ 3 files changed, 11 insertions(+), 5 deletions(-)
+
+diff --git a/src/com/android/gallery3d/filtershow/FilterShowActivity.java b/src/com/android/gallery3d/filtershow/FilterShowActivity.java
+index f9931027b..0d25186ba 100644
+--- a/src/com/android/gallery3d/filtershow/FilterShowActivity.java
++++ b/src/com/android/gallery3d/filtershow/FilterShowActivity.java
+@@ -314,7 +314,7 @@ public class FilterShowActivity extends FragmentActivity implements OnItemClickL
+                 transaction.remove(getSupportFragmentManager().findFragmentByTag(
+                         MainPanel.FRAGMENT_TAG));
+                 transaction.replace(R.id.main_panel_container, panel, MainPanel.FRAGMENT_TAG);
+-                transaction.commit();
++                transaction.commitAllowingStateLoss();
+             }
+         };
+         Fragment main = getSupportFragmentManager().findFragmentByTag(MainPanel.FRAGMENT_TAG);
+@@ -906,7 +906,9 @@ public class FilterShowActivity extends FragmentActivity implements OnItemClickL
+         if (mLoadBitmapTask != null) {
+             mLoadBitmapTask.cancel(false);
+         }
+-        mUserPresetsManager.close();
++        if (mUserPresetsManager != null) {
++            mUserPresetsManager.close();
++        }
+         doUnbindService();
+         super.onDestroy();
+     }
+@@ -1317,7 +1319,9 @@ public class FilterShowActivity extends FragmentActivity implements OnItemClickL
+ 
+     public void showDefaultImageView() {
+         mEditorPlaceHolder.hide();
+-        mImageShow.setVisibility(View.VISIBLE);
++        if (mImageShow != null) {
++            mImageShow.setVisibility(View.VISIBLE);
++        }
+         PrimaryImage.getImage().setCurrentFilter(null);
+         PrimaryImage.getImage().setCurrentFilterRepresentation(null);
+     }
+diff --git a/src/com/android/gallery3d/filtershow/category/MainPanel.java b/src/com/android/gallery3d/filtershow/category/MainPanel.java
+index a44bf42d6..c2ddd24e1 100644
+--- a/src/com/android/gallery3d/filtershow/category/MainPanel.java
++++ b/src/com/android/gallery3d/filtershow/category/MainPanel.java
+@@ -177,7 +177,7 @@ public class MainPanel extends Fragment {
+         if (mCurrentSelected == GEOMETRY) {
+             return;
+         }
+-        if (PrimaryImage.getImage().hasTinyPlanet()) {
++        if (PrimaryImage.getImage().getPreset() != null && PrimaryImage.getImage().hasTinyPlanet()) {
+             return;
+         }
+         boolean fromRight = isRightAnimation(GEOMETRY);
+diff --git a/src/com/android/gallery3d/filtershow/editors/EditorColorBorder.java b/src/com/android/gallery3d/filtershow/editors/EditorColorBorder.java
+index 98659df38..ec44d7ed8 100644
+--- a/src/com/android/gallery3d/filtershow/editors/EditorColorBorder.java
++++ b/src/com/android/gallery3d/filtershow/editors/EditorColorBorder.java
+@@ -176,7 +176,9 @@ public class EditorColorBorder extends ParametricEditor  {
+             c.setColorSet(mBasColors);
+         }
+         updateText();
+-        mControl.updateUI();
++        if (mControl != null) {
++            mControl.updateUI();
++        }
+         mView.invalidate();
+     }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
During monkey test run, observing following crash
1) java.lang.RuntimeException: Unable to destroy activity {com.android.gallery3d/com.android.gallery3d.filtershow .FilterShowActivity}
2) ava.lang.NullPointerException: Attempt to invoke virtual method 'void com.android.gallery3d.filtershow.data.UserPresetsManager.close()' on a null object reference
3) com.android.gallery3d java.lang.NullPointerException: Attempt to invoke virtual method 'boolean com.android.gallery3d.filtershow .pipeline.ImagePreset.contains(byte)' on a null object reference 4) com.android.gallery3d java.lang.NullPointerException: Attempt to invoke virtual method 'void android.view.View.setVisibility(int)' on a null object reference
5) com.android.gallery3d java.lang.NullPointerException: Attempt to invoke interface method 'void com.android.gallery3d.filtershow.controller .Control.updateUI()' on a null object reference
6) java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState.

Tests:
Run monkey test and observe.

Tracked-On: OAM-113637