### PR TITLE
add flag to skip removing permissions at cleardata

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/99_0224-add-flag-to-skip-removing-permissions-in-clearApplic.patch
+++ b/aosp_diff/preliminary/frameworks/base/99_0224-add-flag-to-skip-removing-permissions-in-clearApplic.patch
@@ -1,0 +1,45 @@
+From 1bfe515b2c2770d5284cc182d6e03a668bf1e1eb Mon Sep 17 00:00:00 2001
+From: "Ruan, Hongfu" <hongfu.ruan@intel.com>
+Date: Thu, 14 Dec 2023 10:56:25 +0800
+Subject: [PATCH] add flag to skip removing permissions in
+ clearApplicationUserData
+
+on IVI platform, App is granted all permissions during installation,
+and access rights messages are not expected during normal usage.
+for some purposes(like automation test), "pm --clear" command is used
+to reset Apps. By that, both App user data and permissions will be
+removed, and access rights msg pops up in the following usage
+unexpectedly.
+
+This patch skips permission reset to make sure the behaviors before
+and after pm --clear are same. It takes effect only when property
+"skip.reset.permission" is set to 1.
+
+Tracked-On: OAM-114234
+Signed-off-by: Ruan, Hongfu <hongfu.ruan@intel.com>
+---
+ .../java/com/android/server/pm/PackageManagerService.java  | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/services/core/java/com/android/server/pm/PackageManagerService.java b/services/core/java/com/android/server/pm/PackageManagerService.java
+index b640ef87a952..1dbce7175b71 100644
+--- a/services/core/java/com/android/server/pm/PackageManagerService.java
++++ b/services/core/java/com/android/server/pm/PackageManagerService.java
+@@ -22678,8 +22678,13 @@ public class PackageManagerService extends IPackageManager.Stub
+             Slog.w(TAG, "Package named '" + packageName + "' doesn't exist.");
+             return false;
+         }
+-        mPermissionManager.resetRuntimePermissions(pkg, userId);
+ 
++        // when property "skip.reset.permission" is set to 1, permission reset is bypassed.
++        if (SystemProperties.get("skip.reset.permission", "0").equals("1"))
++            Slog.w(TAG, "skip clear App's permission on pm --clear cmd.");
++        else {
++            mPermissionManager.resetRuntimePermissions(pkg, userId);
++        }
+         clearAppDataLIF(pkg, userId,
+                 FLAG_STORAGE_DE | FLAG_STORAGE_CE | FLAG_STORAGE_EXTERNAL);
+ 
+-- 
+2.41.0
+


### PR DESCRIPTION
this PR gives users an option to keep App permissions even when clear data
operation is called under certain cases. It reads system property to decide the
behavior. By default, the property is not set, so no effect on the system.
It benefits automation test, in which App data needs to be cleared but its
permissions need to be kept.

Test done:

- boot up Android, run "adb shell pm clear com.wedobest.fivechess", found
all granted permissions of fivechess are cleared.

- run "adb shell setprop skip.reset.permission" and above pm clear cmd, the
granted permissions are still there.

Tracked-On: OAM-114234