### PR TITLE
Update color transform reboot setting

### DIFF
--- a/aosp_diff/base_aaos/frameworks/base/99_0257-Update-color-transform-reboot-setting.patch
+++ b/aosp_diff/base_aaos/frameworks/base/99_0257-Update-color-transform-reboot-setting.patch
@@ -1,0 +1,179 @@
+From 1a2cb7f62c018ef140ceea1e8f9ec7113118e4b7 Mon Sep 17 00:00:00 2001
+From: zhonghuis <zhonghui.shi@intel.com>
+Date: Tue, 2 Apr 2024 17:15:54 +0000
+Subject: [PATCH] Update color transform reboot setting
+
+Setup color transform reboot to restore
+the display's color transform setting
+
+Test:
+
+Tracked-On:
+Signed-off-by: zhonghuis <zhonghui.shi@intel.com>
+---
+ core/api/system-current.txt                   |  2 +-
+ .../hardware/display/ColorDisplayManager.java |  4 +-
+ .../SettingsProvider/res/values/defaults.xml  |  2 +-
+ .../display/color/ColorDisplayService.java    | 86 +++++++++++++++++++
+ 4 files changed, 90 insertions(+), 4 deletions(-)
+
+diff --git a/core/api/system-current.txt b/core/api/system-current.txt
+index 1c9ad9248ef3..caf5aff233f3 100644
+--- a/core/api/system-current.txt
++++ b/core/api/system-current.txt
+@@ -3259,7 +3259,7 @@ package android.hardware.display {
+     method @RequiresPermission(android.Manifest.permission.CONTROL_DISPLAY_COLOR_TRANSFORMS) public boolean setNightDisplayCustomEndTime(@NonNull java.time.LocalTime);
+     method @RequiresPermission(android.Manifest.permission.CONTROL_DISPLAY_COLOR_TRANSFORMS) public boolean setNightDisplayCustomStartTime(@NonNull java.time.LocalTime);
+     method @RequiresPermission(android.Manifest.permission.CONTROL_DISPLAY_COLOR_TRANSFORMS) public boolean setSaturationLevel(@IntRange(from=0, to=100) int);
+-    method @RequiresPermission(android.Manifest.permission.CONTROL_DISPLAY_COLOR_TRANSFORMS) public boolean setWhitebalanceLevel(@IntRange(from=0, to=100) int);
++    method @RequiresPermission(android.Manifest.permission.CONTROL_DISPLAY_COLOR_TRANSFORMS) public boolean setWhitebalanceLevel(@IntRange(from=0, to=200) int);
+     field public static final int AUTO_MODE_CUSTOM_TIME = 1; // 0x1
+     field public static final int AUTO_MODE_DISABLED = 0; // 0x0
+     field public static final int AUTO_MODE_TWILIGHT = 2; // 0x2
+diff --git a/core/java/android/hardware/display/ColorDisplayManager.java b/core/java/android/hardware/display/ColorDisplayManager.java
+index afaaaea5eed5..d3bcf6a65edf 100644
+--- a/core/java/android/hardware/display/ColorDisplayManager.java
++++ b/core/java/android/hardware/display/ColorDisplayManager.java
+@@ -420,13 +420,13 @@ public final class ColorDisplayManager {
+     /**
+      * Set the level of color Whitebalance to apply to the display.
+      *
+-     * @param setWhitebalanceLevel 0-100 (inclusive), where 100 is full Whitebalance
++     * @param setWhitebalanceLevel 0-200 (inclusive), where 100 is full Whitebalance
+      * @return whether the Whitebalance level change was applied successfully
+      * @hide
+      */
+     @SystemApi
+     @RequiresPermission(Manifest.permission.CONTROL_DISPLAY_COLOR_TRANSFORMS)
+-    public boolean setWhitebalanceLevel(@IntRange(from = 0, to = 100) int whitebalanceLevel) {
++    public boolean setWhitebalanceLevel(@IntRange(from = 0, to = 200) int whitebalanceLevel) {
+         return mManager.setWhitebalanceLevel(whitebalanceLevel);
+     }
+ 
+diff --git a/packages/SettingsProvider/res/values/defaults.xml b/packages/SettingsProvider/res/values/defaults.xml
+index 652c7fe199df..d2db0d1c850b 100644
+--- a/packages/SettingsProvider/res/values/defaults.xml
++++ b/packages/SettingsProvider/res/values/defaults.xml
+@@ -39,7 +39,7 @@
+     <integer name="def_screen_contrast">128</integer>
+     <!-- Default screen luminance,  from 0 to 255.  128 is 50%. -->
+     <integer name="def_screen_luminance">128</integer>
+-    <!-- Default screen whitebalance, from 0 to 100.  100 is 100%. -->
++    <!-- Default screen whitebalance, from 0 to 200.  100 is 100%. -->
+     <integer name="def_screen_whitebalance">100</integer>
+     <bool name="def_screen_brightness_automatic_mode">false</bool>
+     <fraction name="def_window_animation_scale">100%</fraction>
+diff --git a/services/core/java/com/android/server/display/color/ColorDisplayService.java b/services/core/java/com/android/server/display/color/ColorDisplayService.java
+index b8dcacfec9ff..35ceef4f9698 100644
+--- a/services/core/java/com/android/server/display/color/ColorDisplayService.java
++++ b/services/core/java/com/android/server/display/color/ColorDisplayService.java
+@@ -25,6 +25,7 @@ import static android.hardware.display.ColorDisplayManager.COLOR_MODE_NATURAL;
+ import static android.hardware.display.ColorDisplayManager.COLOR_MODE_SATURATED;
+ import static android.hardware.display.ColorDisplayManager.VENDOR_COLOR_MODE_RANGE_MAX;
+ import static android.hardware.display.ColorDisplayManager.VENDOR_COLOR_MODE_RANGE_MIN;
++import android.provider.Settings;
+ 
+ import static com.android.server.display.color.DisplayTransformManager.LEVEL_COLOR_MATRIX_NIGHT_DISPLAY;
+ 
+@@ -132,6 +133,11 @@ public final class ColorDisplayService extends SystemService {
+     private static final int MIN_COLOR_TEMPERATURE = 4000;
+     private static final int WHITE_BALANCE_SCALE = 20;
+ 
++    private static final int DEFAULT_CONTRAST_LEVEL = 128;
++    private static final int DEFAULT_HUE_LEVEL = 180;
++    private static final int DEFAULT_SATURATION_LEVEL = 50;
++    private static final int DEFAULT_WHITEBALANCE_LEVEL = 100;
++    private static final int DEFAULT_LUMINANCE_LEVEL = 128;
+     /**
+      * Return value if a setting has not been set.
+      */
+@@ -466,6 +472,86 @@ public final class ColorDisplayService extends SystemService {
+                 mHandler.sendEmptyMessage(MSG_APPLY_REDUCE_BRIGHT_COLORS);
+             }
+         }
++        setContrastInitial();    
++        setHueInitial();
++        setSaturationInitial();
++        setWhitebalanceInitial();
++        setLuminanceInitial();
++    }
++
++    void setContrastInitial() {
++        int contrastValue;
++        try {
++            contrastValue = Settings.System.getIntForUser(getContext().getContentResolver(), Settings.System.SCREEN_CONTRAST, UserHandle.myUserId());
++        } catch (Settings.SettingNotFoundException e){
++            contrastValue = DEFAULT_CONTRAST_LEVEL;
++        }
++        final long token = Binder.clearCallingIdentity();
++        try {
++            setContrastLevelInternal(contrastValue);
++        } finally {
++            Binder.restoreCallingIdentity(token);
++        }
++    }
++
++    void setHueInitial() {
++        int hueValue;
++        try {
++            hueValue = Settings.System.getIntForUser(getContext().getContentResolver(), Settings.System.SCREEN_HUE, UserHandle.myUserId());
++        } catch (Settings.SettingNotFoundException e){
++            hueValue = DEFAULT_HUE_LEVEL;
++        }
++        final long token = Binder.clearCallingIdentity();
++        try {
++            setHueLevelInternal(hueValue);
++        } finally {
++            Binder.restoreCallingIdentity(token);
++        }
++    }
++
++    void setSaturationInitial() {
++        int saturationValue ;
++        try {
++            saturationValue  = Settings.System.getIntForUser(getContext().getContentResolver(), Settings.System.SCREEN_SATURATION, UserHandle.myUserId());
++        } catch (Settings.SettingNotFoundException e){
++            saturationValue  = DEFAULT_SATURATION_LEVEL;
++        }
++        final long token = Binder.clearCallingIdentity();
++        try {
++            setSaturationLevelInternal(saturationValue );
++        } finally {
++            Binder.restoreCallingIdentity(token);
++        }
++    }
++
++    void setWhitebalanceInitial() {
++        int whitebalanceValue;
++        try {
++            whitebalanceValue = Settings.System.getIntForUser(getContext().getContentResolver(), Settings.System.SCREEN_WHITEBALANCE, UserHandle.myUserId());
++        } catch (Settings.SettingNotFoundException e){
++            whitebalanceValue = DEFAULT_WHITEBALANCE_LEVEL;
++        }
++        final long token = Binder.clearCallingIdentity();
++        try {
++            setWhitebalanceLevelInternal(whitebalanceValue);
++        } finally {
++            Binder.restoreCallingIdentity(token);
++        }
++    }
++
++    void setLuminanceInitial() {
++        int luminanceValue;
++        try {
++            luminanceValue = Settings.System.getIntForUser(getContext().getContentResolver(), Settings.System.SCREEN_LUMINANCE, UserHandle.myUserId());
++        } catch (Settings.SettingNotFoundException e){
++            luminanceValue = DEFAULT_LUMINANCE_LEVEL;
++        }
++        final long token = Binder.clearCallingIdentity();
++        try {
++            setLuminanceLevelInternal(luminanceValue);
++        } finally {
++            Binder.restoreCallingIdentity(token);
++        }
+     }
+ 
+     private void tearDown() {
+-- 
+2.34.1
+

--- a/aosp_diff/base_aaos/packages/apps/Car/Settings/07_0007-Update-white-balance-default-value.patch
+++ b/aosp_diff/base_aaos/packages/apps/Car/Settings/07_0007-Update-white-balance-default-value.patch
@@ -1,0 +1,40 @@
+From c675cd6c20b63a4b95c5356bbbb24dfd9bb741d4 Mon Sep 17 00:00:00 2001
+From: zhonghuis <zhonghui.shi@intel.com>
+Date: Tue, 2 Apr 2024 17:22:39 +0000
+Subject: [PATCH] Update white balance default value
+
+Test:
+
+Tracked-On:
+Signed-off-by: zhonghuis <zhonghui.shi@intel.com>
+---
+ .../display/WhitebalanceLevelPreferenceController.java      | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/com/android/car/settings/display/WhitebalanceLevelPreferenceController.java b/src/com/android/car/settings/display/WhitebalanceLevelPreferenceController.java
+index 233c3f830..c1887aaa9 100644
+--- a/src/com/android/car/settings/display/WhitebalanceLevelPreferenceController.java
++++ b/src/com/android/car/settings/display/WhitebalanceLevelPreferenceController.java
+@@ -53,8 +53,8 @@ public class WhitebalanceLevelPreferenceController extends PreferenceController<
+     private ColorDisplayManager mColorDisplayManager;
+     private final int mMaximumWhitebalance = 65535;
+     private final int mMinimumWhitebalance = 0;
+-    private final int mDefaultWhitebalanceLevel = 255;
+-    private final int mMaxWhitebalanceLevel = 255;
++    private final int mDefaultWhitebalanceLevel = 100;
++    private final int mMaxWhitebalanceLevel = 200;
+     public static WhitebalanceLevelPreferenceController mWhitebalanceInstance;
+     private final Handler mHandler = new Handler(Looper.getMainLooper());
+ 
+@@ -129,7 +129,7 @@ public class WhitebalanceLevelPreferenceController extends PreferenceController<
+         int linear = convertGammaToLinear(gamma, mMinimumWhitebalance, mMaximumWhitebalance);
+         Settings.System.putIntForUser(getContext().getContentResolver(),
+                 Settings.System.SCREEN_WHITEBALANCE, linear, UserHandle.myUserId());
+-        int whitebalanceLevel = gamma * 100/65535;
++        int whitebalanceLevel = gamma * mMaxWhitebalanceLevel/65535;
+         mColorDisplayManager.setDisplayWhiteBalanceEnabled(true);
+         mColorDisplayManager.setWhitebalanceLevel(whitebalanceLevel);
+         return true;
+-- 
+2.34.1
+


### PR DESCRIPTION
Setup color transform reboot to restore
the display's color transform setting,
and update the default value for white
balance

Test:

Tracked-On: