### PR TITLE
Fixed for SystemUI crash during cold boot cycle test.

### DIFF
--- a/aosp_diff/base_aaos/frameworks/base/99_0254-Fixed-for-SystemUI-crash-during-cold-boot-cycle-test.patch
+++ b/aosp_diff/base_aaos/frameworks/base/99_0254-Fixed-for-SystemUI-crash-during-cold-boot-cycle-test.patch
@@ -1,0 +1,34 @@
+From 5f4dd87f96a134ef172b76ce6d6b1bda301d01bd Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Thu, 21 Mar 2024 09:35:46 +0530
+Subject: [PATCH] Fixed for SystemUI crash during cold boot cycle test.
+
+Prevent ConcurrentModificationException while accessing mListeningUris.
+Swapped ArrayMap with ConcurrentHashMap to allow multi-threaded access
+to mListeningUris.
+
+Tests: Flash the build having this change. Device is booting. Systemui
+is showing normally.
+
+Tracked-On: OAM-116766
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../src/com/android/systemui/tuner/TunerServiceImpl.java        | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/packages/SystemUI/src/com/android/systemui/tuner/TunerServiceImpl.java b/packages/SystemUI/src/com/android/systemui/tuner/TunerServiceImpl.java
+index d97815f92964..1ba62941f0fd 100644
+--- a/packages/SystemUI/src/com/android/systemui/tuner/TunerServiceImpl.java
++++ b/packages/SystemUI/src/com/android/systemui/tuner/TunerServiceImpl.java
+@@ -74,7 +74,7 @@ public class TunerServiceImpl extends TunerService {
+ 
+     private final Observer mObserver = new Observer();
+     // Map of Uris we listen on to their settings keys.
+-    private final ArrayMap<Uri, String> mListeningUris = new ArrayMap<>();
++    private final ConcurrentHashMap<Uri, String> mListeningUris = new ConcurrentHashMap<>();
+     // Map of settings keys to the listener.
+     private final ConcurrentHashMap<String, Set<Tunable>> mTunableLookup =
+             new ConcurrentHashMap<>();
+-- 
+2.17.1
+


### PR DESCRIPTION
Prevent ConcurrentModificationException while accessing mListeningUris. Swapped ArrayMap with ConcurrentHashMap to allow multi-threaded access to mListeningUris.

Tests: Flash the build having this change. Device is booting. Systemui is showing normally.

Tracked-On: OAM-116766