### PR TITLE
Fixed for timeout in audioserver.

### DIFF
--- a/aosp_diff/base_aaos/frameworks/base/99_0249-Fixed-for-timeout-in-audioserver.patch
+++ b/aosp_diff/base_aaos/frameworks/base/99_0249-Fixed-for-timeout-in-audioserver.patch
@@ -1,0 +1,33 @@
+From baaf5bf6e88c1660075e1a756e0e62f843599b33 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Tue, 13 Feb 2024 08:23:29 +0530
+Subject: [PATCH] Fixed for timeout in audioserver.
+
+Make caller wait for installd to become available.
+Reducing caller waiting time.
+
+Tests: delay installd binding, observe no crashes and calls eventually
+succeed.
+
+Tracked-On: OAM-115612
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ services/core/java/com/android/server/pm/Installer.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/services/core/java/com/android/server/pm/Installer.java b/services/core/java/com/android/server/pm/Installer.java
+index caa061dd5a12..a77bcdff9d33 100644
+--- a/services/core/java/com/android/server/pm/Installer.java
++++ b/services/core/java/com/android/server/pm/Installer.java
+@@ -111,7 +111,7 @@ public class Installer extends SystemService {
+             IInstalld.FLAG_CLEAR_APP_DATA_KEEP_ART_PROFILES;
+ 
+     private static final long CONNECT_RETRY_DELAY_MS = DateUtils.SECOND_IN_MILLIS;
+-    private static final long CONNECT_WAIT_MS = 10 * DateUtils.SECOND_IN_MILLIS;
++    private static final long CONNECT_WAIT_MS = 5 * DateUtils.SECOND_IN_MILLIS;
+ 
+     private final boolean mIsolated;
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
Make caller wait for installd to become available. Reducing caller waiting time.

Tests: delay installd binding, observe no crashes and calls eventually succeed.

Tracked-On: OAM-115612