### PR TITLE
Port required Utils One image patches to Android-14

### DIFF
--- a/aosp_diff/preliminary/build/soong/0007-Add-support-for-overide_lib_name-for-IA-perf-variant.patch
+++ b/aosp_diff/preliminary/build/soong/0007-Add-support-for-overide_lib_name-for-IA-perf-variant.patch
@@ -1,24 +1,22 @@
-From e72146e3ca0ebb37c0e78f8ea2bf4fb3da56455f Mon Sep 17 00:00:00 2001
+From 5928b8b0c0bd38c669f2c0abfa21354bea31be72 Mon Sep 17 00:00:00 2001
 From: bodapati <shalini.salomi.bodapati@intel.com>
-Date: Mon, 26 Apr 2021 14:24:42 +0530
+Date:  Mon, 26 Apr 2021 14:24:42 +0530
 Subject: [PATCH] Add support for overide_lib_name for IA perf variants of a
  library
 
-Change-Id: If803bfd12181fc9c32585252b71a182326255549
-Tracked-On: OAM-95425
 Signed-off-by: bodapati <shalini.salomi.bodapati@intel.com>
 ---
  android/module.go | 5 +++++
  cc/cc.go          | 5 +++++
  cc/library.go     | 5 +++++
- cc/vndk.go        | 2 ++
- 4 files changed, 17 insertions(+)
+ cc/vndk.go        | 4 +++-
+ 4 files changed, 18 insertions(+), 1 deletion(-)
 
 diff --git a/android/module.go b/android/module.go
-index 7285a2f21..bab47a252 100644
+index ba474530d..a434baf91 100644
 --- a/android/module.go
 +++ b/android/module.go
-@@ -678,6 +678,7 @@ func SortedUniqueNamedPaths(l NamedPaths) NamedPaths {
+@@ -713,6 +713,7 @@ func SortedUniqueNamedPaths(l NamedPaths) NamedPaths {
  type nameProperties struct {
  	// The name of the module.  Must be unique across all modules.
  	Name *string
@@ -26,7 +24,7 @@ index 7285a2f21..bab47a252 100644
  }
  
  type commonProperties struct {
-@@ -1644,6 +1645,10 @@ func (m *ModuleBase) BaseModuleName() string {
+@@ -1766,6 +1767,10 @@ func (m *ModuleBase) BaseModuleName() string {
  	return String(m.nameProperties.Name)
  }
  
@@ -38,10 +36,10 @@ index 7285a2f21..bab47a252 100644
  	return m
  }
 diff --git a/cc/cc.go b/cc/cc.go
-index 456b73628..74a8c3bc8 100644
+index 0addb60b4..73e3e2fd4 100644
 --- a/cc/cc.go
 +++ b/cc/cc.go
-@@ -504,6 +504,7 @@ type ModuleContextIntf interface {
+@@ -513,6 +513,7 @@ type ModuleContextIntf interface {
  	inRecovery() bool
  	selectedStl() string
  	baseModuleName() string
@@ -49,7 +47,7 @@ index 456b73628..74a8c3bc8 100644
  	getVndkExtendsModuleName() string
  	isAfdoCompile() bool
  	isPgoCompile() bool
-@@ -1598,6 +1599,10 @@ func (ctx *moduleContextImpl) baseModuleName() string {
+@@ -1687,6 +1688,10 @@ func (ctx *moduleContextImpl) baseModuleName() string {
  	return ctx.mod.ModuleBase.BaseModuleName()
  }
  
@@ -61,10 +59,10 @@ index 456b73628..74a8c3bc8 100644
  	return ctx.mod.getVndkExtendsModuleName()
  }
 diff --git a/cc/library.go b/cc/library.go
-index f9bef6c5e..6d2f43935 100644
+index 7051f723c..9981179f8 100644
 --- a/cc/library.go
 +++ b/cc/library.go
-@@ -1177,6 +1177,11 @@ func (library *libraryDecorator) getLibNameHelper(baseModuleName string, inVendo
+@@ -1431,6 +1431,11 @@ func (library *libraryDecorator) getLibNameHelper(baseModuleName string, inVendo
  // getLibName returns the actual canonical name of the library (the name which
  // should be passed to the linker via linker flags).
  func (library *libraryDecorator) getLibName(ctx BaseModuleContext) string {
@@ -77,18 +75,20 @@ index f9bef6c5e..6d2f43935 100644
  
  	if ctx.IsVndkExt() {
 diff --git a/cc/vndk.go b/cc/vndk.go
-index bf6148b1c..ea3e2060c 100644
+index 9b70004c5..a0c8931c1 100644
 --- a/cc/vndk.go
 +++ b/cc/vndk.go
-@@ -698,6 +698,8 @@ func (c *vndkSnapshotSingleton) GenerateBuildActions(ctx android.SingletonContex
+@@ -706,7 +706,9 @@ func (c *vndkSnapshotSingleton) GenerateBuildActions(ctx android.SingletonContex
  		}
  
  		libPath := m.outputFile.Path()
+-		snapshotLibOut := filepath.Join(snapshotArchDir, targetArch, "shared", vndkType, libPath.Base())
 +		qualifiedLibName := m.RelativeInstallPath()
 +                qualifiedLibName = filepath.Join(qualifiedLibName, libPath.Base())
- 		snapshotLibOut := filepath.Join(snapshotArchDir, targetArch, "shared", vndkType, libPath.Base())
++		snapshotLibOut := filepath.Join(snapshotArchDir, targetArch, "shared", vndkType, qualifiedLibName)
  		ret = append(ret, snapshot.CopyFileRule(pctx, ctx, libPath, snapshotLibOut))
  
+ 		// json struct to export snapshot information
 -- 
-2.37.1
+2.17.1
 

--- a/aosp_diff/preliminary/build/soong/0009-Filterout-isa-perf-libraries-from-vndk-list.patch
+++ b/aosp_diff/preliminary/build/soong/0009-Filterout-isa-perf-libraries-from-vndk-list.patch
@@ -1,0 +1,49 @@
+From cd3b13e0103045310ace4b02d9c4f88e6e14d71c Mon Sep 17 00:00:00 2001
+From: "Reddy, Alavala Srinivasa" <alavala.srinivasa.reddy@intel.com>
+Date: Fri, 10 Nov 2023 14:49:06 +0530
+Subject: [PATCH] Filterout isa perf libraries from vndk list
+
+Currently we have added perf libs under vndksp,
+filter them out as they are not new libraries,
+rather avx2 implementations of existing libraries.
+Should have no impact on GSI.
+
+Signed-off-by: bodapati <shalini.salomi.bodapati@intel.com>
+---
+ cc/vndk.go | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/cc/vndk.go b/cc/vndk.go
+index bb96548e2..3e32e8691 100644
+--- a/cc/vndk.go
++++ b/cc/vndk.go
+@@ -871,6 +871,15 @@ func getVndkFileName(m *Module) (string, error) {
+ 	return "", fmt.Errorf("VNDK library should have libraryDecorator or prebuiltLibraryLinker as linker: %T", m.linker)
+ }
+ 
++func filterOutAvxLibs(libList []string) (filtered []string) {
++               for _, lib := range libList {
++                       if !strings.Contains(lib, "_avx2.") {
++                               filtered = append(filtered, lib)
++                       }
++               }
++               return
++       }
++
+ func (c *vndkSnapshotSingleton) buildVndkLibrariesTxtFiles(ctx android.SingletonContext) {
+ 	// Build list of vndk libs as merged & tagged & filter-out(libclang_rt):
+ 	// Since each target have different set of libclang_rt.* files,
+@@ -882,7 +891,9 @@ func (c *vndkSnapshotSingleton) buildVndkLibrariesTxtFiles(ctx android.Singleton
+ 	_, vndkproduct := vndkModuleListRemover(vndkProductLibraries, "libclang_rt.")(ctx)
+ 	var merged []string
+ 	merged = append(merged, addPrefix(llndk, "LLNDK: ")...)
+-	merged = append(merged, addPrefix(vndksp, "VNDK-SP: ")...)
++      	// Currently we have added perf libs under vndksp, filter them out as they are not new libraries,
++       	// rather avx implementations of existing libraries. Should have no impact on GSI
++        merged = append(merged, addPrefix(filterOutAvxLibs(vndksp), "VNDK-SP: ")...)
+ 	merged = append(merged, addPrefix(vndkcore, "VNDK-core: ")...)
+ 	merged = append(merged, addPrefix(vndkprivate, "VNDK-private: ")...)
+ 	merged = append(merged, addPrefix(vndkproduct, "VNDK-product: ")...)
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/frameworks/av/0004-Generate-avx2-version-of-libaudioprocessing-library.patch
+++ b/aosp_diff/preliminary/frameworks/av/0004-Generate-avx2-version-of-libaudioprocessing-library.patch
@@ -1,0 +1,100 @@
+From f686fb2429d3bbf05217d8ddfb911e52fa94a643 Mon Sep 17 00:00:00 2001
+From: "Reddy, Alavala Srinivasa" <alavala.srinivasa.reddy@intel.com>
+Date: Fri, 10 Nov 2023 15:41:31 +0530
+Subject: [PATCH] Generate avx2 version of libaudioprocessing library
+
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ media/libaudioprocessing/Android.bp | 54 +++++++++++++++++++----------
+ 1 file changed, 36 insertions(+), 18 deletions(-)
+
+diff --git a/media/libaudioprocessing/Android.bp b/media/libaudioprocessing/Android.bp
+index 309765aeb8..9a5272db64 100644
+--- a/media/libaudioprocessing/Android.bp
++++ b/media/libaudioprocessing/Android.bp
+@@ -28,29 +28,22 @@ cc_defaults {
+         // uncomment to disable NEON on architectures that actually do support NEON, for benchmarking
+         // "-DUSE_NEON=false",
+     ],
++}
+ 
++cc_defaults {
++    name: "libaudioprocessing_defaults_avx2",
+     arch: {
+         x86: {
+-            avx2: {
+-                cflags: [
+-                    "-mavx2",
+-                    "-mfma",
+-                ],
+-            },
++           cflags: [ "-mavx2", "-mfma"],
+         },
+         x86_64: {
+-            avx2: {
+-                cflags: [
+-                    "-mavx2",
+-                    "-mfma",
+-                ],
+-            },
++           cflags: [ "-mavx2", "-mfma"],
+         },
+     },
+ }
+ 
+-cc_library_shared {
+-    name: "libaudioprocessing",
++cc_defaults {
++    name: "libaudioprocessing_generic",
+     defaults: ["libaudioprocessing_defaults"],
+ 
+     srcs: [
+@@ -70,12 +63,10 @@ cc_library_shared {
+         "libsonic",
+         "libvibrator",
+     ],
+-
+-    whole_static_libs: ["libaudioprocessing_base"],
+ }
+ 
+-cc_library_static {
+-    name: "libaudioprocessing_base",
++cc_defaults {
++    name: "libaudioprocessing_base_generic",
+     defaults: ["libaudioprocessing_defaults"],
+     vendor_available: true,
+ 
+@@ -93,3 +84,30 @@ cc_library_static {
+         },
+     },
+ }
++
++cc_library_static {
++   name: "libaudioprocessing_base",
++   defaults: ["libaudioprocessing_base_generic"],
++}
++
++cc_library_static {
++   name: "libaudioprocessing_base_avx2",
++   defaults: ["libaudioprocessing_base_generic", "libaudioprocessing_defaults_avx2"],
++}
++
++cc_library_shared {
++   name: "libaudioprocessing",
++   defaults: ["libaudioprocessing_generic"],
++   whole_static_libs: ["libaudioprocessing_base"],
++}
++
++cc_library_shared {
++   name: "libaudioprocessing_avx2",
++   defaults: ["libaudioprocessing_generic", "libaudioprocessing_defaults_avx2"],
++   target: {
++       android: {
++          relative_install_path: "IA-Perf/avx2",
++       },
++   },
++   whole_static_libs: ["libaudioprocessing_base_avx2"],
++}
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/frameworks/av/0005-Modify-IA-Perf-variants-of-library-to-have-same-name.patch
+++ b/aosp_diff/preliminary/frameworks/av/0005-Modify-IA-Perf-variants-of-library-to-have-same-name.patch
@@ -1,0 +1,32 @@
+From 114bfc94102c558460009f058a22cd9572951425 Mon Sep 17 00:00:00 2001
+From: "Reddy, Alavala Srinivasa" <alavala.srinivasa.reddy@intel.com>
+Date: Fri, 10 Nov 2023 15:42:55 +0530
+Subject: [PATCH] Modify IA-Perf variants of library to have same name as
+ original
+
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ media/libaudioprocessing/Android.bp | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
+diff --git a/media/libaudioprocessing/Android.bp b/media/libaudioprocessing/Android.bp
+index 9a5272db64..b5b2177619 100644
+--- a/media/libaudioprocessing/Android.bp
++++ b/media/libaudioprocessing/Android.bp
+@@ -103,11 +103,8 @@ cc_library_shared {
+ 
+ cc_library_shared {
+    name: "libaudioprocessing_avx2",
++   override_lib_name: "libaudioprocessing",
+    defaults: ["libaudioprocessing_generic", "libaudioprocessing_defaults_avx2"],
+-   target: {
+-       android: {
+-          relative_install_path: "IA-Perf/avx2",
+-       },
+-   },
++   relative_install_path: "IA-Perf/avx2",
+    whole_static_libs: ["libaudioprocessing_base_avx2"],
+ }
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/frameworks/rs/0001-Generate-avx2-version-of-libRSCpuRef.so.patch
+++ b/aosp_diff/preliminary/frameworks/rs/0001-Generate-avx2-version-of-libRSCpuRef.so.patch
@@ -1,0 +1,62 @@
+From ecad322d261be38f7fe2e62d59dfb3d1dfb3b0bf Mon Sep 17 00:00:00 2001
+From: "Reddy, Alavala Srinivasa" <alavala.srinivasa.reddy@intel.com>
+Date: Fri, 10 Nov 2023 13:00:58 +0530
+Subject: [PATCH] Generate avx2 version of libRSCpuRef.so
+
+Signed-off-by: Shalini Salomi Bodapati <shalini.salomi.bodapati@intel.com>
+---
+ cpu_ref/Android.bp | 27 ++++++++++++++++++++++-----
+ 1 file changed, 22 insertions(+), 5 deletions(-)
+
+diff --git a/cpu_ref/Android.bp b/cpu_ref/Android.bp
+index 32146e03..334b8751 100644
+--- a/cpu_ref/Android.bp
++++ b/cpu_ref/Android.bp
+@@ -2,8 +2,8 @@ package {
+     default_applicable_licenses: ["Android-Apache-2.0"],
+ }
+ 
+-cc_library_shared {
+-    name: "libRSCpuRef",
++cc_defaults {
++    name: "libRSCpuRef_generic",
+     defaults: ["libbcc-targets"],
+     vendor_available: true,
+     native_bridge_supported: true,
+@@ -84,9 +84,6 @@ cc_library_shared {
+         x86_64: {
+             cflags: ["-DARCH_X86_HAVE_SSSE3"],
+             srcs: ["rsCpuIntrinsics_x86.cpp"],
+-	    avx2: {
+-                cflags: ["-DARCH_X86_HAVE_AVX2", "-mavx2", "-mfma"],
+-            },
+         },
+         riscv64: {
+             enabled: false,
+@@ -129,3 +126,23 @@ cc_library_shared {
+         },
+     },
+ }
++
++cc_library_shared {
++   name: "libRSCpuRef",
++   defaults: ["libRSCpuRef_generic"],
++}
++
++cc_library_shared {
++   name: "libRSCpuRef_avx2",
++   defaults: ["libRSCpuRef_generic"],
++   target: {
++       android: {
++          relative_install_path: "IA-Perf/avx2",
++       },
++   },
++   arch: {
++      x86_64: {
++         cflags: ["-DARCH_X86_HAVE_AVX2", "-mavx2", "-mfma"],
++      },
++   }
++}
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/frameworks/rs/0002-Modify-IA-Perf-variants-of-library-to-have-same-name.patch
+++ b/aosp_diff/preliminary/frameworks/rs/0002-Modify-IA-Perf-variants-of-library-to-have-same-name.patch
@@ -1,0 +1,33 @@
+From 2750e9d363cd3c4a14517c626a187cf3163c93ae Mon Sep 17 00:00:00 2001
+From: "Reddy, Alavala Srinivasa" <alavala.srinivasa.reddy@intel.com>
+Date: Fri, 10 Nov 2023 15:48:00 +0530
+Subject: [PATCH] Modify IA-Perf variants of library to have same name as
+ original
+
+Signed-off-by: ahs <amrita.h.s@intel.com>
+---
+ cpu_ref/Android.bp | 7 ++-----
+ 1 file changed, 2 insertions(+), 5 deletions(-)
+
+diff --git a/cpu_ref/Android.bp b/cpu_ref/Android.bp
+index 334b8751..3c7b1bba 100644
+--- a/cpu_ref/Android.bp
++++ b/cpu_ref/Android.bp
+@@ -134,12 +134,9 @@ cc_library_shared {
+ 
+ cc_library_shared {
+    name: "libRSCpuRef_avx2",
++   override_lib_name: "libRSCpuRef",
++   relative_install_path: "IA-Perf/avx2",
+    defaults: ["libRSCpuRef_generic"],
+-   target: {
+-       android: {
+-          relative_install_path: "IA-Perf/avx2",
+-       },
+-   },
+    arch: {
+       x86_64: {
+          cflags: ["-DARCH_X86_HAVE_AVX2", "-mavx2", "-mfma"],
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/packages/modules/NeuralNetworks/0001-Generate-avx2-versions-of-libnueralnetworks.so.patch
+++ b/aosp_diff/preliminary/packages/modules/NeuralNetworks/0001-Generate-avx2-versions-of-libnueralnetworks.so.patch
@@ -1,0 +1,102 @@
+From 2d6e46c2620636456dac4c78f8ab804d9ec53a3d Mon Sep 17 00:00:00 2001
+From: "Reddy, Alavala Srinivasa" <alavala.srinivasa.reddy@intel.com>
+Date: Fri, 10 Nov 2023 10:12:50 +0530
+Subject: [PATCH] Generate avx2 versions of libnueralnetworks.so
+
+Signed-off-by: bodapati <shalini.salomi.bodapati@intel.com>
+---
+ Android.bp         | 18 ------------------
+ apex/Android.bp    |  1 +
+ runtime/Android.bp | 28 ++++++++++++++++++++++++++--
+ 3 files changed, 27 insertions(+), 20 deletions(-)
+
+diff --git a/Android.bp b/Android.bp
+index 072045506..67f935aac 100644
+--- a/Android.bp
++++ b/Android.bp
+@@ -43,24 +43,6 @@ cc_defaults {
+         "-Werror",
+         "-Wextra",
+     ],
+-    arch: {
+-        x86: {
+-            avx2: {
+-                cflags: [
+-                    "-mavx2",
+-                    "-mfma",
+-                ],
+-            },
+-        },
+-        x86_64: {
+-            avx2: {
+-                cflags: [
+-                    "-mavx2",
+-                    "-mfma",
+-                ],
+-            },
+-        },
+-    },
+     product_variables: {
+         debuggable: { // eng and userdebug builds
+             cflags: ["-DNN_DEBUGGABLE"],
+diff --git a/apex/Android.bp b/apex/Android.bp
+index 464419a82..89eecb3ac 100644
+--- a/apex/Android.bp
++++ b/apex/Android.bp
+@@ -43,6 +43,7 @@ apex_defaults {
+     androidManifest: ":com.android.neuralnetworks-androidManifest",
+     native_shared_libs: [
+         "libneuralnetworks",
++        "libneuralnetworks_avx2",
+     ],
+     compile_multilib: "both",
+     key: "com.android.neuralnetworks.key",
+diff --git a/runtime/Android.bp b/runtime/Android.bp
+index 21ec0b9af..5bb127fb1 100644
+--- a/runtime/Android.bp
++++ b/runtime/Android.bp
+@@ -199,8 +199,8 @@ cc_defaults {
+     ],
+ }
+ 
+-cc_library_shared {
+-    name: "libneuralnetworks",
++cc_defaults {
++    name: "libneuralnetworks_generic",
+     llndk: {
+         symbol_file: "libneuralnetworks.map.txt",
+         override_export_include_dirs: ["include"],
+@@ -223,6 +223,30 @@ cc_library_shared {
+     },
+ }
+ 
++cc_library_shared {
++    name: "libneuralnetworks",
++    defaults: ["libneuralnetworks_generic"],
++}
++
++cc_library_shared {
++    name: "libneuralnetworks_avx2",
++    defaults: ["libneuralnetworks_generic"],
++    min_sdk_version: "30",
++    arch: {
++        x86: {
++           cflags: [ "-mavx2", "-mfma", ],
++        },
++        x86_64: {
++           cflags: [ "-mavx2", "-mfma", ],
++        },
++    },
++    target: {
++       android: {
++          relative_install_path: "IA-Perf/avx2",
++       },
++    },
++}
++
+ // Required for tests (b/147158681)
+ cc_library_static {
+     name: "libneuralnetworks_static",
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/packages/modules/NeuralNetworks/0002-Modify-IA-perf-variant-of-library-to-have-same-name-.patch
+++ b/aosp_diff/preliminary/packages/modules/NeuralNetworks/0002-Modify-IA-perf-variant-of-library-to-have-same-name-.patch
@@ -1,0 +1,40 @@
+From 3283deef32d389ca59a27a57f68d6a06ef80b22b Mon Sep 17 00:00:00 2001
+From: "Reddy, Alavala Srinivasa" <alavala.srinivasa.reddy@intel.com>
+Date: Thu, 23 Nov 2023 21:12:44 +0530
+Subject: [PATCH] Modify IA perf variant of library to have same name as
+ original
+
+Signed-off-by: bodapati <shalini.salomi.bodapati@intel.com>
+---
+ runtime/Android.bp | 8 +++-----
+ 1 file changed, 3 insertions(+), 5 deletions(-)
+
+diff --git a/runtime/Android.bp b/runtime/Android.bp
+index 5bb127fb1..0f27228b1 100644
+--- a/runtime/Android.bp
++++ b/runtime/Android.bp
+@@ -230,6 +230,9 @@ cc_library_shared {
+ 
+ cc_library_shared {
+     name: "libneuralnetworks_avx2",
++    host_supported: false,
++    override_lib_name: "libneuralnetworks",
++    relative_install_path: "IA-Perf/avx2",
+     defaults: ["libneuralnetworks_generic"],
+     min_sdk_version: "30",
+     arch: {
+@@ -240,11 +243,6 @@ cc_library_shared {
+            cflags: [ "-mavx2", "-mfma", ],
+         },
+     },
+-    target: {
+-       android: {
+-          relative_install_path: "IA-Perf/avx2",
+-       },
+-    },
+ }
+ 
+ // Required for tests (b/147158681)
+-- 
+2.17.1
+

--- a/aosp_diff/preliminary/system/linkerconfig/02_0002-Config-changes-to-prefer-perf-variants-of-an-.so.patch
+++ b/aosp_diff/preliminary/system/linkerconfig/02_0002-Config-changes-to-prefer-perf-variants-of-an-.so.patch
@@ -1,0 +1,176 @@
+From 3e7e775d55c0bc7786646210fc6bbabd18f1b75b Mon Sep 17 00:00:00 2001
+From: "Reddy, Alavala Srinivasa" <alavala.srinivasa.reddy@intel.com>
+Date: Fri, 10 Nov 2023 09:14:04 +0530
+Subject: [PATCH] Config changes to prefer perf variants of an .so
+
+This patch introduces changes in linkerconfig to
+prefer perf variants of an .so in searchpaths.
+Enables us to have One-image catering to multiple
+IA CPUs which may or may not support all ISA features.
+Example: Pentium SKUs dont support AVX.
+
+Signed-off-by: Vinay Kompella <vinay.kompella@intel.com>
+---
+ contents/namespace/rs.cc                   |  6 ++++++
+ contents/namespace/systemdefault.cc        |  7 +++++++
+ contents/namespace/vndk.cc                 |  6 ++++++
+ modules/environment.cc                     | 21 +++++++++++++++++++++
+ modules/include/linkerconfig/environment.h |  2 ++
+ modules/namespace.cc                       | 10 ++++++++++
+ 6 files changed, 52 insertions(+)
+
+diff --git a/contents/namespace/rs.cc b/contents/namespace/rs.cc
+index c360555..58e2aae 100644
+--- a/contents/namespace/rs.cc
++++ b/contents/namespace/rs.cc
+@@ -19,6 +19,7 @@
+ // the genuine characteristics of Renderscript; /data is in the permitted path
+ // to load the compiled *.so file and libmediandk.so can be used here.
+ 
++#include "linkerconfig/environment.h"
+ #include "linkerconfig/namespacebuilder.h"
+ 
+ #include <android-base/strings.h>
+@@ -34,6 +35,11 @@ Namespace BuildRsNamespace([[maybe_unused]] const Context& ctx) {
+ 
+   ns.AddSearchPath("/odm/${LIB}/vndk-sp");
+   ns.AddSearchPath("/vendor/${LIB}/vndk-sp");
++  if (modules::PlatformSupportsISAFeature("avx2")) {
++	ns.AddSearchPath("/apex/com.android.vndk.v" + Var("VENDOR_VNDK_VERSION") + 
++	"/${LIB}" +
++	modules::GetSearchPathForISAFeature("avx2"));
++  }
+   ns.AddSearchPath("/apex/com.android.vndk.v" + Var("VENDOR_VNDK_VERSION") +
+                    "/${LIB}");
+   ns.AddSearchPath("/odm/${LIB}");
+diff --git a/contents/namespace/systemdefault.cc b/contents/namespace/systemdefault.cc
+index 4826637..a94b956 100644
+--- a/contents/namespace/systemdefault.cc
++++ b/contents/namespace/systemdefault.cc
+@@ -77,6 +77,10 @@ void SetupSystemPermittedPaths(Namespace* ns) {
+       "/vendor/${LIB}/arm/nb",
+   };
+ 
++  if (modules::PlatformSupportsISAFeature("avx2")) {
++    ns->AddPermittedPath("/system/${LIB}" + modules::GetSearchPathForISAFeature("avx2"));
++  }
++
+   for (const std::string& path : permitted_paths) {
+     ns->AddPermittedPath(path);
+   }
+@@ -97,6 +101,9 @@ Namespace BuildSystemDefaultNamespace([[maybe_unused]] const Context& ctx) {
+                /*is_isolated=*/is_fully_treblelized,
+                /*is_visible=*/true);
+ 
++  if (modules::PlatformSupportsISAFeature("avx2")) {
++    ns.AddSearchPath("/system/${LIB}" + modules::GetSearchPathForISAFeature("avx2"));
++  }
+   ns.AddSearchPath("/system/${LIB}");
+   ns.AddSearchPath(system_ext + "/${LIB}");
+   if (!IsProductVndkVersionDefined() || !is_fully_treblelized) {
+diff --git a/contents/namespace/vndk.cc b/contents/namespace/vndk.cc
+index d821eb7..13e71b4 100644
+--- a/contents/namespace/vndk.cc
++++ b/contents/namespace/vndk.cc
+@@ -78,6 +78,12 @@ Namespace BuildVndkNamespace([[maybe_unused]] const Context& ctx,
+     }
+   }
+ 
++  if (modules::PlatformSupportsISAFeature("avx2")) {
++    ns.AddSearchPath(
++        "/apex/com.android.vndk.v" + vndk_version + "/${LIB}" +
++         modules::GetSearchPathForISAFeature("avx2"));
++  }
++
+   // 2. VNDK APEX
+   ns.AddSearchPath("/apex/com.android.vndk.v" + vndk_version + "/${LIB}");
+ 
+diff --git a/modules/environment.cc b/modules/environment.cc
+index 82801f3..4b8c4e1 100644
+--- a/modules/environment.cc
++++ b/modules/environment.cc
+@@ -23,6 +23,9 @@
+ namespace android {
+ namespace linkerconfig {
+ namespace modules {
++
++static int kPlatformSupportsAvx2 = -1;
++
+ bool IsLegacyDevice() {
+   return !Variables::GetValue("ro.vndk.version").has_value() ||
+          Variables::GetValue("ro.treble.enabled") == "false";
+@@ -51,6 +54,24 @@ bool IsProductVndkVersionDefined() {
+ bool IsRecoveryMode() {
+   return access("/system/bin/recovery", F_OK) == 0;
+ }
++
++bool PlatformSupportsISAFeature(const char* isa_feature) {
++  if (strcmp(isa_feature, "avx2") == 0) {
++    if (kPlatformSupportsAvx2 == -1) {
++      __builtin_cpu_init();
++      kPlatformSupportsAvx2 = (__builtin_cpu_supports("avx2")) ? 1 : 0;
++    }
++    return kPlatformSupportsAvx2;
++  }
++  return false;
++}
++
++std::string GetSearchPathForISAFeature(const char* isa_feature) {
++  std::string searchPath = "/IA-Perf/";
++  searchPath += isa_feature;
++  return searchPath;
++}
++
+ }  // namespace modules
+ }  // namespace linkerconfig
+ }  // namespace android
+diff --git a/modules/include/linkerconfig/environment.h b/modules/include/linkerconfig/environment.h
+index 3aa0d32..4a4b324 100644
+--- a/modules/include/linkerconfig/environment.h
++++ b/modules/include/linkerconfig/environment.h
+@@ -26,6 +26,8 @@ std::string GetVendorVndkVersion();
+ std::string GetProductVndkVersion();
+ bool IsProductVndkVersionDefined();
+ bool IsRecoveryMode();
++bool PlatformSupportsISAFeature(const char* isa_feature);
++std::string GetSearchPathForISAFeature(const char* isa_feature);
+ }  // namespace modules
+ }  // namespace linkerconfig
+ }  // namespace android
+diff --git a/modules/namespace.cc b/modules/namespace.cc
+index 531ff3d..eead627 100644
+--- a/modules/namespace.cc
++++ b/modules/namespace.cc
+@@ -20,6 +20,7 @@
+ 
+ #include "linkerconfig/apex.h"
+ #include "linkerconfig/log.h"
++#include "linkerconfig/environment.h"
+ 
+ using android::base::Result;
+ 
+@@ -53,12 +54,21 @@ namespace linkerconfig {
+ namespace modules {
+ 
+ void InitializeWithApex(Namespace& ns, const ApexInfo& apex_info) {
++  if (PlatformSupportsISAFeature("avx2")) {
++    ns.AddSearchPath(apex_info.path + "/${LIB}" + GetSearchPathForISAFeature("avx2"));
++  }  
+   ns.AddSearchPath(apex_info.path + "/${LIB}");
++  if (PlatformSupportsISAFeature("avx2")) {
++    ns.AddPermittedPath(apex_info.path + "/${LIB}" + GetSearchPathForISAFeature("avx2"));
++  }    
+   if (apex_info.InVendor()) {
+     ns.AddSearchPath(apex_info.path + "/${LIB}/hw");
+     ns.AddSearchPath(apex_info.path + "/${LIB}/egl");
+   }
+   ns.AddPermittedPath(apex_info.path + "/${LIB}");
++  if (PlatformSupportsISAFeature("avx2")) {
++    ns.AddPermittedPath("/system/${LIB}" + GetSearchPathForISAFeature("avx2"));
++  }    
+   ns.AddPermittedPath("/system/${LIB}");
+   ns.AddPermittedPath("/system_ext/${LIB}");
+   for (const auto& permitted_path : apex_info.permitted_paths) {
+-- 
+2.17.1
+


### PR DESCRIPTION
Port required One image Optimization patches from Android-12 to Android-14.
Patches include:
        - Generate-avx2-version-of-libaudioprocessing-library
        - Generate-avx2-version-of-libRSCpuRef
        - Generate-avx2-versions-of-libnueralnetworks
        - Modify-IA-Perf-variants-of-library-to-have-same-name

Tracked-On: OAM-113540