### PR TITLE
Fix javacrash on com.google.android.car.kitchensink

### DIFF
--- a/aosp_diff/base_aaos/packages/services/Car/0020-Fix-javacrash-on-com.google.android.car.kitchensink.patch
+++ b/aosp_diff/base_aaos/packages/services/Car/0020-Fix-javacrash-on-com.google.android.car.kitchensink.patch
@@ -1,0 +1,38 @@
+From 2d09521c6a3add614f4d6ff8cc7c138ef42512ac Mon Sep 17 00:00:00 2001
+From: xubing <bing.xu@intel.com>
+Date: Mon, 29 Jan 2024 15:55:42 +0800
+Subject: [PATCH] Fix javacrash on com.google.android.car.kitchensink
+
+It's regression of previous patch, calling package is not allowed
+to draw overlays and the permission of SYSTEM_APPLICATION_OVERLAY
+is not permitted, meanwhile the activity to handle intent
+"android.settings.action.MANAGE_OVERLAY_PERMISSION" is not exist
+on car system, only exist on phone system, so skip the dialog.
+
+Tracked-On: OAM-115329
+Signed-off-by: xubing <bing.xu@intel.com>
+---
+ .../android/car/kitchensink/UserNoiticeDemoUiService.java   | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/tests/EmbeddedKitchenSinkApp/src/com/google/android/car/kitchensink/UserNoiticeDemoUiService.java b/tests/EmbeddedKitchenSinkApp/src/com/google/android/car/kitchensink/UserNoiticeDemoUiService.java
+index 47c9147181..6e27c69144 100644
+--- a/tests/EmbeddedKitchenSinkApp/src/com/google/android/car/kitchensink/UserNoiticeDemoUiService.java
++++ b/tests/EmbeddedKitchenSinkApp/src/com/google/android/car/kitchensink/UserNoiticeDemoUiService.java
+@@ -115,12 +115,8 @@ public class UserNoiticeDemoUiService extends Service {
+                 Log.wtf(TAG, "Dialog already created", new RuntimeException());
+                 return;
+             }
+-            //if permission isn't set, set by hand
++            //Settings app don't permit overlay permission, skip it
+             if (!Settings.canDrawOverlays(this)) {
+-                Intent intent = new Intent();
+-                intent.setAction(Settings.ACTION_MANAGE_OVERLAY_PERMISSION);
+-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+-                getApplicationContext().startActivity(intent);
+                 return;
+             }
+             mDialog = createDialog();
+-- 
+2.34.1
+


### PR DESCRIPTION
It's regression of previous patch, calling package is not allowed to draw overlays and the permission of SYSTEM_APPLICATION_OVERLAY is not permitted, meanwhile the activity to handle intent "android.settings.action.MANAGE_OVERLAY_PERMISSION" is not exist on car system, only exist on phone system, so skip the dialog.

Tracked-On: OAM-115329