### PR TITLE
Fixed for Coverity issue in Car Settings app.

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Car/Settings/06_0006-Fixed-for-Coverity-issue-in-Car-Settings-app.patch
+++ b/aosp_diff/base_aaos/packages/apps/Car/Settings/06_0006-Fixed-for-Coverity-issue-in-Car-Settings-app.patch
@@ -1,0 +1,35 @@
+From 7533f510f928cd452d49d8cb4d54058e867626b0 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Mon, 1 Apr 2024 16:30:05 +0530
+Subject: [PATCH] Fixed for Coverity issue in Car Settings app.
+
+There may be null pointer exception when using volume items to create
+volume preference seek bar.
+If volume item is null, then move to next one.
+
+Tests: Open Settings->Sound option, Volume slider is displaying
+and able to slide it.
+
+Tracked-On: OAM-115481
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../car/settings/sound/VolumeSettingsPreferenceController.java | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/com/android/car/settings/sound/VolumeSettingsPreferenceController.java b/src/com/android/car/settings/sound/VolumeSettingsPreferenceController.java
+index 6341e5707..c3394c566 100644
+--- a/src/com/android/car/settings/sound/VolumeSettingsPreferenceController.java
++++ b/src/com/android/car/settings/sound/VolumeSettingsPreferenceController.java
+@@ -131,6 +131,9 @@ public class VolumeSettingsPreferenceController extends PreferenceController<Pre
+             for (int groupId = 0; groupId < volumeGroupCount; groupId++) {
+                 VolumeItem volumeItem = getVolumeItemForUsages(
+                         mCarAudioManager.getUsagesForVolumeGroupId(mZoneId, groupId));
++                if (volumeItem == null) {
++                    continue;
++                }
+                 VolumeSeekBarPreference volumePreference = createVolumeSeekBarPreference(
+                         groupId, volumeItem.getUsage(), volumeItem.getIcon(),
+                         volumeItem.getMuteIcon(), volumeItem.getTitle());
+-- 
+2.17.1
+


### PR DESCRIPTION
There may be null pointer exception when using volume items to create volume preference seek bar.
If volume item is null, then move to next one.

Tests: Open Settings->Sound option, Volume slider is displaying and able to slide it.

Tracked-On: OAM-115481