### PR TITLE
Add the support for Vulkan 1.3

### DIFF
--- a/aosp_diff/base_aaos/frameworks/native/0001-Add-the-support-for-Vulkan-1.3.patch
+++ b/aosp_diff/base_aaos/frameworks/native/0001-Add-the-support-for-Vulkan-1.3.patch
@@ -1,0 +1,41 @@
+From af790dd7953e4ddc77a761d76ab3f6770ab0fe7f Mon Sep 17 00:00:00 2001
+From: "Li, Gaoshun" <gaoshun.li@intel.com>
+Date: Tue, 6 Feb 2024 12:02:26 +0000
+Subject: [PATCH] Add the support for Vulkan 1.3
+
+Currently, the vulkaninfo will show the Vulkan instance version is 1.1.
+Actually, our mesa implementation already supports version 1.3.
+This change will help to fix it.
+Note,the reason I'm not using VK_API_VERSION_1_3 here is that
+it hasn't been defined in prebuilts/xxx/vulkan_core.h yet.
+In the latest AOSP code, vulkan_core.h will include this definition,
+this code will also be updated to use "*pApiVersion = VK_API_VERSION_1_3;"
+in the commit of '628c41a'.
+When we upgrade to the latest AOSP version, we need to remove this patch.
+
+Tracked-On: OAM-115564
+Signed-off-by: Li,Gaoshun gaoshun.li@intel.com
+---
+ vulkan/libvulkan/api.cpp | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/vulkan/libvulkan/api.cpp b/vulkan/libvulkan/api.cpp
+index d1cd397da4..78352e8825 100644
+--- a/vulkan/libvulkan/api.cpp
++++ b/vulkan/libvulkan/api.cpp
+@@ -1466,7 +1466,11 @@ VkResult EnumerateInstanceVersion(uint32_t* pApiVersion) {
+     if (!EnsureInitialized())
+         return VK_ERROR_OUT_OF_HOST_MEMORY;
+ 
+-    *pApiVersion = VK_API_VERSION_1_1;
++    // The reason I'm not using VK_API_VERSION_1_3 here is that it hasn't been defined in prebuilts/xxx/vulkan_core.h yet.
++    // In the latest AOSP code, vulkan_core.h will include this definition,
++    // this code will also be updated to use "*pApiVersion = VK_API_VERSION_1_3;" in the commit of '628c41a'.
++    // When we upgrade to the latest version, we need to remove this patch.
++    *pApiVersion = ((((uint32_t)(0)) << 29) | (((uint32_t)(1)) << 22) | (((uint32_t)(3)) << 12) | ((uint32_t)(0)));
+     return VK_SUCCESS;
+ }
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
This patch will be applied to frameworks/native/ .

Currently, the vulkaninfo will show the Vulkan instance version is 1.1. Actually, our mesa implementation already supports version 1.3. This change will help to fix it.
Note,the reason I'm not using VK_API_VERSION_1_3 here is that it hasn't been defined in prebuilts/xxx/vulkan_core.h yet. In the latest AOSP code, vulkan_core.h will include this definition, this code will also be updated to use "*pApiVersion = VK_API_VERSION_1_3;" in the commit of '628c41a'.
When we upgrade to the latest AOSP version, we need to remove this patch.

Tracked-On: OAM-115564
Signed-off-by: Li,Gaoshun gaoshun.li@intel.com