### PR TITLE
[WA] Add AppOverrideSettings to hack app layout behavious

### DIFF
--- a/aosp_diff/base_aaos/frameworks/base/0001-Add-AppOverrideSettings-to-hack-app-layout-behavious.patch
+++ b/aosp_diff/base_aaos/frameworks/base/0001-Add-AppOverrideSettings-to-hack-app-layout-behavious.patch
@@ -1,0 +1,125 @@
+From 70441a945bad747a18286729ac09bb88b2b27a0c Mon Sep 17 00:00:00 2001
+From: Marc Mao <marc.mao@intel.com>
+Date: Fri, 22 Dec 2023 13:43:12 +0800
+Subject: [WA] Add AppOverrideSettings to hack app layout behavious
+
+Support forceFullscreen and forceLandscape flag by per app setting.
+The settings is set by Andnroid prop as
+debug.app.override_settings="<appName1>=<flags1>,
+<appName1>=<flags1>,...". flags is a bitset for override features,
+bit0 is forceFullscreen and bit1 is forceLandscape.
+Other bits are not defined.
+
+Tests done: Set the property and checked the App for
+both full screen and landscape modes.
+
+Tracked-On: OAM-113267
+Signed-off-by: Marc Mao <marc.mao@intel.com>
+Signed-off-by: Gao, HuadongX <huadongx.gao@intel.com>
+---
+ core/java/android/app/Activity.java           | 13 ++++
+ core/java/android/app/AppOverrideSetting.java | 60 +++++++++++++++++++
+ 2 files changed, 73 insertions(+)
+ create mode 100644 core/java/android/app/AppOverrideSetting.java
+
+diff --git a/core/java/android/app/Activity.java b/core/java/android/app/Activity.java
+index 750e3d6f6fed..5d37b299fe18 100644
+--- a/core/java/android/app/Activity.java
++++ b/core/java/android/app/Activity.java
+@@ -8037,6 +8037,18 @@ public class Activity extends ContextThemeWrapper
+         performCreate(icicle, null);
+     }
+ 
++    final void applyPhoneAppOverride() {
++        AppOverrideSetting setting = AppOverrideSetting.getInstance(getApplicationInfo().processName);
++        if (setting.forceLandscape()) {
++            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
++            Log.d("PhoneAppOverride", "Force to landscape mode");
++        }
++        if (setting.forceFullscreen()) {
++            setTheme(android.R.style.Theme_NoTitleBar_Fullscreen);
++            Log.d("PhoneAppOverride", "Force to fullscreen mode");
++        }
++    }
++
+     @UnsupportedAppUsage(maxTargetSdk = Build.VERSION_CODES.R, trackingBug = 170729553)
+     final void performCreate(Bundle icicle, PersistableBundle persistentState) {
+         if (Trace.isTagEnabled(Trace.TRACE_TAG_WINDOW_MANAGER)) {
+@@ -8051,6 +8063,7 @@ public class Activity extends ContextThemeWrapper
+         mIsInMultiWindowMode = inMultiWindowMode(windowingMode);
+         mIsInPictureInPictureMode = windowingMode == WINDOWING_MODE_PINNED;
+         restoreHasCurrentPermissionRequest(icicle);
++        applyPhoneAppOverride();
+         if (persistentState != null) {
+             onCreate(icicle, persistentState);
+         } else {
+diff --git a/core/java/android/app/AppOverrideSetting.java b/core/java/android/app/AppOverrideSetting.java
+new file mode 100644
+index 000000000000..52d4998c40d0
+--- /dev/null
++++ b/core/java/android/app/AppOverrideSetting.java
+@@ -0,0 +1,60 @@
++package android.app;
++
++import android.annotation.NonNull;
++import android.os.SystemProperties;
++import android.util.Log;
++
++/** @hide */
++public class AppOverrideSetting {
++    private static String LOG_TAG = "AppOverride";
++    private static final Object LOCK = new Object();
++    private static volatile AppOverrideSetting instance = null;
++    private static int flags = 0;
++
++    /** @hide */
++    public static final int FLAG_FORCE_FULLSCREEN = (1 << 0);
++    public static final int FLAG_FORCE_LANDSCAPE = (1 << 1);
++
++    private AppOverrideSetting(@NonNull String name) {
++        String builtin = "";
++        String prop = SystemProperties.get("debug.app.override_settings");
++        if (prop == null)
++            prop = builtin;
++        else
++            prop += builtin; //prop can override builtin settings
++
++        String[] settings = prop.split(",");
++        for (String setting : settings) {
++            String[] keyValue = setting.split("=");
++            if (keyValue.length == 2) {
++                if (name.equals(keyValue[0])) {
++                    try {
++                        flags = Integer.parseInt(keyValue[1]);
++                    } catch (NumberFormatException e) {
++                        Log.e(LOG_TAG, "Invalid override setting for " + keyValue[0]);
++                    }
++                    break;
++                }
++            }
++        }
++    }
++
++    /** @hide */
++    @NonNull
++    public static AppOverrideSetting getInstance(@NonNull String name) {
++        synchronized (LOCK) {
++            if (instance == null) {
++                instance = new AppOverrideSetting(name);
++            }
++        }
++        return instance;
++    }
++    /** @hide */
++    public boolean forceFullscreen() {
++        return ((flags & FLAG_FORCE_FULLSCREEN) != 0);
++    }
++    /** @hide */
++    public boolean forceLandscape() {
++        return ((flags & FLAG_FORCE_LANDSCAPE) != 0);
++    }
++}
+\ No newline at end of file
+-- 
+2.17.6
+


### PR DESCRIPTION
Support forceFullscreen and forceLandscape flag by per app setting.
The settings is set by Andnroid prop as
debug.app.override_settings="<appName1>=<flags1>,
<appName1>=<flags1>,...". flags is a bitset for override features,
bit0 is forceFullscreen and bit1 is forceLandscape.
Other bits are not defined.

Tests done: Set the property and checked the App for
both full screen and landscape modes.

Tracked-On: OAM-113267
Signed-off-by: Marc Mao <marc.mao@intel.com>
Signed-off-by: Gao, HuadongX <huadongx.gao@intel.com>