### PR TITLE
drm/i915: Fix i915 crash issue

### DIFF
--- a/bsp_diff/base_aaos/kernel/linux-intel-lts2021/0034-drm-i915-Fix-i915-crash-issue.patch
+++ b/bsp_diff/base_aaos/kernel/linux-intel-lts2021/0034-drm-i915-Fix-i915-crash-issue.patch
@@ -1,0 +1,85 @@
+From bbb26ae9c52048fe7788959e8e6052c509ebf404 Mon Sep 17 00:00:00 2001
+From: Wenkui <kui.wen@intel.com>
+Date: Thu, 14 Dec 2023 06:48:06 +0000
+Subject: [PATCH] drm/i915: Fix i915 crash issue
+
+Encountered i915 crash during Monkey test
+
+Add filelist mutex if access device file list to avoid race conditions
+
+Tests Done:
+ -Boot with iGPU
+ -i915 debugfs check
+ -Reboot
+
+Tracked-On:OAM-114178
+Signed-off-by: Wenkui <kui.wen@intel.com>
+---
+ drivers/gpu/drm/i915/i915_driver.c | 2 +-
+ drivers/gpu/drm/i915/i915_sysfs.c  | 8 +++++---
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/i915_driver.c b/drivers/gpu/drm/i915/i915_driver.c
+index a79061f10585..ea6455b64deb 100644
+--- a/drivers/gpu/drm/i915/i915_driver.c
++++ b/drivers/gpu/drm/i915/i915_driver.c
+@@ -1151,13 +1151,13 @@ static void i915_driver_postclose(struct drm_device *dev, struct drm_file *file)
+ 	i915_gem_context_close(file);
+ 	i915_drm_client_put(file_priv->client);
+ 
+-	kfree_rcu(file_priv, rcu);
+ 
+ #if IS_ENABLED(CONFIG_DRM_I915_MEMTRACK)
+ 	i915_gem_remove_sysfs_file_entry(dev, file);
+ 	put_pid(file_priv->tgid);
+ 	kfree(file_priv->process_name);
+ #endif
++	 kfree_rcu(file_priv, rcu);
+ 
+ 	/* Catch up with all the deferred frees from "this" client */
+ 	i915_gem_flush_free_objects(to_i915(dev));
+diff --git a/drivers/gpu/drm/i915/i915_sysfs.c b/drivers/gpu/drm/i915/i915_sysfs.c
+index 09ac6b040576..e58e2e117d50 100644
+--- a/drivers/gpu/drm/i915/i915_sysfs.c
++++ b/drivers/gpu/drm/i915/i915_sysfs.c
+@@ -403,18 +403,18 @@ int i915_gem_create_sysfs_file_entry(struct drm_device *dev,
+         * bin attribute into the new file priv. Otherwise allocate a new
+         * copy of bin attribute, and create its corresponding sysfs file.
+         */
+-	mutex_lock(&dev->struct_mutex);
++	mutex_lock(&dev->filelist_mutex);
+ 	list_for_each_entry (file_local, &dev->filelist, lhead) {
+ 		struct drm_i915_file_private *file_priv_local =
+ 			file_local->driver_priv;
+ 
+ 		if (file_priv->tgid == file_priv_local->tgid) {
+ 			file_priv->obj_attr = file_priv_local->obj_attr;
+-			mutex_unlock(&dev->struct_mutex);
++			mutex_unlock(&dev->filelist_mutex);
+ 			return 0;
+ 		}
+ 	}
+-	mutex_unlock(&dev->struct_mutex);
++	mutex_unlock(&dev->filelist_mutex);
+ 
+ 	if (!dev_priv->mmtkobj_initialized) {
+ 		DRM_ERROR("memtrack_kobj hasn't been initialized yet\n");
+@@ -478,6 +478,7 @@ void i915_gem_remove_sysfs_file_entry(struct drm_device *dev,
+         * that particular tgid, and no other instances for this tgid exist in
+         * the filelist. If so, remove the corresponding sysfs file entry also.
+         */
++	mutex_lock(&dev->filelist_mutex);
+ 	list_for_each_entry (file_local, &dev->filelist, lhead) {
+ 		struct drm_i915_file_private *file_priv_local =
+ 			file_local->driver_priv;
+@@ -485,6 +486,7 @@ void i915_gem_remove_sysfs_file_entry(struct drm_device *dev,
+ 		if (pid_nr(file_priv->tgid) == pid_nr(file_priv_local->tgid))
+ 			open_count++;
+ 	}
++	mutex_unlock(&dev->filelist_mutex);
+ 
+ 	if (open_count == 1) {
+ 		struct i915_gem_file_attr_priv *attr_priv;
+-- 
+2.34.1
+


### PR DESCRIPTION
Encountered i915 crash during Monkey test

Add filelist mutex if access device file list to avoid race conditions

Tests Done:
 -Boot with iGPU
 -i915 debugfs check
 -Reboot

Tracked-On: OAM-114178