### PR TITLE
WA: Fix Monkey Test Failure in Gallery App

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Gallery2/0007-WA-Fix-Monkey-Test-Failure-in-Gallery-App.patch
+++ b/aosp_diff/base_aaos/packages/apps/Gallery2/0007-WA-Fix-Monkey-Test-Failure-in-Gallery-App.patch
@@ -1,0 +1,35 @@
+From e170a150105de1cebd57f6563db4d38440019a04 Mon Sep 17 00:00:00 2001
+From: Salini Venate <salini.venate@intel.com>
+Date: Fri, 1 Mar 2024 10:17:58 +0530
+Subject: [PATCH] WA: Fix Monkey Test Failure in Gallery App
+
+Monkey Test reported below error:
+java.lang.IllegalStateException: Can not perform this
+action after onSaveInstanceState
+at com.android.gallery3d.filtershow.editors
+       .EditorPanel.showImageStatePanel
+
+Use commitAllowingStateLoss() instead of commit() so
+that it will not throw an exception if state loss occurs.
+
+Tracked-On: OAM-115689
+Signed-off-by: Salini Venate <salini.venate@intel.com>
+---
+ src/com/android/gallery3d/filtershow/editors/EditorPanel.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/com/android/gallery3d/filtershow/editors/EditorPanel.java b/src/com/android/gallery3d/filtershow/editors/EditorPanel.java
+index 199ddce8a..8742ebfff 100644
+--- a/src/com/android/gallery3d/filtershow/editors/EditorPanel.java
++++ b/src/com/android/gallery3d/filtershow/editors/EditorPanel.java
+@@ -154,6 +154,6 @@ public class EditorPanel extends Fragment {
+                 transaction.remove(statePanel);
+             }
+         }
+-        transaction.commit();
++        transaction.commitAllowingStateLoss();
+     }
+ }
+-- 
+2.17.1
+


### PR DESCRIPTION
Monkey Test reported below error:
java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
at com.android.gallery3d.filtershow.editors
      .EditorPanel.showImageStatePanel

Use commitAllowingStateLoss() instead of commit() so that it will not throw an exception if state loss occurs.

Tracked-On: OAM-115689