### PR TITLE
Obtain x86 cache info from CPU

### DIFF
--- a/aosp_diff/preliminary/bionic/0004-sysconf-implement-cache-queries.patch
+++ b/aosp_diff/preliminary/bionic/0004-sysconf-implement-cache-queries.patch
@@ -1,0 +1,205 @@
+From 02df7388f139aa5045c482c8f55a4023aeefc0e1 Mon Sep 17 00:00:00 2001
+From: Elliott Hughes <enh@google.com>
+Date: Tue, 22 Aug 2023 15:57:46 -0700
+Subject: [PATCH] sysconf(): implement cache queries.
+
+This is a bit disappointing. I'd not implemented this in the past
+because it wasn't available on all platforms, and -- although the
+riscv64 implementation was just a cool optimization -- I thought that
+the /sys stuff was actually portable, until I ran it on arm64 hardware.
+So here we have getauxval() for riscv64, /sys for x86-64, and our best
+guess based on ctr_el0 for arm64.
+
+Bug: http://b/294034962
+Test: ran tests on the host, an arm64 device, and riscv64 host and qemu
+Change-Id: I420b69b976d30668d4d2ac548c4229e2a4eafb20
+---
+ libc/bionic/sysconf.cpp | 133 +++++++++++++++++++++++++++++++++++-----
+ tests/unistd_test.cpp   |  20 ++++++
+ 2 files changed, 136 insertions(+), 17 deletions(-)
+
+diff --git a/libc/bionic/sysconf.cpp b/libc/bionic/sysconf.cpp
+index 3906e2ef3..edbdef188 100644
+--- a/libc/bionic/sysconf.cpp
++++ b/libc/bionic/sysconf.cpp
+@@ -41,6 +41,107 @@
+ #include "platform/bionic/page.h"
+ #include "private/bionic_tls.h"
+ 
++struct sysconf_cache {
++  long size, assoc, linesize;
++
++  static sysconf_cache from_size_and_geometry(int size_id, int geometry_id) {
++    sysconf_cache result;
++    result.size = getauxval(size_id);
++    unsigned long geometry = getauxval(geometry_id);
++    result.assoc = geometry >> 16;
++    result.linesize = geometry & 0xffff;
++    return result;
++  }
++};
++
++struct sysconf_caches {
++  sysconf_cache l1_i, l1_d, l2, l3, l4;
++};
++
++#if defined(__riscv)
++
++static sysconf_caches* __sysconf_caches() {
++  static sysconf_caches cached = []{
++    sysconf_caches info = {};
++    // riscv64 kernels conveniently hand us all this information.
++    info.l1_i = sysconf_cache::from_size_and_geometry(AT_L1I_CACHESIZE, AT_L1I_CACHEGEOMETRY);
++    info.l1_d = sysconf_cache::from_size_and_geometry(AT_L1D_CACHESIZE, AT_L1D_CACHEGEOMETRY);
++    info.l2 = sysconf_cache::from_size_and_geometry(AT_L2_CACHESIZE, AT_L2_CACHEGEOMETRY);
++    info.l3 = sysconf_cache::from_size_and_geometry(AT_L3_CACHESIZE, AT_L3_CACHEGEOMETRY);
++    return info;
++  }();
++  return &cached;
++}
++
++#elif defined(__aarch64__)
++
++static sysconf_caches* __sysconf_caches() {
++  static sysconf_caches cached = []{
++    sysconf_caches info = {};
++    // arm64 is especially limited. We can infer the L1 line sizes, but that's it.
++    uint64_t ctr_el0;
++    __asm__ __volatile__("mrs %0, ctr_el0" : "=r"(ctr_el0));
++    info.l1_i.linesize = 4 << (ctr_el0 & 0xf);
++    info.l1_d.linesize = 4 << ((ctr_el0 >> 16) & 0xf);
++    return info;
++  }();
++  return &cached;
++}
++
++#else
++
++long __sysconf_fread_long(const char* path) {
++  long result = 0;
++  FILE* fp = fopen(path, "re");
++  if (fp != nullptr) {
++    fscanf(fp, "%ld", &result);
++    fclose(fp);
++  }
++  return result;
++}
++
++static sysconf_caches* __sysconf_caches() {
++  static sysconf_caches cached = []{
++    sysconf_caches info = {};
++    char path[64];
++    for (int i = 0; i < 4; i++) {
++      sysconf_cache c;
++
++      snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu0/cache/index%d/size", i);
++      c.size = __sysconf_fread_long(path) * 1024;
++      if (c.size == 0) break;
++
++      snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu0/cache/index%d/ways_of_associativity", i);
++      c.assoc = __sysconf_fread_long(path);
++
++      snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu0/cache/index%d/coherency_line_size", i);
++      c.linesize = __sysconf_fread_long(path);
++
++      snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu0/cache/index%d/level", i);
++      int level = __sysconf_fread_long(path);
++      if (level == 1) {
++        snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu0/cache/index%d/type", i);
++        FILE* fp = fopen(path, "re");
++        char type = fgetc(fp);
++        fclose(fp);
++        if (type == 'D') {
++          info.l1_d = c;
++        } else if (type == 'I') {
++          info.l1_i = c;
++        }
++      } else if (level == 2) {
++        info.l2 = c;
++      } else if (level == 3) {
++        info.l3 = c;
++      }
++    }
++    return info;
++  }();
++  return &cached;
++}
++
++#endif
++
+ static long __sysconf_rlimit(int resource) {
+   rlimit rl;
+   getrlimit(resource, &rl);
+@@ -218,23 +319,21 @@ long sysconf(int name) {
+     case _SC_XOPEN_STREAMS:     return -1;            // Obsolescent in POSIX.1-2008.
+     case _SC_XOPEN_UUCP:        return -1;
+ 
+-    // We do not have actual implementations for cache queries.
+-    // It's valid to return 0 as the result is unknown.
+-    case _SC_LEVEL1_ICACHE_SIZE:      return 0;
+-    case _SC_LEVEL1_ICACHE_ASSOC:     return 0;
+-    case _SC_LEVEL1_ICACHE_LINESIZE:  return 0;
+-    case _SC_LEVEL1_DCACHE_SIZE:      return 0;
+-    case _SC_LEVEL1_DCACHE_ASSOC:     return 0;
+-    case _SC_LEVEL1_DCACHE_LINESIZE:  return 0;
+-    case _SC_LEVEL2_CACHE_SIZE:       return 0;
+-    case _SC_LEVEL2_CACHE_ASSOC:      return 0;
+-    case _SC_LEVEL2_CACHE_LINESIZE:   return 0;
+-    case _SC_LEVEL3_CACHE_SIZE:       return 0;
+-    case _SC_LEVEL3_CACHE_ASSOC:      return 0;
+-    case _SC_LEVEL3_CACHE_LINESIZE:   return 0;
+-    case _SC_LEVEL4_CACHE_SIZE:       return 0;
+-    case _SC_LEVEL4_CACHE_ASSOC:      return 0;
+-    case _SC_LEVEL4_CACHE_LINESIZE:   return 0;
++    case _SC_LEVEL1_ICACHE_SIZE:      return __sysconf_caches()->l1_i.size;
++    case _SC_LEVEL1_ICACHE_ASSOC:     return __sysconf_caches()->l1_i.assoc;
++    case _SC_LEVEL1_ICACHE_LINESIZE:  return __sysconf_caches()->l1_i.linesize;
++    case _SC_LEVEL1_DCACHE_SIZE:      return __sysconf_caches()->l1_d.size;
++    case _SC_LEVEL1_DCACHE_ASSOC:     return __sysconf_caches()->l1_d.assoc;
++    case _SC_LEVEL1_DCACHE_LINESIZE:  return __sysconf_caches()->l1_d.linesize;
++    case _SC_LEVEL2_CACHE_SIZE:       return __sysconf_caches()->l2.size;
++    case _SC_LEVEL2_CACHE_ASSOC:      return __sysconf_caches()->l2.assoc;
++    case _SC_LEVEL2_CACHE_LINESIZE:   return __sysconf_caches()->l2.linesize;
++    case _SC_LEVEL3_CACHE_SIZE:       return __sysconf_caches()->l3.size;
++    case _SC_LEVEL3_CACHE_ASSOC:      return __sysconf_caches()->l3.assoc;
++    case _SC_LEVEL3_CACHE_LINESIZE:   return __sysconf_caches()->l3.linesize;
++    case _SC_LEVEL4_CACHE_SIZE:       return __sysconf_caches()->l4.size;
++    case _SC_LEVEL4_CACHE_ASSOC:      return __sysconf_caches()->l4.assoc;
++    case _SC_LEVEL4_CACHE_LINESIZE:   return __sysconf_caches()->l4.linesize;
+ 
+     default:
+       errno = EINVAL;
+diff --git a/tests/unistd_test.cpp b/tests/unistd_test.cpp
+index 4c216278b..b639a4e8e 100644
+--- a/tests/unistd_test.cpp
++++ b/tests/unistd_test.cpp
+@@ -1166,6 +1166,26 @@ TEST(UNISTD_TEST, sysconf_unknown) {
+   VERIFY_SYSCONF_UNKNOWN(666);
+ }
+ 
++static void show_cache(const char* name, long size, long assoc, long line_size) {
++  printf("%s cache size: %ld bytes, line size %ld bytes, ", name, size, line_size);
++  if (assoc == 0) {
++    printf("fully");
++  } else {
++    printf("%ld-way", assoc);
++  }
++  printf(" associative\n");
++}
++
++TEST(UNISTD_TEST, sysconf_cache) {
++  // It's not obvious we can _test_ any of these, but we can at least
++  // show the output for humans to inspect.
++  show_cache("L1D", sysconf(_SC_LEVEL1_DCACHE_SIZE), sysconf(_SC_LEVEL1_DCACHE_ASSOC), sysconf(_SC_LEVEL1_DCACHE_LINESIZE));
++  show_cache("L1I", sysconf(_SC_LEVEL1_ICACHE_SIZE), sysconf(_SC_LEVEL1_ICACHE_ASSOC), sysconf(_SC_LEVEL1_ICACHE_LINESIZE));
++  show_cache("L2", sysconf(_SC_LEVEL2_CACHE_SIZE), sysconf(_SC_LEVEL2_CACHE_ASSOC), sysconf(_SC_LEVEL2_CACHE_LINESIZE));
++  show_cache("L3", sysconf(_SC_LEVEL3_CACHE_SIZE), sysconf(_SC_LEVEL3_CACHE_ASSOC), sysconf(_SC_LEVEL3_CACHE_LINESIZE));
++  show_cache("L4", sysconf(_SC_LEVEL4_CACHE_SIZE), sysconf(_SC_LEVEL4_CACHE_ASSOC), sysconf(_SC_LEVEL4_CACHE_LINESIZE));
++}
++
+ TEST(UNISTD_TEST, dup2_same) {
+   // POSIX says of dup2:
+   // If fildes2 is already a valid open file descriptor ...
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/bionic/0005-Enable-dynamic-cache-configuration.patch
+++ b/aosp_diff/preliminary/bionic/0005-Enable-dynamic-cache-configuration.patch
@@ -1,0 +1,598 @@
+From 1d07ccf52856faf491bc05a361dafb7f99075c0b Mon Sep 17 00:00:00 2001
+From: "Soni, Ravi Kumar" <ravi.kumar.soni@intel.com>
+Date: Fri, 10 Nov 2023 10:43:42 +0530
+Subject: [PATCH] Enable dynamic cache configuration
+
+This patch enables bionic to read cache config from the x86/64 CPU.
+Cache config will be used in memory and string functions
+
+Improvements seen on RPL, for various sizes
+
+memmove_non_overlapping
+1.25M - 12%
+1.5M - 20%
+1.75M - 25%
+
+memcpy
+1.25M - 14%
+1.5M - 25%
+1.75M - 28%
+
+Test: bionic/tests/run-on-host.sh 64 && bionic/tests/run-on-host.sh 32
+Signed-off-by: Vinay Prasad Kompella <vinay.kompella@intel.com>
+Signed-off-by: Soni, Ravi Kumar <ravi.kumar.soni@intel.com>
+--
+ libc/Android.bp                               | 26 +++++++++-
+ libc/arch-arm/bionic/cacheinfo.cpp            |  5 ++
+ libc/arch-arm64/bionic/cacheinfo.cpp          |  5 ++
+ libc/arch-x86/bionic/cacheinfo.cpp            | 48 +++++++++++++++++++
+ libc/arch-x86/cache.h                         | 15 ++++++
+ libc/arch-x86/string/cache.h                  | 41 ----------------
+ libc/arch-x86/string/sse2-memmove-slm.S       | 35 ++++++++++++--
+ libc/arch-x86/string/sse2-memset-atom.S       | 31 ++++++++++--
+ libc/arch-x86/string/sse2-memset-slm.S        | 28 +++++++++--
+ libc/arch-x86/string/ssse3-memcpy-atom.S      |  1 -
+ .../kabylake/string/avx2-memmove-kbl.S        | 15 ++++--
+ .../kabylake/string/avx2-memset-kbl.S         |  3 +-
+ libc/arch-x86_64/kabylake/string/cache.h      | 36 --------------
+ libc/arch-x86_64/silvermont/string/cache.h    | 36 --------------
+ .../silvermont/string/sse2-memmove-slm.S      | 15 ++++--
+ .../silvermont/string/sse2-memset-slm.S       |  4 +-
+ .../silvermont/string/sse4-memcmp-slm.S       |  5 +-
+ libc/bionic/libc_init_common.cpp              |  2 +
+ libc/private/bionic_cpuinfo.h                 |  9 ++++
+ 19 files changed, 221 insertions(+), 139 deletions(-)
+ create mode 100644 libc/arch-arm/bionic/cacheinfo.cpp
+ create mode 100644 libc/arch-arm64/bionic/cacheinfo.cpp
+ create mode 100644 libc/arch-x86/bionic/cacheinfo.cpp
+ create mode 100644 libc/arch-x86/cache.h
+ delete mode 100644 libc/arch-x86/string/cache.h
+ delete mode 100644 libc/arch-x86_64/kabylake/string/cache.h
+ delete mode 100644 libc/arch-x86_64/silvermont/string/cache.h
+ create mode 100644 libc/private/bionic_cpuinfo.h
+---
+ libc/arch-x86/string/cache.h                  | 41 -------------------
+ libc/arch-x86/string/sse2-memmove-slm.S       | 20 +++++++--
+ libc/arch-x86/string/sse2-memset-atom.S       | 15 +++++--
+ libc/arch-x86/string/sse2-memset-slm.S        | 12 ++++--
+ libc/arch-x86/string/ssse3-memcpy-atom.S      |  1 -
+ .../kabylake/string/avx2-memmove-kbl.S        | 23 ++++++++---
+ .../kabylake/string/avx2-memset-kbl.S         |  7 +---
+ libc/arch-x86_64/kabylake/string/cache.h      | 36 ----------------
+ libc/arch-x86_64/silvermont/string/cache.h    | 36 ----------------
+ .../silvermont/string/sse2-memmove-slm.S      | 24 ++++++++---
+ .../silvermont/string/sse2-memset-slm.S       |  4 +-
+ .../silvermont/string/sse4-memcmp-slm.S       |  5 +--
+ libc/bionic/libc_init_common.cpp              | 20 +++++++++
+ 13 files changed, 98 insertions(+), 146 deletions(-)
+ delete mode 100644 libc/arch-x86/string/cache.h
+ delete mode 100644 libc/arch-x86_64/kabylake/string/cache.h
+ delete mode 100644 libc/arch-x86_64/silvermont/string/cache.h
+
+diff --git a/libc/arch-x86/string/cache.h b/libc/arch-x86/string/cache.h
+deleted file mode 100644
+index 33719a0cb..000000000
+--- a/libc/arch-x86/string/cache.h
++++ /dev/null
+@@ -1,41 +0,0 @@
+-/*
+-Copyright (c) 2010, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-#ifdef FOR_ATOM
+-#define SHARED_CACHE_SIZE (512 * 1024) /* Atom L2 Cache */
+-#endif
+-#ifdef FOR_SILVERMONT
+-#define SHARED_CACHE_SIZE (1024 * 1024) /* Silvermont L2 Cache */
+-#endif
+-
+-#define DATA_CACHE_SIZE (24 * 1024) /* Atom and Silvermont L1 Data Cache */
+-
+-#define SHARED_CACHE_SIZE_HALF (SHARED_CACHE_SIZE / 2)
+-#define DATA_CACHE_SIZE_HALF (DATA_CACHE_SIZE / 2)
+diff --git a/libc/arch-x86/string/sse2-memmove-slm.S b/libc/arch-x86/string/sse2-memmove-slm.S
+index 79b5d1b7e..49dd9ef30 100644
+--- a/libc/arch-x86/string/sse2-memmove-slm.S
++++ b/libc/arch-x86/string/sse2-memmove-slm.S
+@@ -29,7 +29,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+ #define FOR_SILVERMONT
+-#include "cache.h"
+ 
+ #ifndef MEMMOVE
+ # define MEMMOVE	memmove_generic
+@@ -94,6 +93,8 @@ name:		\
+ #define RETURN_END	POP (%ebx); ret
+ #define RETURN		RETURN_END; CFI_PUSH (%ebx)
+ 
++# define SETUP_PIC_REG(x)	call	__x86.get_pc_thunk.x
++
+ 	.section .text.sse2,"ax",@progbits
+ ENTRY (MEMMOVE)
+ 	ENTRANCE
+@@ -193,7 +194,13 @@ L(mm_len_128_or_more_forward):
+ 	cmp	%edi, %ebx
+ 	jbe	L(mm_copy_remaining_forward)
+ 
+-	cmp	$SHARED_CACHE_SIZE_HALF, %ecx
++	PUSH(%ebx)
++	SETUP_PIC_REG(bx)
++	add	$_GLOBAL_OFFSET_TABLE_, %ebx
++	cmp	__x86_shared_cache_size_half@GOTOFF(%ebx), %ecx
++	/* Restore ebx. We can place a pop before jump as it doesnt effect any flags */
++	POP(%ebx)
++
+ 	jae	L(mm_large_page_loop_forward)
+ 
+ 	.p2align 4
+@@ -424,7 +431,14 @@ L(mm_len_128_or_more_backward):
+ 	cmp	%edi, %ebx
+ 	jae	L(mm_main_loop_backward_end)
+ 
+-	cmp	$SHARED_CACHE_SIZE_HALF, %ecx
++	
++	PUSH(%ebx)
++	SETUP_PIC_REG(bx)
++	add	$_GLOBAL_OFFSET_TABLE_, %ebx
++	cmp	__x86_shared_cache_size_half@GOTOFF(%ebx), %ecx
++	/* Restore ebx. We can place a pop before jump as it doesnt effect any flags */
++	POP(%ebx)
++	
+ 	jae	L(mm_large_page_loop_backward)
+ 
+ 	.p2align 4
+diff --git a/libc/arch-x86/string/sse2-memset-atom.S b/libc/arch-x86/string/sse2-memset-atom.S
+index 320afec11..2650b8a16 100644
+--- a/libc/arch-x86/string/sse2-memset-atom.S
++++ b/libc/arch-x86/string/sse2-memset-atom.S
+@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include <private/bionic_asm.h>
+ 
+ #define FOR_ATOM
+-#include "cache.h"
++
+ 
+ #ifndef L
+ # define L(label)	.L##label
+@@ -64,6 +64,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #define RETURN		RETURN_END; CFI_PUSH(%ebx)
+ #define JMPTBL(I, B)	I - B
+ 
++# define SETUP_PIC_REG(x)	call	__x86.get_pc_thunk.x
++
+ /* Load an entry in a jump table into EBX and branch to it.  TABLE is a
+    jump table with relative offsets.   */
+ # define BRANCH_TO_JMPTBL_ENTRY(TABLE)				\
+@@ -256,15 +258,20 @@ L(aligned_16_less128bytes):
+ 	ALIGN(4)
+ L(128bytesormore):
+ 	PUSH(%ebx)
+-	mov	$SHARED_CACHE_SIZE, %ebx
++	SETUP_PIC_REG(bx)
++	add	$_GLOBAL_OFFSET_TABLE_, %ebx
++	mov	__x86_shared_cache_size_memset@GOTOFF(%ebx), %ebx
+ 	cmp	%ebx, %ecx
+ 	jae	L(128bytesormore_nt_start)
+ 
+ 
+ 	POP(%ebx)
+ # define RESTORE_EBX_STATE CFI_PUSH(%ebx)
+-	cmp	$DATA_CACHE_SIZE, %ecx
+-
++	PUSH(%ebx)
++	SETUP_PIC_REG(bx)
++	add	$_GLOBAL_OFFSET_TABLE_, %ebx
++	cmp	__x86_data_cache_size@GOTOFF(%ebx), %ecx
++	POP(%ebx)
+ 	jae	L(128bytes_L2_normal)
+ 	subl	$128, %ecx
+ L(128bytesormore_normal):
+diff --git a/libc/arch-x86/string/sse2-memset-slm.S b/libc/arch-x86/string/sse2-memset-slm.S
+index 5cff141ad..8b97e4737 100644
+--- a/libc/arch-x86/string/sse2-memset-slm.S
++++ b/libc/arch-x86/string/sse2-memset-slm.S
+@@ -31,7 +31,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include <private/bionic_asm.h>
+ 
+ #define FOR_SILVERMONT
+-#include "cache.h"
+ 
+ #ifndef L
+ # define L(label)	.L##label
+@@ -64,6 +63,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ # define RETURN		RETURN_END; CFI_PUSH(%ebx)
+ # define JMPTBL(I, B)	I - B
+ 
++# define SETUP_PIC_REG(x)	call	__x86.get_pc_thunk.x
++
+ /* Load an entry in a jump table into EBX and branch to it.  TABLE is a
+    jump table with relative offsets.   */
+ # define BRANCH_TO_JMPTBL_ENTRY(TABLE)				\
+@@ -177,14 +178,19 @@ L(aligned_16_less128bytes):
+ 	ALIGN(4)
+ L(128bytesormore):
+ 	PUSH(%ebx)
+-	mov	$SHARED_CACHE_SIZE, %ebx
++	SETUP_PIC_REG(bx)
++	add	$_GLOBAL_OFFSET_TABLE_, %ebx
++	mov	__x86_shared_cache_size_memset@GOTOFF(%ebx), %ebx
++
+ 	cmp	%ebx, %ecx
+ 	jae	L(128bytesormore_nt_start)
+ 
+ 	POP(%ebx)
+ 
+ 	PUSH(%ebx)
+-	mov	$DATA_CACHE_SIZE, %ebx
++	SETUP_PIC_REG(bx)
++	add	$_GLOBAL_OFFSET_TABLE_, %ebx
++	mov	__x86_data_cache_size@GOTOFF(%ebx), %ebx
+ 
+ 	cmp	%ebx, %ecx
+ 	jae	L(128bytes_L2_normal)
+diff --git a/libc/arch-x86/string/ssse3-memcpy-atom.S b/libc/arch-x86/string/ssse3-memcpy-atom.S
+index fe3082ee7..83e198504 100644
+--- a/libc/arch-x86/string/ssse3-memcpy-atom.S
++++ b/libc/arch-x86/string/ssse3-memcpy-atom.S
+@@ -29,7 +29,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+ #define FOR_ATOM
+-#include "cache.h"
+ 
+ #ifndef MEMCPY
+ # define MEMCPY	memcpy_atom
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-memmove-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-memmove-kbl.S
+index 02e9ec1d2..668361d2c 100644
+--- a/libc/arch-x86_64/kabylake/string/avx2-memmove-kbl.S
++++ b/libc/arch-x86_64/kabylake/string/avx2-memmove-kbl.S
+@@ -28,7 +28,6 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+-#include "cache.h"
+ 
+ #ifndef MEMMOVE
+ # define MEMMOVE		memmove_avx2
+@@ -228,8 +227,8 @@ L(mm_len_256_or_more_forward):
+         cmp     %r8, %rbx
+         jbe     L(mm_copy_remaining_forward)
+ 
+-        cmp     $SHARED_CACHE_SIZE_HALF, %rdx
+-        jae     L(mm_large_page_loop_forward)
++	cmp	__x86_shared_cache_size_half(%rip), %rdx
++        ja	L(mm_overlapping_check_forward)
+ 
+         .p2align 4
+ L(mm_main_loop_forward):
+@@ -497,8 +496,8 @@ L(mm_len_256_or_more_backward):
+ 	cmp	%r9, %rbx
+ 	jae	L(mm_recalc_len)
+ 
+-	cmp	$SHARED_CACHE_SIZE_HALF, %rdx
+-	jae	L(mm_large_page_loop_backward)
++	cmp	__x86_shared_cache_size_half(%rip), %rdx
++	ja	L(mm_overlapping_check_backward)
+ 
+ 	.p2align 4
+ L(mm_main_loop_backward):
+@@ -560,6 +559,12 @@ L(mm_return):
+ /* Big length copy forward part.  */
+ 
+ 	.p2align 4
++L(mm_overlapping_check_forward):
++	mov	%rsi, %r9
++	add	%rdx, %r9
++	cmp	__x86_shared_cache_size(%rip), %r9
++	jbe	L(mm_main_loop_forward)
++
+ L(mm_large_page_loop_forward):
+ 	vmovdqu	  (%r8, %rsi), %ymm0
+ 	vmovdqu	  32(%r8, %rsi), %ymm1
+@@ -577,6 +582,14 @@ L(mm_large_page_loop_forward):
+ 
+ /* Big length copy backward part.  */
+ 	.p2align 4
++
++L(mm_overlapping_check_backward):
++	mov	%rdi, %r11
++	sub	%rsi, %r11 /* r11 = dst - src, diff */
++	add	%rdx, %r11
++	cmp	__x86_shared_cache_size(%rip), %r11
++	jbe	L(mm_main_loop_backward)
++
+ L(mm_large_page_loop_backward):
+ 	vmovdqu	  -64(%r9, %r8), %ymm0
+ 	vmovdqu	  -32(%r9, %r8), %ymm1
+diff --git a/libc/arch-x86_64/kabylake/string/avx2-memset-kbl.S b/libc/arch-x86_64/kabylake/string/avx2-memset-kbl.S
+index 09dd07dd1..4759cfc6e 100644
+--- a/libc/arch-x86_64/kabylake/string/avx2-memset-kbl.S
++++ b/libc/arch-x86_64/kabylake/string/avx2-memset-kbl.S
+@@ -30,7 +30,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ 
+-#include "cache.h"
+ 
+ #ifndef L
+ # define L(label)	.L##label
+@@ -123,11 +122,7 @@ L(256bytesmore):
+ 	cmpq	%rcx, %rdx
+ 	je	L(return)
+ 
+-#ifdef SHARED_CACHE_SIZE
+-	cmp	$SHARED_CACHE_SIZE, %r8
+-#else
+-	cmp	__x86_64_shared_cache_size(%rip), %r8
+-#endif
++	cmp	__x86_shared_cache_size_memset(%rip), %r8
+ 	ja	L(256bytesmore_nt)
+ 
+ 	ALIGN (4)
+diff --git a/libc/arch-x86_64/kabylake/string/cache.h b/libc/arch-x86_64/kabylake/string/cache.h
+deleted file mode 100644
+index 4131509fb..000000000
+--- a/libc/arch-x86_64/kabylake/string/cache.h
++++ /dev/null
+@@ -1,36 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-/* Values are optimized for Core Architecture */
+-#define SHARED_CACHE_SIZE (4096*1024)  /* Core Architecture L2 Cache */
+-#define DATA_CACHE_SIZE   (24*1024)    /* Core Architecture L1 Data Cache */
+-
+-#define SHARED_CACHE_SIZE_HALF (SHARED_CACHE_SIZE / 2)
+-#define DATA_CACHE_SIZE_HALF   (DATA_CACHE_SIZE / 2)
+diff --git a/libc/arch-x86_64/silvermont/string/cache.h b/libc/arch-x86_64/silvermont/string/cache.h
+deleted file mode 100644
+index 3606d2a1a..000000000
+--- a/libc/arch-x86_64/silvermont/string/cache.h
++++ /dev/null
+@@ -1,36 +0,0 @@
+-/*
+-Copyright (c) 2014, Intel Corporation
+-All rights reserved.
+-
+-Redistribution and use in source and binary forms, with or without
+-modification, are permitted provided that the following conditions are met:
+-
+-    * Redistributions of source code must retain the above copyright notice,
+-    * this list of conditions and the following disclaimer.
+-
+-    * Redistributions in binary form must reproduce the above copyright notice,
+-    * this list of conditions and the following disclaimer in the documentation
+-    * and/or other materials provided with the distribution.
+-
+-    * Neither the name of Intel Corporation nor the names of its contributors
+-    * may be used to endorse or promote products derived from this software
+-    * without specific prior written permission.
+-
+-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-*/
+-
+-/* Values are optimized for Silvermont */
+-#define SHARED_CACHE_SIZE (1024*1024)  /* Silvermont L2 Cache */
+-#define DATA_CACHE_SIZE   (24*1024)    /* Silvermont L1 Data Cache */
+-
+-#define SHARED_CACHE_SIZE_HALF (SHARED_CACHE_SIZE / 2)
+-#define DATA_CACHE_SIZE_HALF   (DATA_CACHE_SIZE / 2)
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-memmove-slm.S b/libc/arch-x86_64/silvermont/string/sse2-memmove-slm.S
+index 7024f4950..57f85d50c 100644
+--- a/libc/arch-x86_64/silvermont/string/sse2-memmove-slm.S
++++ b/libc/arch-x86_64/silvermont/string/sse2-memmove-slm.S
+@@ -28,7 +28,6 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+-#include "cache.h"
+ 
+ #ifndef MEMMOVE
+ # define MEMMOVE		memmove_generic
+@@ -189,8 +188,8 @@ L(mm_len_128_or_more_forward):
+ 	cmp	%r8, %rbx
+ 	jbe	L(mm_copy_remaining_forward)
+ 
+-	cmp	$SHARED_CACHE_SIZE_HALF, %rdx
+-	jae	L(mm_large_page_loop_forward)
++	cmp	__x86_shared_cache_size_half(%rip), %rdx
++	ja	L(mm_overlapping_check_forward)
+ 
+ 	.p2align 4
+ L(mm_main_loop_forward):
+@@ -414,8 +413,8 @@ L(mm_len_128_or_more_backward):
+ 	cmp	%r9, %rbx
+ 	jae	L(mm_recalc_len)
+ 
+-	cmp	$SHARED_CACHE_SIZE_HALF, %rdx
+-	jae	L(mm_large_page_loop_backward)
++	cmp __x86_shared_cache_size_half(%rip), %rdx	
++	ja	L(mm_overlapping_check_backward)
+ 
+ 	.p2align 4
+ L(mm_main_loop_backward):
+@@ -481,6 +480,13 @@ L(mm_return):
+ /* Big length copy forward part.  */
+ 
+ 	.p2align 4
++
++L(mm_overlapping_check_forward):
++	mov	%rsi, %r9
++	add	%rdx, %r9
++	cmp	__x86_shared_cache_size(%rip), %r9
++	jbe	L(mm_main_loop_forward)
++
+ L(mm_large_page_loop_forward):
+ 	movdqu	(%r8, %rsi), %xmm0
+ 	movdqu	16(%r8, %rsi), %xmm1
+@@ -498,6 +504,14 @@ L(mm_large_page_loop_forward):
+ 
+ /* Big length copy backward part.  */
+ 	.p2align 4
++
++L(mm_overlapping_check_backward):
++	mov	%rdi, %r11
++	sub	%rsi, %r11    /* r11 = dst - src, diff */
++	add	%rdx, %r11
++	cmp	__x86_shared_cache_size(%rip), %r11
++	jbe	L(mm_main_loop_backward)
++
+ L(mm_large_page_loop_backward):
+ 	movdqu	-64(%r9, %r8), %xmm0
+ 	movdqu	-48(%r9, %r8), %xmm1
+diff --git a/libc/arch-x86_64/silvermont/string/sse2-memset-slm.S b/libc/arch-x86_64/silvermont/string/sse2-memset-slm.S
+index cceadd297..b94e94d3c 100644
+--- a/libc/arch-x86_64/silvermont/string/sse2-memset-slm.S
++++ b/libc/arch-x86_64/silvermont/string/sse2-memset-slm.S
+@@ -30,8 +30,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ #include <private/bionic_asm.h>
+ 
+-#include "cache.h"
+-
+ #ifndef L
+ # define L(label)	.L##label
+ #endif
+@@ -119,7 +117,7 @@ L(128bytesmore):
+ #ifdef SHARED_CACHE_SIZE
+ 	cmp	$SHARED_CACHE_SIZE, %r8
+ #else
+-	cmp	__x86_64_shared_cache_size(%rip), %r8
++	cmp	__x86_shared_cache_size_memset(%rip), %r8
+ #endif
+ 	ja	L(128bytesmore_nt)
+ 
+diff --git a/libc/arch-x86_64/silvermont/string/sse4-memcmp-slm.S b/libc/arch-x86_64/silvermont/string/sse4-memcmp-slm.S
+index 6cfcd767f..c6db137eb 100644
+--- a/libc/arch-x86_64/silvermont/string/sse4-memcmp-slm.S
++++ b/libc/arch-x86_64/silvermont/string/sse4-memcmp-slm.S
+@@ -28,7 +28,6 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+ 
+-#include "cache.h"
+ 
+ #ifndef MEMCMP
+ # define MEMCMP		memcmp_generic
+@@ -356,7 +355,7 @@ L(512bytesormore):
+ #ifdef DATA_CACHE_SIZE_HALF
+ 	mov	$DATA_CACHE_SIZE_HALF, %r8
+ #else
+-	mov	__x86_64_data_cache_size_half(%rip), %r8
++	mov	__x86_data_cache_size_half(%rip), %r8
+ #endif
+ 	mov	%r8, %r9
+ 	shr	$1, %r8
+@@ -672,7 +671,7 @@ L(512bytesormorein2aligned):
+ #ifdef DATA_CACHE_SIZE_HALF
+ 	mov	$DATA_CACHE_SIZE_HALF, %r8
+ #else
+-	mov	__x86_64_data_cache_size_half(%rip), %r8
++	mov	__x86_data_cache_size_half(%rip), %r8
+ #endif
+ 	mov	%r8, %r9
+ 	shr	$1, %r8
+diff --git a/libc/bionic/libc_init_common.cpp b/libc/bionic/libc_init_common.cpp
+index 59b2ddb33..37316d214 100644
+--- a/libc/bionic/libc_init_common.cpp
++++ b/libc/bionic/libc_init_common.cpp
+@@ -62,6 +62,23 @@ __LIBC_HIDDEN__ WriteProtected<libc_globals> __libc_globals;
+ __BIONIC_WEAK_VARIABLE_FOR_NATIVE_BRIDGE
+ const char* __progname;
+ 
++#if defined(__i386__) || defined(__x86_64__)
++// Default sizes based on the old hard-coded values for Atom/Silvermont (x86) and Core 2 (x86-64)...
++size_t __x86_data_cache_size = 24 * 1024;
++size_t __x86_data_cache_size_half = __x86_data_cache_size / 2;
++size_t __x86_shared_cache_size = sizeof(long) == 8 ? 4096 * 1024 : 1024 * 1024;
++size_t __x86_shared_cache_size_half = __x86_shared_cache_size / 2;
++size_t __x86_shared_cache_size_memset = __x86_shared_cache_size * 2;
++// ...overwritten at runtime based on the cpu's reported cache sizes.
++static void __libc_init_x86_cache_info() {
++  __x86_data_cache_size = sysconf(_SC_LEVEL1_DCACHE_SIZE);
++  __x86_data_cache_size_half = __x86_data_cache_size / 2;
++  __x86_shared_cache_size = sysconf(_SC_LEVEL2_CACHE_SIZE);
++  __x86_shared_cache_size_half = __x86_shared_cache_size / 2;
++  __x86_shared_cache_size_memset = __x86_shared_cache_size * 2;
++}
++#endif
++
+ void __libc_init_globals() {
+   // Initialize libc globals that are needed in both the linker and in libc.
+   // In dynamic binaries, this is run at least twice for different copies of the
+@@ -171,6 +188,9 @@ void __libc_init_common() {
+   __system_properties_init(); // Requires 'environ'.
+   __libc_init_fdsan(); // Requires system properties (for debug.fdsan).
+   __libc_init_fdtrack();
++  #if defined(__i386__) || defined(__x86_64__)
++  __libc_init_x86_cache_info();
++  #endif
+ }
+ 
+ void __libc_init_fork_handler() {
+-- 
+2.42.0
+


### PR DESCRIPTION
The cache info today is hardcoded in cache.h
May not be optimal across various uarchs/SKUs
Leverage bionic sysconf to get the underlying cache.

Improvements seen on RPL, for various sizes
memmove_non_overlapping
1.25M - 31%
1.5M - 30%
1.75M - 28%

memcpy
1.25M - 31%
1.5M - 31%
1.75M - 30%

The bionic benchmarks (which only go up to 128KiB) show no change, as you'd expect.

Test: bionic/tests/run-on-host.sh 64 && bionic/tests/run-on-host.sh 32