### PR TITLE
Update color transform reboot setting

### DIFF
--- a/aosp_diff/base_aaos/frameworks/base/99_0256-Update-color-transform-reboot-setting.patch
+++ b/aosp_diff/base_aaos/frameworks/base/99_0256-Update-color-transform-reboot-setting.patch
@@ -1,0 +1,196 @@
+From 470da1d53b3b07451feeb29046cdebe9c5830fcd Mon Sep 17 00:00:00 2001
+From: zhonghuis <zhonghui.shi@intel.com>
+Date: Fri, 12 Apr 2024 15:47:46 +0000
+Subject: [PATCH] Update color transform reboot setting
+
+Add properties to persist and restore the display's color
+transform setting, upon reboot, reads values and applies to
+set the display color transform accordingly
+
+Tracked-On: OAM-117073
+Signed-off-by: zhonghuis <zhonghui.shi@intel.com>
+---
+ .../display/color/ColorDisplayService.java    | 121 ++++++++++++++++++
+ 1 file changed, 121 insertions(+)
+
+diff --git a/services/core/java/com/android/server/display/color/ColorDisplayService.java b/services/core/java/com/android/server/display/color/ColorDisplayService.java
+index b8dcacfec9ff..138ab3bdfc87 100644
+--- a/services/core/java/com/android/server/display/color/ColorDisplayService.java
++++ b/services/core/java/com/android/server/display/color/ColorDisplayService.java
+@@ -91,6 +91,11 @@ import java.time.LocalTime;
+ import java.time.ZoneId;
+ import java.time.format.DateTimeParseException;
+ import java.util.concurrent.atomic.AtomicInteger;
++import java.io.File;
++import java.io.FileInputStream;
++import java.io.FileOutputStream;
++import java.util.Properties;
++import java.io.BufferedOutputStream;
+ 
+ /**
+  * Controls the display's color transforms.
+@@ -132,6 +137,19 @@ public final class ColorDisplayService extends SystemService {
+     private static final int MIN_COLOR_TEMPERATURE = 4000;
+     private static final int WHITE_BALANCE_SCALE = 20;
+ 
++    private static final int DEFAULT_CONTRAST_LEVEL = 128;
++    private static final int DEFAULT_HUE_LEVEL = 180;
++    private static final int DEFAULT_SATURATION_LEVEL = 50;
++    private static final int DEFAULT_WHITEBALANCE_LEVEL = 100;
++    private static final int DEFAULT_LUMINANCE_LEVEL = 128;
++
++    private static final String PROP_KEY_PATH = "colordisplay.";
++    private static final String PROP_KEY_CONTRAST = PROP_KEY_PATH + "contrastValue";
++    private static final String PROP_KEY_HUE = PROP_KEY_PATH + "hueValue";
++    private static final String PROP_KEY_SATURATION = PROP_KEY_PATH + "saturationValue";
++    private static final String PROP_KEY_WHITEBALANCE = PROP_KEY_PATH + "whitebalanceValue";
++    private static final String PROP_KEY_LUMINANCE = PROP_KEY_PATH + "luminanceValue";
++    private static final String PROP_FILE_PATH = "/data/system/colordisplay.properties";
+     /**
+      * Return value if a setting has not been set.
+      */
+@@ -466,6 +484,104 @@ public final class ColorDisplayService extends SystemService {
+                 mHandler.sendEmptyMessage(MSG_APPLY_REDUCE_BRIGHT_COLORS);
+             }
+         }
++        setContrastInitial();    
++        setHueInitial();
++        setSaturationInitial();
++        setWhitebalanceInitial();
++        setLuminanceInitial();
++    }
++
++    void setContrastInitial() {
++        int contrastValue = setColorTransformProperty(PROP_KEY_CONTRAST, DEFAULT_CONTRAST_LEVEL);
++        contrastValue = (contrastValue >= 0 && contrastValue <= 255) ? contrastValue : DEFAULT_CONTRAST_LEVEL;
++        final long token = Binder.clearCallingIdentity();
++        try {
++            setContrastLevelInternal(contrastValue);
++        } finally {
++            Binder.restoreCallingIdentity(token);
++        }
++    }
++
++    void setHueInitial() {
++        int hueValue = setColorTransformProperty(PROP_KEY_HUE, DEFAULT_HUE_LEVEL);
++        hueValue = (hueValue >= 0 && hueValue <= 360) ? hueValue : DEFAULT_HUE_LEVEL;
++        final long token = Binder.clearCallingIdentity();
++        try {
++            setHueLevelInternal(hueValue);
++        } finally {
++            Binder.restoreCallingIdentity(token);
++        }
++    }
++
++    void setSaturationInitial() {
++        int saturationValue = setColorTransformProperty(PROP_KEY_SATURATION, DEFAULT_SATURATION_LEVEL);
++        saturationValue = (saturationValue >= 0 && saturationValue <= 100) ? saturationValue : DEFAULT_SATURATION_LEVEL;
++        final long token = Binder.clearCallingIdentity();
++        try {
++            setSaturationLevelInternal(saturationValue);
++        } finally {
++            Binder.restoreCallingIdentity(token);
++        }
++    }
++
++    void setWhitebalanceInitial() {
++        int whitebalanceValue = setColorTransformProperty(PROP_KEY_WHITEBALANCE, DEFAULT_WHITEBALANCE_LEVEL);
++        whitebalanceValue = (whitebalanceValue >= 0 && whitebalanceValue <= 200) ? whitebalanceValue : DEFAULT_WHITEBALANCE_LEVEL;
++        final long token = Binder.clearCallingIdentity();
++        try {
++            setWhitebalanceLevelInternal(whitebalanceValue);
++        } finally {
++            Binder.restoreCallingIdentity(token);
++        }
++    }
++
++    void setLuminanceInitial() {
++        int luminanceValue = setColorTransformProperty(PROP_KEY_LUMINANCE, DEFAULT_LUMINANCE_LEVEL);
++        luminanceValue = (luminanceValue >= 0 && luminanceValue <= 255) ? luminanceValue : DEFAULT_LUMINANCE_LEVEL;
++        final long token = Binder.clearCallingIdentity();
++        try {
++            setLuminanceLevelInternal(luminanceValue);
++        } finally {
++            Binder.restoreCallingIdentity(token);
++        }
++    }
++
++    int setColorTransformProperty(String propertyName, int defaultVal) {
++        Properties properties = new Properties();
++        File propFile = new File(PROP_FILE_PATH);
++        try {
++            if (propFile.exists() && propFile.canRead()) {
++                try (FileInputStream fis = new FileInputStream(propFile)) {
++                    properties.load(fis);
++                } 
++
++                return Integer.parseInt(properties.getProperty(propertyName, String.valueOf(defaultVal)));
++            } 
++        } catch (Exception e) {
++            e.printStackTrace(); 
++        }
++        return defaultVal;
++    }
++
++    void updateColorTransformProperty(String propertyName, int newVal) {
++        Properties properties = new Properties();
++        File propFile = new File(PROP_FILE_PATH);
++        try {
++            if (propFile.exists() && propFile.canRead()) {
++                try (FileInputStream fis = new FileInputStream(propFile)) {
++                    properties.load(fis);
++                } 
++            }
++            properties.setProperty(propertyName, String.valueOf(newVal));
++            try (FileOutputStream fos = new FileOutputStream(propFile);
++                BufferedOutputStream bos = new BufferedOutputStream(fos)) {
++                properties.store(bos, "Updated ColorDisplayService property");
++                bos.flush();
++                fos.getFD().sync(); 
++            } 
++        } catch (Exception e) {
++            e.printStackTrace(); 
++        }
+     }
+ 
+     private void tearDown() {
+@@ -1034,24 +1150,28 @@ public final class ColorDisplayService extends SystemService {
+     }
+ 
+     void setSaturationLevelInternal(int saturationLevel) {
++        updateColorTransformProperty(PROP_KEY_SATURATION, saturationLevel);
+         final Message message = mHandler.obtainMessage(MSG_APPLY_GLOBAL_SATURATION);
+         message.arg1 = saturationLevel;
+         mHandler.sendMessage(message);
+     }
+ 
+     void setHueLevelInternal(int hueLevel) {
++        updateColorTransformProperty(PROP_KEY_HUE, hueLevel);
+         final Message message = mHandler.obtainMessage(MSG_APPLY_GLOBAL_HUE);
+         message.arg1 = hueLevel;
+         mHandler.sendMessage(message);
+     }
+ 
+     void setContrastLevelInternal(int contrastLevel) {
++        updateColorTransformProperty(PROP_KEY_CONTRAST, contrastLevel);
+         final Message message = mHandler.obtainMessage(MSG_APPLY_GLOBAL_CONTRAST);
+         message.arg1 = contrastLevel;
+         mHandler.sendMessage(message);
+     }
+ 
+     void setWhitebalanceLevelInternal(int whitebalanceLevel) {
++        updateColorTransformProperty(PROP_KEY_WHITEBALANCE, whitebalanceLevel);
+         if (mDisplayWhiteBalanceTintController.isAvailable(getContext())) {
+             // Prepare the display white balance transform matrix.
+             mDisplayWhiteBalanceTintController.setUp(getContext(), true /* needsLinear */);
+@@ -1062,6 +1182,7 @@ public final class ColorDisplayService extends SystemService {
+     }
+ 
+     void setLuminanceLevelInternal(int luminanceLevel) {
++        updateColorTransformProperty(PROP_KEY_LUMINANCE, luminanceLevel);
+         final Message message = mHandler.obtainMessage(MSG_APPLY_GLOBAL_LUMINANCE);
+         message.arg1 = luminanceLevel;
+         mHandler.sendMessage(message);
+-- 
+2.34.1
+


### PR DESCRIPTION
Add properties to persist and restore the display's color transform setting, upon reboot, reads values and applies to set the display color transform accordingly

Tracked-On: OAM-117073