### PR TITLE
Allow SystemUpdater app access udisk files

### DIFF
--- a/aosp_diff/base_aaos/frameworks/base/99_0250-Allow-SystemUpdater-app-access-udisk-files.patch
+++ b/aosp_diff/base_aaos/frameworks/base/99_0250-Allow-SystemUpdater-app-access-udisk-files.patch
@@ -1,0 +1,33 @@
+From 21e28892b53e2bdbbec4244a3b3c9319d04230c7 Mon Sep 17 00:00:00 2001
+From: jizhenlo <zhenlong.z.ji@intel.com>
+Date: Mon, 26 Feb 2024 13:35:36 +0800
+Subject: [PATCH] Allow SystemUpdater app access udisk files
+
+Signed-off-by: jizhenlo <zhenlong.z.ji@intel.com>
+---
+ .../java/com/android/server/StorageManagerService.java   | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/services/core/java/com/android/server/StorageManagerService.java b/services/core/java/com/android/server/StorageManagerService.java
+index 6fc01bd64688..adf50587b771 100644
+--- a/services/core/java/com/android/server/StorageManagerService.java
++++ b/services/core/java/com/android/server/StorageManagerService.java
+@@ -4404,6 +4404,15 @@ class StorageManagerService extends IStorageManager.Stub
+                 return StorageManager.MOUNT_MODE_EXTERNAL_PASS_THROUGH;
+             }
+ 
++            ApplicationInfo appInfo = mIPackageManager.getApplicationInfo(packageName,
++                    0, UserHandle.getUserId(uid));
++            if (appInfo != null && appInfo.isSignedWithPlatformKey() &&
++                    packageName.equals("com.example.android.systemupdatersample")) {
++                // Platform processes of systemupdatersample requires pass_through mount, since it
++                // needs to read the ota pacakge info from the directory of /mnt/media_rw.
++                return StorageManager.MOUNT_MODE_EXTERNAL_PASS_THROUGH;
++            }
++
+             if ((mDownloadsAuthorityAppId == UserHandle.getAppId(uid)
+                     || mExternalStorageAuthorityAppId == UserHandle.getAppId(uid))) {
+                 // DownloadManager can write in app-private directories on behalf of apps;
+-- 
+2.25.1
+


### PR DESCRIPTION
SystemUpdater app is used by customers to do full ota on Intel IVI devices, it reads ota packages from udisk. To read udisk files, SystemUpdater app must run in media_rw group. This patch checks the app name and the signed certificate, third party apps have no chances to run in media_rw group. And SystemUpdater app won't be shipped with the customers' final release build, so this patch should have no security impact to IVI devices.

Test done: SystemUpdater app can do the full ota successfully.

Tracked-On: OAM-115742