### PR TITLE
remove some code to fix a reboot bug

### DIFF
--- a/aosp_diff/preliminary/system/core/03_0003-WA-remove-some-code-to-fix-a-reboot-bug.patch
+++ b/aosp_diff/preliminary/system/core/03_0003-WA-remove-some-code-to-fix-a-reboot-bug.patch
@@ -1,0 +1,54 @@
+From 06f05a718d5ae579440d7d2dfdfc20c5c8928e2b Mon Sep 17 00:00:00 2001
+From: "Guo, Jade" <jade.guo@intel.com>
+Date: Thu, 7 Sep 2023 16:44:54 +0800
+Subject: [PATCH] remove some code to fix a reboot bug
+
+System will boot twice after flashing images if we keep this piece of code. Safely remove it to bypass
+the bug.
+
+The code removed is part of the commit a7635718 "Pass wiped and fs_type to vold to format encrypted partition".
+
+Tracked-On: OAM-111863
+Signed-off-by: Guo, Jade <jade.guo@intel.com>
+---
+ fs_mgr/fs_mgr.cpp | 21 +--------------------
+ 1 file changed, 1 insertion(+), 20 deletions(-)
+
+diff --git a/fs_mgr/fs_mgr.cpp b/fs_mgr/fs_mgr.cpp
+index 8896ec33c..8b482c106 100644
+--- a/fs_mgr/fs_mgr.cpp
++++ b/fs_mgr/fs_mgr.cpp
+@@ -1550,29 +1550,10 @@ MountAllResult fs_mgr_mount_all(Fstab* fstab, int mount_mode) {
+                 crypt_footer = true;
+             }
+ 
+-            // EncryptInplace will be used when vdc gives an error or needs to format partitions
+-            // other than /data
+-            if (should_use_metadata_encryption(current_entry) &&
+-                current_entry.mount_point == "/data") {
+-
+-                // vdc->Format requires "ro.crypto.type" to set an encryption flag
+-                encryptable = FS_MGR_MNTALL_DEV_IS_METADATA_ENCRYPTED;
+-                set_type_property(encryptable);
+-
+-                if (!call_vdc({"cryptfs", "encryptFstab", current_entry.blk_device,
+-                               current_entry.mount_point, "true" /* shouldFormat */,
+-                               current_entry.fs_type},
+-                              nullptr)) {
+-                    LERROR << "Encryption failed";
+-                } else {
+-                    userdata_mounted = true;
+-                    continue;
+-                }
+-            }
+-
+             if (fs_mgr_do_format(current_entry, crypt_footer) == 0) {
+                 // Let's replay the mount actions.
+                 i = top_idx - 1;
++                wiped = false;
+                 continue;
+             } else {
+                 LERROR << __FUNCTION__ << "(): Format failed. "
+-- 
+2.42.0
+


### PR DESCRIPTION
System will boot twice after flashing images if we keep this piece of code. Safely remove it to bypass the bug.