### PR TITLE
Fix null pointer dereference coverity

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Car/Settings/05_0005-Fix-null-pointer-dereference-coverity.patch
+++ b/aosp_diff/base_aaos/packages/apps/Car/Settings/05_0005-Fix-null-pointer-dereference-coverity.patch
@@ -1,0 +1,76 @@
+From 6273073e7d4847a2092cf8848bcd9186d3d01104 Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Mon, 22 Jan 2024 16:43:33 +0530
+Subject: [PATCH] Fix null pointer dereference coverity
+
+CID 200863: (#1 of 1): Dereference null return value (NULL_RETURNS)
+
+Do null check before accessing the network interfaces.
+
+Tracked-On: OAM-115263
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ .../system/IpAddressPreferenceController.java | 36 ++++++++++---------
+ 1 file changed, 20 insertions(+), 16 deletions(-)
+
+diff --git a/src/com/android/car/settings/system/IpAddressPreferenceController.java b/src/com/android/car/settings/system/IpAddressPreferenceController.java
+index 15a47734a..d2e2fbf99 100644
+--- a/src/com/android/car/settings/system/IpAddressPreferenceController.java
++++ b/src/com/android/car/settings/system/IpAddressPreferenceController.java
+@@ -27,6 +27,7 @@ import androidx.preference.Preference;
+ import com.android.car.settings.common.FragmentController;
+ import com.android.car.settings.common.PreferenceController;
+ 
++import java.util.Enumeration;
+ import java.util.Collections;
+ import java.util.List;
+ import java.net.NetworkInterface;
+@@ -53,26 +54,29 @@ public class IpAddressPreferenceController extends
+ 
+     public static String getIPAddress(boolean useIPv4) {
+         try {
+-            List<NetworkInterface> interfaces = Collections.list(NetworkInterface.getNetworkInterfaces());
+-            for (NetworkInterface intf : interfaces) {
+-                List<InetAddress> addrs = Collections.list(intf.getInetAddresses());
+-                for (InetAddress addr : addrs) {
+-                    if (!addr.isLoopbackAddress()) {
+-                        String sAddr = addr.getHostAddress();
+-                        //boolean isIPv4 = InetAddressUtils.isIPv4Address(sAddr);
+-                        boolean isIPv4 = sAddr.indexOf(':')<0;
+-                        if (useIPv4) {
+-                            if (isIPv4)
+-                                return sAddr;
+-                        } else {
+-                            if (!isIPv4) {
+-                                int delim = sAddr.indexOf('%'); // drop ip6 zone suffix
+-                                return delim<0 ? sAddr.toUpperCase() : sAddr.substring(0, delim).toUpperCase();
++            Enumeration<NetworkInterface> nw_interfaces = NetworkInterface.getNetworkInterfaces();
++            if (nw_interfaces != null) {
++                List<NetworkInterface> interfaces = Collections.list(nw_interfaces);
++                for (NetworkInterface intf : interfaces) {
++                    List<InetAddress> addrs = Collections.list(intf.getInetAddresses());
++                    for (InetAddress addr : addrs) {
++                        if (!addr.isLoopbackAddress()) {
++                            String sAddr = addr.getHostAddress();
++                            //boolean isIPv4 = InetAddressUtils.isIPv4Address(sAddr);
++                            boolean isIPv4 = sAddr.indexOf(':')<0;
++                            if (useIPv4) {
++                                if (isIPv4)
++                                    return sAddr;
++                            } else {
++                                if (!isIPv4) {
++                                    int delim = sAddr.indexOf('%'); // drop ip6 zone suffix
++                                    return delim<0 ? sAddr.toUpperCase() : sAddr.substring(0, delim).toUpperCase();
++                                }
+                             }
+                         }
+                     }
+                 }
+-            }
++	    }
+         } catch (Exception ex) { }
+         return "";
+     }
+-- 
+2.17.1
+


### PR DESCRIPTION
Fix null pointer dereference coverity
CID 200863: (https://github.com/projectceladon/vendor-intel-utils/pull/1 of 1): Dereference null return value (NULL_RETURNS)

Do null check before accessing the network interfaces.

Tracked-On: OAM-115263
Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>