### PR TITLE
Fix JavaCarsh on com.android.gallery3d when clicking the menu of

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Gallery2/0008-Fix-JavaCarsh-on-com.android.gallery3d-when-clicking.patch
+++ b/aosp_diff/base_aaos/packages/apps/Gallery2/0008-Fix-JavaCarsh-on-com.android.gallery3d-when-clicking.patch
@@ -1,0 +1,35 @@
+From 68676d5fbaa6499a101f558aac3798f0996cbe8e Mon Sep 17 00:00:00 2001
+From: xubing <bing.xu@intel.com>
+Date: Thu, 14 Mar 2024 15:47:26 +0800
+Subject: [PATCH] Fix JavaCarsh on com.android.gallery3d when clicking the menu
+ of resetting history
+
+User click the menu of resetting history, App should do nothing
+when there is no primary image.
+
+Test: Run monkey test and observe, no crash happen.
+
+Tracked-On: OAM-116645
+Signed-off-by: xubing <bing.xu@intel.com>
+---
+ src/com/android/gallery3d/filtershow/FilterShowActivity.java | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/com/android/gallery3d/filtershow/FilterShowActivity.java b/src/com/android/gallery3d/filtershow/FilterShowActivity.java
+index 0d25186ba..088c4bba8 100644
+--- a/src/com/android/gallery3d/filtershow/FilterShowActivity.java
++++ b/src/com/android/gallery3d/filtershow/FilterShowActivity.java
+@@ -1299,6 +1299,10 @@ public class FilterShowActivity extends FragmentActivity implements OnItemClickL
+     }
+ 
+     void resetHistory() {
++        //we should do nothing if there is no primary image
++        if (mPrimaryImage == null) {
++            return;
++        }
+         HistoryManager adapter = mPrimaryImage.getHistory();
+         adapter.reset();
+         HistoryItem historyItem = adapter.getItem(0);
+-- 
+2.34.1
+


### PR DESCRIPTION
resetting history

User click the menu of resetting history, App should do nothing when there is no primary image.

Test: Run monkey test and observe, no crash happen.

Tracked-On: OAM-116645