### PR TITLE
Fixed for CarLauncher issue during suspend.

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Car/Launcher/0002-Fixed-for-CarLauncher-issue-during-suspend.patch
+++ b/aosp_diff/base_aaos/packages/apps/Car/Launcher/0002-Fixed-for-CarLauncher-issue-during-suspend.patch
@@ -1,0 +1,62 @@
+From 5647b75a68a5008d180629670b7579fb3ee9ecf6 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Tue, 19 Mar 2024 16:36:56 +0530
+Subject: [PATCH] Fixed for CarLauncher issue during suspend.
+
+When device goes in suspend state and resume back, map place holder
+activity get killed.
+Restart maps place holder activity, if it is not running.
+
+Tests: adb shell; echo mem > /sys/power/state
+device goes to sleep state and now press any keyboard key to wake up,
+Maps placeholder is blank.
+
+Tracked-On: OAM-114651
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../android/car/carlauncher/CarLauncher.java  | 21 ++++++++++++++++---
+ 1 file changed, 18 insertions(+), 3 deletions(-)
+
+diff --git a/src/com/android/car/carlauncher/CarLauncher.java b/src/com/android/car/carlauncher/CarLauncher.java
+index 30c8c21a..6f153e64 100644
+--- a/src/com/android/car/carlauncher/CarLauncher.java
++++ b/src/com/android/car/carlauncher/CarLauncher.java
+@@ -18,6 +18,7 @@ package com.android.car.carlauncher;
+ 
+ import static android.app.ActivityTaskManager.INVALID_TASK_ID;
+ import static android.car.user.CarUserManager.USER_LIFECYCLE_EVENT_TYPE_SWITCHING;
++import static android.car.user.CarUserManager.USER_LIFECYCLE_EVENT_TYPE_UNLOCKED;
+ import static android.view.WindowManager.LayoutParams.PRIVATE_FLAG_TRUSTED_OVERLAY;
+ 
+ import android.app.ActivityManager;
+@@ -172,10 +173,24 @@ public class CarLauncher extends FragmentActivity {
+     private final UserLifecycleListener mUserLifecyleListener = new UserLifecycleListener() {
+         @Override
+         public void onEvent(@NonNull CarUserManager.UserLifecycleEvent event) {
+-            if (event.getEventType() == USER_LIFECYCLE_EVENT_TYPE_SWITCHING) {
+-                // When user-switching, onDestroy in the previous user's CarLauncher isn't called.
+-                // So tries to release the resource explicitly.
++            if (DEBUG) {
++                Log.d(TAG, "UserLifecycleListener.onEvent: For User " + getUserId()
++                        + ", received an event " + event);
++            }
++            // When user-unlocked, if Maps isn't launched yet, then try to start it.
++            if (event.getEventType() == USER_LIFECYCLE_EVENT_TYPE_UNLOCKED
++                    && getUserId() == event.getUserId()
++                    && mTaskViewTaskId == INVALID_TASK_ID) {
++                startMapsInTaskView();
++                return;
++            }
++
++            // When user-switching, onDestroy in the previous user's CarLauncher isn't called.
++            // So tries to release the resource explicitly.
++            if (event.getEventType() == USER_LIFECYCLE_EVENT_TYPE_SWITCHING
++                    && getUserId() == event.getPreviousUserId()) {
+                 release();
++                return;
+             }
+         }
+     };
+-- 
+2.17.1
+


### PR DESCRIPTION
When device goes in suspend state and resume back, map place holder activity get killed.
Restart maps place holder activity, if it is not running.

Tests: adb shell; echo mem > /sys/power/state
device goes to sleep state and now press any keyboard key to wake up, Maps placeholder is blank.

Tracked-On: OAM-114651