### PR TITLE
[WA] Enabled API Level 34 and Target Level 8.

### DIFF
--- a/bsp_diff/celadon_ivi/device/intel/mixins/0001-WA-Enabled-API-Level-34-and-Target-Level-8.patch
+++ b/bsp_diff/celadon_ivi/device/intel/mixins/0001-WA-Enabled-API-Level-34-and-Target-Level-8.patch
@@ -1,0 +1,29 @@
+From ab1b776c1545e3cb2ed6a99ba719b454abcdd4c5 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Wed, 3 Apr 2024 19:11:12 +0530
+Subject: [PATCH] [WA] Enabled API Level 34 and Target Level 8.
+
+Removing gate keeper software service as it is depreceated in Android
+14.
+
+Test: Image is built successfully and booted.
+
+Tracked-On: OAM-117091
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ groups/trusty/false/product.mk | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/groups/trusty/false/product.mk b/groups/trusty/false/product.mk
+index e354253..8afff01 100644
+--- a/groups/trusty/false/product.mk
++++ b/groups/trusty/false/product.mk
+@@ -1,3 +1,4 @@
+ PRODUCT_PACKAGES += \
+-    android.hardware.gatekeeper@1.0-service.software \
+     android.hardware.security.keymint-service
++
++
+-- 
+2.17.1
+


### PR DESCRIPTION
Removing gate keeper software service as it is depreceated in Android 14.

Tests: Image is built successfully and booted.

Tracked-On: OAM-117091