### PR TITLE
Disable audio codec.

### DIFF
--- a/aosp_diff/base_aaos/frameworks/av/media/libmediaplayerservice/0001-Without-considering-online-video-set-a-property-in-N.patch
+++ b/aosp_diff/base_aaos/frameworks/av/media/libmediaplayerservice/0001-Without-considering-online-video-set-a-property-in-N.patch
@@ -1,0 +1,83 @@
+From b632d2a1dac94e8a2f7193243b96c0cc9a00999e Mon Sep 17 00:00:00 2001
+From: "zhepeng.xu" <zhepengx.xu@intel.com>
+Date: Thu, 21 Mar 2024 13:35:31 +0800
+Subject: [PATCH] Without considering online-video, set a property in Nuplayer
+ to dynamically disable the audio codec. In order to quickly eliminate the
+ audio cause when video freezes occur in the future.
+
+Tracked-On:OAM-116765
+Signed-off-by:zhepeng.xu <zhepengx.xu@intel.com>
+---
+ .../nuplayer/NuPlayer.cpp                     | 21 +++++++++++++------
+ .../libmediaplayerservice/nuplayer/NuPlayer.h |  1 +
+ 2 files changed, 16 insertions(+), 6 deletions(-)
+
+diff --git a/media/libmediaplayerservice/nuplayer/NuPlayer.cpp b/media/libmediaplayerservice/nuplayer/NuPlayer.cpp
+index 9ae7ddbe47..2379259aa3 100644
+--- a/media/libmediaplayerservice/nuplayer/NuPlayer.cpp
++++ b/media/libmediaplayerservice/nuplayer/NuPlayer.cpp
+@@ -211,6 +211,8 @@ NuPlayer::NuPlayer(pid_t pid, const sp<MediaClock> &mediaClock)
+       mDataSourceType(DATA_SOURCE_TYPE_NONE) {
+     CHECK(mediaClock != NULL);
+     clearFlushComplete();
++
++    mDisableAudio = property_get_bool("persist.sys.disable.audio", false);
+ }
+ 
+ NuPlayer::~NuPlayer() {
+@@ -1033,11 +1035,13 @@ void NuPlayer::onMessageReceived(const sp<AMessage> &msg) {
+             }
+ 
+             // Don't try to re-open audio sink if there's an existing decoder.
+-            if (mAudioSink != NULL && mAudioDecoder == NULL) {
+-                if (instantiateDecoder(true, &mAudioDecoder) == -EWOULDBLOCK) {
+-                    rescan = true;
++            if (!mDisableAudio) {
++                if (mAudioSink != NULL && mAudioDecoder == NULL) {
++                    if (instantiateDecoder(true, &mAudioDecoder) == -EWOULDBLOCK) {
++                        rescan = true;
++                    }
+                 }
+-            }
++	        }
+ 
+             if (!mHadAnySourcesBefore
+                     && (mAudioDecoder != NULL || mVideoDecoder != NULL)) {
+@@ -1495,7 +1499,9 @@ void NuPlayer::onResume() {
+     // |mAudioDecoder| may have been released due to the pause timeout, so re-create it if
+     // needed.
+     if (audioDecoderStillNeeded() && mAudioDecoder == NULL) {
+-        instantiateDecoder(true /* audio */, &mAudioDecoder);
++        if (!mDisableAudio) {
++            instantiateDecoder(true /* audio */, &mAudioDecoder);
++        }
+     }
+     if (mRenderer != NULL) {
+         mRenderer->resume();
+@@ -1872,7 +1878,10 @@ void NuPlayer::restartAudio(
+         mOffloadAudio = false;
+     }
+     if (needsToCreateAudioDecoder) {
+-        instantiateDecoder(true /* audio */, &mAudioDecoder, !forceNonOffload);
++        if (!mDisableAudio) {
++            ALOGD("enable instantiateDecoder");
++                instantiateDecoder(true /* audio */, &mAudioDecoder, !forceNonOffload);
++        }
+     }
+ }
+ 
+diff --git a/media/libmediaplayerservice/nuplayer/NuPlayer.h b/media/libmediaplayerservice/nuplayer/NuPlayer.h
+index adb707537d..e31d2d16e2 100644
+--- a/media/libmediaplayerservice/nuplayer/NuPlayer.h
++++ b/media/libmediaplayerservice/nuplayer/NuPlayer.h
+@@ -112,6 +112,7 @@ protected:
+ public:
+     struct NuPlayerStreamListener;
+     struct Source;
++    bool mDisableAudio;
+ 
+ private:
+     struct Decoder;
+-- 
+2.34.1
+


### PR DESCRIPTION
Without considering online-video, set a property in Nuplayer to dynamically disable the audio codec. In order to quickly eliminate the audio cause when video freezes occur in the future.

Tracked-On:OAM-116765