### PR TITLE
Fixed for crashe during Monkey test run.

### DIFF
--- a/aosp_diff/base_aaos/frameworks/base/99_0242-Fixed-for-crashe-during-Monkey-test-run.patch
+++ b/aosp_diff/base_aaos/frameworks/base/99_0242-Fixed-for-crashe-during-Monkey-test-run.patch
@@ -1,0 +1,41 @@
+From 2dffee28010c62a01047e58dd3f1699250987562 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Mon, 22 Jan 2024 10:09:25 +0530
+Subject: [PATCH] Fixed for crashe during Monkey test run.
+
+Following crash were observed
+java.lang.NullPointerException: Attempt to invoke virtual method
+'void com.android.systemui.statusbar.phone.NotificationPanelView
+Controller.setQsScrimEnabled(boolean)' on a null object reference
+
+Check for null condition, so during monkey test run, if view is
+destroyed (which is very rare in manual test), then it can safely
+handle.
+
+Tests:
+Run monkey test and observe, test is pass.
+
+Tracked-On: OAM-114271
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../src/com/android/systemui/statusbar/phone/StatusBar.java   | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+index 8e4769065db2..a539564b831a 100644
+--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
++++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+@@ -2243,7 +2243,9 @@ public class StatusBar extends SystemUI implements
+ 
+     // Called by NavigationBarFragment
+     public void setQsScrimEnabled(boolean scrimEnabled) {
+-        mNotificationPanelViewController.setQsScrimEnabled(scrimEnabled);
++        if (mNotificationPanelViewController != null) {
++            mNotificationPanelViewController.setQsScrimEnabled(scrimEnabled);
++        }
+     }
+ 
+     /** Temporarily hides Bubbles if the status bar is hidden. */
+-- 
+2.17.1
+


### PR DESCRIPTION
Following crash were observed
java.lang.NullPointerException: Attempt to invoke virtual method 'void com.android.systemui.statusbar.phone.NotificationPanelView Controller.setQsScrimEnabled(boolean)' on a null object reference

Check for null condition, so during monkey test run, if view is destroyed (which is very rare in manual test), then it can safely handle.

Tests:
Run monkey test and observe, test is pass.

Tracked-On: OAM-114271