### PR TITLE
WA - Fix Monkey Test crash in DeskClock

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/DeskClock/0003-WA-Fix-Monkey-Test-crash-in-DeskClock.patch
+++ b/aosp_diff/base_aaos/packages/apps/DeskClock/0003-WA-Fix-Monkey-Test-crash-in-DeskClock.patch
@@ -1,0 +1,46 @@
+From 3e642fb9041e7aae5f926caba20ab8e1b7fbdf14 Mon Sep 17 00:00:00 2001
+From: Salini Venate <salini.venate@intel.com>
+Date: Thu, 21 Mar 2024 14:40:46 +0530
+Subject: [PATCH] WA - Fix Monkey Test crash in DeskClock
+
+Below crash was seen during MonkeyTest:
+java.lang.IllegalStateException: FragmentManager
+is already executing transactions
+
+Use commitNowAllowingStateLoss instead of commitAllowingStateLoss.
+commitNowAllowingStateLoss executes the transaction immediately
+on the calling thread unlike commitAllowingStateLoss which schedules
+the transaction to be executed asynchronously on the main thread.
+
+NOTE: commitNowAllowingStateLoss may potentially lead to ANR if
+the transaction takes a long time to execute.
+
+Tracked-On: OAM-116600
+Signed-off-by: Salini Venate <salini.venate@intel.com>
+---
+ src/com/android/deskclock/timer/TimerPagerAdapter.kt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/com/android/deskclock/timer/TimerPagerAdapter.kt b/src/com/android/deskclock/timer/TimerPagerAdapter.kt
+index fa4993394..7dd63143f 100644
+--- a/src/com/android/deskclock/timer/TimerPagerAdapter.kt
++++ b/src/com/android/deskclock/timer/TimerPagerAdapter.kt
+@@ -118,7 +118,7 @@ internal class TimerPagerAdapter(
+ 
+     override fun finishUpdate(container: ViewGroup) {
+         if (mCurrentTransaction != null) {
+-            mCurrentTransaction!!.commitAllowingStateLoss()
++            mCurrentTransaction!!.commitNowAllowingStateLoss()
+             mCurrentTransaction = null
+ 
+             if (!mFragmentManager.isDestroyed) {
+@@ -164,4 +164,4 @@ internal class TimerPagerAdapter(
+             item.setUserVisibleHint(visible)
+         }
+     }
+-}
+\ No newline at end of file
++}
+-- 
+2.17.1
+


### PR DESCRIPTION
Below crash was seen during MonkeyTest:
java.lang.IllegalStateException: FragmentManager
is already executing transactions

Use commitNowAllowingStateLoss instead of commitAllowingStateLoss. commitNowAllowingStateLoss executes the transaction immediately on the calling thread unlike commitAllowingStateLoss which schedules the transaction to be executed asynchronously on the main thread.

NOTE: commitNowAllowingStateLoss may potentially lead to ANR if the transaction takes a long time to execute.

Tracked-On: OAM-116600