### PR TITLE
Allow uknown source apks to be installed

### DIFF
--- a/aosp_diff/base_aaos/frameworks/base/99_0247-Allow-install-unknown-source-apks-in-ivi-by-default.patch
+++ b/aosp_diff/base_aaos/frameworks/base/99_0247-Allow-install-unknown-source-apks-in-ivi-by-default.patch
@@ -1,0 +1,54 @@
+From 366b28d9640e79f1c14fb047eba9b9e8f066bfb2 Mon Sep 17 00:00:00 2001
+From: jizhenlo <zhenlong.z.ji@intel.com>
+Date: Tue, 14 Feb 2023 12:38:59 +0800
+Subject: [PATCH] Allow install unknown source apks in ivi by default
+
+There is no "Allow unknown source apks" option in IVI Settings.
+With this patch, all the applications are allowed to install
+irrespective of user choice.
+
+Tracked-On: OAM-108915
+Signed-off-by: jizhenlo <zhenlong.z.ji@intel.com>
+---
+ .../PackageInstallerActivity.java             | 25 +------------------
+ 1 file changed, 1 insertion(+), 24 deletions(-)
+
+diff --git a/packages/PackageInstaller/src/com/android/packageinstaller/PackageInstallerActivity.java b/packages/PackageInstaller/src/com/android/packageinstaller/PackageInstallerActivity.java
+index 9c6113ce4b47..6f4e4b938c4f 100644
+--- a/packages/PackageInstaller/src/com/android/packageinstaller/PackageInstallerActivity.java
++++ b/packages/PackageInstaller/src/com/android/packageinstaller/PackageInstallerActivity.java
+@@ -511,30 +511,7 @@ public class PackageInstallerActivity extends AlertActivity {
+             showDialogInner(DLG_ANONYMOUS_SOURCE);
+             return;
+         }
+-        // Shouldn't use static constant directly, see b/65534401.
+-        final int appOpCode =
+-                AppOpsManager.permissionToOpCode(Manifest.permission.REQUEST_INSTALL_PACKAGES);
+-        final int appOpMode = mAppOpsManager.noteOpNoThrow(appOpCode, mOriginatingUid,
+-                mOriginatingPackage, mCallingAttributionTag,
+-                "Started package installation activity");
+-        if (mLocalLOGV) Log.i(TAG, "handleUnknownSources(): appMode=" + appOpMode);
+-        switch (appOpMode) {
+-            case AppOpsManager.MODE_DEFAULT:
+-                mAppOpsManager.setMode(appOpCode, mOriginatingUid,
+-                        mOriginatingPackage, AppOpsManager.MODE_ERRORED);
+-                // fall through
+-            case AppOpsManager.MODE_ERRORED:
+-                showDialogInner(DLG_EXTERNAL_SOURCE_BLOCKED);
+-                break;
+-            case AppOpsManager.MODE_ALLOWED:
+-                initiateInstall();
+-                break;
+-            default:
+-                Log.e(TAG, "Invalid app op mode " + appOpMode
+-                        + " for OP_REQUEST_INSTALL_PACKAGES found for uid " + mOriginatingUid);
+-                finish();
+-                break;
+-        }
++        initiateInstall();
+     }
+ 
+     /**
+-- 
+2.25.1
+


### PR DESCRIPTION
To fix a issue reported by Coverity previously, a patch is removed but the replacement patch is forgotten to be committed. Need to commit the missed patch.

Test Done: Unknown source apks can be installed.

Tracked-On: OAM-115697