### PR TITLE
Fixed for Toast message size view.

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Car/Settings/0005-Fixed-for-Toast-message-size-view.patch
+++ b/aosp_diff/base_aaos/packages/apps/Car/Settings/0005-Fixed-for-Toast-message-size-view.patch
@@ -1,0 +1,46 @@
+From 2aeeef17734211e20c8b0f3e4013b9454469b80f Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Fri, 5 Jan 2024 10:57:48 +0530
+Subject: [PATCH] Fixed for Toast message size view.
+
+When tap on build number in settings to enable developer option, it
+shows toast message which is very small in size.
+
+Increased size of Toast message.
+
+Tests: Enable developer option from settings and able to see toast
+message clearly.
+
+Tracked-On: OAM-114463
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../settings/system/BuildNumberPreferenceController.java    | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/car/settings/system/BuildNumberPreferenceController.java b/src/com/android/car/settings/system/BuildNumberPreferenceController.java
+index ad4b797ed..8e78df108 100644
+--- a/src/com/android/car/settings/system/BuildNumberPreferenceController.java
++++ b/src/com/android/car/settings/system/BuildNumberPreferenceController.java
+@@ -20,6 +20,8 @@ import android.car.drivingstate.CarUxRestrictions;
+ import android.content.Context;
+ import android.os.Build;
+ import android.os.UserManager;
++import android.text.SpannableString;
++import android.text.style.RelativeSizeSpan;
+ import android.widget.Toast;
+ 
+ import androidx.preference.Preference;
+@@ -94,7 +96,9 @@ public class BuildNumberPreferenceController extends PreferenceController<Prefer
+         if (mDevHitToast != null) {
+             mDevHitToast.cancel();
+         }
+-        mDevHitToast = Toast.makeText(getContext(), text, duration);
++        SpannableString ss =  new SpannableString(text);
++        ss.setSpan(new RelativeSizeSpan(2f), 0, text.length(), 0);
++        mDevHitToast = Toast.makeText(getContext(), ss, duration);
+         mDevHitToast.show();
+     }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
When tap on build number in settings to enable developer option, it shows toast message which is very small in size.

Increased size of Toast message.

Tests: Enable developer option from settings and able to see toast message clearly.

Tracked-On: OAM-114463