### PR TITLE
Fix JavaCrash of com.android.camera2

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Camera2/06_0006-Fix-JavaCrash-of-com.android.camera2.patch
+++ b/aosp_diff/base_aaos/packages/apps/Camera2/06_0006-Fix-JavaCrash-of-com.android.camera2.patch
@@ -1,0 +1,43 @@
+From 7b60b91101103d472f16bec494056823d9a4b1e6 Mon Sep 17 00:00:00 2001
+From: xubing <bing.xu@intel.com>
+Date: Mon, 26 Feb 2024 15:46:28 +0800
+Subject: [PATCH] Fix JavaCrash of com.android.camera2
+
+It's corner case, if removed item is mViewItems[BUFFER_CENTER] and
+the item is last item, the item will be null and crash will happen,
+so we need add protection for this case.
+
+Test: Run monkey test and observe, no crash happen.
+
+Tracked-On: OAM-115328
+Signed-off-by: xubing <bing.xu@intel.com>
+---
+ src/com/android/camera/widget/FilmstripView.java | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/src/com/android/camera/widget/FilmstripView.java b/src/com/android/camera/widget/FilmstripView.java
+index f6d56c52f..efd228c70 100644
+--- a/src/com/android/camera/widget/FilmstripView.java
++++ b/src/com/android/camera/widget/FilmstripView.java
+@@ -1376,11 +1376,13 @@ public class FilmstripView extends ViewGroup {
+ 
+             // The animation part.
+             if (inFullScreen()) {
+-                mViewItems[BUFFER_CENTER].setVisibility(VISIBLE);
+-                ViewItem nextItem = mViewItems[BUFFER_CENTER + 1];
+-                if (nextItem != null) {
+-                    nextItem.setVisibility(INVISIBLE);
+-                }
++		if (mViewItems[BUFFER_CENTER] != null) {
++                    mViewItems[BUFFER_CENTER].setVisibility(VISIBLE);
++                    ViewItem nextItem = mViewItems[BUFFER_CENTER + 1];
++                    if (nextItem != null) {
++                        nextItem.setVisibility(INVISIBLE);
++                    }
++		}
+             }
+ 
+             // Translate the views to their original places.
+-- 
+2.34.1
+


### PR DESCRIPTION
It's corner case, if removed item is mViewItems[BUFFER_CENTER] and the item is last item, the item will be null and crash will happen, so we need add protection for this case.

Test: Run monkey test and observe, no crash happen.

Tracked-On: OAM-115328