### PR TITLE
Revert aosp l2cap/smp patches to fix BT connection issue

### DIFF
--- a/aosp_diff/base_aaos/system/bt/53_0053-Revert-tL2C_TX_COMPLETE_CB_INFO-is-unused.patch
+++ b/aosp_diff/base_aaos/system/bt/53_0053-Revert-tL2C_TX_COMPLETE_CB_INFO-is-unused.patch
@@ -1,0 +1,146 @@
+From 3a08d30fa1b2546f2a1bc25d0921b4eb2b4d61ee Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Tue, 20 Feb 2024 12:27:12 +0530
+Subject: [PATCH] Revert "tL2C_TX_COMPLETE_CB_INFO is unused"
+
+This reverts commit 0afa91e3d2091999d5beb7591675f4a92973c5a7.
+
+The assumption in the original CL "L2cap tx completes immediately"
+seems to be incorrect.
+
+Tracked-On: OAM-112831
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ stack/l2cap/l2c_int.h   |  7 +++++++
+ stack/l2cap/l2c_link.cc | 35 +++++++++++++++++++++++------------
+ 2 files changed, 30 insertions(+), 12 deletions(-)
+
+diff --git a/stack/l2cap/l2c_int.h b/stack/l2cap/l2c_int.h
+index b16678ba6..6c3d711b2 100644
+--- a/stack/l2cap/l2c_int.h
++++ b/stack/l2cap/l2c_int.h
+@@ -645,6 +645,13 @@ typedef struct {
+ 
+ typedef void(tL2C_FCR_MGMT_EVT_HDLR)(uint8_t, tL2C_CCB*);
+ 
++/* Necessary info for postponed TX completion callback
++*/
++typedef struct {
++  uint16_t local_cid;
++  uint16_t num_sdu;
++} tL2C_TX_COMPLETE_CB_INFO;
++
+ /* The offset in a buffer that L2CAP will use when building commands.
+ */
+ #define L2CAP_SEND_CMD_OFFSET 0
+diff --git a/stack/l2cap/l2c_link.cc b/stack/l2cap/l2c_link.cc
+index 3f56effba..b4ed68594 100644
+--- a/stack/l2cap/l2c_link.cc
++++ b/stack/l2cap/l2c_link.cc
+@@ -41,6 +41,7 @@
+ #include "types/bt_transport.h"
+ #include "types/raw_address.h"
+ 
++
+ extern tBTM_CB btm_cb;
+ 
+ bool BTM_ReadPowerMode(const RawAddress& remote_bda, tBTM_PM_MODE* p_mode);
+@@ -53,8 +54,10 @@ void btm_acl_set_paging(bool value);
+ void btm_ble_decrement_link_topology_mask(uint8_t link_role);
+ void btm_sco_acl_removed(const RawAddress* bda);
+ 
+-static void l2c_link_send_to_lower(tL2C_LCB* p_lcb, BT_HDR* p_buf);
+-static BT_HDR* l2cu_get_next_buffer_to_send(tL2C_LCB* p_lcb);
++static void l2c_link_send_to_lower(tL2C_LCB* p_lcb, BT_HDR* p_buf,
++                                   tL2C_TX_COMPLETE_CB_INFO* p_cbi);
++static BT_HDR* l2cu_get_next_buffer_to_send(tL2C_LCB* p_lcb,
++                                            tL2C_TX_COMPLETE_CB_INFO* p_cbi);
+ 
+ /*******************************************************************************
+  *
+@@ -937,7 +940,7 @@ void l2c_link_check_send_pkts(tL2C_LCB* p_lcb, uint16_t local_cid,
+         LOG_DEBUG("Sending to lower layer");
+         p_buf = (BT_HDR*)list_front(p_lcb->link_xmit_data_q);
+         list_remove(p_lcb->link_xmit_data_q, p_buf);
+-        l2c_link_send_to_lower(p_lcb, p_buf);
++        l2c_link_send_to_lower(p_lcb, p_buf, NULL);
+       } else if (single_write) {
+         /* If only doing one write, break out */
+         LOG_DEBUG("single_write is true, skipping");
+@@ -945,11 +948,12 @@ void l2c_link_check_send_pkts(tL2C_LCB* p_lcb, uint16_t local_cid,
+       }
+       /* If nothing on the link queue, check the channel queue */
+       else {
++        tL2C_TX_COMPLETE_CB_INFO cbi = {};
+         LOG_DEBUG("Check next buffer");
+-        p_buf = l2cu_get_next_buffer_to_send(p_lcb);
++        p_buf = l2cu_get_next_buffer_to_send(p_lcb, &cbi);
+         if (p_buf != NULL) {
+           LOG_DEBUG("Sending next buffer");
+-          l2c_link_send_to_lower(p_lcb, p_buf);
++          l2c_link_send_to_lower(p_lcb, p_buf, &cbi);
+         }
+       }
+     }
+@@ -993,7 +997,7 @@ void l2c_link_check_send_pkts(tL2C_LCB* p_lcb, uint16_t local_cid,
+       LOG_DEBUG("Sending to lower layer");
+       p_buf = (BT_HDR*)list_front(p_lcb->link_xmit_data_q);
+       list_remove(p_lcb->link_xmit_data_q, p_buf);
+-      l2c_link_send_to_lower(p_lcb, p_buf);
++      l2c_link_send_to_lower(p_lcb, p_buf, NULL);
+     }
+ 
+     if (!single_write) {
+@@ -1004,13 +1008,14 @@ void l2c_link_check_send_pkts(tL2C_LCB* p_lcb, uint16_t local_cid,
+               (l2cb.controller_le_xmit_window != 0 &&
+                (p_lcb->transport == BT_TRANSPORT_LE))) &&
+              (p_lcb->sent_not_acked < p_lcb->link_xmit_quota)) {
+-        p_buf = l2cu_get_next_buffer_to_send(p_lcb);
++        tL2C_TX_COMPLETE_CB_INFO cbi = {};
++        p_buf = l2cu_get_next_buffer_to_send(p_lcb, &cbi);
+         if (p_buf == NULL) {
+           LOG_DEBUG("No next buffer, skipping");
+-          break;
+-        }
++	  break;
++	}
+         LOG_DEBUG("Sending to lower layer");
+-        l2c_link_send_to_lower(p_lcb, p_buf);
++        l2c_link_send_to_lower(p_lcb, p_buf, &cbi);
+       }
+     }
+ 
+@@ -1145,7 +1150,8 @@ static void l2c_link_send_to_lower_ble(tL2C_LCB* p_lcb, BT_HDR* p_buf) {
+             l2cb.ble_round_robin_quota, l2cb.ble_round_robin_unacked);
+ }
+ 
+-static void l2c_link_send_to_lower(tL2C_LCB* p_lcb, BT_HDR* p_buf) {
++static void l2c_link_send_to_lower(tL2C_LCB* p_lcb, BT_HDR* p_buf,
++                                   tL2C_TX_COMPLETE_CB_INFO* p_cbi) {
+   if (p_lcb->transport == BT_TRANSPORT_BR_EDR) {
+     l2c_link_send_to_lower_br_edr(p_lcb, p_buf);
+   } else {
+@@ -1483,7 +1489,8 @@ tL2C_CCB* l2cu_get_next_channel_in_rr(tL2C_LCB* p_lcb) {
+  * Returns          pointer to buffer or NULL
+  *
+  ******************************************************************************/
+-BT_HDR* l2cu_get_next_buffer_to_send(tL2C_LCB* p_lcb) {
++BT_HDR* l2cu_get_next_buffer_to_send(tL2C_LCB* p_lcb,
++                                     tL2C_TX_COMPLETE_CB_INFO* p_cbi) {
+   tL2C_CCB* p_ccb;
+   BT_HDR* p_buf;
+ 
+@@ -1522,6 +1529,10 @@ BT_HDR* l2cu_get_next_buffer_to_send(tL2C_LCB* p_lcb) {
+           return (NULL);
+         }
+ 
++        /* Prepare callback info for TX completion */
++        p_cbi->local_cid = p_ccb->local_cid;
++        p_cbi->num_sdu = 1;
++
+         l2cu_check_channel_congestion(p_ccb);
+         l2cu_set_acl_hci_header(p_buf, p_ccb);
+         return (p_buf);
+-- 
+2.17.1
+

--- a/aosp_diff/base_aaos/system/bt/54_0054-Revert-L2cap-fixed-channel-tx-complete-is-unused.patch
+++ b/aosp_diff/base_aaos/system/bt/54_0054-Revert-L2cap-fixed-channel-tx-complete-is-unused.patch
@@ -1,0 +1,138 @@
+From fc6c1b7cbbf9e6bd5aa549e1a1b106fe3ba2d6a9 Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Tue, 20 Feb 2024 12:32:24 +0530
+Subject: [PATCH] Revert "L2cap fixed channel tx complete is unused"
+
+This reverts commit 1f6cf09bcd50d14f5eefa0ba948166ac5d306b88.
+
+The assumption in the original CL "L2cap tx completes immediately"
+seems to be incorrect.
+
+Tracked-On: OAM-112831
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ stack/include/l2c_api.h  |  2 ++
+ stack/l2cap/l2c_int.h    |  3 +++
+ stack/l2cap/l2c_link.cc  |  4 ++++
+ stack/l2cap/l2c_utils.cc |  4 ++++
+ stack/smp/smp_l2c.cc     | 12 ++++++++++++
+ 5 files changed, 25 insertions(+)
+
+diff --git a/stack/include/l2c_api.h b/stack/include/l2c_api.h
+index 52f41614e..f884e1bb0 100644
+--- a/stack/include/l2c_api.h
++++ b/stack/include/l2c_api.h
+@@ -701,6 +701,8 @@ typedef struct {
+   tL2CA_FIXED_CONGESTION_STATUS_CB* pL2CA_FixedCong_Cb;
+ 
+   uint16_t default_idle_tout;
++  tL2CA_TX_COMPLETE_CB*
++      pL2CA_FixedTxComplete_Cb; /* fixed channel tx complete callback */
+ } tL2CAP_FIXED_CHNL_REG;
+ 
+ /*******************************************************************************
+diff --git a/stack/l2cap/l2c_int.h b/stack/l2cap/l2c_int.h
+index 6c3d711b2..ab314fdf4 100644
+--- a/stack/l2cap/l2c_int.h
++++ b/stack/l2cap/l2c_int.h
+@@ -650,6 +650,7 @@ typedef void(tL2C_FCR_MGMT_EVT_HDLR)(uint8_t, tL2C_CCB*);
+ typedef struct {
+   uint16_t local_cid;
+   uint16_t num_sdu;
++  tL2CA_TX_COMPLETE_CB* cb;
+ } tL2C_TX_COMPLETE_CB_INFO;
+ 
+ /* The offset in a buffer that L2CAP will use when building commands.
+@@ -721,6 +722,8 @@ extern void l2cu_set_acl_hci_header(BT_HDR* p_buf, tL2C_CCB* p_ccb);
+ extern void l2cu_check_channel_congestion(tL2C_CCB* p_ccb);
+ extern void l2cu_disconnect_chnl(tL2C_CCB* p_ccb);
+ 
++extern void l2cu_tx_complete(tL2C_TX_COMPLETE_CB_INFO* p_cbi);
++
+ extern void l2cu_send_peer_ble_par_req(tL2C_LCB* p_lcb, uint16_t min_int,
+                                        uint16_t max_int, uint16_t latency,
+                                        uint16_t timeout);
+diff --git a/stack/l2cap/l2c_link.cc b/stack/l2cap/l2c_link.cc
+index b4ed68594..c94e818e0 100644
+--- a/stack/l2cap/l2c_link.cc
++++ b/stack/l2cap/l2c_link.cc
+@@ -1157,6 +1157,7 @@ static void l2c_link_send_to_lower(tL2C_LCB* p_lcb, BT_HDR* p_buf,
+   } else {
+     l2c_link_send_to_lower_ble(p_lcb, p_buf);
+   }
++  if (p_cbi) l2cu_tx_complete(p_cbi);
+ }
+ 
+ /*******************************************************************************
+@@ -1497,6 +1498,8 @@ BT_HDR* l2cu_get_next_buffer_to_send(tL2C_LCB* p_lcb,
+   /* Highest priority are fixed channels */
+   int xx;
+ 
++  p_cbi->cb = NULL;
++
+   for (xx = 0; xx < L2CAP_NUM_FIXED_CHNLS; xx++) {
+     p_ccb = p_lcb->p_fixed_ccbs[xx];
+     if (p_ccb == NULL) continue;
+@@ -1530,6 +1533,7 @@ BT_HDR* l2cu_get_next_buffer_to_send(tL2C_LCB* p_lcb,
+         }
+ 
+         /* Prepare callback info for TX completion */
++        p_cbi->cb = l2cb.fixed_reg[xx].pL2CA_FixedTxComplete_Cb;
+         p_cbi->local_cid = p_ccb->local_cid;
+         p_cbi->num_sdu = 1;
+ 
+diff --git a/stack/l2cap/l2c_utils.cc b/stack/l2cap/l2c_utils.cc
+index 72c5326fa..4a8dd4e9f 100644
+--- a/stack/l2cap/l2c_utils.cc
++++ b/stack/l2cap/l2c_utils.cc
+@@ -3162,6 +3162,10 @@ tL2C_CCB* l2cu_find_ccb_by_cid(tL2C_LCB* p_lcb, uint16_t local_cid) {
+   return (p_ccb);
+ }
+ 
++void l2cu_tx_complete(tL2C_TX_COMPLETE_CB_INFO* p_cbi) {
++  if (p_cbi->cb != NULL) p_cbi->cb(p_cbi->local_cid, p_cbi->num_sdu);
++}
++
+ /******************************************************************************
+  *
+  * Function         l2cu_set_acl_hci_header
+diff --git a/stack/smp/smp_l2c.cc b/stack/smp/smp_l2c.cc
+index 6c286b133..e73b8dd00 100644
+--- a/stack/smp/smp_l2c.cc
++++ b/stack/smp/smp_l2c.cc
+@@ -35,6 +35,8 @@
+ #include "osi/include/osi.h"  // UNUSED_ATTR
+ #include "smp_int.h"
+ 
++static void smp_tx_complete_callback(uint16_t cid, uint16_t num_pkt);
++
+ static void smp_connect_callback(uint16_t channel, const RawAddress& bd_addr,
+                                  bool connected, uint16_t reason,
+                                  tBT_TRANSPORT transport);
+@@ -61,6 +63,7 @@ void smp_l2cap_if_init(void) {
+ 
+   fixed_reg.pL2CA_FixedConn_Cb = smp_connect_callback;
+   fixed_reg.pL2CA_FixedData_Cb = smp_data_received;
++  fixed_reg.pL2CA_FixedTxComplete_Cb = smp_tx_complete_callback;
+ 
+   fixed_reg.pL2CA_FixedCong_Cb =
+       NULL; /* do not handle congestion on this channel */
+@@ -215,6 +218,15 @@ static void smp_data_received(uint16_t channel, const RawAddress& bd_addr,
+   osi_free(p_buf);
+ }
+ 
++/*******************************************************************************
++ *
++ * Function         smp_tx_complete_callback
++ *
++ * Description      SMP channel tx complete callback
++ *
++ ******************************************************************************/
++static void smp_tx_complete_callback(uint16_t cid, uint16_t num_pkt) {}
++
+ /*******************************************************************************
+  *
+  * Function         smp_br_connect_callback
+-- 
+2.17.1
+

--- a/aosp_diff/base_aaos/system/bt/55_0055-Revert-SMP-Assume-L2cap-tx-completes-immediately.patch
+++ b/aosp_diff/base_aaos/system/bt/55_0055-Revert-SMP-Assume-L2cap-tx-completes-immediately.patch
@@ -1,0 +1,86 @@
+From d456a2a6ca40797ea961745c27b3556ce14fefeb Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Tue, 20 Feb 2024 12:39:05 +0530
+Subject: [PATCH] Revert "SMP: Assume L2cap tx completes immediately"
+
+This reverts commit 8326b49c4cf83b747dcaf4b69f8040db1db5d09e.
+
+The assumption in the original CL "L2cap tx completes immediately"
+seems to be incorrect.
+
+Tracked-On: OAM-112831
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ stack/smp/smp_l2c.cc   | 19 ++++++++++++++++++-
+ stack/smp/smp_utils.cc | 16 +++-------------
+ 2 files changed, 21 insertions(+), 14 deletions(-)
+
+diff --git a/stack/smp/smp_l2c.cc b/stack/smp/smp_l2c.cc
+index e73b8dd00..4eff4ceec 100644
+--- a/stack/smp/smp_l2c.cc
++++ b/stack/smp/smp_l2c.cc
+@@ -225,7 +225,24 @@ static void smp_data_received(uint16_t channel, const RawAddress& bd_addr,
+  * Description      SMP channel tx complete callback
+  *
+  ******************************************************************************/
+-static void smp_tx_complete_callback(uint16_t cid, uint16_t num_pkt) {}
++static void smp_tx_complete_callback(uint16_t cid, uint16_t num_pkt) {
++  tSMP_CB* p_cb = &smp_cb;
++
++  if (p_cb->total_tx_unacked >= num_pkt)
++    p_cb->total_tx_unacked -= num_pkt;
++  else
++    SMP_TRACE_ERROR("Unexpected %s: num_pkt = %d", __func__, num_pkt);
++
++  if (p_cb->total_tx_unacked == 0 && p_cb->wait_for_authorization_complete) {
++    tSMP_INT_DATA smp_int_data;
++    smp_int_data.status = SMP_SUCCESS;
++    if (cid == L2CAP_SMP_CID) {
++      smp_sm_event(p_cb, SMP_AUTH_CMPL_EVT, &smp_int_data);
++    } else {
++      smp_br_state_machine_event(p_cb, SMP_BR_AUTH_CMPL_EVT, &smp_int_data);
++    }
++  }
++}
+ 
+ /*******************************************************************************
+  *
+diff --git a/stack/smp/smp_utils.cc b/stack/smp/smp_utils.cc
+index 54d4aeba4..1c16b5013 100644
+--- a/stack/smp/smp_utils.cc
++++ b/stack/smp/smp_utils.cc
+@@ -341,28 +341,18 @@ bool smp_send_msg_to_L2CAP(const RawAddress& rem_bda, BT_HDR* p_toL2CAP) {
+   }
+ 
+   SMP_TRACE_EVENT("%s", __func__);
++  smp_cb.total_tx_unacked += 1;
+ 
+   smp_log_metrics(rem_bda, true /* outgoing */,
+                   p_toL2CAP->data + p_toL2CAP->offset, p_toL2CAP->len);
+ 
+   l2cap_ret = L2CA_SendFixedChnlData(fixed_cid, rem_bda, p_toL2CAP);
+   if (l2cap_ret == L2CAP_DW_FAILED) {
++    smp_cb.total_tx_unacked -= 1;
+     SMP_TRACE_ERROR("SMP failed to pass msg to L2CAP");
+     return false;
+-  } else {
+-    tSMP_CB* p_cb = &smp_cb;
+-
+-    if (p_cb->wait_for_authorization_complete) {
+-      tSMP_INT_DATA smp_int_data;
+-      smp_int_data.status = SMP_SUCCESS;
+-      if (fixed_cid == L2CAP_SMP_CID) {
+-        smp_sm_event(p_cb, SMP_AUTH_CMPL_EVT, &smp_int_data);
+-      } else {
+-        smp_br_state_machine_event(p_cb, SMP_BR_AUTH_CMPL_EVT, &smp_int_data);
+-      }
+-    }
++  } else
+     return true;
+-  }
+ }
+ 
+ /*******************************************************************************
+-- 
+2.17.1
+


### PR DESCRIPTION
[Problem]
In SMP layer, the acknowledgement for packets being sent is not checked properly, causing the SMP control block to reset, which is flushing the unsent smp packets in l2cap queue. This packet drop is causing the remote reference device to disconnect with DUT as pairing is incomplete. SMP signing info cmd is flushed in l2cap layer.

[Solution]
So SMP to register the tx_complete_cb with l2cap for getting the acknowledgement for sent pkts. Wait for all sent pkts acknowledgement, until then do not reset the SMP control block.
Now SMP signing info cmd is being sent to reference device and able to see DUT in reference device paired devices list.

Tracked-On: OAM-112831
Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
Signed-off-by: Bharat B Panda <bharat.b.panda@intel.com>