### PR TITLE
Fix to hwcomposer dump api

### DIFF
--- a/aosp_diff/preliminary/hardware/interfaces/11_0001-Enable-graphics.composer3-AIDL-HAL-service.patch
+++ b/aosp_diff/preliminary/hardware/interfaces/11_0001-Enable-graphics.composer3-AIDL-HAL-service.patch
@@ -1,4 +1,4 @@
-From fc664c5554f137ee17f1594d25dbffa4c08a869c Mon Sep 17 00:00:00 2001
+From 33fdd0e9683e8acc71f5749f61add47954aba616 Mon Sep 17 00:00:00 2001
 From: manxiaoliang <xiaoliangx.man@intel.com>
 Date: Wed, 23 Aug 2023 08:21:53 +0000
 Subject: [PATCH] Enable graphics.composer3 AIDL HAL service.
@@ -12,7 +12,7 @@ Signed-off-by: manxiaoliang <xiaoliangx.man@intel.com>
  graphics/composer/aidl/default/Android.bp     |   78 ++
  graphics/composer/aidl/default/Composer.cpp   |   98 ++
  graphics/composer/aidl/default/Composer.h     |   52 +
- .../composer/aidl/default/ComposerClient.cpp  |  598 +++++++++
+ .../composer/aidl/default/ComposerClient.cpp  |  598 ++++++++
  .../composer/aidl/default/ComposerClient.h    |  151 +++
  .../aidl/default/ComposerCommandEngine.cpp    |  459 +++++++
  .../aidl/default/ComposerCommandEngine.h      |  119 ++
@@ -20,7 +20,7 @@ Signed-off-by: manxiaoliang <xiaoliangx.man@intel.com>
  graphics/composer/aidl/default/Util.h         |   94 ++
  ...rdware.graphics.composer3-service.intel.rc |    7 +
  ...dware.graphics.composer3-service.intel.xml |   10 +
- .../composer/aidl/default/impl/HalImpl.cpp    | 1194 +++++++++++++++++
+ .../composer/aidl/default/impl/HalImpl.cpp    | 1199 +++++++++++++++++
  graphics/composer/aidl/default/impl/HalImpl.h |  264 ++++
  .../composer/aidl/default/impl/HwcLoader.cpp  |   97 ++
  .../composer/aidl/default/impl/HwcLoader.h    |   48 +
@@ -30,7 +30,7 @@ Signed-off-by: manxiaoliang <xiaoliangx.man@intel.com>
  .../aidl/default/include/IComposerHal.h       |  225 ++++
  .../aidl/default/include/IResourceManager.h   |   75 ++
  graphics/composer/aidl/default/service.cpp    |   61 +
- 21 files changed, 4302 insertions(+)
+ 21 files changed, 4307 insertions(+)
  create mode 100644 graphics/composer/aidl/default/Android.bp
  create mode 100644 graphics/composer/aidl/default/Composer.cpp
  create mode 100644 graphics/composer/aidl/default/Composer.h
@@ -55,7 +55,7 @@ Signed-off-by: manxiaoliang <xiaoliangx.man@intel.com>
 
 diff --git a/graphics/composer/aidl/default/Android.bp b/graphics/composer/aidl/default/Android.bp
 new file mode 100644
-index 000000000..0783f284f
+index 0000000000..0783f284f3
 --- /dev/null
 +++ b/graphics/composer/aidl/default/Android.bp
 @@ -0,0 +1,78 @@
@@ -139,7 +139,7 @@ index 000000000..0783f284f
 +
 diff --git a/graphics/composer/aidl/default/Composer.cpp b/graphics/composer/aidl/default/Composer.cpp
 new file mode 100644
-index 000000000..4a57d9600
+index 0000000000..4a57d96004
 --- /dev/null
 +++ b/graphics/composer/aidl/default/Composer.cpp
 @@ -0,0 +1,98 @@
@@ -243,7 +243,7 @@ index 000000000..4a57d9600
 +
 diff --git a/graphics/composer/aidl/default/Composer.h b/graphics/composer/aidl/default/Composer.h
 new file mode 100644
-index 000000000..5c2b5e2cb
+index 0000000000..5c2b5e2cbc
 --- /dev/null
 +++ b/graphics/composer/aidl/default/Composer.h
 @@ -0,0 +1,52 @@
@@ -302,7 +302,7 @@ index 000000000..5c2b5e2cb
 \ No newline at end of file
 diff --git a/graphics/composer/aidl/default/ComposerClient.cpp b/graphics/composer/aidl/default/ComposerClient.cpp
 new file mode 100644
-index 000000000..f142f998e
+index 0000000000..f142f998ef
 --- /dev/null
 +++ b/graphics/composer/aidl/default/ComposerClient.cpp
 @@ -0,0 +1,598 @@
@@ -906,7 +906,7 @@ index 000000000..f142f998e
 +} // namespace aidl::android::hardware::graphics::composer3::impl
 diff --git a/graphics/composer/aidl/default/ComposerClient.h b/graphics/composer/aidl/default/ComposerClient.h
 new file mode 100644
-index 000000000..2a849522d
+index 0000000000..2a849522d5
 --- /dev/null
 +++ b/graphics/composer/aidl/default/ComposerClient.h
 @@ -0,0 +1,151 @@
@@ -1063,7 +1063,7 @@ index 000000000..2a849522d
 +
 diff --git a/graphics/composer/aidl/default/ComposerCommandEngine.cpp b/graphics/composer/aidl/default/ComposerCommandEngine.cpp
 new file mode 100644
-index 000000000..ff66f9dfe
+index 0000000000..ff66f9dfee
 --- /dev/null
 +++ b/graphics/composer/aidl/default/ComposerCommandEngine.cpp
 @@ -0,0 +1,459 @@
@@ -1528,7 +1528,7 @@ index 000000000..ff66f9dfe
 +} // namespace aidl::android::hardware::graphics::composer3::impl
 diff --git a/graphics/composer/aidl/default/ComposerCommandEngine.h b/graphics/composer/aidl/default/ComposerCommandEngine.h
 new file mode 100644
-index 000000000..ae6828570
+index 0000000000..ae68285709
 --- /dev/null
 +++ b/graphics/composer/aidl/default/ComposerCommandEngine.h
 @@ -0,0 +1,119 @@
@@ -1653,7 +1653,7 @@ index 000000000..ae6828570
 +
 diff --git a/graphics/composer/aidl/default/NOTICE b/graphics/composer/aidl/default/NOTICE
 new file mode 100644
-index 000000000..316b4eb5a
+index 0000000000..316b4eb5a9
 --- /dev/null
 +++ b/graphics/composer/aidl/default/NOTICE
 @@ -0,0 +1,190 @@
@@ -1849,7 +1849,7 @@ index 000000000..316b4eb5a
 +
 diff --git a/graphics/composer/aidl/default/Util.h b/graphics/composer/aidl/default/Util.h
 new file mode 100644
-index 000000000..53057879f
+index 0000000000..53057879f8
 --- /dev/null
 +++ b/graphics/composer/aidl/default/Util.h
 @@ -0,0 +1,94 @@
@@ -1949,7 +1949,7 @@ index 000000000..53057879f
 +} // namespace aidl::android::hardware::graphics::composer3::impl
 diff --git a/graphics/composer/aidl/default/android.hardware.graphics.composer3-service.intel.rc b/graphics/composer/aidl/default/android.hardware.graphics.composer3-service.intel.rc
 new file mode 100644
-index 000000000..5819e7d0c
+index 0000000000..5819e7d0c8
 --- /dev/null
 +++ b/graphics/composer/aidl/default/android.hardware.graphics.composer3-service.intel.rc
 @@ -0,0 +1,7 @@
@@ -1962,7 +1962,7 @@ index 000000000..5819e7d0c
 +    task_profiles ServiceCapacityLow
 diff --git a/graphics/composer/aidl/default/android.hardware.graphics.composer3-service.intel.xml b/graphics/composer/aidl/default/android.hardware.graphics.composer3-service.intel.xml
 new file mode 100644
-index 000000000..861b4b7f4
+index 0000000000..861b4b7f40
 --- /dev/null
 +++ b/graphics/composer/aidl/default/android.hardware.graphics.composer3-service.intel.xml
 @@ -0,0 +1,10 @@
@@ -1979,10 +1979,10 @@ index 000000000..861b4b7f4
 \ No newline at end of file
 diff --git a/graphics/composer/aidl/default/impl/HalImpl.cpp b/graphics/composer/aidl/default/impl/HalImpl.cpp
 new file mode 100644
-index 000000000..4397ea542
+index 0000000000..d387ee2531
 --- /dev/null
 +++ b/graphics/composer/aidl/default/impl/HalImpl.cpp
-@@ -0,0 +1,1194 @@
+@@ -0,0 +1,1199 @@
 +/*
 + * Copyright 2021, The Android Open Source Project
 + *
@@ -2258,7 +2258,12 @@ index 000000000..4397ea542
 +
 +    uint32_t len = 0;
 +    mDispatch.dump(mDevice, &len, nullptr);
-+    mDispatch.dump(mDevice, &len, output->data());
++    if (len > 0) {
++        // mDispatch.dump(..) api is expecting char *.
++        // So reserve memory before passing address as an argument.
++        output->reserve(len);
++        mDispatch.dump(mDevice, &len, output->data());
++    }
 +}
 +
 +void HalImpl::registerEventCallback(EventCallback* callback) {
@@ -3179,7 +3184,7 @@ index 000000000..4397ea542
 +} // namespace aidl::android::hardware::graphics::composer3::impl
 diff --git a/graphics/composer/aidl/default/impl/HalImpl.h b/graphics/composer/aidl/default/impl/HalImpl.h
 new file mode 100644
-index 000000000..d6876b15e
+index 0000000000..d6876b15e6
 --- /dev/null
 +++ b/graphics/composer/aidl/default/impl/HalImpl.h
 @@ -0,0 +1,264 @@
@@ -3449,7 +3454,7 @@ index 000000000..d6876b15e
 +} // namespace aidl::android::hardware::graphics::composer3::impl
 diff --git a/graphics/composer/aidl/default/impl/HwcLoader.cpp b/graphics/composer/aidl/default/impl/HwcLoader.cpp
 new file mode 100644
-index 000000000..0c60bac28
+index 0000000000..0c60bac288
 --- /dev/null
 +++ b/graphics/composer/aidl/default/impl/HwcLoader.cpp
 @@ -0,0 +1,97 @@
@@ -3552,7 +3557,7 @@ index 000000000..0c60bac28
 +} //namespace aidl::android::hardware::graphics::composer3::passthrough
 diff --git a/graphics/composer/aidl/default/impl/HwcLoader.h b/graphics/composer/aidl/default/impl/HwcLoader.h
 new file mode 100644
-index 000000000..471f5e31d
+index 0000000000..471f5e31dc
 --- /dev/null
 +++ b/graphics/composer/aidl/default/impl/HwcLoader.h
 @@ -0,0 +1,48 @@
@@ -3606,7 +3611,7 @@ index 000000000..471f5e31d
 +}  // namespace aidl::android::hardware::graphics::composer3::passthrough
 diff --git a/graphics/composer/aidl/default/impl/ResourceManager.cpp b/graphics/composer/aidl/default/impl/ResourceManager.cpp
 new file mode 100644
-index 000000000..bb9cb9247
+index 0000000000..bb9cb92472
 --- /dev/null
 +++ b/graphics/composer/aidl/default/impl/ResourceManager.cpp
 @@ -0,0 +1,251 @@
@@ -3863,7 +3868,7 @@ index 000000000..bb9cb9247
 +} // namespace aidl::android::hardware::graphics::composer3::impl
 diff --git a/graphics/composer/aidl/default/impl/ResourceManager.h b/graphics/composer/aidl/default/impl/ResourceManager.h
 new file mode 100644
-index 000000000..97dcdfedf
+index 0000000000..97dcdfedf9
 --- /dev/null
 +++ b/graphics/composer/aidl/default/impl/ResourceManager.h
 @@ -0,0 +1,79 @@
@@ -3948,7 +3953,7 @@ index 000000000..97dcdfedf
 +} // namespace aidl::android::hardware::graphics::composer3::impl
 diff --git a/graphics/composer/aidl/default/impl/TranslateHwcAidl.h b/graphics/composer/aidl/default/impl/TranslateHwcAidl.h
 new file mode 100644
-index 000000000..7f55cccdd
+index 0000000000..7f55cccdd0
 --- /dev/null
 +++ b/graphics/composer/aidl/default/impl/TranslateHwcAidl.h
 @@ -0,0 +1,152 @@
@@ -4106,7 +4111,7 @@ index 000000000..7f55cccdd
 +} // namespace aidl::android::hardware::graphics::composer3::impl
 diff --git a/graphics/composer/aidl/default/include/IComposerHal.h b/graphics/composer/aidl/default/include/IComposerHal.h
 new file mode 100644
-index 000000000..6fe25c5b7
+index 0000000000..6fe25c5b7f
 --- /dev/null
 +++ b/graphics/composer/aidl/default/include/IComposerHal.h
 @@ -0,0 +1,225 @@
@@ -4337,7 +4342,7 @@ index 000000000..6fe25c5b7
 +} // namespace aidl::android::hardware::graphics::composer3::detail
 diff --git a/graphics/composer/aidl/default/include/IResourceManager.h b/graphics/composer/aidl/default/include/IResourceManager.h
 new file mode 100644
-index 000000000..7def129b1
+index 0000000000..7def129b16
 --- /dev/null
 +++ b/graphics/composer/aidl/default/include/IResourceManager.h
 @@ -0,0 +1,75 @@
@@ -4418,7 +4423,7 @@ index 000000000..7def129b1
 +} // namespace aidl::android::hardware::graphics::composer3::impl
 diff --git a/graphics/composer/aidl/default/service.cpp b/graphics/composer/aidl/default/service.cpp
 new file mode 100644
-index 000000000..d6274310e
+index 0000000000..d6274310e2
 --- /dev/null
 +++ b/graphics/composer/aidl/default/service.cpp
 @@ -0,0 +1,61 @@
@@ -4485,5 +4490,5 @@ index 000000000..d6274310e
 +}
 \ No newline at end of file
 -- 
-2.17.1
+2.43.0
 


### PR DESCRIPTION
dumpsys SurfaceFlinger command is crashing system due to usage of uninitialized string variable's data address.
Fixed it by allocating memory before accessing address of string variable data.

Testdone: Verified with dumpsys and dumpsys SurfaceFlinger
          No crash observed.

Tracked-On: OAM-116838