### PR TITLE
Set default value of display hardware settings

### DIFF
--- a/aosp_diff/base_aaos/frameworks/base/99_0256-Set-default-value-of-display-hardware-settings.patch
+++ b/aosp_diff/base_aaos/frameworks/base/99_0256-Set-default-value-of-display-hardware-settings.patch
@@ -1,0 +1,99 @@
+From 78824cce41327a0f3858e7e2cc53275d29262b53 Mon Sep 17 00:00:00 2001
+From: xubing <bing.xu@intel.com>
+Date: Tue, 26 Mar 2024 16:34:27 +0800
+Subject: [PATCH] Set default value of display hardware settings
+
+Set default value of display hardware settings, include
+Hue, Contrast, Saturation, Whitebalance and Luminance.
+
+Test: Feature funciotn is ready, test OK.
+
+Tracked-On: OAM-116761
+Signed-off-by: xubing <bing.xu@intel.com>
+---
+ packages/SettingsProvider/res/values/defaults.xml | 12 +++++++++++-
+ .../providers/settings/DatabaseHelper.java        | 15 +++++++++++++++
+ .../display/color/DisplayTransformManager.java    |  8 ++++----
+ 3 files changed, 30 insertions(+), 5 deletions(-)
+
+diff --git a/packages/SettingsProvider/res/values/defaults.xml b/packages/SettingsProvider/res/values/defaults.xml
+index 8e6e251ff3f2..652c7fe199df 100644
+--- a/packages/SettingsProvider/res/values/defaults.xml
++++ b/packages/SettingsProvider/res/values/defaults.xml
+@@ -29,8 +29,18 @@
+     <bool name="def_auto_time">true</bool>
+     <bool name="def_auto_time_zone">true</bool>
+     <bool name="def_accelerometer_rotation">false</bool>
+-    <!-- Default screen brightness, from 0 to 255.  102 is 40%. -->
++    <!-- Default screen backlight, from 0 to 255.  102 is 40%. -->
+     <integer name="def_screen_brightness">102</integer>
++    <!-- Default screen saturation, from 0 to 100.  50 is 50%. -->
++    <integer name="def_screen_saturation">50</integer>
++    <!-- Default screen hue, from 0 to 360.  180 is 50%. -->
++    <integer name="def_screen_hue">180</integer>
++    <!-- Default screen contrast, from 0 to 255.  128 is 50%. -->
++    <integer name="def_screen_contrast">128</integer>
++    <!-- Default screen luminance,  from 0 to 255.  128 is 50%. -->
++    <integer name="def_screen_luminance">128</integer>
++    <!-- Default screen whitebalance, from 0 to 100.  100 is 100%. -->
++    <integer name="def_screen_whitebalance">100</integer>
+     <bool name="def_screen_brightness_automatic_mode">false</bool>
+     <fraction name="def_window_animation_scale">100%</fraction>
+     <fraction name="def_window_transition_scale">100%</fraction>
+diff --git a/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java b/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
+index 268603fa8b0d..7b3afe0bd6b2 100644
+--- a/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
++++ b/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
+@@ -2256,6 +2256,21 @@ class DatabaseHelper extends SQLiteOpenHelper {
+             loadIntegerSetting(stmt, Settings.System.SCREEN_BRIGHTNESS,
+                     R.integer.def_screen_brightness);
+ 
++            loadIntegerSetting(stmt, Settings.System.SCREEN_CONTRAST,
++                    R.integer.def_screen_contrast);
++
++            loadIntegerSetting(stmt, Settings.System.SCREEN_HUE,
++                    R.integer.def_screen_hue);
++
++            loadIntegerSetting(stmt, Settings.System.SCREEN_LUMINANCE,
++                    R.integer.def_screen_luminance);
++
++            loadIntegerSetting(stmt, Settings.System.SCREEN_SATURATION,
++                    R.integer.def_screen_saturation);
++
++            loadIntegerSetting(stmt, Settings.System.SCREEN_WHITEBALANCE,
++                    R.integer.def_screen_whitebalance);
++
+             loadIntegerSetting(stmt, Settings.System.SCREEN_BRIGHTNESS_FOR_VR,
+                     com.android.internal.R.integer.config_screenBrightnessForVrSettingDefault);
+ 
+diff --git a/services/core/java/com/android/server/display/color/DisplayTransformManager.java b/services/core/java/com/android/server/display/color/DisplayTransformManager.java
+index 4d3223aa727a..8be8db7f8520 100644
+--- a/services/core/java/com/android/server/display/color/DisplayTransformManager.java
++++ b/services/core/java/com/android/server/display/color/DisplayTransformManager.java
+@@ -56,19 +56,19 @@ public class DisplayTransformManager {
+      */
+     public static final int LEVEL_COLOR_MATRIX_SATURATION = 150;
+     /**
+-     * Color transform level used to adjust the color saturation of the display.
++     * Color transform level used to adjust the color hue of the display.
+      */
+     public static final int LEVEL_COLOR_MATRIX_HUE = 100;
+     /**
+-     * Color transform level used to adjust the color saturation of the display.
++     * Color transform level used to adjust the color contrast of the display.
+      */
+     public static final int LEVEL_COLOR_MATRIX_CONTRAST = 100;
+     /**
+-     * Color transform level used to adjust the color saturation of the display.
++     * Color transform level used to adjust the color white balance of the display.
+      */
+     public static final int LEVEL_COLOR_MATRIX_WHITEBALANCE = 100;
+     /**
+-     * Color transform level used to adjust the color saturation of the display.
++     * Color transform level used to adjust the color luminance of the display.
+      */
+     public static final int LEVEL_COLOR_MATRIX_LUMINANCE = 150;
+     /**
+-- 
+2.34.1
+

--- a/aosp_diff/base_aaos/packages/apps/Car/Settings/06_0006-Reset-all-display-hardware-settings-to-default-value.patch
+++ b/aosp_diff/base_aaos/packages/apps/Car/Settings/06_0006-Reset-all-display-hardware-settings-to-default-value.patch
@@ -1,0 +1,495 @@
+From 354c4a0c17034df30c9aba17eae058410b927f9f Mon Sep 17 00:00:00 2001
+From: xubing <bing.xu@intel.com>
+Date: Fri, 22 Mar 2024 08:59:21 +0800
+Subject: [PATCH] Reset all display hardware settings to default value
+
+Reset all display hardware settings to default value, include
+Hue, Contrast, Saturation, Whitebalance and Luminance.
+
+Test: Feature funciotn is ready, test OK.
+
+Tracked-On: OAM-116761
+Signed-off-by: xubing <bing.xu@intel.com>
+---
+ res/values/preference_keys.xml                |   1 +
+ res/values/strings.xml                        |   3 +
+ res/xml/display_settings_fragment.xml         |   4 +
+ .../ContrastLevelPreferenceController.java    |  22 ++-
+ ...playActionButtonsPreferenceController.java | 141 ++++++++++++++++++
+ .../display/HueLevelPreferenceController.java |  23 ++-
+ .../LuminanceLevelPreferenceController.java   |  22 ++-
+ .../SaturationLevelPreferenceController.java  |  26 +++-
+ ...WhitebalanceLevelPreferenceController.java |  22 ++-
+ 9 files changed, 250 insertions(+), 14 deletions(-)
+ create mode 100644 src/com/android/car/settings/display/DisplayActionButtonsPreferenceController.java
+
+diff --git a/res/values/preference_keys.xml b/res/values/preference_keys.xml
+index bcf93e274..c76f5763a 100644
+--- a/res/values/preference_keys.xml
++++ b/res/values/preference_keys.xml
+@@ -349,6 +349,7 @@
+     <string name="pk_saturation_level" translatable="false">saturation_level</string>
+     <string name="pk_whitebalance_level" translatable="false">whitebalance_level</string>
+     <string name="pk_luminance_level" translatable="false">luminance_level</string>
++    <string name="pk_display_reset_settings" translatable="false">display_reset_settings</string>
+     <string name="pk_display_extra_settings" translatable="false">display_extra_settings</string>
+     <!-- DateTime Settings -->
+     <string name="pk_auto_datetime_switch" translatable="false">auto_datetime_switch</string>
+diff --git a/res/values/strings.xml b/res/values/strings.xml
+index 1115c78c8..f0e3511b1 100644
+--- a/res/values/strings.xml
++++ b/res/values/strings.xml
+@@ -680,6 +680,9 @@
+     <string name="force_stop">Force stop</string>
+     <!-- Manage applications, title for dialog when killing persistent apps. [CHAR LIMIT=40] -->
+     <string name="force_stop_dialog_title">Force stop?</string>
++    <string name="restore_display_settings">Restore all display settings to default</string>
++    <string name="restore_display_dialog_title">Force restore?</string>
++    <string name="restore_display_dialog_text">Restore all dispaly settings to default value.</string>
+     <!-- Manage applications, text for dialog when killing persistent apps. [CHAR LIMIT=200] -->
+     <string name="force_stop_dialog_text">If you force stop an app, it may misbehave.</string>
+     <!-- Manage applications, title for dialog when turning on prioritize app performance setting. [CHAR LIMIT=40] -->
+diff --git a/res/xml/display_settings_fragment.xml b/res/xml/display_settings_fragment.xml
+index 4177d1c74..a76d035e6 100644
+--- a/res/xml/display_settings_fragment.xml
++++ b/res/xml/display_settings_fragment.xml
+@@ -20,6 +20,10 @@
+     xmlns:settings="http://schemas.android.com/apk/res-auto"
+     android:title="@string/display_settings"
+     android:key="@string/psk_display_settings">
++    <com.android.car.settings.common.ActionButtonsPreference
++        android:key="@string/pk_display_reset_settings"
++        settings:controller="com.android.car.settings.display.DisplayActionButtonsPreferenceController"
++        settings:searchable="false"/>
+     <com.android.car.settings.common.SeekBarPreference
+         android:key="@string/pk_brightness_level"
+         android:title="@string/backlight"
+diff --git a/src/com/android/car/settings/display/ContrastLevelPreferenceController.java b/src/com/android/car/settings/display/ContrastLevelPreferenceController.java
+index 8ef67921c..78dbee99d 100644
+--- a/src/com/android/car/settings/display/ContrastLevelPreferenceController.java
++++ b/src/com/android/car/settings/display/ContrastLevelPreferenceController.java
+@@ -47,7 +47,9 @@ public class ContrastLevelPreferenceController extends PreferenceController<Seek
+             Settings.System.SCREEN_CONTRAST);
+     private final int mMaximumContrast = 65535;
+     private final int mMinimumContrast = 0;
+-
++    private final int mDefaultContrastLevel = 128;
++    private final int mMaxContrastLevel = 255;
++    public static ContrastLevelPreferenceController mContrastInstance;
+     private ColorDisplayManager mColorDisplayManager;
+     private final Handler mHandler = new Handler(Looper.getMainLooper());
+ 
+@@ -62,6 +64,21 @@ public class ContrastLevelPreferenceController extends PreferenceController<Seek
+                                              FragmentController fragmentController, CarUxRestrictions uxRestrictions) {
+         super(context, preferenceKey, fragmentController, uxRestrictions);
+         getColorDisplayManager();
++        mContrastInstance = this;
++    }
++
++    public static ContrastLevelPreferenceController getContrastInstance() {
++        return mContrastInstance;
++    }
++
++    public void setDefaultContrastLevel() {
++        int gamma = (Integer) mDefaultContrastLevel * mMaximumContrast/mMaxContrastLevel;
++        int linear = convertGammaToLinear(gamma, mMinimumContrast, mMaximumContrast);
++        Settings.System.putIntForUser(getContext().getContentResolver(),
++                Settings.System.SCREEN_CONTRAST, linear, UserHandle.myUserId());
++        int contrastLevel = gamma * mMaxContrastLevel/mMaximumContrast;
++        getPreference().setValue(gamma);
++        mColorDisplayManager.setContrastLevel(mDefaultContrastLevel);
+     }
+ 
+     ColorDisplayManager getColorDisplayManager() {
+@@ -112,12 +129,11 @@ public class ContrastLevelPreferenceController extends PreferenceController<Seek
+     }
+ 
+     private int getSeekbarValue() {
+-        int gamma = mMaximumContrast;
++        int gamma = mMaximumContrast / 2;
+         try {
+             int linear = Settings.System.getIntForUser(getContext().getContentResolver(),
+                     Settings.System.SCREEN_CONTRAST, UserHandle.myUserId());
+             gamma = convertLinearToGamma(linear, mMinimumContrast, mMaximumContrast);
+-            LOG.w("getSeekbarValue linear:" + linear);
+         } catch (Settings.SettingNotFoundException e) {
+             LOG.w("Can't find setting for SCREEN_CONTRAST.");
+         }
+diff --git a/src/com/android/car/settings/display/DisplayActionButtonsPreferenceController.java b/src/com/android/car/settings/display/DisplayActionButtonsPreferenceController.java
+new file mode 100644
+index 000000000..bcd36c445
+--- /dev/null
++++ b/src/com/android/car/settings/display/DisplayActionButtonsPreferenceController.java
+@@ -0,0 +1,141 @@
++/*
++ * Copyright (C) 2020 The Android Open Source Project
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *      http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++package com.android.car.settings.display;
++
++import static android.app.Activity.RESULT_OK;
++import static com.android.car.settings.applications.ApplicationsUtils.isKeepEnabledPackage;
++import static com.android.car.settings.applications.ApplicationsUtils.isProfileOrDeviceOwner;
++import static com.android.car.settings.common.ActionButtonsPreference.ActionButtons;
++import static com.android.car.settings.display.ContrastLevelPreferenceController.getContrastInstance;
++import static com.android.car.settings.display.HueLevelPreferenceController.getHueInstance;
++import static com.android.car.settings.display.LuminanceLevelPreferenceController.getLuminanceInstance;
++import static com.android.car.settings.display.SaturationLevelPreferenceController.getSaturationInstance;
++import static com.android.car.settings.display.WhitebalanceLevelPreferenceController.getWhitebalanceInstance;
++import static com.android.car.settings.enterprise.ActionDisabledByAdminDialogFragment.DISABLED_BY_ADMIN_CONFIRM_DIALOG_TAG;
++
++import android.app.Activity;
++import android.app.ActivityManager;
++import android.app.admin.DevicePolicyManager;
++import android.car.drivingstate.CarUxRestrictions;
++import android.content.BroadcastReceiver;
++import android.content.ComponentName;
++import android.content.Context;
++import android.content.Intent;
++import android.content.pm.ApplicationInfo;
++import android.content.pm.PackageInfo;
++import android.content.pm.PackageManager;
++import android.content.pm.ResolveInfo;
++import android.net.Uri;
++import android.os.Bundle;
++import android.os.UserHandle;
++import android.os.UserManager;
++import android.util.ArraySet;
++import android.view.View;
++
++import androidx.annotation.Nullable;
++import androidx.annotation.VisibleForTesting;
++
++import com.android.car.settings.R;
++import com.android.car.settings.common.ActionButtonInfo;
++import com.android.car.settings.common.ActionButtonsPreference;
++import com.android.car.settings.common.ActivityResultCallback;
++import com.android.car.settings.common.ConfirmationDialogFragment;
++import com.android.car.settings.common.FragmentController;
++import com.android.car.settings.common.Logger;
++import com.android.car.settings.common.PreferenceController;
++import com.android.settingslib.Utils;
++import com.android.settingslib.applications.ApplicationsState;
++
++import java.util.ArrayList;
++import java.util.Arrays;
++import java.util.List;
++import java.util.Set;
++
++/**
++ * Shows actions associated with an application, like uninstall and forceStop.
++ *
++ * <p>To uninstall an app, it must <i>not</i> be:
++ * <ul>
++ * <li>a system bundled app
++ * <li>system signed
++ * <li>managed by an active admin from a device policy
++ * <li>a device or profile owner
++ * <li>the only home app
++ * <li>the default home app
++ * <li>for a user with the {@link UserManager#DISALLOW_APPS_CONTROL} restriction
++ * <li>for a user with the {@link UserManager#DISALLOW_UNINSTALL_APPS} restriction
++ * </ul>
++ *
++ * <p>For apps that cannot be uninstalled, a disable option is shown instead (or enable if the app
++ * is already disabled).
++ */
++public class DisplayActionButtonsPreferenceController extends
++        PreferenceController<ActionButtonsPreference>  {
++    private static final Logger LOG = new Logger(
++            DisplayActionButtonsPreferenceController.class);
++
++    @Override
++    protected Class<ActionButtonsPreference> getPreferenceType() {
++        return ActionButtonsPreference.class;
++    }
++    @VisibleForTesting
++    static final String RESET_DISPLAY_CONFIRM_DIALOG_TAG =
++            "com.android.car.settings.display.ResetDisplaySettingsConfirmDialog";
++
++
++    @VisibleForTesting
++    final ConfirmationDialogFragment.ConfirmListener mResetDisplayConfirmListener =
++            new ConfirmationDialogFragment.ConfirmListener() {
++                @Override
++                public void onConfirm(@Nullable Bundle arguments) {
++                    LOG.d("mResetDisplayConfirmListener ");
++                    getContrastInstance().setDefaultContrastLevel();
++                    getHueInstance().setDefaultHueLevel();
++                    getLuminanceInstance().setDefaultLuminanceLevel();
++                    getSaturationInstance().setDefaultSaturationLevel();
++                    getWhitebalanceInstance().setDefaultWhitebalanceLevel();
++                }
++            };
++
++    private final View.OnClickListener mResetDisplayClickListener = i -> {
++        ConfirmationDialogFragment dialogFragment =
++                new ConfirmationDialogFragment.Builder(getContext())
++                        .setTitle(R.string.restore_display_dialog_title)
++                        .setMessage(R.string.restore_display_dialog_text)
++                        .setPositiveButton(android.R.string.ok,
++                                mResetDisplayConfirmListener)
++                        .setNegativeButton(android.R.string.cancel, /* rejectListener= */ null)
++                        .build();
++        getFragmentController().showDialog(dialogFragment, RESET_DISPLAY_CONFIRM_DIALOG_TAG);
++    };
++
++    public DisplayActionButtonsPreferenceController(Context context, String preferenceKey,
++                                                    FragmentController fragmentController, CarUxRestrictions uxRestrictions) {
++        super(context, preferenceKey, fragmentController, uxRestrictions);
++    }
++
++    @Override
++    protected void onCreateInternal() {
++        getPreference().getButton(ActionButtons.BUTTON2)
++                .setText(R.string.restore_display_settings)
++                .setIcon(R.drawable.ic_warning)
++                .setOnClickListener(mResetDisplayClickListener)
++                .setEnabled(true);
++
++    }
++
++}
+diff --git a/src/com/android/car/settings/display/HueLevelPreferenceController.java b/src/com/android/car/settings/display/HueLevelPreferenceController.java
+index c4f36c4ce..9ce7d6c27 100644
+--- a/src/com/android/car/settings/display/HueLevelPreferenceController.java
++++ b/src/com/android/car/settings/display/HueLevelPreferenceController.java
+@@ -48,6 +48,9 @@ public class HueLevelPreferenceController extends PreferenceController<SeekBarPr
+             Settings.System.SCREEN_HUE);
+     private final int mMaximumHue = 65535;
+     private final int mMinimumHue = 0;
++    private final int mDefaultHueLevel = 180;
++    private final int mMaxHueLevel = 360;
++    public static HueLevelPreferenceController mHueInstance;
+ 
+     private ColorDisplayManager mColorDisplayManager;
+     private final Handler mHandler = new Handler(Looper.getMainLooper());
+@@ -63,6 +66,21 @@ public class HueLevelPreferenceController extends PreferenceController<SeekBarPr
+                                         FragmentController fragmentController, CarUxRestrictions uxRestrictions) {
+         super(context, preferenceKey, fragmentController, uxRestrictions);
+         getColorDisplayManager();
++        mHueInstance = this;
++    }
++
++    public static HueLevelPreferenceController getHueInstance() {
++        return mHueInstance;
++    }
++
++    public void setDefaultHueLevel() {
++        int gamma = (Integer) mDefaultHueLevel * mMaximumHue/mMaxHueLevel;
++        int linear = convertGammaToLinear(gamma, mMinimumHue, mMaximumHue);
++        Settings.System.putIntForUser(getContext().getContentResolver(),
++                Settings.System.SCREEN_HUE, linear, UserHandle.myUserId());
++        int HueLevel = gamma * mMaxHueLevel/mMaximumHue;
++        getPreference().setValue(gamma);
++        mColorDisplayManager.setHueLevel(mDefaultHueLevel);
+     }
+ 
+     ColorDisplayManager getColorDisplayManager() {
+@@ -109,18 +127,17 @@ public class HueLevelPreferenceController extends PreferenceController<SeekBarPr
+         int linear = convertGammaToLinear(gamma, mMinimumHue, mMaximumHue);
+         Settings.System.putIntForUser(getContext().getContentResolver(),
+                 Settings.System.SCREEN_HUE, linear, UserHandle.myUserId());
+-        int hueLevel = gamma * 360/65535;
++        int hueLevel = gamma * mMaxHueLevel/mMaximumHue;
+         mColorDisplayManager.setHueLevel(hueLevel);
+         return true;
+     }
+ 
+     private int getSeekbarValue() {
+-        int gamma = mMaximumHue;
++        int gamma = mMaximumHue / 2;
+         try {
+             int linear = Settings.System.getIntForUser(getContext().getContentResolver(),
+                     Settings.System.SCREEN_HUE, UserHandle.myUserId());
+             gamma = convertLinearToGamma(linear, mMinimumHue, mMaximumHue);
+-            LOG.w("getSeekbarValue linear:" + linear);
+         } catch (Settings.SettingNotFoundException e) {
+             LOG.w("Can't find setting for SCREEN_BRIGHTNESS.");
+         }
+diff --git a/src/com/android/car/settings/display/LuminanceLevelPreferenceController.java b/src/com/android/car/settings/display/LuminanceLevelPreferenceController.java
+index 6bd14445e..be86ba93e 100644
+--- a/src/com/android/car/settings/display/LuminanceLevelPreferenceController.java
++++ b/src/com/android/car/settings/display/LuminanceLevelPreferenceController.java
+@@ -42,6 +42,9 @@ public class LuminanceLevelPreferenceController extends PreferenceController<See
+             Settings.System.SCREEN_LUMINANCE);
+     private final int mMaximumLuminance = 65535;
+     private final int mMinimumLuminance = 0;
++    private final int mDefaultLuminanceLevel = 128;
++    private final int mMaxLuminanceLevel = 255;
++    public static LuminanceLevelPreferenceController mLuminanceInstance;
+ 
+     private ColorDisplayManager mColorDisplayManager;
+     private final Handler mHandler = new Handler(Looper.getMainLooper());
+@@ -57,6 +60,21 @@ public class LuminanceLevelPreferenceController extends PreferenceController<See
+                                               FragmentController fragmentController, CarUxRestrictions uxRestrictions) {
+         super(context, preferenceKey, fragmentController, uxRestrictions);
+         getColorDisplayManager();
++        mLuminanceInstance = this;
++    }
++
++    public static LuminanceLevelPreferenceController getLuminanceInstance() {
++        return mLuminanceInstance;
++    }
++
++    public void setDefaultLuminanceLevel() {
++        int gamma = (Integer) mDefaultLuminanceLevel * mMaximumLuminance/mMaxLuminanceLevel;
++        int linear = convertGammaToLinear(gamma, mMinimumLuminance, mMaximumLuminance);
++        Settings.System.putIntForUser(getContext().getContentResolver(),
++                Settings.System.SCREEN_LUMINANCE, linear, UserHandle.myUserId());
++        int LuminanceLevel = gamma * mMaxLuminanceLevel/mMaximumLuminance;
++        getPreference().setValue(gamma);
++        mColorDisplayManager.setLuminanceLevel(mDefaultLuminanceLevel);
+     }
+ 
+     ColorDisplayManager getColorDisplayManager() {
+@@ -101,13 +119,13 @@ public class LuminanceLevelPreferenceController extends PreferenceController<See
+         int linear = convertGammaToLinear(gamma, mMinimumLuminance, mMaximumLuminance);
+         Settings.System.putIntForUser(getContext().getContentResolver(),
+                 Settings.System.SCREEN_LUMINANCE, linear, UserHandle.myUserId());
+-        int luminanceLevel = gamma * 255/65535;
++        int luminanceLevel = gamma * mMaxLuminanceLevel/mMaximumLuminance;
+         mColorDisplayManager.setLuminanceLevel(luminanceLevel);
+         return true;
+     }
+ 
+     private int getSeekbarValue() {
+-        int gamma = mMaximumLuminance;
++        int gamma = mMaximumLuminance / 2;
+         try {
+             int linear = Settings.System.getIntForUser(getContext().getContentResolver(),
+                     Settings.System.SCREEN_LUMINANCE, UserHandle.myUserId());
+diff --git a/src/com/android/car/settings/display/SaturationLevelPreferenceController.java b/src/com/android/car/settings/display/SaturationLevelPreferenceController.java
+index 74ce3c6ee..46daa7792 100644
+--- a/src/com/android/car/settings/display/SaturationLevelPreferenceController.java
++++ b/src/com/android/car/settings/display/SaturationLevelPreferenceController.java
+@@ -52,9 +52,12 @@ public class SaturationLevelPreferenceController extends PreferenceController<Se
+     private static final Uri SATURATION_URI = Settings.System.getUriFor(
+             Settings.System.SCREEN_SATURATION);
+     private final int mMaximumSaturation = 65535;
++    private final int mMinimumSaturation = 0;
++    private final int mDefaultSaturationLevel = 50;
++    private final int mMaxSaturationLevel = 100;
++    public static SaturationLevelPreferenceController mSaturationInstance;
+ 
+     private ColorDisplayManager mColorDisplayManager;
+-    private final int mMinimumSaturation = 0;
+     private final Handler mHandler = new Handler(Looper.getMainLooper());
+ 
+     private final ContentObserver mSaturationObserver = new ContentObserver(mHandler) {
+@@ -68,6 +71,21 @@ public class SaturationLevelPreferenceController extends PreferenceController<Se
+                                                FragmentController fragmentController, CarUxRestrictions uxRestrictions) {
+         super(context, preferenceKey, fragmentController, uxRestrictions);
+         getColorDisplayManager();
++        mSaturationInstance = this;
++    }
++
++    public static SaturationLevelPreferenceController getSaturationInstance() {
++        return mSaturationInstance;
++    }
++
++    public void setDefaultSaturationLevel() {
++        int gamma = (Integer) mDefaultSaturationLevel * mMaximumSaturation/mMaxSaturationLevel;
++        int linear = convertGammaToLinear(gamma, mMinimumSaturation, mMaximumSaturation);
++        Settings.System.putIntForUser(getContext().getContentResolver(),
++                Settings.System.SCREEN_SATURATION, linear, UserHandle.myUserId());
++        int SaturationLevel = gamma * mMaxSaturationLevel/mMaximumSaturation;
++        getPreference().setValue(gamma);
++        mColorDisplayManager.setSaturationLevel(mDefaultSaturationLevel);
+     }
+ 
+     ColorDisplayManager getColorDisplayManager() {
+@@ -113,19 +131,19 @@ public class SaturationLevelPreferenceController extends PreferenceController<Se
+         int linear = convertGammaToLinear(gamma, mMinimumSaturation, mMaximumSaturation);
+         Settings.System.putIntForUser(getContext().getContentResolver(),
+                 Settings.System.SCREEN_SATURATION, linear, UserHandle.myUserId());
+-        int saturationLevel = gamma * 100/65535;
++        int saturationLevel = gamma * mMaxSaturationLevel/mMaximumSaturation;
+         mColorDisplayManager.setSaturationLevel(saturationLevel);
+         return true;
+     }
+ 
+     private int getSeekbarValue() {
+-        int gamma = GAMMA_SPACE_MAX;
++        int gamma = mMaximumSaturation / 2;
+         try {
+             int linear = Settings.System.getIntForUser(getContext().getContentResolver(),
+                     Settings.System.SCREEN_SATURATION, UserHandle.myUserId());
+             gamma = convertLinearToGamma(linear, mMinimumSaturation, mMaximumSaturation);
+         } catch (Settings.SettingNotFoundException e) {
+-            LOG.w("Can't find setting for SCREEN_BRIGHTNESS.");
++            LOG.w("Can't find setting for SCREEN_SATURATION.");
+         }
+         return gamma;
+     }
+diff --git a/src/com/android/car/settings/display/WhitebalanceLevelPreferenceController.java b/src/com/android/car/settings/display/WhitebalanceLevelPreferenceController.java
+index a20320000..233c3f830 100644
+--- a/src/com/android/car/settings/display/WhitebalanceLevelPreferenceController.java
++++ b/src/com/android/car/settings/display/WhitebalanceLevelPreferenceController.java
+@@ -53,6 +53,9 @@ public class WhitebalanceLevelPreferenceController extends PreferenceController<
+     private ColorDisplayManager mColorDisplayManager;
+     private final int mMaximumWhitebalance = 65535;
+     private final int mMinimumWhitebalance = 0;
++    private final int mDefaultWhitebalanceLevel = 255;
++    private final int mMaxWhitebalanceLevel = 255;
++    public static WhitebalanceLevelPreferenceController mWhitebalanceInstance;
+     private final Handler mHandler = new Handler(Looper.getMainLooper());
+ 
+     private final ContentObserver mWhitebalanceObserver = new ContentObserver(mHandler) {
+@@ -66,8 +69,24 @@ public class WhitebalanceLevelPreferenceController extends PreferenceController<
+                                                  FragmentController fragmentController, CarUxRestrictions uxRestrictions) {
+         super(context, preferenceKey, fragmentController, uxRestrictions);
+         getColorDisplayManager();
++        mWhitebalanceInstance = this;
+     }
+ 
++    public static WhitebalanceLevelPreferenceController getWhitebalanceInstance() {
++        return mWhitebalanceInstance;
++    }
++
++    public void setDefaultWhitebalanceLevel() {
++        int gamma = (Integer) mDefaultWhitebalanceLevel * mMaximumWhitebalance/mMaxWhitebalanceLevel;
++        int linear = convertGammaToLinear(gamma, mMinimumWhitebalance, mMaximumWhitebalance);
++        Settings.System.putIntForUser(getContext().getContentResolver(),
++                Settings.System.SCREEN_WHITEBALANCE, linear, UserHandle.myUserId());
++        int WhitebalanceLevel = gamma * mMaxWhitebalanceLevel/mMaximumWhitebalance;
++        getPreference().setValue(gamma);
++        mColorDisplayManager.setWhitebalanceLevel(mDefaultWhitebalanceLevel);
++    }
++
++
+     ColorDisplayManager getColorDisplayManager() {
+         if (mColorDisplayManager == null) {
+             mColorDisplayManager = getContext().getSystemService(ColorDisplayManager.class);
+@@ -117,7 +136,7 @@ public class WhitebalanceLevelPreferenceController extends PreferenceController<
+     }
+ 
+     private int getSeekbarValue() {
+-        int gamma = GAMMA_SPACE_MAX;
++        int gamma = mMaximumWhitebalance;
+         try {
+             int linear = Settings.System.getIntForUser(getContext().getContentResolver(),
+                     Settings.System.SCREEN_WHITEBALANCE, UserHandle.myUserId());
+@@ -130,7 +149,6 @@ public class WhitebalanceLevelPreferenceController extends PreferenceController<
+ 
+     @Override
+     public int getAvailabilityStatus() {
+-
+         return AVAILABLE;
+     }
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
Set default value of display hardware settings, include Hue, Contrast, Saturation, Whitebalance and Luminance.

Test: Feature funciotn is ready, test OK.

Tracked-On: OAM-116761