### PR TITLE
Upgrade AOSP 12L tag to 12.1.0_r11

### DIFF
--- a/aosp_diff/base_aaos/build/make/0004-Update-security_patch_level-string.patch
+++ b/aosp_diff/base_aaos/build/make/0004-Update-security_patch_level-string.patch
@@ -19,7 +19,7 @@ index 0daae6bdcb..d14bd65167 100644
      #  It must be of the form "YYYY-MM-DD" on production devices.
      #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
      #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
--    PLATFORM_SECURITY_PATCH := 2022-06-05
+-    PLATFORM_SECURITY_PATCH := 2022-07-05
 +    PLATFORM_SECURITY_PATCH := 2024-03-01
  endif
  .KATI_READONLY := PLATFORM_SECURITY_PATCH


### PR DESCRIPTION
This patch will upgrade the AOSP tag to r11 from r8.

Tests Done: Build and boot

Tracked-On: OAM-116549