### PR TITLE
Fixed to support playing .mkv & .ts videos from File App.

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Gallery2/0006-Fixed-to-support-playing-mkv-ts-videos-from-File-A.patch
+++ b/aosp_diff/base_aaos/packages/apps/Gallery2/0006-Fixed-to-support-playing-mkv-ts-videos-from-File-A.patch
@@ -1,0 +1,35 @@
+From a7d9c44ed5401c71dc570d85a7a6ab79051385f5 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Wed, 3 Jan 2024 16:48:31 +0530
+Subject: [PATCH] Fixed to support playing .mkv & .ts videos from File App.
+
+When user trying to play .mkv/.ts video from File app, it could not
+find any player app to play this file.
+
+Adding support in Gallery app to play these video files.
+
+Tests:
+Open File app, and play .mkv/.ts video. it plays successfully.
+
+Tracked-On: OAM-114430
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ AndroidManifest.xml | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/AndroidManifest.xml b/AndroidManifest.xml
+index 57db4e89f..a8db5ec1b 100644
+--- a/AndroidManifest.xml
++++ b/AndroidManifest.xml
+@@ -73,6 +73,8 @@
+                 <data android:mimeType="video/3gpp2" />
+                 <data android:mimeType="video/webm" />
+                 <data android:mimeType="video/avi" />
++                <data android:mimeType="video/x-matroska" />
++                <data android:mimeType="video/mp2ts" />
+              </intent-filter>
+              <intent-filter>
+                 <!-- HTTP live support -->
+-- 
+2.17.1
+


### PR DESCRIPTION
When user trying to play .mkv/.ts video from File app, it could not find any player app to play this file.

Adding support in Gallery app to play these video files.

Tests:
Open File app, and play .mkv/.ts video. it plays successfully.

Tracked-On: OAM-114430