### PR TITLE
Refine the pm.installer reconnection about installd

### DIFF
--- a/aosp_diff/base_aaos/frameworks/av/40_0040-WA-Extended-time-to-check-for-timeout.patch
+++ b/aosp_diff/base_aaos/frameworks/av/40_0040-WA-Extended-time-to-check-for-timeout.patch
@@ -1,0 +1,39 @@
+From ad7dee95d244438814fbb7ed6d62a488cdff20f5 Mon Sep 17 00:00:00 2001
+From: "Lu, Xingjiang" <xingjiang.lu@intel.com>
+Date: Wed, 27 Mar 2024 18:25:47 +0800
+Subject: [PATCH] [WA] Extended time to check for timeout
+
+Extend check time to ensure Timecheck not to send tombstone when
+serviceManager was occupied and audiopolicyService cannot published
+successfully.
+
+The timeout value should be greater than the max timeout value of
+pm.installer, to avoid the worst case happen.
+
+TEST: 500 cycles per S3/S5 test.
+
+
+Tracked-On: OAM-116189
+Signed-off-by: Chen, Haochuan <haochuan.chen@intel.com>
+Signed-off-by: Wan, Xinxin <xinxin.wan@intel.com>
+Signed-off-by: Lu, Xingjiang <xingjiang.lu@intel.com>
+---
+ services/audiopolicy/service/AudioPolicyService.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/services/audiopolicy/service/AudioPolicyService.cpp b/services/audiopolicy/service/AudioPolicyService.cpp
+index 20e305e864..9af00fd73f 100644
+--- a/services/audiopolicy/service/AudioPolicyService.cpp
++++ b/services/audiopolicy/service/AudioPolicyService.cpp
+@@ -1094,7 +1094,7 @@ status_t AudioPolicyService::onTransact(
+     }
+
+     std::string tag("IAudioPolicyService command " + std::to_string(code));
+-    TimeCheck check(tag.c_str());
++    TimeCheck check(tag.c_str(), 12000);
+
+     switch (code) {
+         case SHELL_COMMAND_TRANSACTION: {
+--
+2.34.1
+

--- a/aosp_diff/base_aaos/frameworks/base/99_0257-Use-a-private-thread-to-replace-the-public-one-in-in.patch
+++ b/aosp_diff/base_aaos/frameworks/base/99_0257-Use-a-private-thread-to-replace-the-public-one-in-in.patch
@@ -1,0 +1,57 @@
+From 7234032294158956c7bd2fa6f48e72b29cba644e Mon Sep 17 00:00:00 2001
+From: "Lu, Xingjiang" <xingjiang.lu@intel.com>
+Date: Mon, 4 Mar 2024 18:31:12 +0800
+Subject: [PATCH] Use a private thread to replace the public one
+
+Use a private thread to replace the public one, to prevent the
+reconnection failure when pm.installer want to bind the installd from
+ServiceManager.
+
+In case of pm.installer fail to initialize caused by installd service
+not ready, there was a WA patch from AOSP and add a reconnection
+callback which handled by BackgroundThread. But sometimes in cycling
+test, this public thread might be busy and handling the tasks from other
+services, then pm.installer can't reconnect installd before timeout.
+
+Also, AudioServer/AudioPolicyService depends on installd has been
+registered to ServiceManager successfully. Increase the timeout value of
+TimeCheck for AudioPolicyService might avoid the fatal exception to be
+occurred.
+
+TEST: 500 cycles per S3/S5 test.
+
+
+Tracked-on: OAM-116189
+Signed-off-by: Xie, Hongcheng <hongcheng.xie@intel.com>
+Signed-off-by: Lu, Xingjiang <xingjiang.lu@intel.com>
+---
+ .../core/java/com/android/server/pm/Installer.java  | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
+
+diff --git a/services/core/java/com/android/server/pm/Installer.java b/services/core/java/com/android/server/pm/Installer.java
+index 13c5bb0230e2..fc9d6b784e51 100644
+--- a/services/core/java/com/android/server/pm/Installer.java
++++ b/services/core/java/com/android/server/pm/Installer.java
+@@ -178,9 +178,16 @@ public class Installer extends SystemService {
+             }
+         } else {
+             Slog.w(TAG, "installd not found; trying again");
+-            BackgroundThread.getHandler().postDelayed(() -> {
+-                connect();
+-            }, CONNECT_RETRY_DELAY_MS);
++            new Thread(new Runnable() {
++                public void run() {
++                    try {
++                        Thread.sleep(CONNECT_RETRY_DELAY_MS);
++                        connect();
++                    } catch (Exception e) {
++                        Slog.e(TAG, "found exception " + e + " in reconnect()");
++                    }
++                }
++            }).start();
+         }
+     }
+
+--
+2.34.1
+


### PR DESCRIPTION
Use a private Thread to instead of the common BackgroundThread in pm.installer, to prevent the callback handler not to be blocked by the other tasks.

Pm.installer will try to reconnect installd if necessary, but sometimes the reconnection function cannot be performed due to the callback thread, as well as BackgroundThread becomes busy.

In the corner case, audioserver and audiopolicyservice might be crashed due to the same reason in stability testing.

Tracked-On: OAM-116189