### PR TITLE
overlayfs: Use userxattrs on supporting kernels.

### DIFF
--- a/aosp_diff/base_aaos/system/core/04_0004-overlayfs-Use-userxattrs-on-supporting-kernels.patch
+++ b/aosp_diff/base_aaos/system/core/04_0004-overlayfs-Use-userxattrs-on-supporting-kernels.patch
@@ -1,0 +1,58 @@
+From d1cc20cdfd8756518c7dc6a0ede2d9a813c83352 Mon Sep 17 00:00:00 2001
+From: David Anderson <dvander@google.com>
+Date: Fri, 19 Nov 2021 16:00:27 -0800
+Subject: [PATCH] overlayfs: Use userxattrs on supporting kernels.
+
+In previous kernels, overlayfs stored its xattrs with a "trusted."
+prefix. This requires CAP_SYS_ADMIN. As a workaround, we carried
+out-of-tree kernel patches to bypass the security checks on these attrs.
+
+The 5.15 kernel however has a new mount option "userxattr". When this is
+set, the "trusted." prefix is replaced with "user.", which eliminates
+the CAP_SYS_ADMIN requirement.
+
+On kernels >= 5.15 we can use this feature and drop some of our
+out-of-tree patches.
+
+Bug: 204981027
+Test: adb remount on cuttlefish with >=5.15
+Change-Id: I3f0ca637a62c949fe481eea84f2c682f1ff4517a
+---
+ fs_mgr/fs_mgr_overlayfs.cpp | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/fs_mgr/fs_mgr_overlayfs.cpp b/fs_mgr/fs_mgr_overlayfs.cpp
+index cb2f249bb..18b5a86b1 100644
+--- a/fs_mgr/fs_mgr_overlayfs.cpp
++++ b/fs_mgr/fs_mgr_overlayfs.cpp
+@@ -322,6 +322,17 @@ std::string fs_mgr_get_overlayfs_candidate(const std::string& mount_point) {
+ const auto kLowerdirOption = "lowerdir="s;
+ const auto kUpperdirOption = "upperdir="s;
+ 
++static inline bool KernelSupportsUserXattrs() {
++    struct utsname uts;
++    uname(&uts);
++
++    int major, minor;
++    if (sscanf(uts.release, "%d.%d", &major, &minor) != 2) {
++        return false;
++    }
++    return major > 5 || (major == 5 && minor >= 15);
++}
++
+ // default options for mount_point, returns empty string for none available.
+ std::string fs_mgr_get_overlayfs_options(const std::string& mount_point) {
+     auto candidate = fs_mgr_get_overlayfs_candidate(mount_point);
+@@ -331,6 +342,9 @@ std::string fs_mgr_get_overlayfs_options(const std::string& mount_point) {
+     if (fs_mgr_overlayfs_valid() == OverlayfsValidResult::kOverrideCredsRequired) {
+         ret += ",override_creds=off";
+     }
++    if (KernelSupportsUserXattrs()) {
++        ret += ",userxattr";
++    }
+     return ret;
+ }
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
In previous kernels, overlayfs stored its xattrs with a "trusted." prefix. This requires CAP_SYS_ADMIN. As a workaround, we carried out-of-tree kernel patches to bypass the security checks on these attrs.

The 5.15 kernel however has a new mount option "userxattr". When this is set, the "trusted." prefix is replaced with "user.", which eliminates the CAP_SYS_ADMIN requirement.

On kernels >= 5.15 we can use this feature and drop some of our out-of-tree patches.

Test done: Device can boot up successfully after pushing files to /vendor/etc/vintf/manifest

Tracked-On: OAM-114073