### PR TITLE
Fixed for Crashes During Monkey Test.

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Contacts/0001-Fixed-for-Crash-in-Contact-app-during-Monkey-Test.patch
+++ b/aosp_diff/base_aaos/packages/apps/Contacts/0001-Fixed-for-Crash-in-Contact-app-during-Monkey-Test.patch
@@ -1,0 +1,45 @@
+From cdd18f1ee4fe2391e1fda1e0dca8558c687dd2a9 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Fri, 15 Dec 2023 10:02:25 +0530
+Subject: [PATCH] Fixed for Crash in Contact app during Monkey Test.
+
+During monkey test run, observing following crash
+java.lang.IllegalStateException: Can not perform this action after
+onSaveInstanceState at android.app.FragmentManagerImpl.checkStateLoss
+(FragmentManager.java:1882)
+at android.app.FragmentManagerImpl.enqueueAction(FragmentManager.java
+:1905)
+at android.app.BackStackRecord.commitInternal(BackStackRecord.java:688)
+at android.app.BackStackRecord.commit(BackStackRecord.java:646)
+at com.android.contacts.activities.PeopleActivity
+.updateViewConfiguration(PeopleActivity.java:739)
+
+when you use commit() it will can throw an exception if state loss
+occurs but commitAllowingStateLoss() saves transaction without state
+loss so that will doesn't throw an exception if state loss occurs.
+
+Tests:
+Run monkey test and observe, test is pass.
+
+Tracked-On: OAM-113422
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ src/com/android/contacts/activities/PeopleActivity.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/com/android/contacts/activities/PeopleActivity.java b/src/com/android/contacts/activities/PeopleActivity.java
+index 243ec003b..112fa1b93 100644
+--- a/src/com/android/contacts/activities/PeopleActivity.java
++++ b/src/com/android/contacts/activities/PeopleActivity.java
+@@ -736,7 +736,7 @@ public class PeopleActivity extends AppCompatContactsActivity implements
+             fragment.updateStatus(mProviderStatus);
+         }
+         if (!transaction.isEmpty()) {
+-            transaction.commit();
++            transaction.commitAllowingStateLoss();
+             fragmentManager.executePendingTransactions();
+         }
+ 
+-- 
+2.17.1
+

--- a/aosp_diff/base_aaos/packages/services/Car/0018-Fixed-for-Crash-in-KitchenSink-app-During-Monkey-Tes.patch
+++ b/aosp_diff/base_aaos/packages/services/Car/0018-Fixed-for-Crash-in-KitchenSink-app-During-Monkey-Tes.patch
@@ -1,0 +1,45 @@
+From 78e1c48805e0087a1103d975b7078abdf6eea1db Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Fri, 15 Dec 2023 10:08:33 +0530
+Subject: [PATCH] Fixed for Crash in KitchenSink app During Monkey Test.
+
+During monkey test run, observing following crash
+android.util.AndroidRuntimeException: Calling startActivity() from
+outside of an Activity context requires the FLAG_ACTIVITY_NEW_TASK flag.
+Is this really what you want?
+at android.app.ContextImpl.startActivity(ContextImpl.java:1088)
+at android.app.ContextImpl.startActivity(ContextImpl.java:1064)
+at android.content.ContextWrapper.startActivity(ContextWrapper.java:411)
+at com.google.android.car.kitchensink.UserNoiticeDemoUiService
+.startDialog(UserNoiticeDemoUiService.java:122)
+
+we cannot start an activity from a non-activity context unless you
+pass the intent flag FLAG_ACTIVITY_NEW_TASK. If you attempt to start an
+activity without passing this flag.
+
+Tests:
+Run monkey test and observe, test is pass.
+
+Tracked-On: OAM-113423
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../android/car/kitchensink/UserNoiticeDemoUiService.java      | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/tests/EmbeddedKitchenSinkApp/src/com/google/android/car/kitchensink/UserNoiticeDemoUiService.java b/tests/EmbeddedKitchenSinkApp/src/com/google/android/car/kitchensink/UserNoiticeDemoUiService.java
+index 502c9bca9c..47c9147181 100644
+--- a/tests/EmbeddedKitchenSinkApp/src/com/google/android/car/kitchensink/UserNoiticeDemoUiService.java
++++ b/tests/EmbeddedKitchenSinkApp/src/com/google/android/car/kitchensink/UserNoiticeDemoUiService.java
+@@ -119,7 +119,8 @@ public class UserNoiticeDemoUiService extends Service {
+             if (!Settings.canDrawOverlays(this)) {
+                 Intent intent = new Intent();
+                 intent.setAction(Settings.ACTION_MANAGE_OVERLAY_PERMISSION);
+-                startActivity(intent);
++                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
++                getApplicationContext().startActivity(intent);
+                 return;
+             }
+             mDialog = createDialog();
+-- 
+2.17.1
+


### PR DESCRIPTION
During monkey test run, observing following crash
1) android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?
at android.app.ContextImpl.startActivity(ContextImpl.java:1088) at android.app.ContextImpl.startActivity(ContextImpl.java:1064) at android.content.ContextWrapper.startActivity(ContextWrapper.java:411) at com.google.android.car.kitchensink.UserNoiticeDemoUiService .startDialog(UserNoiticeDemoUiService.java:122)

we cannot start an activity from a non-activity context unless you pass the intent flag FLAG_ACTIVITY_NEW_TASK. If you attempt to start an activity without passing this flag.

2) java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState at android.app.FragmentManagerImpl.checkStateLoss (FragmentManager.java:1882) at android.app.FragmentManagerImpl .enqueueAction(FragmentManager.java:1905)
at android.app.BackStackRecord.commitInternal(BackStackRecord.java:688) at android.app.BackStackRecord.commit(BackStackRecord.java:646) at com.android.contacts.activities.PeopleActivity
.updateViewConfiguration(PeopleActivity.java:739)

when you use commit() it will can throw an exception if state loss occurs but commitAllowingStateLoss() saves transaction without state loss so that will doesn't throw an exception if state loss occurs. tracking this issue under-OAM-113422

Tests:
Run monkey test and observe, test is pass.

Tracked-On: OAM-113423