### PR TITLE
Revert "Remove uuid when device leaves bonded state"

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Bluetooth/06_0006-Revert-Remove-uuid-when-device-leaves-bonded-state.patch
+++ b/aosp_diff/base_aaos/packages/apps/Bluetooth/06_0006-Revert-Remove-uuid-when-device-leaves-bonded-state.patch
@@ -1,0 +1,47 @@
+From 6539e6f1d41b50f75c55617f6e79e331ed233195 Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Tue, 30 Jan 2024 19:50:21 +0530
+Subject: [PATCH] Revert "Remove uuid when device leaves bonded state"
+
+This reverts commit f7aa659bc7a3d9d89e54d9e154876a054c5bc269.
+
+Reason for revert: Breaks devices with sensitive SDP/SMP timing conditions
+
+Cherry picked from AOSP:
+https://android-review.googlesource.com/c/platform/packages/modules/Bluetooth/+/2511479
+Commit-id: 2305dc8ad1a8d0944abbad5fa1ef1bec6da8556a
+
+Tracked-On: OAM-114062
+Signed-off-by: Chris Manton <cmanton@google.com>
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ src/com/android/bluetooth/btservice/RemoteDevices.java | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/src/com/android/bluetooth/btservice/RemoteDevices.java b/src/com/android/bluetooth/btservice/RemoteDevices.java
+index 34cbba749..7d18cff1c 100644
+--- a/src/com/android/bluetooth/btservice/RemoteDevices.java
++++ b/src/com/android/bluetooth/btservice/RemoteDevices.java
+@@ -343,9 +343,8 @@ final class RemoteDevices {
+          */
+         void setBondState(int newBondState) {
+             synchronized (mObject) {
+-                if ((mBondState == BluetoothDevice.BOND_BONDED
+-                        && newBondState == BluetoothDevice.BOND_BONDING)
+-                        || newBondState == BluetoothDevice.BOND_NONE) {
++                this.mBondState = newBondState;
++                if (newBondState == BluetoothDevice.BOND_NONE) {
+                     /* Clearing the Uuids local copy when the device is unpaired. If not cleared,
+                     cachedBluetoothDevice issued a connect using the local cached copy of uuids,
+                     without waiting for the ACTION_UUID intent.
+@@ -353,7 +352,6 @@ final class RemoteDevices {
+                     mUuids = null;
+                     mAlias = null;
+                 }
+-                mBondState = newBondState;
+             }
+         }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
Revert "Remove uuid when device leaves bonded state"

This reverts commit f7aa659bc7a3d9d89e54d9e154876a054c5bc269.

Reason for revert: Breaks devices with sensitive SDP/SMP timing conditions

Issue:
During device pairing, the device uuids are being removed from the cache
because of wrong bond state check, resulting in failure in profile
connections.

Solution:
Clear cached uuids only when the bond state is NONE.

Cherry picked from AOSP:
https://android-review.googlesource.com/c/platform/packages/modules/Bluetooth/+/2511479
Commit-id: 2305dc8ad1a8d0944abbad5fa1ef1bec6da8556a

Tracked-On: OAM-114062
Signed-off-by: Chris Manton <cmanton@google.com>
Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>