### PR TITLE
optee-app: fix the conflict issue of the diff file

### DIFF
--- a/aosp_diff/base_aaos/vendor/intel/optee/optee_apps/0001-Fix-issues-of-optee-keymaster.patch
+++ b/aosp_diff/base_aaos/vendor/intel/optee/optee_apps/0001-Fix-issues-of-optee-keymaster.patch
@@ -1,19 +1,19 @@
-From f8aab9ca231d6945f105c703eeca48818a3ce54a Mon Sep 17 00:00:00 2001
+From 4bbbedf788b2c740a324866d480f346608164c12 Mon Sep 17 00:00:00 2001
 From: "Yan, Shaopu" <shaopu.yan@intel.com>
-Date: Mon, 4 Sep 2023 14:58:06 +0800
+Date: Wed, 6 Mar 2024 22:13:06 +0800
 Subject: [PATCH] Fix issues of optee keymaster
 
 - fix the initialization issue of resultParams
 - make the build pass for optee keymaster
 - disabled the gatekeeper build for currently
 
-Tracked-On: OAM-112066
+Tracked-On: OAM-116519
 Signed-off-by: Yan, Shaopu <shaopu.yan@intel.com>
 ---
- gatekeeper/Android.mk                     | 2 +-
- keymaster/3.0/optee_keymaster3_device.cpp | 6 ++++--
- keymaster/Android.mk                      | 2 +-
- 3 files changed, 6 insertions(+), 4 deletions(-)
+ gatekeeper/Android.mk                   | 2 +-
+ keymaster/3.0/OpteeKeymaster3Device.cpp | 2 +-
+ keymaster/Android.mk                    | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/gatekeeper/Android.mk b/gatekeeper/Android.mk
 index 69b8604..9f2daee 100644
@@ -27,25 +27,11 @@ index 69b8604..9f2daee 100644
 +#include $(LOCAL_PATH)/ta/Android.mk
  
  #endif # Include only for HiKey ones.
-diff --git a/keymaster/3.0/optee_keymaster3_device.cpp b/keymaster/3.0/optee_keymaster3_device.cpp
-index 140ae76..47a8378 100644
---- a/keymaster/3.0/optee_keymaster3_device.cpp
-+++ b/keymaster/3.0/optee_keymaster3_device.cpp
-@@ -20,10 +20,12 @@
- #include <memory>
- #include <new>
- 
--#include <authorization_set.h>
-+#include <keymaster/authorization_set.h>
- #include <keymaster/android_keymaster_messages.h>
- #include <optee_keymaster/optee_keymaster3_device.h>
- #include <optee_keymaster/ipc/optee_keymaster_ipc.h>
-+#include <keymaster_tags.h>
-+
- 
- #undef LOG_TAG
- #define LOG_TAG "OpteeKeymaster_cpp"
-@@ -544,7 +546,7 @@ Return<void> OpteeKeymaster3Device::begin(KeyPurpose purpose, const hidl_vec<uin
+diff --git a/keymaster/3.0/OpteeKeymaster3Device.cpp b/keymaster/3.0/OpteeKeymaster3Device.cpp
+index 5e7eff3..874f0dc 100644
+--- a/keymaster/3.0/OpteeKeymaster3Device.cpp
++++ b/keymaster/3.0/OpteeKeymaster3Device.cpp
+@@ -384,7 +384,7 @@ Return<void> OpteeKeymaster3Device::begin(KeyPurpose purpose, const hidl_vec<uin
      BeginOperationResponse response(impl_->message_version());
      impl_->BeginOperation(request, &response);
  
@@ -55,10 +41,10 @@ index 140ae76..47a8378 100644
          resultParams = kmParamSet2Hidl(response.output_params);
      }
 diff --git a/keymaster/Android.mk b/keymaster/Android.mk
-index f58dfce..3419311 100644
+index d3120df..4e0a471 100644
 --- a/keymaster/Android.mk
 +++ b/keymaster/Android.mk
-@@ -95,6 +95,6 @@ include $(BUILD_EXECUTABLE)
+@@ -22,6 +22,6 @@ LOCAL_PATH:= $(call my-dir)
  ################################################################################
  # Build keymaster HAL TA                                                       #
  ################################################################################


### PR DESCRIPTION
since the repo of "platform/external/optee/apps" is target to reversion upstream-master, recent updates to the AOSP codebase have caused conflicts when applying the original diff.

Tracked-On: OAM-116519