### PR TITLE
Add new keymaster error code for provisioning

### DIFF
--- a/aosp_diff/base_aaos/hardware/intel/0001-Subject-PATCH-Update-GenerateAndroidMk.py-fix-compil 1.patch
+++ b/aosp_diff/base_aaos/hardware/intel/0001-Subject-PATCH-Update-GenerateAndroidMk.py-fix-compil 1.patch
@@ -1,0 +1,4560 @@
+From 2bbd4e4ca551ed3f8a53cc3b1c967824d37da73d Mon Sep 17 00:00:00 2001
+From: "zhepeng.xu" <zhepengx.xu@intel.com>
+Date: Sun, 7 Apr 2024 18:12:44 +0800
+Subject: [PATCH]  Subject: [PATCH] Update GenerateAndroidMk.py fix compile
+ issue and update tpl for  cmrt and media_driver. Add
+ 'media_add_curr_to_include_path()' to media_srcs.cmake
+
+ Tracked-On:OAM-117128
+ Signed-off-by:zhepeng.xu <zhepengx.xu@intel.com>
+---
+ .../Android/GenerateAndroidMk.py              | 65 ++++++++++++-------
+ Tools/MediaDriverTools/Android/mk/cmrt.tpl    |  4 ++
+ .../Android/mk/media_driver.tpl               | 29 +++++++--
+ .../agnostic/common/cp/media_srcs.cmake       |  3 +-
+ .../common/heap_manager/media_srcs.cmake      |  3 +-
+ .../agnostic/common/hw/media_srcs.cmake       |  3 +-
+ .../agnostic/common/hw/vdbox/media_srcs.cmake |  3 +-
+ .../common/media_interfaces/media_srcs.cmake  |  3 +-
+ .../agnostic/common/os/media_srcs.cmake       |  2 +
+ .../common/os/user_setting/media_srcs.cmake   |  3 +-
+ .../common/renderhal/media_srcs.cmake         |  3 +-
+ .../agnostic/common/shared/media_srcs.cmake   |  3 +-
+ .../agnostic/common/vp/hal/media_srcs.cmake   |  2 +
+ .../agnostic/common/vp/kdll/media_srcs.cmake  |  2 +
+ .../common/vp/kernel/media_srcs.cmake         |  3 +-
+ .../linux/common/codec/media_srcs.cmake       |  3 +-
+ .../linux/common/cp/ddi/media_srcs.cmake      |  2 +
+ .../linux/common/cp/os/media_srcs.cmake       |  2 +
+ media_common/linux/common/os/media_srcs.cmake |  2 +
+ .../agnostic/Xe_M/Xe_HPM/hw/media_srcs.cmake  |  3 +-
+ .../Xe_M/Xe_HPM/hw/vdbox/media_srcs.cmake     |  3 +-
+ .../agnostic/Xe_M/Xe_HPM/media_srcs.cmake     |  3 +-
+ .../Xe_M/Xe_HPM/vp/hal/media_srcs.cmake       |  2 +
+ .../agnostic/Xe_M/Xe_XPM/hw/media_srcs.cmake  |  3 +-
+ .../Xe_M/Xe_XPM/hw/vdbox/media_srcs.cmake     |  3 +-
+ .../Xe_M/Xe_XPM/vp/hal/media_srcs.cmake       |  2 +
+ .../vp/kernel/cmfcpatch/media_srcs.cmake      |  2 +
+ .../Xe_M/Xe_XPM/vp/kernel/media_srcs.cmake    |  2 +
+ .../Xe_R/Xe_HP/hw/render/media_srcs.cmake     |  3 +-
+ .../Xe_R/Xe_HPG/hw/render/media_srcs.cmake    |  3 +-
+ .../Xe_R/Xe_HP_base/hw/blt/media_srcs.cmake   |  3 +-
+ .../Xe_HP_base/hw/render/media_srcs.cmake     |  3 +-
+ .../agnostic/common/hw/media_srcs.cmake       |  3 +-
+ .../agnostic/common/hw/vdbox/media_srcs.cmake |  2 +
+ .../common/media_interfaces/media_srcs.cmake  |  3 +-
+ .../common/renderhal/media_srcs.cmake         |  3 +-
+ .../agnostic/common/shared/media_srcs.cmake   |  2 +
+ .../common/shared/mediacopy/media_srcs.cmake  |  3 +-
+ .../agnostic/common/vp/hal/media_srcs.cmake   |  1 +
+ .../agnostic/common/vp/kdll/media_srcs.cmake  |  3 +-
+ .../g12/g12_base/hw/render/media_srcs.cmake   |  3 +-
+ .../agnostic/gen11/cm/media_srcs.cmake        |  3 +-
+ .../agnostic/gen11/hw/media_srcs.cmake        |  3 +-
+ .../agnostic/gen11/hw/vdbox/media_srcs.cmake  |  3 +-
+ .../agnostic/gen11/renderhal/media_srcs.cmake |  3 +-
+ .../agnostic/gen11/vp/hal/media_srcs.cmake    |  3 +-
+ .../gen11_icllp/vp/hal/media_srcs.cmake       |  3 +-
+ .../gen11_icllp/vp/kernel/media_srcs.cmake    |  2 +
+ .../gen11_jsl_ehl/renderhal/media_srcs.cmake  |  3 +-
+ .../gen11_jsl_ehl/vp/hal/media_srcs.cmake     |  3 +-
+ .../agnostic/gen12/cm/media_srcs.cmake        |  3 +-
+ .../agnostic/gen12/hw/media_srcs.cmake        |  3 +-
+ .../agnostic/gen12/hw/vdbox/media_srcs.cmake  |  3 +-
+ media_driver/agnostic/gen12/media_srcs.cmake  |  3 +-
+ .../agnostic/gen12/vp/hal/media_srcs.cmake    |  3 +-
+ .../agnostic/gen12_tgllp/media_srcs.cmake     |  3 +-
+ .../gen12_tgllp/vp/hal/media_srcs.cmake       |  3 +-
+ .../vp/kernel/cmfc/media_srcs.cmake           |  3 +-
+ .../vp/kernel/cmfccmlpch/media_srcs.cmake     |  3 +-
+ .../vp/kernel/cmfcpatch/media_srcs.cmake      |  3 +-
+ .../gen12_tgllp/vp/kernel/media_srcs.cmake    |  3 +-
+ .../agnostic/gen8/cm/media_srcs.cmake         |  3 +-
+ .../agnostic/gen8/hw/media_srcs.cmake         |  3 +-
+ .../agnostic/gen8/hw/vdbox/media_srcs.cmake   |  3 +-
+ .../agnostic/gen8/renderhal/media_srcs.cmake  |  3 +-
+ .../agnostic/gen8/vp/hal/media_srcs.cmake     |  2 +
+ .../agnostic/gen8/vp/kernel/media_srcs.cmake  |  3 +-
+ .../gen8_bdw/hw/vdbox/media_srcs.cmake        |  3 +-
+ .../gen8_bdw/renderhal/media_srcs.cmake       |  3 +-
+ .../agnostic/gen9/cm/media_srcs.cmake         |  3 +-
+ .../agnostic/gen9/hw/media_srcs.cmake         |  3 +-
+ .../agnostic/gen9/hw/vdbox/media_srcs.cmake   |  3 +-
+ .../agnostic/gen9/renderhal/media_srcs.cmake  |  3 +-
+ .../agnostic/gen9/vp/hal/media_srcs.cmake     |  2 +
+ .../agnostic/gen9/vp/kernel/media_srcs.cmake  |  3 +-
+ .../gen9_bxt/hw/vdbox/media_srcs.cmake        |  3 +-
+ .../agnostic/gen9_bxt/vp/hal/media_srcs.cmake |  3 +-
+ .../gen9_glk/hw/vdbox/media_srcs.cmake        |  3 +-
+ .../agnostic/gen9_glk/vp/hal/media_srcs.cmake |  2 +
+ .../gen9_kbl/hw/vdbox/media_srcs.cmake        |  3 +-
+ .../gen9_skl/hw/vdbox/media_srcs.cmake        |  3 +-
+ media_driver/linux/common/os/media_srcs.cmake |  2 +
+ .../media_interfaces_dg2/media_srcs.cmake     |  3 +-
+ .../media_interfaces_m10_cnl/media_srcs.cmake |  3 +-
+ .../media_srcs.cmake                          |  3 +-
+ .../media_srcs.cmake                          |  3 +-
+ .../media_srcs.cmake                          |  3 +-
+ .../media_srcs.cmake                          |  3 +-
+ .../media_srcs.cmake                          |  3 +-
+ .../media_interfaces_m12_dg1/media_srcs.cmake |  3 +-
+ .../media_interfaces_m12_rkl/media_srcs.cmake |  3 +-
+ .../media_srcs.cmake                          |  3 +-
+ .../media_interfaces_m8_bdw/media_srcs.cmake  |  3 +-
+ .../media_interfaces_m9_bxt/media_srcs.cmake  |  3 +-
+ .../media_interfaces_m9_cfl/media_srcs.cmake  |  3 +-
+ .../media_interfaces_m9_glk/media_srcs.cmake  |  3 +-
+ .../media_interfaces_m9_kbl/media_srcs.cmake  |  3 +-
+ .../media_interfaces_m9_skl/media_srcs.cmake  |  3 +-
+ .../media_interfaces_pvc/media_srcs.cmake     |  3 +-
+ .../media_srcs.cmake                          |  3 +-
+ .../agnostic/Xe_M/Xe_HPM/hw/media_srcs.cmake  |  2 +
+ .../Xe_M/Xe_HPM/hw/vdbox/media_srcs.cmake     |  3 +-
+ .../Xe_HPM/shared/mediacopy/media_srcs.cmake  |  3 +-
+ .../vp/hal/feature_manager/media_srcs.cmake   |  3 +-
+ .../Xe_HPM/vp/hal/packet/media_srcs.cmake     |  3 +-
+ .../Xe_HPM/vp/hal/pipeline/media_srcs.cmake   |  3 +-
+ .../hal/platform_interface/media_srcs.cmake   |  3 +-
+ .../vp/hal/feature_manager/media_srcs.cmake   |  3 +-
+ .../Xe_XPM/vp/hal/packet/media_srcs.cmake     |  3 +-
+ .../Xe_XPM/vp/hal/pipeline/media_srcs.cmake   |  3 +-
+ .../hal/platform_interface/media_srcs.cmake   |  3 +-
+ .../Xe_M/Xe_XPM_base/hw/media_srcs.cmake      |  3 +-
+ .../shared/mediacopy/media_srcs.cmake         |  3 +-
+ .../vp/hal/feature_manager/media_srcs.cmake   |  3 +-
+ .../vp/hal/packet/media_srcs.cmake            |  3 +-
+ .../Xe_R/Xe_HP/renderhal/media_srcs.cmake     |  3 +-
+ .../Xe_R/Xe_HPC/renderhal/media_srcs.cmake    |  3 +-
+ .../Xe_R/Xe_HPG/renderhal/media_srcs.cmake    |  3 +-
+ .../Xe_HP_Base/renderhal/media_srcs.cmake     |  3 +-
+ .../media_sfc_interface/media_srcs.cmake      |  3 +-
+ .../shared/scalability/media_srcs.cmake       |  2 +
+ .../common/vp/hal/packet/media_srcs.cmake     |  3 +-
+ .../common/vp/hal/pipeline/media_srcs.cmake   |  3 +-
+ .../hal/shared/scalability/media_srcs.cmake   |  2 +
+ .../g12/g12_0/renderhal/media_srcs.cmake      |  3 +-
+ .../g12/g12_1/renderhal/media_srcs.cmake      |  3 +-
+ .../g12/g12_base/renderhal/media_srcs.cmake   |  3 +-
+ .../agnostic/gen12/vp/hal/media_srcs.cmake    |  3 +-
+ .../hal/platform_interface/media_srcs.cmake   |  3 +-
+ .../m12/m12/vp/hal/packet/media_srcs.cmake    |  2 +
+ .../m12_0/shared/mediacopy/media_srcs.cmake   |  3 +-
+ .../vp/hal/feature_manager/media_srcs.cmake   |  3 +-
+ .../hal/dec/av1/pipeline/media_srcs.cmake     |  3 +-
+ .../hal/dec/avc/pipeline/media_srcs.cmake     |  3 +-
+ .../hal/dec/hevc/pipeline/media_srcs.cmake    |  3 +-
+ .../codec/hal/dec/jpeg/media_srcs.cmake       |  3 +-
+ .../codec/hal/dec/mpeg2/media_srcs.cmake      |  3 +-
+ .../hal/dec/vp8/pipeline/media_srcs.cmake     |  3 +-
+ .../hal/dec/vp9/pipeline/media_srcs.cmake     |  3 +-
+ .../codec/hal/enc/av1/packet/media_srcs.cmake |  2 +
+ .../hal/enc/av1/pipeline/media_srcs.cmake     |  3 +-
+ .../hal/enc/hevc/features/media_srcs.cmake    |  3 +-
+ .../hal/enc/hevc/packet/media_srcs.cmake      |  3 +-
+ .../hal/enc/hevc/pipeline/media_srcs.cmake    |  3 +-
+ .../hal/enc/vp9/features/media_srcs.cmake     |  3 +-
+ .../codec/hal/enc/vp9/packet/media_srcs.cmake |  3 +-
+ .../hal/enc/vp9/pipeline/media_srcs.cmake     |  3 +-
+ .../Xe_M_plus/Xe_LPM_plus/hw/media_srcs.cmake |  3 +-
+ .../Xe_LPM_plus/hw/vdbox/media_srcs.cmake     |  3 +-
+ .../vp/hal/feature_manager/media_srcs.cmake   |  3 +-
+ .../vp/hal/packet/media_srcs.cmake            |  3 +-
+ .../vp/hal/pipeline/media_srcs.cmake          |  3 +-
+ .../hal/platform_interface/media_srcs.cmake   |  3 +-
+ .../hal/dec/av1/features/media_srcs.cmake     |  3 +-
+ .../codec/hal/dec/av1/packet/media_srcs.cmake |  2 +
+ .../hal/dec/av1/pipeline/media_srcs.cmake     |  2 +
+ .../codec/hal/dec/avc/packet/media_srcs.cmake |  2 +
+ .../hal/dec/avc/pipeline/media_srcs.cmake     |  2 +
+ .../codec/hal/dec/hevc/mmc/media_srcs.cmake   |  3 +-
+ .../hal/dec/hevc/packet/media_srcs.cmake      |  3 +-
+ .../hal/dec/hevc/pipeline/media_srcs.cmake    |  3 +-
+ .../hal/dec/jpeg/packet/media_srcs.cmake      |  2 +
+ .../hal/dec/jpeg/pipeline/media_srcs.cmake    |  2 +
+ .../codec/hal/dec/mpeg2/mmc/media_srcs.cmake  |  2 +
+ .../hal/dec/mpeg2/packet/media_srcs.cmake     |  2 +
+ .../hal/dec/mpeg2/pipeline/media_srcs.cmake   |  2 +
+ .../codec/hal/dec/shared/media_srcs.cmake     |  3 +-
+ .../codec/hal/dec/vp8/mmc/media_srcs.cmake    |  2 +
+ .../codec/hal/dec/vp8/packet/media_srcs.cmake |  2 +
+ .../hal/dec/vp8/pipeline/media_srcs.cmake     |  2 +
+ .../codec/hal/dec/vp9/mmc/media_srcs.cmake    |  3 +-
+ .../codec/hal/dec/vp9/packet/media_srcs.cmake |  3 +-
+ .../hal/dec/vp9/pipeline/media_srcs.cmake     |  3 +-
+ .../hal/enc/av1/features/media_srcs.cmake     |  2 +
+ .../enc/av1/features/preenc/media_srcs.cmake  |  3 +-
+ .../codec/hal/enc/av1/packet/media_srcs.cmake |  3 +-
+ .../hal/enc/av1/pipeline/media_srcs.cmake     |  2 +
+ .../hal/enc/avc/features/media_srcs.cmake     |  3 +-
+ .../hal/enc/avc/pipeline/media_srcs.cmake     |  3 +-
+ .../hal/enc/hevc/features/media_srcs.cmake    |  2 +
+ .../enc/hevc/features/preenc/media_srcs.cmake |  2 +
+ .../hal/enc/hevc/pipeline/media_srcs.cmake    |  3 +-
+ .../hal/enc/jpeg/pipeline/media_srcs.cmake    |  3 +-
+ .../hal/enc/shared/common/media_srcs.cmake    |  3 +-
+ .../codec/hal/enc/vp9/packet/media_srcs.cmake |  3 +-
+ .../hal/enc/vp9/pipeline/media_srcs.cmake     |  3 +-
+ .../codec/hal/shared/media_srcs.cmake         |  3 +-
+ .../Xe_LPM_plus_base/hw/media_srcs.cmake      |  2 +-
+ .../hw/vdbox/media_srcs.cmake                 |  3 +-
+ .../shared/mediaDecompress/media_srcs.cmake   |  3 +-
+ .../shared/mediacopy/media_srcs.cmake         |  3 +-
+ .../vp/hal/feature_manager/media_srcs.cmake   |  3 +-
+ .../vp/hal/packet/media_srcs.cmake            |  3 +-
+ .../Xe_R/Xe_HPG/renderhal/media_srcs.cmake    |  3 +-
+ .../Xe_R/Xe_HPG_Base/hw/media_srcs.cmake      |  3 +-
+ .../Xe_HPG_Base/renderhal/media_srcs.cmake    |  3 +-
+ .../vp/kernel/cmfcpatch/media_srcs.cmake      |  3 +-
+ .../Xe_HPG_Base/vp/kernel/media_srcs.cmake    |  3 +-
+ .../hal/dec/av1/features/media_srcs.cmake     |  2 +
+ .../codec/hal/dec/av1/packet/media_srcs.cmake |  3 +-
+ .../hal/dec/av1/pipeline/media_srcs.cmake     |  3 +-
+ .../hal/dec/avc/features/media_srcs.cmake     |  3 +-
+ .../codec/hal/dec/avc/packet/media_srcs.cmake |  3 +-
+ .../hal/dec/avc/pipeline/media_srcs.cmake     |  3 +-
+ .../hal/dec/hevc/features/media_srcs.cmake    |  3 +-
+ .../codec/hal/dec/hevc/mmc/media_srcs.cmake   |  3 +-
+ .../hal/dec/hevc/packet/media_srcs.cmake      |  3 +-
+ .../hal/dec/hevc/pipeline/media_srcs.cmake    |  3 +-
+ .../hal/dec/hevc/scalability/media_srcs.cmake |  3 +-
+ .../hal/dec/jpeg/bitstream/media_srcs.cmake   |  3 +-
+ .../hal/dec/jpeg/features/media_srcs.cmake    |  3 +-
+ .../hal/dec/jpeg/packet/media_srcs.cmake      |  3 +-
+ .../hal/dec/jpeg/pipeline/media_srcs.cmake    |  3 +-
+ .../hal/dec/mpeg2/features/media_srcs.cmake   |  3 +-
+ .../codec/hal/dec/mpeg2/mmc/media_srcs.cmake  |  3 +-
+ .../hal/dec/mpeg2/packet/media_srcs.cmake     |  3 +-
+ .../hal/dec/mpeg2/pipeline/media_srcs.cmake   |  3 +-
+ .../hal/dec/shared/bufferMgr/media_srcs.cmake |  3 +-
+ .../hal/dec/shared/features/media_srcs.cmake  |  3 +-
+ .../hal/dec/shared/hucItf/media_srcs.cmake    |  3 +-
+ .../codec/hal/dec/shared/media_srcs.cmake     |  2 +
+ .../codec/hal/dec/shared/mmc/media_srcs.cmake |  3 +-
+ .../hal/dec/shared/packet/media_srcs.cmake    |  2 +
+ .../hal/dec/shared/pipeline/media_srcs.cmake  |  2 +
+ .../dec/shared/scalability/media_srcs.cmake   |  2 +
+ .../dec/shared/statusreport/media_srcs.cmake  |  2 +
+ .../hal/dec/vp8/features/media_srcs.cmake     |  3 +-
+ .../codec/hal/dec/vp8/mmc/media_srcs.cmake    |  3 +-
+ .../codec/hal/dec/vp8/packet/media_srcs.cmake |  3 +-
+ .../hal/dec/vp8/pipeline/media_srcs.cmake     |  3 +-
+ .../hal/dec/vp9/features/media_srcs.cmake     |  3 +-
+ .../codec/hal/dec/vp9/mmc/media_srcs.cmake    |  3 +-
+ .../codec/hal/dec/vp9/packet/media_srcs.cmake |  3 +-
+ .../hal/dec/vp9/pipeline/media_srcs.cmake     |  3 +-
+ .../hal/dec/vp9/scalability/media_srcs.cmake  |  3 +-
+ .../hal/enc/av1/features/media_srcs.cmake     |  3 +-
+ .../codec/hal/enc/av1/packet/media_srcs.cmake |  3 +-
+ .../hal/enc/av1/pipeline/media_srcs.cmake     |  2 +
+ .../hal/enc/avc/features/media_srcs.cmake     |  3 +-
+ .../hal/enc/avc/features/roi/media_srcs.cmake |  2 +
+ .../codec/hal/enc/avc/packet/media_srcs.cmake |  2 +
+ .../hal/enc/avc/pipeline/media_srcs.cmake     |  2 +
+ .../hal/enc/hevc/features/media_srcs.cmake    |  2 +
+ .../enc/hevc/features/roi/media_srcs.cmake    |  2 +
+ .../hal/enc/hevc/packet/media_srcs.cmake      |  3 +-
+ .../hal/enc/hevc/pipeline/media_srcs.cmake    |  3 +-
+ .../hal/enc/jpeg/features/media_srcs.cmake    |  3 +-
+ .../hal/enc/jpeg/packet/media_srcs.cmake      |  2 +
+ .../hal/enc/jpeg/pipeline/media_srcs.cmake    |  3 +-
+ .../shared/bitstreamWriter/media_srcs.cmake   |  3 +-
+ .../hal/enc/shared/bufferMgr/media_srcs.cmake |  3 +-
+ .../hal/enc/shared/features/media_srcs.cmake  |  3 +-
+ .../codec/hal/enc/shared/media_srcs.cmake     |  3 +-
+ .../codec/hal/enc/shared/mmc/media_srcs.cmake |  3 +-
+ .../hal/enc/shared/packet/media_srcs.cmake    |  3 +-
+ .../hal/enc/shared/pipeline/media_srcs.cmake  |  3 +-
+ .../enc/shared/scalability/media_srcs.cmake   |  3 +-
+ .../enc/shared/statusreport/media_srcs.cmake  |  2 +
+ .../hal/enc/vp9/features/media_srcs.cmake     |  3 +-
+ .../codec/hal/enc/vp9/packet/media_srcs.cmake |  3 +-
+ .../hal/enc/vp9/pipeline/media_srcs.cmake     |  2 +
+ .../common/codec/hal/shared/media_srcs.cmake  |  2 +
+ .../agnostic/common/cp/media_srcs.cmake       |  3 +-
+ .../agnostic/common/hw/media_srcs.cmake       |  3 +-
+ .../agnostic/common/hw/vdbox/media_srcs.cmake |  3 +-
+ .../common/media_bin_mgr/media_srcs.cmake     |  3 +-
+ .../common/media_interfaces/media_srcs.cmake  |  3 +-
+ .../agnostic/common/os/media_srcs.cmake       |  2 +
+ .../common/os/private/media_srcs.cmake        |  2 +
+ .../agnostic/common/os/share/media_srcs.cmake |  2 +
+ .../common/os/user_setting/media_srcs.cmake   |  3 +-
+ .../common/renderhal/media_srcs.cmake         |  3 +-
+ .../common/shared/bufferMgr/media_srcs.cmake  |  2 +
+ .../common/shared/features/media_srcs.cmake   |  3 +-
+ .../media_sfc_interface/media_srcs.cmake      |  3 +-
+ .../agnostic/common/shared/media_srcs.cmake   |  3 +-
+ .../shared/mediacontext/media_srcs.cmake      |  3 +-
+ .../common/shared/mediacopy/media_srcs.cmake  |  3 +-
+ .../common/shared/mmc/media_srcs.cmake        |  3 +-
+ .../common/shared/packet/media_srcs.cmake     |  3 +-
+ .../common/shared/pipeline/media_srcs.cmake   |  3 +-
+ .../common/shared/profiler/media_srcs.cmake   |  2 +
+ .../shared/scalability/media_srcs.cmake       |  2 +
+ .../shared/statusreport/media_srcs.cmake      |  2 +
+ .../common/shared/task/media_srcs.cmake       |  3 +-
+ .../common/vp/cm_fc_ld/media_srcs.cmake       |  2 +
+ .../common/vp/hal/bufferMgr/media_srcs.cmake  |  3 +-
+ .../vp/hal/feature_manager/media_srcs.cmake   |  3 +-
+ .../common/vp/hal/features/media_srcs.cmake   |  3 +-
+ .../common/vp/hal/mmc/media_srcs.cmake        |  3 +-
+ .../common/vp/hal/packet/media_srcs.cmake     |  3 +-
+ .../common/vp/hal/pipeline/media_srcs.cmake   |  3 +-
+ .../hal/platform_interface/media_srcs.cmake   |  3 +-
+ .../vp/hal/scalability/media_srcs.cmake       |  3 +-
+ .../hal/shared/scalability/media_srcs.cmake   |  2 +
+ .../vp/hal/statusreport/media_srcs.cmake      |  3 +-
+ .../hal/utils/hal_ddi_share/media_srcs.cmake  |  3 +-
+ .../common/vp/hal/utils/media_srcs.cmake      |  3 +-
+ .../linux/media_include_paths_linux.cmake     |  2 +-
+ .../linux/Xe_M_plus/ddi/media_srcs.cmake      |  3 +-
+ .../common/codec/ddi/dec/media_srcs.cmake     |  3 +-
+ .../common/codec/ddi/enc/media_srcs.cmake     |  2 +
+ .../common/codec/ddi/shared/media_srcs.cmake  |  3 +-
+ .../linux/common/cp/ddi/media_srcs.cmake      |  2 +
+ .../linux/common/cp/media_srcs.cmake          |  2 +
+ .../linux/common/ddi/media_srcs.cmake         |  3 +-
+ .../common/os/i915/include/media_srcs.cmake   |  2 +
+ .../os/i915/include/uapi/media_srcs.cmake     |  2 +
+ .../i915_production/include/media_srcs.cmake  |  3 +-
+ .../os/i915_production/media_srcs.cmake       |  2 +
+ .../linux/common/os/media_srcs.cmake          |  2 +
+ .../common/os/osservice/media_srcs.cmake      |  2 +
+ .../linux/common/vp/ddi/media_srcs.cmake      |  2 +
+ .../linux/xe_lpm_plus_r0/ddi/media_srcs.cmake |  3 +-
+ .../encode/av1/ddi/media_srcs.cmake           |  2 +
+ .../encode/avc/ddi/media_srcs.cmake           |  3 +-
+ .../encode/hevc/ddi/media_srcs.cmake          |  3 +-
+ .../encode/jpeg/ddi/media_srcs.cmake          |  2 +
+ .../encode/vp9/ddi/media_srcs.cmake           |  3 +-
+ .../xe_lpm_plus_r0/vp/ddi/media_srcs.cmake    |  3 +-
+ 320 files changed, 699 insertions(+), 272 deletions(-)
+
+diff --git a/Tools/MediaDriverTools/Android/GenerateAndroidMk.py b/Tools/MediaDriverTools/Android/GenerateAndroidMk.py
+index 84126a73e..234cb34bb 100755
+--- a/Tools/MediaDriverTools/Android/GenerateAndroidMk.py
++++ b/Tools/MediaDriverTools/Android/GenerateAndroidMk.py
+@@ -43,42 +43,44 @@ def remove(f):
+     cmd = "rm " + f + "> /dev/null 2>&1"
+     os.system(cmd)
+ 
++
+ def getDriverName(root):
+     driver = "mod"
+     if not path.exists(path.join(root, driver)):
+         driver = "media-driver"
+     if not path.exists(path.join(root, driver)):
+-        raise Exception("driver path " + driver +" not existed")
++        raise Exception("driver path " + driver + " not existed")
+     return driver
+ 
++
+ class Generator:
+     def __init__(self, src, root, makefile=None):
+-        #where to put the Android makefile
++        # where to put the Android makefile
+         self.makefile = makefile if makefile else src
+ 
+-        #where is the major source file
++        # where is the major source file
+         self.src = src
+ 
+-        #driver name
++        # driver name
+         driver = getDriverName(root)
+-        #where to put build file and template
++        # where to put build file and template
+         self.tool = path.join(root, driver, TOOL_DIR)
+ 
+         """where to put the template"""
+         self.templ = path.join(root, driver, TEMPLATE_DIR)
+ 
+-    #major function
++    # major function
+     def generate(self):
+ 
+-        if path.exists(self.src) == False:
++        if not path.exists(self.src):
+             raise Exception(self.src + "not existed")
+-        self.generateMakefile()
++        self.generateMakefile(debug=True)
+ 
+         mk = path.join(self.makefile, "Android.mk")
+-        #remove old Android.mk
++        # remove old Android.mk
+         remove(mk)
+ 
+-        #create new Android.mk
++        # create new Android.mk
+         with open(self.getTemplatePath()) as f:
+             tpl = f.read()
+         tpl = tpl.replace("@LOCAL_SRC_FILES", self.getSources())
+@@ -88,7 +90,7 @@ class Generator:
+             f.write(tpl)
+         print("generated " + self.getName() + " to " + self.makefile)
+ 
+-    #virtuall functions
++    # virtuall functions
+     def getTemplate(self):
+         raise Exception("pure virtul function")
+ 
+@@ -108,19 +110,19 @@ class Generator:
+         return path.join(self.tool, 'build', self.getName())
+ 
+     def adjustSources(self, lines):
+-        #print(lines)
++        # print(lines)
+         return lines
+ 
+     def adjustIncludes(self, lines):
+-        #print(lines)
++        # print(lines)
+         return lines
+ 
+     def getCmakeCmd(self):
+         return "cmake " + self.src
+ 
+     def generateMakefile(self, debug=False):
+-        #Win env can help us debug the script
+-        #but we do not want generate makefile on Win-system
++        # Win env can help us debug the script
++        # but we do not want generate makefile on Win-system
+         if os.name == "nt":
+             return
+         verbose = ";" if debug else "> /dev/null 2>&1;"
+@@ -136,11 +138,13 @@ class Generator:
+         includes = []
+         lines = text.split("\n")
+         for l in lines:
+-            #normpath will make sure we did not refer outside.
++            # normpath will make sure we did not refer outside.
++            l = l.strip()[2:]
++            if l == '/linux':
++                continue
++
+             p = path.normpath(l)
+-            j = p.find(self.src)
+-            if j != -1:
+-                includes.append(p[j:].replace(self.src, "$(LOCAL_PATH)"))
++            includes.append(path.join("$(LOCAL_PATH)", path.relpath(p, self.src)))
+         return INDENT + ("\n" + INDENT).join(includes) if includes else ""
+ 
+     def getDefines(self, name):
+@@ -161,7 +165,7 @@ class Generator:
+         lines = re.findall(".*?\\.o:\\n", text)
+         lines = [l.replace(".o:\n", " \\") for l in lines]
+         self.adjustSources(lines)
+-        #make source pretty
++        # make source pretty
+         return INDENT + ("\n" + INDENT).join(lines)
+ 
+ 
+@@ -175,6 +179,7 @@ class GmmGeneator(Generator):
+ 
+     def getMakefile(self):
+         return "Source/GmmLib/Makefile"
++
+     def getFlagsfile(self):
+         return "Source/GmmLib/CMakeFiles/igfx_gmmumd_dll.dir/flags.make"
+ 
+@@ -184,7 +189,7 @@ class GmmGeneator(Generator):
+             if j == -1:
+                 lines[i] = path.join("Source/GmmLib", l)
+             else:
+-                lines[i] = path.join("Source", l[j+3:])
++                lines[i] = path.join("Source", l[j + 3:])
+ 
+ 
+ class CmrtGeneator(Generator):
+@@ -207,7 +212,7 @@ class CmrtGeneator(Generator):
+             if j == -1:
+                 lines[i] = path.join("linux", l)
+             else:
+-                lines[i] = l[j+3:]
++                lines[i] = l[j + 3:]
+ 
+ 
+ class DriverGeneator(Generator):
+@@ -217,11 +222,17 @@ class DriverGeneator(Generator):
+ 
+     def getCmakeCmd(self):
+         wd = path.join(self.src, "..")
+-        cmd = 'cmake ' + wd +' -DCMAKE_INSTALL_PREFIX=/usr'
++        cmd = 'cmake ' + wd + ' -DCMAKE_INSTALL_PREFIX=/usr'
+         cmd += ' -DBUILD_ALONG_WITH_CMRTLIB=1 -DBS_DIR_GMMLIB=' + path.join(wd, '../gmmlib/Source/GmmLib/')
+         cmd += ' -DBS_DIR_COMMON=' + path.join(wd, '../gmmlib/Source/Common/')
+         cmd += ' -DBS_DIR_INC=' + path.join(wd, '../gmmlib/Source/inc/')
+         cmd += ' -DBS_DIR_MEDIA=' + wd
++        cmd += (' -DSKIP_GMM_CHECK=ON'
++            ' -DGEN12=ON'
++            # ' -DENABLE_PRODUCTION_KMD=ON'  # For /media_softlet/agnostic/Xe_R/Xe_HPC/renderhal
++            # ' -DGEN10=ON'  # For /media_interface/media_interfaces_m10_cnl 
++            ' -DGEN12_RKL=ON'  # For /media_interface/media_interfaces_m12_rkl
++        )
+         return cmd
+ 
+     def getTemplate(self):
+@@ -234,14 +245,18 @@ class DriverGeneator(Generator):
+         return "media_driver/CMakeFiles/iHD_drv_video.dir/flags.make"
+ 
+     def adjustSources(self, lines):
+-        lines[:] = [l for l in lines if "media_libva_putsurface_linux.cpp" not in l]
++        lines[:] = [l.replace('__/', '../') for l in lines
++                    if "media_libva_putsurface_linux.cpp" not in l
++                    and '/private/' not in l
++                    ]
++
+ 
+ class Main:
+ 
+     def run(self):
+         tool = path.dirname(__file__)
+         root = path.abspath(path.join(tool, "../../../../"))
+-        print("root = "+root)
++        print("root = " + root)
+         gens = [GmmGeneator(root), CmrtGeneator(root), DriverGeneator(root)]
+         for g in gens:
+             g.generate()
+diff --git a/Tools/MediaDriverTools/Android/mk/cmrt.tpl b/Tools/MediaDriverTools/Android/mk/cmrt.tpl
+index 470cc64b3..2ec860983 100644
+--- a/Tools/MediaDriverTools/Android/mk/cmrt.tpl
++++ b/Tools/MediaDriverTools/Android/mk/cmrt.tpl
+@@ -33,6 +33,10 @@ LOCAL_C_INCLUDES += \
+ @LOCAL_C_INCLUDES
+ 
+ LOCAL_CFLAGS += \
++    -Wno-error \
++    -Wno-unused-variable \
++    -Wno-unused-parameter \
++    -Wno-unused-private-field \
+     -Wno-non-virtual-dtor \
+     -DANDROID=1 \
+ @LOCAL_CFLAGS
+diff --git a/Tools/MediaDriverTools/Android/mk/media_driver.tpl b/Tools/MediaDriverTools/Android/mk/media_driver.tpl
+index f51b83d43..1cf17a83d 100644
+--- a/Tools/MediaDriverTools/Android/mk/media_driver.tpl
++++ b/Tools/MediaDriverTools/Android/mk/media_driver.tpl
+@@ -33,9 +33,6 @@ LOCAL_SHARED_LIBRARIES := \
+     libdrm \
+     libva \
+     liblog \
+-
+-
+-LOCAL_STATIC_LIBRARIES = \
+     libgmm_umd \
+ 
+ LOCAL_CPPFLAGS = \
+@@ -45,6 +42,27 @@ LOCAL_CPPFLAGS = \
+     -fexceptions \
+     -frtti \
+     -std=c++14 \
++    -Wno-error \
++    -Wno-ignored-qualifiers \
++    -Wno-unused-parameter \
++    -Wno-missing-braces \
++    -Wno-overloaded-virtual \
++    -Wno-unused-variable \
++    -Wno-missing-field-initializers \
++    -Wno-unused-function \
++    -Wno-logical-op-parentheses \
++    -Wno-implicit-fallthrough \
++    -Wno-comment \
++    -Wno-unused-private-field \
++    -Wno-unused-value \
++    -Wno-parentheses-equality \
++    -Wno-unused-label \
++    -Wno-parentheses \
++    -Wno-c++11-narrowing \
++    -Wno-unused-lambda-capture \
++    -Wno-unreachable-code-loop-increment \
++    -Wno-delete-incomplete \
++    -DGMM_LIB_DLL \
+ @LOCAL_CFLAGS
+ 
+ LOCAL_CONLYFLAGS = -x c++
+@@ -52,11 +70,12 @@ LOCAL_CFLAGS = $(LOCAL_CPPFLAGS)
+ 
+ LOCAL_C_INCLUDES  = \
+ @LOCAL_C_INCLUDES
+-
++    $(LOCAL_PATH)/agnostic/gen12_tgllp/vp/kernel/swsb \
++    $(LOCAL_PATH)/../cmrtlib/linux/hardware \
+ 
+ #LOCAL_CPP_FEATURES := rtti exceptions
+ 
+ LOCAL_MODULE := i965_drv_video
+ LOCAL_PROPRIETARY_MODULE := true
+ 
+-include $(BUILD_SHARED_LIBRARY)
++include $(BUILD_SHARED_LIBRARY)
+\ No newline at end of file
+diff --git a/media_common/agnostic/common/cp/media_srcs.cmake b/media_common/agnostic/common/cp/media_srcs.cmake
+index 646ecd382..e285ae4e7 100644
+--- a/media_common/agnostic/common/cp/media_srcs.cmake
++++ b/media_common/agnostic/common/cp/media_srcs.cmake
+@@ -38,4 +38,5 @@ set(COMMON_CP_DIRECTORIES_
+ set(CP_INTERFACE_DIRECTORIES_
+     ${CP_INTERFACE_DIRECTORIES_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_common/agnostic/common/heap_manager/media_srcs.cmake b/media_common/agnostic/common/heap_manager/media_srcs.cmake
+index f882c7e7f..726dd44da 100644
+--- a/media_common/agnostic/common/heap_manager/media_srcs.cmake
++++ b/media_common/agnostic/common/heap_manager/media_srcs.cmake
+@@ -36,4 +36,5 @@ source_group( "Common Files" FILES ${TMP_HEADERS_} )
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_common/agnostic/common/hw/media_srcs.cmake b/media_common/agnostic/common/hw/media_srcs.cmake
+index 45dc8126c..c1e365fa9 100644
+--- a/media_common/agnostic/common/hw/media_srcs.cmake
++++ b/media_common/agnostic/common/hw/media_srcs.cmake
+@@ -118,4 +118,5 @@ set(SOFTLET_MHW_SFC_PRIVATE_INCLUDE_DIRS_
+ set(SOFTLET_MHW_VEBOX_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_MHW_VEBOX_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_common/agnostic/common/hw/vdbox/media_srcs.cmake b/media_common/agnostic/common/hw/vdbox/media_srcs.cmake
+index 912dc9f1f..68b9fa843 100644
+--- a/media_common/agnostic/common/hw/vdbox/media_srcs.cmake
++++ b/media_common/agnostic/common/hw/vdbox/media_srcs.cmake
+@@ -53,4 +53,5 @@ set(TMP_SOFTLET_MHW_VDBOX_HUC_HEADERS_ "")
+ set(SOFTLET_MHW_VDBOX_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_MHW_VDBOX_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_common/agnostic/common/media_interfaces/media_srcs.cmake b/media_common/agnostic/common/media_interfaces/media_srcs.cmake
+index a53df43bb..70bbbf0b2 100644
+--- a/media_common/agnostic/common/media_interfaces/media_srcs.cmake
++++ b/media_common/agnostic/common/media_interfaces/media_srcs.cmake
+@@ -34,4 +34,5 @@ set(SOFTLET_COMMON_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_common/agnostic/common/os/media_srcs.cmake b/media_common/agnostic/common/os/media_srcs.cmake
+index 2d6f2cb65..f821f84be 100644
+--- a/media_common/agnostic/common/os/media_srcs.cmake
++++ b/media_common/agnostic/common/os/media_srcs.cmake
+@@ -41,3 +41,5 @@ set(SOFTLET_MOS_PUBLIC_INCLUDE_DIRS_
+ )
+ 
+ source_group( "mos_softlet" FILES ${TMP_HEADERS_} )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_common/agnostic/common/os/user_setting/media_srcs.cmake b/media_common/agnostic/common/os/user_setting/media_srcs.cmake
+index 2f84e8ddd..359b6e37f 100644
+--- a/media_common/agnostic/common/os/user_setting/media_srcs.cmake
++++ b/media_common/agnostic/common/os/user_setting/media_srcs.cmake
+@@ -50,4 +50,5 @@ set(SOFTLET_COMMON_DLL_PRIVATE_INCLUDE_DIRS_
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+ 
+-source_group( "mos_softlet" FILES ${TMP_HEADERS_} ${TMP_SHARED_HEADERS_} )
+\ No newline at end of file
++source_group( "mos_softlet" FILES ${TMP_HEADERS_} ${TMP_SHARED_HEADERS_} )
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_common/agnostic/common/renderhal/media_srcs.cmake b/media_common/agnostic/common/renderhal/media_srcs.cmake
+index 821a1c2ac..fc73a7f7c 100644
+--- a/media_common/agnostic/common/renderhal/media_srcs.cmake
++++ b/media_common/agnostic/common/renderhal/media_srcs.cmake
+@@ -33,4 +33,5 @@ source_group( "MHW\\Render Hal" FILES ${TMP_HEADERS_} )
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_common/agnostic/common/shared/media_srcs.cmake b/media_common/agnostic/common/shared/media_srcs.cmake
+index bdb57f148..f8b0d4805 100644
+--- a/media_common/agnostic/common/shared/media_srcs.cmake
++++ b/media_common/agnostic/common/shared/media_srcs.cmake
+@@ -34,4 +34,5 @@ source_group( "Common Files" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_common/agnostic/common/vp/hal/media_srcs.cmake b/media_common/agnostic/common/vp/hal/media_srcs.cmake
+index 986cc1521..95a34c3cc 100644
+--- a/media_common/agnostic/common/vp/hal/media_srcs.cmake
++++ b/media_common/agnostic/common/vp/hal/media_srcs.cmake
+@@ -37,3 +37,5 @@ set (SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_common/agnostic/common/vp/kdll/media_srcs.cmake b/media_common/agnostic/common/vp/kdll/media_srcs.cmake
+index dadef518c..4e7da6a4e 100644
+--- a/media_common/agnostic/common/vp/kdll/media_srcs.cmake
++++ b/media_common/agnostic/common/vp/kdll/media_srcs.cmake
+@@ -35,3 +35,5 @@ set (SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+ 
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_common/agnostic/common/vp/kernel/media_srcs.cmake b/media_common/agnostic/common/vp/kernel/media_srcs.cmake
+index 4833778f8..952ec7805 100755
+--- a/media_common/agnostic/common/vp/kernel/media_srcs.cmake
++++ b/media_common/agnostic/common/vp/kernel/media_srcs.cmake
+@@ -37,4 +37,5 @@ set(TMP_HEADERS_ "")
+ set (SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_common/linux/common/codec/media_srcs.cmake b/media_common/linux/common/codec/media_srcs.cmake
+index 35f1d982b..874e86245 100644
+--- a/media_common/linux/common/codec/media_srcs.cmake
++++ b/media_common/linux/common/codec/media_srcs.cmake
+@@ -32,4 +32,5 @@ set(SOFTLET_CODEC_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_CODEC_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+-endif()
+\ No newline at end of file
++endif()
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_common/linux/common/cp/ddi/media_srcs.cmake b/media_common/linux/common/cp/ddi/media_srcs.cmake
+index ec1813eb8..5a71c2173 100644
+--- a/media_common/linux/common/cp/ddi/media_srcs.cmake
++++ b/media_common/linux/common/cp/ddi/media_srcs.cmake
+@@ -31,3 +31,5 @@ set(COMMON_CP_DIRECTORIES_
+     ${COMMON_CP_DIRECTORIES_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_common/linux/common/cp/os/media_srcs.cmake b/media_common/linux/common/cp/os/media_srcs.cmake
+index cde44d828..feb81e0bf 100644
+--- a/media_common/linux/common/cp/os/media_srcs.cmake
++++ b/media_common/linux/common/cp/os/media_srcs.cmake
+@@ -43,3 +43,5 @@ set(CP_INTERFACE_DIRECTORIES_
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+ endif()
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_common/linux/common/os/media_srcs.cmake b/media_common/linux/common/os/media_srcs.cmake
+index e117b5e8d..7b968fe9a 100644
+--- a/media_common/linux/common/os/media_srcs.cmake
++++ b/media_common/linux/common/os/media_srcs.cmake
+@@ -45,3 +45,5 @@ set(SOFTLET_MOS_PUBLIC_INCLUDE_DIRS_
+ )
+ 
+ endif() # CMAKE_WDDM_LINUX
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/Xe_M/Xe_HPM/hw/media_srcs.cmake b/media_driver/agnostic/Xe_M/Xe_HPM/hw/media_srcs.cmake
+index 08668d10c..b884d6919 100644
+--- a/media_driver/agnostic/Xe_M/Xe_HPM/hw/media_srcs.cmake
++++ b/media_driver/agnostic/Xe_M/Xe_HPM/hw/media_srcs.cmake
+@@ -49,4 +49,5 @@ source_group("MHW\\VEBOX" FILES ${TMP_VEBOX_SOURCES_} ${TMP_VEBOX_HEADERS_})
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/Xe_M/Xe_HPM/hw/vdbox/media_srcs.cmake b/media_driver/agnostic/Xe_M/Xe_HPM/hw/vdbox/media_srcs.cmake
+index 6c51093d6..e78ffbcfb 100644
+--- a/media_driver/agnostic/Xe_M/Xe_HPM/hw/vdbox/media_srcs.cmake
++++ b/media_driver/agnostic/Xe_M/Xe_HPM/hw/vdbox/media_srcs.cmake
+@@ -53,4 +53,5 @@ source_group( "MHW\\Vdbox" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/Xe_M/Xe_HPM/media_srcs.cmake b/media_driver/agnostic/Xe_M/Xe_HPM/media_srcs.cmake
+index 3f79f298a..e169134a1 100644
+--- a/media_driver/agnostic/Xe_M/Xe_HPM/media_srcs.cmake
++++ b/media_driver/agnostic/Xe_M/Xe_HPM/media_srcs.cmake
+@@ -29,4 +29,5 @@ set(MEDIA_BIN_HEADERS_
+ set(MEDIA_BIN_INCLUDE_DIR
+     ${MEDIA_BIN_INCLUDE_DIR}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/Xe_M/Xe_HPM/vp/hal/media_srcs.cmake b/media_driver/agnostic/Xe_M/Xe_HPM/vp/hal/media_srcs.cmake
+index 93c2fecb6..64dc33200 100644
+--- a/media_driver/agnostic/Xe_M/Xe_HPM/vp/hal/media_srcs.cmake
++++ b/media_driver/agnostic/Xe_M/Xe_HPM/vp/hal/media_srcs.cmake
+@@ -61,3 +61,5 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/Xe_M/Xe_XPM/hw/media_srcs.cmake b/media_driver/agnostic/Xe_M/Xe_XPM/hw/media_srcs.cmake
+index a319b640c..569576944 100644
+--- a/media_driver/agnostic/Xe_M/Xe_XPM/hw/media_srcs.cmake
++++ b/media_driver/agnostic/Xe_M/Xe_XPM/hw/media_srcs.cmake
+@@ -89,4 +89,5 @@ source_group("MHW\\Common MI" FILES ${TMP_MI_SOURCES_} ${TMP_MI_HEADERS_})
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/Xe_M/Xe_XPM/hw/vdbox/media_srcs.cmake b/media_driver/agnostic/Xe_M/Xe_XPM/hw/vdbox/media_srcs.cmake
+index f5202ee1e..a9173d2b7 100644
+--- a/media_driver/agnostic/Xe_M/Xe_XPM/hw/vdbox/media_srcs.cmake
++++ b/media_driver/agnostic/Xe_M/Xe_XPM/hw/vdbox/media_srcs.cmake
+@@ -52,4 +52,5 @@ source_group( "MHW\\Vdbox" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/Xe_M/Xe_XPM/vp/hal/media_srcs.cmake b/media_driver/agnostic/Xe_M/Xe_XPM/vp/hal/media_srcs.cmake
+index c30e91b25..ddbb35faa 100644
+--- a/media_driver/agnostic/Xe_M/Xe_XPM/vp/hal/media_srcs.cmake
++++ b/media_driver/agnostic/Xe_M/Xe_XPM/vp/hal/media_srcs.cmake
+@@ -70,3 +70,5 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/Xe_M/Xe_XPM/vp/kernel/cmfcpatch/media_srcs.cmake b/media_driver/agnostic/Xe_M/Xe_XPM/vp/kernel/cmfcpatch/media_srcs.cmake
+index 731a08290..7029a5750 100644
+--- a/media_driver/agnostic/Xe_M/Xe_XPM/vp/kernel/cmfcpatch/media_srcs.cmake
++++ b/media_driver/agnostic/Xe_M/Xe_XPM/vp/kernel/cmfcpatch/media_srcs.cmake
+@@ -46,3 +46,5 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/Xe_M/Xe_XPM/vp/kernel/media_srcs.cmake b/media_driver/agnostic/Xe_M/Xe_XPM/vp/kernel/media_srcs.cmake
+index ad17fec62..6f11b30ab 100644
+--- a/media_driver/agnostic/Xe_M/Xe_XPM/vp/kernel/media_srcs.cmake
++++ b/media_driver/agnostic/Xe_M/Xe_XPM/vp/kernel/media_srcs.cmake
+@@ -51,3 +51,5 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/Xe_R/Xe_HP/hw/render/media_srcs.cmake b/media_driver/agnostic/Xe_R/Xe_HP/hw/render/media_srcs.cmake
+index e8dd43f5a..cf2412d04 100644
+--- a/media_driver/agnostic/Xe_R/Xe_HP/hw/render/media_srcs.cmake
++++ b/media_driver/agnostic/Xe_R/Xe_HP/hw/render/media_srcs.cmake
+@@ -41,4 +41,5 @@ source_group("MHW\\Render Engine" FILES ${TMP_RENDER_SOURCES_} ${TMP_RENDER_HEAD
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/Xe_R/Xe_HPG/hw/render/media_srcs.cmake b/media_driver/agnostic/Xe_R/Xe_HPG/hw/render/media_srcs.cmake
+index e3c4cdd7b..dced06116 100644
+--- a/media_driver/agnostic/Xe_R/Xe_HPG/hw/render/media_srcs.cmake
++++ b/media_driver/agnostic/Xe_R/Xe_HPG/hw/render/media_srcs.cmake
+@@ -42,4 +42,5 @@ source_group("MHW\\Render Engine" FILES ${TMP_RENDER_SOURCES_} ${TMP_RENDER_HEAD
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/Xe_R/Xe_HP_base/hw/blt/media_srcs.cmake b/media_driver/agnostic/Xe_R/Xe_HP_base/hw/blt/media_srcs.cmake
+index eee609ad5..89c0549ca 100644
+--- a/media_driver/agnostic/Xe_R/Xe_HP_base/hw/blt/media_srcs.cmake
++++ b/media_driver/agnostic/Xe_R/Xe_HP_base/hw/blt/media_srcs.cmake
+@@ -42,4 +42,5 @@ source_group("MHW\\BLT" FILES ${TMP_BLT_SOURCES_} ${TMP_BLT_HEADERS_})
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/Xe_R/Xe_HP_base/hw/render/media_srcs.cmake b/media_driver/agnostic/Xe_R/Xe_HP_base/hw/render/media_srcs.cmake
+index 5b66048d4..9c40d027b 100644
+--- a/media_driver/agnostic/Xe_R/Xe_HP_base/hw/render/media_srcs.cmake
++++ b/media_driver/agnostic/Xe_R/Xe_HP_base/hw/render/media_srcs.cmake
+@@ -43,4 +43,5 @@ source_group("MHW\\Render Engine" FILES ${TMP_RENDER_SOURCES_} ${TMP_RENDER_HEAD
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/common/hw/media_srcs.cmake b/media_driver/agnostic/common/hw/media_srcs.cmake
+index 6947c4300..6558ab95b 100644
+--- a/media_driver/agnostic/common/hw/media_srcs.cmake
++++ b/media_driver/agnostic/common/hw/media_srcs.cmake
+@@ -94,4 +94,5 @@ source_group("MHW\\BLT" FILES ${TMP_5_SOURCES_} ${TMP_5_HEADERS_})
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+diff --git a/media_driver/agnostic/common/hw/vdbox/media_srcs.cmake b/media_driver/agnostic/common/hw/vdbox/media_srcs.cmake
+index 184928a80..1c6b3b585 100644
+--- a/media_driver/agnostic/common/hw/vdbox/media_srcs.cmake
++++ b/media_driver/agnostic/common/hw/vdbox/media_srcs.cmake
+@@ -52,3 +52,5 @@ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/common/media_interfaces/media_srcs.cmake b/media_driver/agnostic/common/media_interfaces/media_srcs.cmake
+index 1727adbaa..1fd448378 100644
+--- a/media_driver/agnostic/common/media_interfaces/media_srcs.cmake
++++ b/media_driver/agnostic/common/media_interfaces/media_srcs.cmake
+@@ -44,4 +44,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/common/renderhal/media_srcs.cmake b/media_driver/agnostic/common/renderhal/media_srcs.cmake
+index 0db298627..6fc53cab6 100644
+--- a/media_driver/agnostic/common/renderhal/media_srcs.cmake
++++ b/media_driver/agnostic/common/renderhal/media_srcs.cmake
+@@ -54,4 +54,5 @@ source_group( "MHW\\OCA" FILES ${TMP_SOURCES2_} ${TMP_HEADERS2_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/common/shared/media_srcs.cmake b/media_driver/agnostic/common/shared/media_srcs.cmake
+index b7fa736bb..d1adb8c30 100644
+--- a/media_driver/agnostic/common/shared/media_srcs.cmake
++++ b/media_driver/agnostic/common/shared/media_srcs.cmake
+@@ -46,3 +46,5 @@ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/common/shared/mediacopy/media_srcs.cmake b/media_driver/agnostic/common/shared/mediacopy/media_srcs.cmake
+index 518cbb013..8dd97f51e 100644
+--- a/media_driver/agnostic/common/shared/mediacopy/media_srcs.cmake
++++ b/media_driver/agnostic/common/shared/mediacopy/media_srcs.cmake
+@@ -38,4 +38,5 @@ source_group( "Common Files" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/common/vp/hal/media_srcs.cmake b/media_driver/agnostic/common/vp/hal/media_srcs.cmake
+index 15f1149f2..ab84ed722 100644
+--- a/media_driver/agnostic/common/vp/hal/media_srcs.cmake
++++ b/media_driver/agnostic/common/vp/hal/media_srcs.cmake
+@@ -115,3 +115,4 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++media_add_curr_to_include_path()
+diff --git a/media_driver/agnostic/common/vp/kdll/media_srcs.cmake b/media_driver/agnostic/common/vp/kdll/media_srcs.cmake
+index c811a97e1..d522f0e22 100644
+--- a/media_driver/agnostic/common/vp/kdll/media_srcs.cmake
++++ b/media_driver/agnostic/common/vp/kdll/media_srcs.cmake
+@@ -43,4 +43,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/g12/g12_base/hw/render/media_srcs.cmake b/media_driver/agnostic/g12/g12_base/hw/render/media_srcs.cmake
+index 98cb53b14..7326d41c1 100644
+--- a/media_driver/agnostic/g12/g12_base/hw/render/media_srcs.cmake
++++ b/media_driver/agnostic/g12/g12_base/hw/render/media_srcs.cmake
+@@ -44,4 +44,5 @@ source_group("MHW\\Render Engine" FILES ${TMP_RENDER_SOURCES_} ${TMP_RENDER_HEAD
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen11/cm/media_srcs.cmake b/media_driver/agnostic/gen11/cm/media_srcs.cmake
+index caa9ade43..6cd631507 100644
+--- a/media_driver/agnostic/gen11/cm/media_srcs.cmake
++++ b/media_driver/agnostic/gen11/cm/media_srcs.cmake
+@@ -41,4 +41,5 @@ source_group( "CM" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen11/hw/media_srcs.cmake b/media_driver/agnostic/gen11/hw/media_srcs.cmake
+index 05525570c..b8ecdf38f 100644
+--- a/media_driver/agnostic/gen11/hw/media_srcs.cmake
++++ b/media_driver/agnostic/gen11/hw/media_srcs.cmake
+@@ -101,4 +101,5 @@ source_group("MHW\\State Heap" FILES ${TMP_5_SOURCES_} ${TMP_5_HEADERS_})
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen11/hw/vdbox/media_srcs.cmake b/media_driver/agnostic/gen11/hw/vdbox/media_srcs.cmake
+index c3d811496..923957863 100644
+--- a/media_driver/agnostic/gen11/hw/vdbox/media_srcs.cmake
++++ b/media_driver/agnostic/gen11/hw/vdbox/media_srcs.cmake
+@@ -56,4 +56,5 @@ source_group( "MHW\\Vdbox" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen11/renderhal/media_srcs.cmake b/media_driver/agnostic/gen11/renderhal/media_srcs.cmake
+index f4ae6db4b..6d0f38f4d 100644
+--- a/media_driver/agnostic/gen11/renderhal/media_srcs.cmake
++++ b/media_driver/agnostic/gen11/renderhal/media_srcs.cmake
+@@ -42,4 +42,5 @@ source_group( "MHW\\Render Hal" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen11/vp/hal/media_srcs.cmake b/media_driver/agnostic/gen11/vp/hal/media_srcs.cmake
+index 0ae641b24..6324f1adc 100644
+--- a/media_driver/agnostic/gen11/vp/hal/media_srcs.cmake
++++ b/media_driver/agnostic/gen11/vp/hal/media_srcs.cmake
+@@ -50,4 +50,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen11_icllp/vp/hal/media_srcs.cmake b/media_driver/agnostic/gen11_icllp/vp/hal/media_srcs.cmake
+index 8385e3569..700a31141 100644
+--- a/media_driver/agnostic/gen11_icllp/vp/hal/media_srcs.cmake
++++ b/media_driver/agnostic/gen11_icllp/vp/hal/media_srcs.cmake
+@@ -58,4 +58,5 @@ set(TMP_2_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen11_icllp/vp/kernel/media_srcs.cmake b/media_driver/agnostic/gen11_icllp/vp/kernel/media_srcs.cmake
+index 13bb8b350..8b9c05b3d 100755
+--- a/media_driver/agnostic/gen11_icllp/vp/kernel/media_srcs.cmake
++++ b/media_driver/agnostic/gen11_icllp/vp/kernel/media_srcs.cmake
+@@ -47,3 +47,5 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen11_jsl_ehl/renderhal/media_srcs.cmake b/media_driver/agnostic/gen11_jsl_ehl/renderhal/media_srcs.cmake
+index ecbc6da31..8d636a1b0 100644
+--- a/media_driver/agnostic/gen11_jsl_ehl/renderhal/media_srcs.cmake
++++ b/media_driver/agnostic/gen11_jsl_ehl/renderhal/media_srcs.cmake
+@@ -41,4 +41,5 @@ source_group( "MHW\\Render Hal" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen11_jsl_ehl/vp/hal/media_srcs.cmake b/media_driver/agnostic/gen11_jsl_ehl/vp/hal/media_srcs.cmake
+index e69965592..74f4f3cf6 100644
+--- a/media_driver/agnostic/gen11_jsl_ehl/vp/hal/media_srcs.cmake
++++ b/media_driver/agnostic/gen11_jsl_ehl/vp/hal/media_srcs.cmake
+@@ -59,4 +59,5 @@ set(TMP_2_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen12/cm/media_srcs.cmake b/media_driver/agnostic/gen12/cm/media_srcs.cmake
+index 24a2ba822..92f805568 100644
+--- a/media_driver/agnostic/gen12/cm/media_srcs.cmake
++++ b/media_driver/agnostic/gen12/cm/media_srcs.cmake
+@@ -42,4 +42,5 @@ source_group( "CM" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen12/hw/media_srcs.cmake b/media_driver/agnostic/gen12/hw/media_srcs.cmake
+index 2179aa3ce..6349fb4c2 100644
+--- a/media_driver/agnostic/gen12/hw/media_srcs.cmake
++++ b/media_driver/agnostic/gen12/hw/media_srcs.cmake
+@@ -88,4 +88,5 @@ source_group("MHW\\State Heap" FILES ${TMP_STATE_HEAP_SOURCES_} ${TMP_STATE_HEAP
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen12/hw/vdbox/media_srcs.cmake b/media_driver/agnostic/gen12/hw/vdbox/media_srcs.cmake
+index d58b43af9..b44cb3560 100644
+--- a/media_driver/agnostic/gen12/hw/vdbox/media_srcs.cmake
++++ b/media_driver/agnostic/gen12/hw/vdbox/media_srcs.cmake
+@@ -63,4 +63,5 @@ source_group( "MHW\\Vdbox" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen12/media_srcs.cmake b/media_driver/agnostic/gen12/media_srcs.cmake
+index 53ba7bf72..df1aa7253 100644
+--- a/media_driver/agnostic/gen12/media_srcs.cmake
++++ b/media_driver/agnostic/gen12/media_srcs.cmake
+@@ -30,4 +30,5 @@ set(MEDIA_BIN_HEADERS_
+ set(MEDIA_BIN_INCLUDE_DIR
+     ${MEDIA_BIN_INCLUDE_DIR}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen12/vp/hal/media_srcs.cmake b/media_driver/agnostic/gen12/vp/hal/media_srcs.cmake
+index 4a4413200..8ffff46d7 100644
+--- a/media_driver/agnostic/gen12/vp/hal/media_srcs.cmake
++++ b/media_driver/agnostic/gen12/vp/hal/media_srcs.cmake
+@@ -54,4 +54,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen12_tgllp/media_srcs.cmake b/media_driver/agnostic/gen12_tgllp/media_srcs.cmake
+index 52ed8707b..309d795f6 100644
+--- a/media_driver/agnostic/gen12_tgllp/media_srcs.cmake
++++ b/media_driver/agnostic/gen12_tgllp/media_srcs.cmake
+@@ -28,4 +28,5 @@ set(MEDIA_BIN_HEADERS_
+ set(MEDIA_BIN_INCLUDE_DIR
+     ${MEDIA_BIN_INCLUDE_DIR}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen12_tgllp/vp/hal/media_srcs.cmake b/media_driver/agnostic/gen12_tgllp/vp/hal/media_srcs.cmake
+index 0013249d4..535f2c6e2 100644
+--- a/media_driver/agnostic/gen12_tgllp/vp/hal/media_srcs.cmake
++++ b/media_driver/agnostic/gen12_tgllp/vp/hal/media_srcs.cmake
+@@ -58,4 +58,5 @@ set(TMP_2_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfc/media_srcs.cmake b/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfc/media_srcs.cmake
+index c405f0727..30fe315ab 100644
+--- a/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfc/media_srcs.cmake
++++ b/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfc/media_srcs.cmake
+@@ -57,4 +57,5 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+ set(MEDIA_BIN_INCLUDE_DIR
+     ${MEDIA_BIN_INCLUDE_DIR}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfccmlpch/media_srcs.cmake b/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfccmlpch/media_srcs.cmake
+index e99c37459..24cdf2302 100644
+--- a/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfccmlpch/media_srcs.cmake
++++ b/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfccmlpch/media_srcs.cmake
+@@ -58,4 +58,5 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+ set(MEDIA_BIN_INCLUDE_DIR
+     ${MEDIA_BIN_INCLUDE_DIR}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfcpatch/media_srcs.cmake b/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfcpatch/media_srcs.cmake
+index c09182328..12883cc5c 100644
+--- a/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfcpatch/media_srcs.cmake
++++ b/media_driver/agnostic/gen12_tgllp/vp/kernel/cmfcpatch/media_srcs.cmake
+@@ -58,4 +58,5 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+ set(MEDIA_BIN_INCLUDE_DIR
+     ${MEDIA_BIN_INCLUDE_DIR}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen12_tgllp/vp/kernel/media_srcs.cmake b/media_driver/agnostic/gen12_tgllp/vp/kernel/media_srcs.cmake
+index 4ac44154d..e7db78ca2 100644
+--- a/media_driver/agnostic/gen12_tgllp/vp/kernel/media_srcs.cmake
++++ b/media_driver/agnostic/gen12_tgllp/vp/kernel/media_srcs.cmake
+@@ -62,4 +62,5 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+ set(MEDIA_BIN_INCLUDE_DIR
+     ${MEDIA_BIN_INCLUDE_DIR}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen8/cm/media_srcs.cmake b/media_driver/agnostic/gen8/cm/media_srcs.cmake
+index 2784a1cfd..76fe6ab0b 100644
+--- a/media_driver/agnostic/gen8/cm/media_srcs.cmake
++++ b/media_driver/agnostic/gen8/cm/media_srcs.cmake
+@@ -42,4 +42,5 @@ source_group("CM" FILES ${TMP_SOURCES_} ${TMP_HEADERS_})
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen8/hw/media_srcs.cmake b/media_driver/agnostic/gen8/hw/media_srcs.cmake
+index 2df0924b8..14da836ac 100644
+--- a/media_driver/agnostic/gen8/hw/media_srcs.cmake
++++ b/media_driver/agnostic/gen8/hw/media_srcs.cmake
+@@ -89,4 +89,5 @@ source_group("MHW\\State Heap" FILES ${TMP_5_SOURCES_} ${TMP_5_HEADERS_})
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen8/hw/vdbox/media_srcs.cmake b/media_driver/agnostic/gen8/hw/vdbox/media_srcs.cmake
+index 4320df028..decb9cbaf 100644
+--- a/media_driver/agnostic/gen8/hw/vdbox/media_srcs.cmake
++++ b/media_driver/agnostic/gen8/hw/vdbox/media_srcs.cmake
+@@ -34,4 +34,5 @@ source_group("MHW\\Vdbox" FILES ${TMP_SOURCES_} ${TMP_HEADERS_})
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen8/renderhal/media_srcs.cmake b/media_driver/agnostic/gen8/renderhal/media_srcs.cmake
+index f27379540..1dcf454ee 100644
+--- a/media_driver/agnostic/gen8/renderhal/media_srcs.cmake
++++ b/media_driver/agnostic/gen8/renderhal/media_srcs.cmake
+@@ -41,4 +41,5 @@ source_group( "MHW\\Render Hal" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen8/vp/hal/media_srcs.cmake b/media_driver/agnostic/gen8/vp/hal/media_srcs.cmake
+index a28caf729..281c07d80 100644
+--- a/media_driver/agnostic/gen8/vp/hal/media_srcs.cmake
++++ b/media_driver/agnostic/gen8/vp/hal/media_srcs.cmake
+@@ -62,3 +62,5 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen8/vp/kernel/media_srcs.cmake b/media_driver/agnostic/gen8/vp/kernel/media_srcs.cmake
+index be9116c8d..17d281266 100755
+--- a/media_driver/agnostic/gen8/vp/kernel/media_srcs.cmake
++++ b/media_driver/agnostic/gen8/vp/kernel/media_srcs.cmake
+@@ -44,4 +44,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen8_bdw/hw/vdbox/media_srcs.cmake b/media_driver/agnostic/gen8_bdw/hw/vdbox/media_srcs.cmake
+index e6460cb59..490cf7374 100644
+--- a/media_driver/agnostic/gen8_bdw/hw/vdbox/media_srcs.cmake
++++ b/media_driver/agnostic/gen8_bdw/hw/vdbox/media_srcs.cmake
+@@ -44,4 +44,5 @@ source_group( "MHW\\Vdbox" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen8_bdw/renderhal/media_srcs.cmake b/media_driver/agnostic/gen8_bdw/renderhal/media_srcs.cmake
+index 25996ea24..e2f36128e 100644
+--- a/media_driver/agnostic/gen8_bdw/renderhal/media_srcs.cmake
++++ b/media_driver/agnostic/gen8_bdw/renderhal/media_srcs.cmake
+@@ -34,4 +34,5 @@ source_group("MHW\\Render Hal" FILES ${TMP_SOURCES_} ${TMP_HEADERS_})
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen9/cm/media_srcs.cmake b/media_driver/agnostic/gen9/cm/media_srcs.cmake
+index 9c4b8c1be..a0bea6793 100644
+--- a/media_driver/agnostic/gen9/cm/media_srcs.cmake
++++ b/media_driver/agnostic/gen9/cm/media_srcs.cmake
+@@ -42,4 +42,5 @@ source_group( "CM" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen9/hw/media_srcs.cmake b/media_driver/agnostic/gen9/hw/media_srcs.cmake
+index 687ae8442..3aaeb042a 100644
+--- a/media_driver/agnostic/gen9/hw/media_srcs.cmake
++++ b/media_driver/agnostic/gen9/hw/media_srcs.cmake
+@@ -98,4 +98,5 @@ source_group("MHW\\State Heap" FILES ${TMP_5_SOURCES_} ${TMP_5_HEADERS_})
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen9/hw/vdbox/media_srcs.cmake b/media_driver/agnostic/gen9/hw/vdbox/media_srcs.cmake
+index 578f03d57..072dc8369 100644
+--- a/media_driver/agnostic/gen9/hw/vdbox/media_srcs.cmake
++++ b/media_driver/agnostic/gen9/hw/vdbox/media_srcs.cmake
+@@ -35,4 +35,5 @@ source_group( "MHW\\Vdbox" FILES ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen9/renderhal/media_srcs.cmake b/media_driver/agnostic/gen9/renderhal/media_srcs.cmake
+index b23e83d44..782aea218 100644
+--- a/media_driver/agnostic/gen9/renderhal/media_srcs.cmake
++++ b/media_driver/agnostic/gen9/renderhal/media_srcs.cmake
+@@ -41,4 +41,5 @@ source_group( "MHW\\Render Hal" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen9/vp/hal/media_srcs.cmake b/media_driver/agnostic/gen9/vp/hal/media_srcs.cmake
+index 88cd40160..6cfdf3836 100644
+--- a/media_driver/agnostic/gen9/vp/hal/media_srcs.cmake
++++ b/media_driver/agnostic/gen9/vp/hal/media_srcs.cmake
+@@ -64,3 +64,5 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen9/vp/kernel/media_srcs.cmake b/media_driver/agnostic/gen9/vp/kernel/media_srcs.cmake
+index bd130d932..f00b14fd4 100755
+--- a/media_driver/agnostic/gen9/vp/kernel/media_srcs.cmake
++++ b/media_driver/agnostic/gen9/vp/kernel/media_srcs.cmake
+@@ -47,4 +47,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen9_bxt/hw/vdbox/media_srcs.cmake b/media_driver/agnostic/gen9_bxt/hw/vdbox/media_srcs.cmake
+index 9f6983b89..e50be4705 100644
+--- a/media_driver/agnostic/gen9_bxt/hw/vdbox/media_srcs.cmake
++++ b/media_driver/agnostic/gen9_bxt/hw/vdbox/media_srcs.cmake
+@@ -56,4 +56,5 @@ source_group( "MHW\\Vdbox" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen9_bxt/vp/hal/media_srcs.cmake b/media_driver/agnostic/gen9_bxt/vp/hal/media_srcs.cmake
+index cf35bd74c..f8486bd70 100644
+--- a/media_driver/agnostic/gen9_bxt/vp/hal/media_srcs.cmake
++++ b/media_driver/agnostic/gen9_bxt/vp/hal/media_srcs.cmake
+@@ -55,4 +55,5 @@ set(TMP_2_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen9_glk/hw/vdbox/media_srcs.cmake b/media_driver/agnostic/gen9_glk/hw/vdbox/media_srcs.cmake
+index 716e5b304..d13d1217b 100644
+--- a/media_driver/agnostic/gen9_glk/hw/vdbox/media_srcs.cmake
++++ b/media_driver/agnostic/gen9_glk/hw/vdbox/media_srcs.cmake
+@@ -43,4 +43,5 @@ source_group( "MHW\\Vdbox" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen9_glk/vp/hal/media_srcs.cmake b/media_driver/agnostic/gen9_glk/vp/hal/media_srcs.cmake
+index d5b0b7526..b8a112429 100644
+--- a/media_driver/agnostic/gen9_glk/vp/hal/media_srcs.cmake
++++ b/media_driver/agnostic/gen9_glk/vp/hal/media_srcs.cmake
+@@ -56,3 +56,5 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen9_kbl/hw/vdbox/media_srcs.cmake b/media_driver/agnostic/gen9_kbl/hw/vdbox/media_srcs.cmake
+index b2f01324e..e2294f9e0 100644
+--- a/media_driver/agnostic/gen9_kbl/hw/vdbox/media_srcs.cmake
++++ b/media_driver/agnostic/gen9_kbl/hw/vdbox/media_srcs.cmake
+@@ -56,4 +56,5 @@ source_group( "MHW\\Vdbox" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/agnostic/gen9_skl/hw/vdbox/media_srcs.cmake b/media_driver/agnostic/gen9_skl/hw/vdbox/media_srcs.cmake
+index 3c8610a93..450e5cdcd 100644
+--- a/media_driver/agnostic/gen9_skl/hw/vdbox/media_srcs.cmake
++++ b/media_driver/agnostic/gen9_skl/hw/vdbox/media_srcs.cmake
+@@ -55,4 +55,5 @@ source_group( "MHW\\Vdbox" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/linux/common/os/media_srcs.cmake b/media_driver/linux/common/os/media_srcs.cmake
+index 8fdb07865..191fef7cb 100644
+--- a/media_driver/linux/common/os/media_srcs.cmake
++++ b/media_driver/linux/common/os/media_srcs.cmake
+@@ -75,3 +75,5 @@ set (MOS_PUBLIC_INCLUDE_DIRS_
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+ endif() #NOT CMAKE_WDDM_LINUX
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_dg2/media_srcs.cmake b/media_driver/media_interface/media_interfaces_dg2/media_srcs.cmake
+index 1bfce0eae..e7295a637 100644
+--- a/media_driver/media_interface/media_interfaces_dg2/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_dg2/media_srcs.cmake
+@@ -40,4 +40,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_m10_cnl/media_srcs.cmake b/media_driver/media_interface/media_interfaces_m10_cnl/media_srcs.cmake
+index 6a4bdfbe8..a1a7b0316 100644
+--- a/media_driver/media_interface/media_interfaces_m10_cnl/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_m10_cnl/media_srcs.cmake
+@@ -39,4 +39,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_m11_icllp/media_srcs.cmake b/media_driver/media_interface/media_interfaces_m11_icllp/media_srcs.cmake
+index 62fe1fc5a..0b2a22bd6 100644
+--- a/media_driver/media_interface/media_interfaces_m11_icllp/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_m11_icllp/media_srcs.cmake
+@@ -39,4 +39,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_m11_jsl_ehl/media_srcs.cmake b/media_driver/media_interface/media_interfaces_m11_jsl_ehl/media_srcs.cmake
+index 65b862d57..18cb6e2d6 100644
+--- a/media_driver/media_interface/media_interfaces_m11_jsl_ehl/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_m11_jsl_ehl/media_srcs.cmake
+@@ -39,4 +39,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_m12_adln/media_srcs.cmake b/media_driver/media_interface/media_interfaces_m12_adln/media_srcs.cmake
+index 9f99d1d97..682de439e 100644
+--- a/media_driver/media_interface/media_interfaces_m12_adln/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_m12_adln/media_srcs.cmake
+@@ -40,4 +40,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_m12_adlp/media_srcs.cmake b/media_driver/media_interface/media_interfaces_m12_adlp/media_srcs.cmake
+index e57a611f6..bb21b6c9a 100644
+--- a/media_driver/media_interface/media_interfaces_m12_adlp/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_m12_adlp/media_srcs.cmake
+@@ -40,4 +40,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_m12_adls/media_srcs.cmake b/media_driver/media_interface/media_interfaces_m12_adls/media_srcs.cmake
+index ee244e9fd..54b5a2e06 100644
+--- a/media_driver/media_interface/media_interfaces_m12_adls/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_m12_adls/media_srcs.cmake
+@@ -40,4 +40,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_m12_dg1/media_srcs.cmake b/media_driver/media_interface/media_interfaces_m12_dg1/media_srcs.cmake
+index 1c1d50c4c..d6c20fcce 100644
+--- a/media_driver/media_interface/media_interfaces_m12_dg1/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_m12_dg1/media_srcs.cmake
+@@ -40,4 +40,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_m12_rkl/media_srcs.cmake b/media_driver/media_interface/media_interfaces_m12_rkl/media_srcs.cmake
+index 8021465f2..ddc9b4c44 100644
+--- a/media_driver/media_interface/media_interfaces_m12_rkl/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_m12_rkl/media_srcs.cmake
+@@ -40,4 +40,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_m12_tgllp/media_srcs.cmake b/media_driver/media_interface/media_interfaces_m12_tgllp/media_srcs.cmake
+index 0cfc415cd..9ded714dd 100644
+--- a/media_driver/media_interface/media_interfaces_m12_tgllp/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_m12_tgllp/media_srcs.cmake
+@@ -39,4 +39,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_m8_bdw/media_srcs.cmake b/media_driver/media_interface/media_interfaces_m8_bdw/media_srcs.cmake
+index 4db7eaeee..1afef00c0 100644
+--- a/media_driver/media_interface/media_interfaces_m8_bdw/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_m8_bdw/media_srcs.cmake
+@@ -40,4 +40,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_m9_bxt/media_srcs.cmake b/media_driver/media_interface/media_interfaces_m9_bxt/media_srcs.cmake
+index d96f53740..c83144594 100644
+--- a/media_driver/media_interface/media_interfaces_m9_bxt/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_m9_bxt/media_srcs.cmake
+@@ -40,4 +40,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_m9_cfl/media_srcs.cmake b/media_driver/media_interface/media_interfaces_m9_cfl/media_srcs.cmake
+index 27480be30..660e7bd29 100644
+--- a/media_driver/media_interface/media_interfaces_m9_cfl/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_m9_cfl/media_srcs.cmake
+@@ -40,4 +40,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_m9_glk/media_srcs.cmake b/media_driver/media_interface/media_interfaces_m9_glk/media_srcs.cmake
+index a67d14eb6..354958a8e 100644
+--- a/media_driver/media_interface/media_interfaces_m9_glk/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_m9_glk/media_srcs.cmake
+@@ -40,4 +40,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_m9_kbl/media_srcs.cmake b/media_driver/media_interface/media_interfaces_m9_kbl/media_srcs.cmake
+index e1c3f08fd..483044c66 100644
+--- a/media_driver/media_interface/media_interfaces_m9_kbl/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_m9_kbl/media_srcs.cmake
+@@ -39,4 +39,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_m9_skl/media_srcs.cmake b/media_driver/media_interface/media_interfaces_m9_skl/media_srcs.cmake
+index 8db37bf37..1588eeba4 100644
+--- a/media_driver/media_interface/media_interfaces_m9_skl/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_m9_skl/media_srcs.cmake
+@@ -39,4 +39,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_pvc/media_srcs.cmake b/media_driver/media_interface/media_interfaces_pvc/media_srcs.cmake
+index 22486377f..20511f018 100644
+--- a/media_driver/media_interface/media_interfaces_pvc/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_pvc/media_srcs.cmake
+@@ -40,4 +40,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_interface/media_interfaces_xehp_sdv/media_srcs.cmake b/media_driver/media_interface/media_interfaces_xehp_sdv/media_srcs.cmake
+index 410aaca75..4564525c4 100644
+--- a/media_driver/media_interface/media_interfaces_xehp_sdv/media_srcs.cmake
++++ b/media_driver/media_interface/media_interfaces_xehp_sdv/media_srcs.cmake
+@@ -40,4 +40,5 @@ set(COMMON_HEADERS_
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/hw/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/hw/media_srcs.cmake
+index f82866f8e..e1fcfde8c 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/hw/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/hw/media_srcs.cmake
+@@ -19,3 +19,5 @@
+ # OTHER DEALINGS IN THE SOFTWARE.
+ 
+ media_include_subdirectory(vdbox)
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/hw/vdbox/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/hw/vdbox/media_srcs.cmake
+index 21860411a..7cbee233b 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/hw/vdbox/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/hw/vdbox/media_srcs.cmake
+@@ -35,4 +35,5 @@ source_group( "MHW\\Vdbox" FILES ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/shared/mediacopy/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/shared/mediacopy/media_srcs.cmake
+index 0523ef611..81c1a1d1d 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/shared/mediacopy/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/shared/mediacopy/media_srcs.cmake
+@@ -46,4 +46,5 @@ source_group( "SharedNext\\M12\\shared\\MediaCopy" FILES ${TMP_SOURCES_} ${TMP_H
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/vp/hal/feature_manager/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/vp/hal/feature_manager/media_srcs.cmake
+index 3a3b96d44..517ba6e8a 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/vp/hal/feature_manager/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/vp/hal/feature_manager/media_srcs.cmake
+@@ -44,4 +44,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/vp/hal/packet/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/vp/hal/packet/media_srcs.cmake
+index 677d6e2b5..83299231b 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/vp/hal/packet/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/vp/hal/packet/media_srcs.cmake
+@@ -43,4 +43,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/vp/hal/pipeline/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/vp/hal/pipeline/media_srcs.cmake
+index 916c52742..f0d77d378 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/vp/hal/pipeline/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/vp/hal/pipeline/media_srcs.cmake
+@@ -43,4 +43,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/vp/hal/platform_interface/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/vp/hal/platform_interface/media_srcs.cmake
+index 3cab4c565..61f5a62c7 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/vp/hal/platform_interface/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_HPM/vp/hal/platform_interface/media_srcs.cmake
+@@ -43,4 +43,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/feature_manager/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/feature_manager/media_srcs.cmake
+index 6ec9c781a..680dd82c2 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/feature_manager/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/feature_manager/media_srcs.cmake
+@@ -44,4 +44,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/packet/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/packet/media_srcs.cmake
+index 37eb7e928..2e3cf7499 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/packet/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/packet/media_srcs.cmake
+@@ -44,4 +44,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/pipeline/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/pipeline/media_srcs.cmake
+index eda8ee89b..31e61970f 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/pipeline/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/pipeline/media_srcs.cmake
+@@ -44,4 +44,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/platform_interface/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/platform_interface/media_srcs.cmake
+index 82660d3a3..2f499867a 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/platform_interface/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM/vp/hal/platform_interface/media_srcs.cmake
+@@ -43,4 +43,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/hw/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/hw/media_srcs.cmake
+index b04b96a2a..d2f1c2b71 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/hw/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/hw/media_srcs.cmake
+@@ -34,4 +34,5 @@ source_group("MHW\\Common MI" FILES ${TMP_MI_HEADERS_})
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/shared/mediacopy/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/shared/mediacopy/media_srcs.cmake
+index f8704407f..8e2f771f8 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/shared/mediacopy/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/shared/mediacopy/media_srcs.cmake
+@@ -44,4 +44,5 @@ source_group( "SharedNext\\M12\\shared\\MediaCopy" FILES ${TMP_SOURCES_} ${TMP_H
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/vp/hal/feature_manager/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/vp/hal/feature_manager/media_srcs.cmake
+index c7b335010..0976d76b1 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/vp/hal/feature_manager/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/vp/hal/feature_manager/media_srcs.cmake
+@@ -44,4 +44,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/vp/hal/packet/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/vp/hal/packet/media_srcs.cmake
+index 55738ccdb..bc802471e 100644
+--- a/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/vp/hal/packet/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_M/Xe_XPM_base/vp/hal/packet/media_srcs.cmake
+@@ -46,4 +46,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_R/Xe_HP/renderhal/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_R/Xe_HP/renderhal/media_srcs.cmake
+index 67aa2cbb7..6474858fc 100644
+--- a/media_driver/media_softlet/agnostic/Xe_R/Xe_HP/renderhal/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_R/Xe_HP/renderhal/media_srcs.cmake
+@@ -42,4 +42,5 @@ source_group( "MHW\\Render Hal" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_R/Xe_HPC/renderhal/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_R/Xe_HPC/renderhal/media_srcs.cmake
+index efc495fe1..e9e1635aa 100644
+--- a/media_driver/media_softlet/agnostic/Xe_R/Xe_HPC/renderhal/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_R/Xe_HPC/renderhal/media_srcs.cmake
+@@ -42,4 +42,5 @@ source_group( "MHW\\Render Hal" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_R/Xe_HPG/renderhal/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_R/Xe_HPG/renderhal/media_srcs.cmake
+index d3f1e140c..b81657b23 100644
+--- a/media_driver/media_softlet/agnostic/Xe_R/Xe_HPG/renderhal/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_R/Xe_HPG/renderhal/media_srcs.cmake
+@@ -42,4 +42,5 @@ source_group( "MHW\\Render Hal" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/Xe_R/Xe_HP_Base/renderhal/media_srcs.cmake b/media_driver/media_softlet/agnostic/Xe_R/Xe_HP_Base/renderhal/media_srcs.cmake
+index 3bc2b5b60..b605e16f7 100644
+--- a/media_driver/media_softlet/agnostic/Xe_R/Xe_HP_Base/renderhal/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/Xe_R/Xe_HP_Base/renderhal/media_srcs.cmake
+@@ -42,4 +42,5 @@ source_group( "MHW\\Render Hal" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/common/shared/media_sfc_interface/media_srcs.cmake b/media_driver/media_softlet/agnostic/common/shared/media_sfc_interface/media_srcs.cmake
+index 3688a023c..22ea9759b 100644
+--- a/media_driver/media_softlet/agnostic/common/shared/media_sfc_interface/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/common/shared/media_sfc_interface/media_srcs.cmake
+@@ -41,4 +41,5 @@ source_group( "Common Files" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/common/shared/scalability/media_srcs.cmake b/media_driver/media_softlet/agnostic/common/shared/scalability/media_srcs.cmake
+index 5a8662302..93d5b82e2 100644
+--- a/media_driver/media_softlet/agnostic/common/shared/scalability/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/common/shared/scalability/media_srcs.cmake
+@@ -40,3 +40,5 @@ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/common/vp/hal/packet/media_srcs.cmake b/media_driver/media_softlet/agnostic/common/vp/hal/packet/media_srcs.cmake
+index 3fe587c29..8adca5e40 100644
+--- a/media_driver/media_softlet/agnostic/common/vp/hal/packet/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/common/vp/hal/packet/media_srcs.cmake
+@@ -44,4 +44,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/common/vp/hal/pipeline/media_srcs.cmake b/media_driver/media_softlet/agnostic/common/vp/hal/pipeline/media_srcs.cmake
+index bcd63c6bc..863fed2e8 100644
+--- a/media_driver/media_softlet/agnostic/common/vp/hal/pipeline/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/common/vp/hal/pipeline/media_srcs.cmake
+@@ -42,4 +42,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/common/vp/hal/shared/scalability/media_srcs.cmake b/media_driver/media_softlet/agnostic/common/vp/hal/shared/scalability/media_srcs.cmake
+index 6069d6ec0..694940e60 100644
+--- a/media_driver/media_softlet/agnostic/common/vp/hal/shared/scalability/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/common/vp/hal/shared/scalability/media_srcs.cmake
+@@ -50,3 +50,5 @@ set (VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/g12/g12_0/renderhal/media_srcs.cmake b/media_driver/media_softlet/agnostic/g12/g12_0/renderhal/media_srcs.cmake
+index 95e3edbfd..2b9f9943b 100644
+--- a/media_driver/media_softlet/agnostic/g12/g12_0/renderhal/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/g12/g12_0/renderhal/media_srcs.cmake
+@@ -42,4 +42,5 @@ source_group( "MHW\\Render Hal" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/g12/g12_1/renderhal/media_srcs.cmake b/media_driver/media_softlet/agnostic/g12/g12_1/renderhal/media_srcs.cmake
+index e43300a25..129e128cd 100644
+--- a/media_driver/media_softlet/agnostic/g12/g12_1/renderhal/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/g12/g12_1/renderhal/media_srcs.cmake
+@@ -43,4 +43,5 @@ source_group( "MHW\\Render Hal" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/g12/g12_base/renderhal/media_srcs.cmake b/media_driver/media_softlet/agnostic/g12/g12_base/renderhal/media_srcs.cmake
+index 7131d56fa..27f725c3f 100644
+--- a/media_driver/media_softlet/agnostic/g12/g12_base/renderhal/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/g12/g12_base/renderhal/media_srcs.cmake
+@@ -42,4 +42,5 @@ source_group( "MHW\\Render Hal" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/gen12/vp/hal/media_srcs.cmake b/media_driver/media_softlet/agnostic/gen12/vp/hal/media_srcs.cmake
+index 1ef7afca5..9e7b1e447 100644
+--- a/media_driver/media_softlet/agnostic/gen12/vp/hal/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/gen12/vp/hal/media_srcs.cmake
+@@ -46,4 +46,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/gen12_tgllp/vp/hal/platform_interface/media_srcs.cmake b/media_driver/media_softlet/agnostic/gen12_tgllp/vp/hal/platform_interface/media_srcs.cmake
+index d0afc8e51..42ddf7b60 100644
+--- a/media_driver/media_softlet/agnostic/gen12_tgllp/vp/hal/platform_interface/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/gen12_tgllp/vp/hal/platform_interface/media_srcs.cmake
+@@ -44,4 +44,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/m12/m12/vp/hal/packet/media_srcs.cmake b/media_driver/media_softlet/agnostic/m12/m12/vp/hal/packet/media_srcs.cmake
+index 1f07d0773..9c8d4a5ce 100644
+--- a/media_driver/media_softlet/agnostic/m12/m12/vp/hal/packet/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/m12/m12/vp/hal/packet/media_srcs.cmake
+@@ -47,3 +47,5 @@ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/m12/m12_0/shared/mediacopy/media_srcs.cmake b/media_driver/media_softlet/agnostic/m12/m12_0/shared/mediacopy/media_srcs.cmake
+index a585c030f..e78beea15 100644
+--- a/media_driver/media_softlet/agnostic/m12/m12_0/shared/mediacopy/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/m12/m12_0/shared/mediacopy/media_srcs.cmake
+@@ -42,4 +42,5 @@ source_group( SharedNext\\Gen12\\shared\\MediaCopy FILES ${TMP_SOURCES_} ${TMP_H
+ set(COMMON_PRIVATE_INCLUDE_DIRS_
+     ${COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_driver/media_softlet/agnostic/m12/m12_0/vp/hal/feature_manager/media_srcs.cmake b/media_driver/media_softlet/agnostic/m12/m12_0/vp/hal/feature_manager/media_srcs.cmake
+index ff4cf7054..1b017851c 100644
+--- a/media_driver/media_softlet/agnostic/m12/m12_0/vp/hal/feature_manager/media_srcs.cmake
++++ b/media_driver/media_softlet/agnostic/m12/m12_0/vp/hal/feature_manager/media_srcs.cmake
+@@ -43,4 +43,5 @@ set(TMP_HEADERS_ "")
+ set(VP_PRIVATE_INCLUDE_DIRS_
+     ${VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/av1/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/av1/pipeline/media_srcs.cmake
+index d035c0eab..40f703ab9 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/av1/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/av1/pipeline/media_srcs.cmake
+@@ -38,4 +38,5 @@ endif()
+ set(SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/avc/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/avc/pipeline/media_srcs.cmake
+index de7cec332..6259e4f82 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/avc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/avc/pipeline/media_srcs.cmake
+@@ -37,4 +37,5 @@ endif()
+ set(SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/hevc/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/hevc/pipeline/media_srcs.cmake
+index e366ae5f5..6d7e0d8b3 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/hevc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/hevc/pipeline/media_srcs.cmake
+@@ -38,4 +38,5 @@ endif()
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/jpeg/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/jpeg/media_srcs.cmake
+index 3d1de0441..5c4d7477f 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/jpeg/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/jpeg/media_srcs.cmake
+@@ -37,4 +37,5 @@ endif()
+ set(SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/mpeg2/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/mpeg2/media_srcs.cmake
+index 9d6a6d9de..599ad8d26 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/mpeg2/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/mpeg2/media_srcs.cmake
+@@ -38,4 +38,5 @@ endif()
+ set(SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp8/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp8/pipeline/media_srcs.cmake
+index a4c1cd446..1c3cf162a 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp8/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp8/pipeline/media_srcs.cmake
+@@ -37,4 +37,5 @@ endif()
+ set(SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp9/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp9/pipeline/media_srcs.cmake
+index 1465433ec..9636a8170 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp9/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/dec/vp9/pipeline/media_srcs.cmake
+@@ -37,4 +37,5 @@ endif()
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/packet/media_srcs.cmake
+index 7611cb7c1..954592c8b 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/packet/media_srcs.cmake
+@@ -48,3 +48,5 @@ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/pipeline/media_srcs.cmake
+index d0b91b211..e1c9d99c0 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/av1/pipeline/media_srcs.cmake
+@@ -49,4 +49,5 @@ endif()
+ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/features/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/features/media_srcs.cmake
+index 38071e2b3..4957372af 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/features/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/features/media_srcs.cmake
+@@ -49,4 +49,5 @@ endif()
+ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/packet/media_srcs.cmake
+index d23d52d7c..289a58888 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/packet/media_srcs.cmake
+@@ -49,4 +49,5 @@ endif()
+ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/pipeline/media_srcs.cmake
+index 5066da8a5..07a9a45ec 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/hevc/pipeline/media_srcs.cmake
+@@ -49,4 +49,5 @@ endif()
+ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/features/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/features/media_srcs.cmake
+index 90364a302..6ed51e805 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/features/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/features/media_srcs.cmake
+@@ -48,4 +48,5 @@ set(TMP_HEADERS_ "")
+ set(SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/packet/media_srcs.cmake
+index 9ad88f0a9..4bd633d00 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/packet/media_srcs.cmake
+@@ -47,4 +47,5 @@ set(TMP_HEADERS_ "")
+ set(SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/pipeline/media_srcs.cmake
+index 4e71d7ff1..3ead21771 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/codec/hal/enc/vp9/pipeline/media_srcs.cmake
+@@ -46,4 +46,5 @@ set(TMP_HEADERS_ "")
+ set(SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/media_srcs.cmake
+index 7773c76b2..ae885ad9e 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/media_srcs.cmake
+@@ -114,4 +114,5 @@ set(SOFTLET_MHW_SFC_PRIVATE_INCLUDE_DIRS_
+ set(SOFTLET_MHW_BLT_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_MHW_BLT_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox/media_srcs.cmake
+index 28d37874c..2ac4571fc 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/hw/vdbox/media_srcs.cmake
+@@ -120,4 +120,5 @@ set(TMP_SOFTLET_MHW_VDBOX_MFX_HEADERS_ "")
+ set(SOFTLET_MHW_VDBOX_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_MHW_VDBOX_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/feature_manager/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/feature_manager/media_srcs.cmake
+index 3be1fce98..31dc37f21 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/feature_manager/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/feature_manager/media_srcs.cmake
+@@ -43,4 +43,5 @@ set(TMP_HEADERS_ "")
+ set(SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/packet/media_srcs.cmake
+index 74a12953a..eb2d83fb1 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/packet/media_srcs.cmake
+@@ -44,4 +44,5 @@ set(TMP_HEADERS_ "")
+ set(SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/pipeline/media_srcs.cmake
+index dcfe54539..15453b05c 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/pipeline/media_srcs.cmake
+@@ -42,4 +42,5 @@ set(TMP_HEADERS_ "")
+ set(SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/platform_interface/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/platform_interface/media_srcs.cmake
+index e3dcbf9cc..1d7f2ab4d 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/platform_interface/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus/vp/hal/platform_interface/media_srcs.cmake
+@@ -42,4 +42,5 @@ set(TMP_HEADERS_ "")
+ set(SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/features/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/features/media_srcs.cmake
+index 88aa77529..3c2a40368 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/features/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/features/media_srcs.cmake
+@@ -40,4 +40,5 @@ endif()
+ set(SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/packet/media_srcs.cmake
+index 559cea98d..350f87a92 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/packet/media_srcs.cmake
+@@ -43,3 +43,5 @@ set(SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/pipeline/media_srcs.cmake
+index 2c9e24b11..c96fdc639 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/av1/pipeline/media_srcs.cmake
+@@ -43,3 +43,5 @@ set(SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+ 
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/packet/media_srcs.cmake
+index 8e44b9575..4ddd687b8 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/packet/media_srcs.cmake
+@@ -43,3 +43,5 @@ set(SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+ 
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/pipeline/media_srcs.cmake
+index 2fd0e3417..8217818f1 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/avc/pipeline/media_srcs.cmake
+@@ -41,3 +41,5 @@ set(SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+ 
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/mmc/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/mmc/media_srcs.cmake
+index c56d30a06..92faee4c9 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/mmc/media_srcs.cmake
+@@ -37,4 +37,5 @@ endif()
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/packet/media_srcs.cmake
+index 74527276e..e30c672af 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/packet/media_srcs.cmake
+@@ -51,4 +51,5 @@ endif()
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/pipeline/media_srcs.cmake
+index df29e8dc6..946a77466 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/hevc/pipeline/media_srcs.cmake
+@@ -39,4 +39,5 @@ endif()
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/packet/media_srcs.cmake
+index 5d7a38417..255a7921b 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/packet/media_srcs.cmake
+@@ -40,3 +40,5 @@ set(SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/pipeline/media_srcs.cmake
+index 5119f8a2b..bab913480 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/jpeg/pipeline/media_srcs.cmake
+@@ -41,3 +41,5 @@ set(SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/mmc/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/mmc/media_srcs.cmake
+index 1f2bc79d8..20daa4e0c 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/mmc/media_srcs.cmake
+@@ -38,3 +38,5 @@ set(SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/packet/media_srcs.cmake
+index 9f48819fa..f97b8b2a8 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/packet/media_srcs.cmake
+@@ -44,3 +44,5 @@ set(SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/pipeline/media_srcs.cmake
+index ea67db617..0ca27af71 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/mpeg2/pipeline/media_srcs.cmake
+@@ -39,3 +39,5 @@ set(SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/shared/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/shared/media_srcs.cmake
+index aa8b3019f..58d42bf15 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/shared/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/shared/media_srcs.cmake
+@@ -32,4 +32,5 @@ source_group( CodecHalNext\\Xe_LPM_plus_base\\Decode FILES ${SOFTLET_DECODE_COMM
+ set(SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/mmc/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/mmc/media_srcs.cmake
+index 19f267d62..fd9108b04 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/mmc/media_srcs.cmake
+@@ -38,3 +38,5 @@ set(SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/packet/media_srcs.cmake
+index 85cc09474..7e1888155 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/packet/media_srcs.cmake
+@@ -43,3 +43,5 @@ set(SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/pipeline/media_srcs.cmake
+index f1bda272b..c22be6f8d 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp8/pipeline/media_srcs.cmake
+@@ -40,3 +40,5 @@ set(SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/mmc/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/mmc/media_srcs.cmake
+index 5b9d2bc0d..b853366ca 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/mmc/media_srcs.cmake
+@@ -37,4 +37,5 @@ endif()
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/packet/media_srcs.cmake
+index 361fefa2f..a6c5b874f 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/packet/media_srcs.cmake
+@@ -49,4 +49,5 @@ endif()
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/pipeline/media_srcs.cmake
+index eeedb861f..7a7bfab59 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/dec/vp9/pipeline/media_srcs.cmake
+@@ -39,4 +39,5 @@ endif()
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/media_srcs.cmake
+index 9a79a5efc..c8c682fc1 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/media_srcs.cmake
+@@ -56,3 +56,5 @@ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/preenc/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/preenc/media_srcs.cmake
+index 76a15992f..a74ee4838 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/preenc/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/features/preenc/media_srcs.cmake
+@@ -51,4 +51,5 @@ endif()
+ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/packet/media_srcs.cmake
+index 0105efef7..b2e9e202c 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/packet/media_srcs.cmake
+@@ -47,4 +47,5 @@ endif()
+ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/pipeline/media_srcs.cmake
+index 621eabf17..75d0146c0 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/av1/pipeline/media_srcs.cmake
+@@ -49,3 +49,5 @@ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/features/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/features/media_srcs.cmake
+index c1ad31949..928342ddc 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/features/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/features/media_srcs.cmake
+@@ -51,4 +51,5 @@ endif()
+ set(SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/pipeline/media_srcs.cmake
+index 8e36c538c..8ea6e46f8 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/avc/pipeline/media_srcs.cmake
+@@ -49,4 +49,5 @@ endif()
+ set(SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/media_srcs.cmake
+index ec46201dd..20340ee23 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/media_srcs.cmake
+@@ -54,3 +54,5 @@ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/preenc/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/preenc/media_srcs.cmake
+index 0cc377f8e..6b79dc49a 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/preenc/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/features/preenc/media_srcs.cmake
+@@ -52,3 +52,5 @@ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/pipeline/media_srcs.cmake
+index 4a03820b6..d96400124 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/hevc/pipeline/media_srcs.cmake
+@@ -50,4 +50,5 @@ endif()
+ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/jpeg/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/jpeg/pipeline/media_srcs.cmake
+index 97f508717..f1b0593ef 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/jpeg/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/jpeg/pipeline/media_srcs.cmake
+@@ -49,4 +49,5 @@ endif()
+ set(SOFTLET_ENCODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/shared/common/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/shared/common/media_srcs.cmake
+index af54bfe69..0d86d5d8f 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/shared/common/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/shared/common/media_srcs.cmake
+@@ -44,4 +44,5 @@ set(TMP_HEADERS_ "")
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/packet/media_srcs.cmake
+index 2f395ffc2..1b6e1c4eb 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/packet/media_srcs.cmake
+@@ -45,4 +45,5 @@ set(TMP_HEADERS_ "")
+ set(SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/pipeline/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/pipeline/media_srcs.cmake
+index ab1d6d0f6..9a359a616 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/enc/vp9/pipeline/media_srcs.cmake
+@@ -46,4 +46,5 @@ set(TMP_HEADERS_ "")
+ set(SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/shared/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/shared/media_srcs.cmake
+index ce4db0e96..2c184eecf 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/shared/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/codec/hal/shared/media_srcs.cmake
+@@ -56,4 +56,5 @@ set(TMP_HW_HEADERS_ "")
+ set(SOFTLET_CODEC_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_CODEC_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/media_srcs.cmake
+index 9d35b1e2b..cc47ee978 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/media_srcs.cmake
+@@ -85,4 +85,4 @@ set(SOFTLET_MHW_BLT_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_MHW_BLT_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+-#media_add_curr_to_include_path()
+\ No newline at end of file
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/vdbox/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/vdbox/media_srcs.cmake
+index ad443a2e7..45f32908b 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/vdbox/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/hw/vdbox/media_srcs.cmake
+@@ -103,4 +103,5 @@ set(TMP_SOFTLET_MHW_VDBOX_MFX_HEADERS_ "")
+ set(SOFTLET_MHW_VDBOX_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_MHW_VDBOX_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediaDecompress/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediaDecompress/media_srcs.cmake
+index 5bfd5d7b5..f033715c2 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediaDecompress/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediaDecompress/media_srcs.cmake
+@@ -43,4 +43,5 @@ source_group( "SharedNext\\Xe_LPM_plus_base\\shared\\MediaMemDecompress" FILES $
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediacopy/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediacopy/media_srcs.cmake
+index 93cf0b65d..820a49533 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediacopy/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/shared/mediacopy/media_srcs.cmake
+@@ -48,4 +48,5 @@ source_group( "SharedNext\\Xe_LPM_plus_base\\shared\\MediaCopy" FILES ${TMP_SOUR
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/feature_manager/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/feature_manager/media_srcs.cmake
+index 158bf289d..53645415a 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/feature_manager/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/feature_manager/media_srcs.cmake
+@@ -42,4 +42,5 @@ set(TMP_HEADERS_ "")
+ set(SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/packet/media_srcs.cmake b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/packet/media_srcs.cmake
+index 2c0179e0c..bfd959d99 100644
+--- a/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_M_plus/Xe_LPM_plus_base/vp/hal/packet/media_srcs.cmake
+@@ -46,4 +46,5 @@ set(TMP_HEADERS_ "")
+ set(SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_R/Xe_HPG/renderhal/media_srcs.cmake b/media_softlet/agnostic/Xe_R/Xe_HPG/renderhal/media_srcs.cmake
+index 40e0c55f8..d0dba1bb7 100644
+--- a/media_softlet/agnostic/Xe_R/Xe_HPG/renderhal/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_R/Xe_HPG/renderhal/media_srcs.cmake
+@@ -41,4 +41,5 @@ source_group( "MHW\\Render Hal" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_R/Xe_HPG_Base/hw/media_srcs.cmake b/media_softlet/agnostic/Xe_R/Xe_HPG_Base/hw/media_srcs.cmake
+index f97b43e65..59f93ded8 100644
+--- a/media_softlet/agnostic/Xe_R/Xe_HPG_Base/hw/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_R/Xe_HPG_Base/hw/media_srcs.cmake
+@@ -50,4 +50,5 @@ source_group("MHW\\State Heap" FILES ${TMP_STATE_HEAP_SOURCES_} ${TMP_STATE_HEAP
+ set(SOFTLET_MHW_RENDER_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_MHW_RENDER_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_R/Xe_HPG_Base/renderhal/media_srcs.cmake b/media_softlet/agnostic/Xe_R/Xe_HPG_Base/renderhal/media_srcs.cmake
+index d67416111..1e2d3733c 100644
+--- a/media_softlet/agnostic/Xe_R/Xe_HPG_Base/renderhal/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_R/Xe_HPG_Base/renderhal/media_srcs.cmake
+@@ -42,4 +42,5 @@ source_group( "MHW\\Render Hal" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/cmfcpatch/media_srcs.cmake b/media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/cmfcpatch/media_srcs.cmake
+index 47f03f549..8f506b636 100644
+--- a/media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/cmfcpatch/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/cmfcpatch/media_srcs.cmake
+@@ -58,4 +58,5 @@ set(SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+ set(MEDIA_BIN_INCLUDE_DIR
+     ${MEDIA_BIN_INCLUDE_DIR}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/media_srcs.cmake b/media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/media_srcs.cmake
+index c7ccc516a..6097486fe 100644
+--- a/media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/media_srcs.cmake
++++ b/media_softlet/agnostic/Xe_R/Xe_HPG_Base/vp/kernel/media_srcs.cmake
+@@ -64,4 +64,5 @@ set (SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+ set(MEDIA_BIN_INCLUDE_DIR
+     ${MEDIA_BIN_INCLUDE_DIR}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/av1/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/av1/features/media_srcs.cmake
+index 86f9b87ec..76b150ff6 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/av1/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/av1/features/media_srcs.cmake
+@@ -45,3 +45,5 @@ set(SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/av1/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/av1/packet/media_srcs.cmake
+index 7a439f5bc..efd912645 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/av1/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/av1/packet/media_srcs.cmake
+@@ -40,4 +40,5 @@ endif()
+ set(SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/av1/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/av1/pipeline/media_srcs.cmake
+index 293a6a331..4d688ad00 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/av1/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/av1/pipeline/media_srcs.cmake
+@@ -36,4 +36,5 @@ endif()
+ set(SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/avc/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/avc/features/media_srcs.cmake
+index 578955752..bd690624d 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/avc/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/avc/features/media_srcs.cmake
+@@ -44,4 +44,5 @@ endif()
+ set(SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/avc/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/avc/packet/media_srcs.cmake
+index 704c5b8ef..f467ab9a4 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/avc/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/avc/packet/media_srcs.cmake
+@@ -42,4 +42,5 @@ endif()
+ set(SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/avc/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/avc/pipeline/media_srcs.cmake
+index 6c6804d24..99af99faa 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/avc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/avc/pipeline/media_srcs.cmake
+@@ -37,4 +37,5 @@ endif()
+ set(SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_AVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/hevc/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/hevc/features/media_srcs.cmake
+index 28b13974f..feb53a6a1 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/hevc/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/hevc/features/media_srcs.cmake
+@@ -46,4 +46,5 @@ endif()
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/hevc/mmc/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/hevc/mmc/media_srcs.cmake
+index 63f23fbff..f39d4a77f 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/hevc/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/hevc/mmc/media_srcs.cmake
+@@ -36,4 +36,5 @@ endif()
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/hevc/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/hevc/packet/media_srcs.cmake
+index ed49aeac7..09999ee22 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/hevc/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/hevc/packet/media_srcs.cmake
+@@ -52,4 +52,5 @@ endif()
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/hevc/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/hevc/pipeline/media_srcs.cmake
+index 155de25a7..529990c52 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/hevc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/hevc/pipeline/media_srcs.cmake
+@@ -37,4 +37,5 @@ endif()
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/hevc/scalability/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/hevc/scalability/media_srcs.cmake
+index e55c775a8..95c8820f6 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/hevc/scalability/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/hevc/scalability/media_srcs.cmake
+@@ -48,4 +48,5 @@ endif()
+ set(SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/jpeg/bitstream/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/jpeg/bitstream/media_srcs.cmake
+index b992f497d..0c2bdc805 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/jpeg/bitstream/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/jpeg/bitstream/media_srcs.cmake
+@@ -36,4 +36,5 @@ endif()
+ set(SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/jpeg/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/jpeg/features/media_srcs.cmake
+index 9e917cf50..a834b2310 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/jpeg/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/jpeg/features/media_srcs.cmake
+@@ -40,4 +40,5 @@ endif()
+ set(SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/jpeg/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/jpeg/packet/media_srcs.cmake
+index 5d8711ed5..5bbd91e51 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/jpeg/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/jpeg/packet/media_srcs.cmake
+@@ -40,4 +40,5 @@ endif()
+ set(SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/jpeg/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/jpeg/pipeline/media_srcs.cmake
+index 2d2ad7be5..be9484133 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/jpeg/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/jpeg/pipeline/media_srcs.cmake
+@@ -37,4 +37,5 @@ endif()
+ set(SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/mpeg2/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/mpeg2/features/media_srcs.cmake
+index 72ebf588c..ff8a4721b 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/mpeg2/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/mpeg2/features/media_srcs.cmake
+@@ -40,4 +40,5 @@ endif()
+ set(SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/mpeg2/mmc/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/mpeg2/mmc/media_srcs.cmake
+index 515685cf3..267ad761f 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/mpeg2/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/mpeg2/mmc/media_srcs.cmake
+@@ -36,4 +36,5 @@ endif()
+ set(SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/mpeg2/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/mpeg2/packet/media_srcs.cmake
+index e8d939c71..712dc17a9 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/mpeg2/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/mpeg2/packet/media_srcs.cmake
+@@ -42,4 +42,5 @@ endif()
+ set(SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/mpeg2/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/mpeg2/pipeline/media_srcs.cmake
+index a99d3f79e..48e461970 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/mpeg2/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/mpeg2/pipeline/media_srcs.cmake
+@@ -37,4 +37,5 @@ endif()
+ set(SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_MPEG2_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/bufferMgr/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/bufferMgr/media_srcs.cmake
+index 2cea9ce6b..93361e4bc 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/bufferMgr/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/bufferMgr/media_srcs.cmake
+@@ -36,4 +36,5 @@ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_COMMON_SOURCES
+ set(SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/features/media_srcs.cmake
+index 428c41069..3055f4054 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/features/media_srcs.cmake
+@@ -43,4 +43,5 @@ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_COMMON_SOURCES
+ set(SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/hucItf/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/hucItf/media_srcs.cmake
+index 2dae920b3..202b3498f 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/hucItf/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/hucItf/media_srcs.cmake
+@@ -43,4 +43,5 @@ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_COMMON_SOURCES
+ set(SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/media_srcs.cmake
+index e0c830b96..d225eb45f 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/media_srcs.cmake
+@@ -50,3 +50,5 @@ set(SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_
+ )
+ 
+ 
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/mmc/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/mmc/media_srcs.cmake
+index 9c21f6a3e..50c6e1275 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/mmc/media_srcs.cmake
+@@ -34,4 +34,5 @@ source_group( CodecHalNext\\Shared\\Decode FILES ${SOFTLET_DECODE_COMMON_SOURCES
+ set(SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/packet/media_srcs.cmake
+index ccb103b85..332b6fc3f 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/packet/media_srcs.cmake
+@@ -47,3 +47,5 @@ set(SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/pipeline/media_srcs.cmake
+index 85c081f9b..70c2a0346 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/pipeline/media_srcs.cmake
+@@ -43,3 +43,5 @@ set(SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/scalability/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/scalability/media_srcs.cmake
+index c32ce5490..1d6e4e2c5 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/scalability/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/scalability/media_srcs.cmake
+@@ -44,3 +44,5 @@ set(SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+ 
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/shared/statusreport/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/shared/statusreport/media_srcs.cmake
+index 8f54cdcec..0a77cfd2c 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/shared/statusreport/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/shared/statusreport/media_srcs.cmake
+@@ -36,3 +36,5 @@ set(SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp8/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp8/features/media_srcs.cmake
+index c6d8c02f8..b9748ff08 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp8/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp8/features/media_srcs.cmake
+@@ -42,4 +42,5 @@ endif()
+ set(SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp8/mmc/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp8/mmc/media_srcs.cmake
+index fff300b33..7f0563df5 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp8/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp8/mmc/media_srcs.cmake
+@@ -36,4 +36,5 @@ endif()
+ set(SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp8/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp8/packet/media_srcs.cmake
+index cf69e6dd5..1e9553805 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp8/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp8/packet/media_srcs.cmake
+@@ -40,4 +40,5 @@ endif()
+ set(SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp8/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp8/pipeline/media_srcs.cmake
+index 04dbdba1a..7fa40ddbb 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp8/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp8/pipeline/media_srcs.cmake
+@@ -36,4 +36,5 @@ endif()
+ set(SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP8_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp9/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp9/features/media_srcs.cmake
+index b9eb744b1..ea2cda94d 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp9/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp9/features/media_srcs.cmake
+@@ -41,4 +41,5 @@ endif()
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp9/mmc/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp9/mmc/media_srcs.cmake
+index 455572f48..aa603f66c 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp9/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp9/mmc/media_srcs.cmake
+@@ -35,4 +35,5 @@ endif()
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp9/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp9/packet/media_srcs.cmake
+index 193d8b9a9..81f85d532 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp9/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp9/packet/media_srcs.cmake
+@@ -49,4 +49,5 @@ endif()
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp9/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp9/pipeline/media_srcs.cmake
+index 8c304faae..63137a422 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp9/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp9/pipeline/media_srcs.cmake
+@@ -40,4 +40,5 @@ endif()
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/dec/vp9/scalability/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/dec/vp9/scalability/media_srcs.cmake
+index 4d412499e..6a2ade645 100644
+--- a/media_softlet/agnostic/common/codec/hal/dec/vp9/scalability/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/dec/vp9/scalability/media_srcs.cmake
+@@ -40,4 +40,5 @@ endif()
+ set(SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_DECODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/av1/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/av1/features/media_srcs.cmake
+index 149e2bb16..8b37518b1 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/av1/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/av1/features/media_srcs.cmake
+@@ -62,4 +62,5 @@ endif()
+ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/av1/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/av1/packet/media_srcs.cmake
+index fcfbccc12..ea36e9865 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/av1/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/av1/packet/media_srcs.cmake
+@@ -55,4 +55,5 @@ endif()
+ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/av1/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/av1/pipeline/media_srcs.cmake
+index c8f9b8942..b59c19c2b 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/av1/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/av1/pipeline/media_srcs.cmake
+@@ -53,3 +53,5 @@ set(SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AV1_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/avc/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/avc/features/media_srcs.cmake
+index e83b3912b..e69752cda 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/avc/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/avc/features/media_srcs.cmake
+@@ -70,4 +70,5 @@ endif()
+ set(SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/avc/features/roi/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/avc/features/roi/media_srcs.cmake
+index 0520f77a7..fff3fc704 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/avc/features/roi/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/avc/features/roi/media_srcs.cmake
+@@ -54,3 +54,5 @@ set(SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/avc/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/avc/packet/media_srcs.cmake
+index b4ff07b8a..3ab286610 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/avc/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/avc/packet/media_srcs.cmake
+@@ -52,3 +52,5 @@ set(SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/avc/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/avc/pipeline/media_srcs.cmake
+index ecf63fd3a..31109baf4 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/avc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/avc/pipeline/media_srcs.cmake
+@@ -52,3 +52,5 @@ set(SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_AVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/hevc/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/hevc/features/media_srcs.cmake
+index 63b983255..840581351 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/hevc/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/hevc/features/media_srcs.cmake
+@@ -73,3 +73,5 @@ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/hevc/features/roi/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/hevc/features/roi/media_srcs.cmake
+index 9c8e34da2..2f5587433 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/hevc/features/roi/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/hevc/features/roi/media_srcs.cmake
+@@ -68,3 +68,5 @@ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/hevc/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/hevc/packet/media_srcs.cmake
+index 536e0a541..d97016318 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/hevc/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/hevc/packet/media_srcs.cmake
+@@ -61,4 +61,5 @@ endif()
+ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/hevc/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/hevc/pipeline/media_srcs.cmake
+index df035676d..3e425e1b8 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/hevc/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/hevc/pipeline/media_srcs.cmake
+@@ -53,4 +53,5 @@ endif()
+ set(SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_HEVC_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/jpeg/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/jpeg/features/media_srcs.cmake
+index c8715f695..d34c1e757 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/jpeg/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/jpeg/features/media_srcs.cmake
+@@ -52,4 +52,5 @@ endif()
+ set(SOFTLET_ENCODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/jpeg/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/jpeg/packet/media_srcs.cmake
+index 5db85359b..e3b59b0da 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/jpeg/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/jpeg/packet/media_srcs.cmake
+@@ -48,3 +48,5 @@ set(SOFTLET_ENCODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/jpeg/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/jpeg/pipeline/media_srcs.cmake
+index 9b958e478..31360cde1 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/jpeg/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/jpeg/pipeline/media_srcs.cmake
+@@ -51,4 +51,5 @@ endif()
+ set(SOFTLET_ENCODE_JPEG_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_JPEG_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/bitstreamWriter/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/bitstreamWriter/media_srcs.cmake
+index bf644c2c4..799c90702 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/bitstreamWriter/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/bitstreamWriter/media_srcs.cmake
+@@ -47,4 +47,5 @@ endif()
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/media_srcs.cmake
+index 41ff2844f..d8159cc08 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/bufferMgr/media_srcs.cmake
+@@ -57,4 +57,5 @@ endif()
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/features/media_srcs.cmake
+index 591f269ef..5ed365571 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/features/media_srcs.cmake
+@@ -59,4 +59,5 @@ endif()
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/media_srcs.cmake
+index f0d449023..b90afc0c3 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/media_srcs.cmake
+@@ -48,4 +48,5 @@ endif()
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/mmc/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/mmc/media_srcs.cmake
+index 3ad2f687a..45140cde3 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/mmc/media_srcs.cmake
+@@ -44,4 +44,5 @@ set(TMP_HEADERS_ "")
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/packet/media_srcs.cmake
+index f86a68d0c..1a3b25382 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/packet/media_srcs.cmake
+@@ -51,4 +51,5 @@ endif()
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/pipeline/media_srcs.cmake
+index 6bb45c997..1b49c481e 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/pipeline/media_srcs.cmake
+@@ -49,4 +49,5 @@ endif()
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/scalability/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/scalability/media_srcs.cmake
+index 31ef7cb7c..55c1fbc5e 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/scalability/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/scalability/media_srcs.cmake
+@@ -52,4 +52,5 @@ endif()
+ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/shared/statusreport/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/shared/statusreport/media_srcs.cmake
+index 0800891e6..aafe7cb1c 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/shared/statusreport/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/shared/statusreport/media_srcs.cmake
+@@ -49,3 +49,5 @@ set(SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/vp9/features/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/vp9/features/media_srcs.cmake
+index be7e6e31e..75c589f73 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/vp9/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/vp9/features/media_srcs.cmake
+@@ -64,4 +64,5 @@ endif()
+ set(SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/vp9/packet/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/vp9/packet/media_srcs.cmake
+index bec8c435f..b622a98e1 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/vp9/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/vp9/packet/media_srcs.cmake
+@@ -57,4 +57,5 @@ endif()
+ set(SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/enc/vp9/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/enc/vp9/pipeline/media_srcs.cmake
+index 17179bf07..c0d45abdf 100644
+--- a/media_softlet/agnostic/common/codec/hal/enc/vp9/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/enc/vp9/pipeline/media_srcs.cmake
+@@ -52,3 +52,5 @@ set(SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_ENCODE_VP9_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/codec/hal/shared/media_srcs.cmake b/media_softlet/agnostic/common/codec/hal/shared/media_srcs.cmake
+index 6e2f41acd..98661a198 100644
+--- a/media_softlet/agnostic/common/codec/hal/shared/media_srcs.cmake
++++ b/media_softlet/agnostic/common/codec/hal/shared/media_srcs.cmake
+@@ -51,3 +51,5 @@ set(SOFTLET_CODEC_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_CODEC_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/cp/media_srcs.cmake b/media_softlet/agnostic/common/cp/media_srcs.cmake
+index 32887f8db..5cd54bb42 100644
+--- a/media_softlet/agnostic/common/cp/media_srcs.cmake
++++ b/media_softlet/agnostic/common/cp/media_srcs.cmake
+@@ -68,4 +68,5 @@ set(SOFTLET_COMMON_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/hw/media_srcs.cmake b/media_softlet/agnostic/common/hw/media_srcs.cmake
+index 67d384c2a..9f4159337 100644
+--- a/media_softlet/agnostic/common/hw/media_srcs.cmake
++++ b/media_softlet/agnostic/common/hw/media_srcs.cmake
+@@ -154,4 +154,5 @@ set(SOFTLET_MHW_BLT_PRIVATE_INCLUDE_DIRS_
+ set(SOFTLET_MHW_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_MHW_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/hw/vdbox/media_srcs.cmake b/media_softlet/agnostic/common/hw/vdbox/media_srcs.cmake
+index 3df8104e4..56224d79e 100644
+--- a/media_softlet/agnostic/common/hw/vdbox/media_srcs.cmake
++++ b/media_softlet/agnostic/common/hw/vdbox/media_srcs.cmake
+@@ -94,4 +94,5 @@ set(TMP_SOFTLET_MHW_VDBOX_MFX_HEADERS_ "")
+ set(SOFTLET_MHW_VDBOX_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_MHW_VDBOX_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/media_bin_mgr/media_srcs.cmake b/media_softlet/agnostic/common/media_bin_mgr/media_srcs.cmake
+index d2dd4d270..0bab09f42 100644
+--- a/media_softlet/agnostic/common/media_bin_mgr/media_srcs.cmake
++++ b/media_softlet/agnostic/common/media_bin_mgr/media_srcs.cmake
+@@ -39,4 +39,5 @@ set(MEDIA_BIN_HEADERS_
+ set(MEDIA_BIN_INCLUDE_DIR
+     ${MEDIA_BIN_INCLUDE_DIR}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/media_interfaces/media_srcs.cmake b/media_softlet/agnostic/common/media_interfaces/media_srcs.cmake
+index 25254a832..a47a8f832 100644
+--- a/media_softlet/agnostic/common/media_interfaces/media_srcs.cmake
++++ b/media_softlet/agnostic/common/media_interfaces/media_srcs.cmake
+@@ -48,4 +48,5 @@ source_group( "SharedNext\\shared" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/os/media_srcs.cmake b/media_softlet/agnostic/common/os/media_srcs.cmake
+index 8cba88625..3af039aa7 100644
+--- a/media_softlet/agnostic/common/os/media_srcs.cmake
++++ b/media_softlet/agnostic/common/os/media_srcs.cmake
+@@ -106,3 +106,5 @@ set(SOFTLET_COMMON_DLL_PRIVATE_INCLUDE_DIRS_
+ )
+ 
+ source_group( "mos_softlet" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} ${TMP_MOS_HAL_SHARED_SOURCES_} )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/os/private/media_srcs.cmake b/media_softlet/agnostic/common/os/private/media_srcs.cmake
+index a3335cc23..b27d8a2ef 100644
+--- a/media_softlet/agnostic/common/os/private/media_srcs.cmake
++++ b/media_softlet/agnostic/common/os/private/media_srcs.cmake
+@@ -27,3 +27,5 @@ set(SOFTLET_MOS_PRIVATE_SOURCES_
+     ${TMP_SOURCES_}
+ )
+ source_group( "mos_softlet" FILES ${TMP_SOURCES_})
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/os/share/media_srcs.cmake b/media_softlet/agnostic/common/os/share/media_srcs.cmake
+index 51d6a396e..253ad532d 100644
+--- a/media_softlet/agnostic/common/os/share/media_srcs.cmake
++++ b/media_softlet/agnostic/common/os/share/media_srcs.cmake
+@@ -57,3 +57,5 @@ set(SOFTLET_COMMON_DLL_PRIVATE_INCLUDE_DIRS_
+ )
+ 
+ source_group( "mos_softlet" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/os/user_setting/media_srcs.cmake b/media_softlet/agnostic/common/os/user_setting/media_srcs.cmake
+index 3e115031b..3b1078ec0 100644
+--- a/media_softlet/agnostic/common/os/user_setting/media_srcs.cmake
++++ b/media_softlet/agnostic/common/os/user_setting/media_srcs.cmake
+@@ -39,4 +39,5 @@ set(SOFTLET_COMMON_DLL_SOURCES_
+     ${TMP_SHARED_SOURCES_}
+ )
+ 
+-source_group( "mos_softlet" FILES ${TMP_SOURCES_} ${TMP_SHARED_SOURCES_})
+\ No newline at end of file
++source_group( "mos_softlet" FILES ${TMP_SOURCES_} ${TMP_SHARED_SOURCES_})
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/renderhal/media_srcs.cmake b/media_softlet/agnostic/common/renderhal/media_srcs.cmake
+index 33eb9908d..c9d7537bb 100644
+--- a/media_softlet/agnostic/common/renderhal/media_srcs.cmake
++++ b/media_softlet/agnostic/common/renderhal/media_srcs.cmake
+@@ -45,4 +45,5 @@ source_group( "MHW\\Render Hal" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/shared/bufferMgr/media_srcs.cmake b/media_softlet/agnostic/common/shared/bufferMgr/media_srcs.cmake
+index d29444c80..123c1750b 100644
+--- a/media_softlet/agnostic/common/shared/bufferMgr/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/bufferMgr/media_srcs.cmake
+@@ -32,3 +32,5 @@ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/shared/features/media_srcs.cmake b/media_softlet/agnostic/common/shared/features/media_srcs.cmake
+index 61c017abd..1e8614f86 100644
+--- a/media_softlet/agnostic/common/shared/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/features/media_srcs.cmake
+@@ -34,4 +34,5 @@ set(TMP_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/shared/media_sfc_interface/media_srcs.cmake b/media_softlet/agnostic/common/shared/media_sfc_interface/media_srcs.cmake
+index 2df90d4fa..ce70f941d 100644
+--- a/media_softlet/agnostic/common/shared/media_sfc_interface/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/media_sfc_interface/media_srcs.cmake
+@@ -35,4 +35,5 @@ set(TMP_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/shared/media_srcs.cmake b/media_softlet/agnostic/common/shared/media_srcs.cmake
+index 4e585903e..91c1abc59 100644
+--- a/media_softlet/agnostic/common/shared/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/media_srcs.cmake
+@@ -78,4 +78,5 @@ source_group(SharedNext\\shared FILES ${TMP_HEADERS_} ${TMP_SOURCES_})
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/shared/mediacontext/media_srcs.cmake b/media_softlet/agnostic/common/shared/mediacontext/media_srcs.cmake
+index 62dbdaedc..c734f4045 100644
+--- a/media_softlet/agnostic/common/shared/mediacontext/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/mediacontext/media_srcs.cmake
+@@ -41,4 +41,5 @@ set(SOFTLET_COMMON_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/shared/mediacopy/media_srcs.cmake b/media_softlet/agnostic/common/shared/mediacopy/media_srcs.cmake
+index cf6422371..a478435ba 100644
+--- a/media_softlet/agnostic/common/shared/mediacopy/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/mediacopy/media_srcs.cmake
+@@ -40,4 +40,5 @@ set(TMP_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/shared/mmc/media_srcs.cmake b/media_softlet/agnostic/common/shared/mmc/media_srcs.cmake
+index afbadafbe..e38deab3b 100644
+--- a/media_softlet/agnostic/common/shared/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/mmc/media_srcs.cmake
+@@ -33,4 +33,5 @@ set(TMP_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/shared/packet/media_srcs.cmake b/media_softlet/agnostic/common/shared/packet/media_srcs.cmake
+index ef504496c..5c815e04e 100644
+--- a/media_softlet/agnostic/common/shared/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/packet/media_srcs.cmake
+@@ -34,4 +34,5 @@ set(TMP_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/shared/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/shared/pipeline/media_srcs.cmake
+index ee778547c..0767d9fb5 100644
+--- a/media_softlet/agnostic/common/shared/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/pipeline/media_srcs.cmake
+@@ -32,4 +32,5 @@ set(TMP_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/shared/profiler/media_srcs.cmake b/media_softlet/agnostic/common/shared/profiler/media_srcs.cmake
+index dc5233b33..3a24a3124 100644
+--- a/media_softlet/agnostic/common/shared/profiler/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/profiler/media_srcs.cmake
+@@ -32,3 +32,5 @@ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/shared/scalability/media_srcs.cmake b/media_softlet/agnostic/common/shared/scalability/media_srcs.cmake
+index 9a990f3eb..5dcbe32e1 100644
+--- a/media_softlet/agnostic/common/shared/scalability/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/scalability/media_srcs.cmake
+@@ -52,3 +52,5 @@ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/shared/statusreport/media_srcs.cmake b/media_softlet/agnostic/common/shared/statusreport/media_srcs.cmake
+index 7b0ff3531..eef7b1727 100644
+--- a/media_softlet/agnostic/common/shared/statusreport/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/statusreport/media_srcs.cmake
+@@ -33,3 +33,5 @@ set(TMP_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR})
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/shared/task/media_srcs.cmake b/media_softlet/agnostic/common/shared/task/media_srcs.cmake
+index 37a5d9a57..4d5640db3 100644
+--- a/media_softlet/agnostic/common/shared/task/media_srcs.cmake
++++ b/media_softlet/agnostic/common/shared/task/media_srcs.cmake
+@@ -33,4 +33,5 @@ set(TMP_HEADERS_
+ set(SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_COMMON_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/vp/cm_fc_ld/media_srcs.cmake b/media_softlet/agnostic/common/vp/cm_fc_ld/media_srcs.cmake
+index c4bb0a7dd..2f348736e 100644
+--- a/media_softlet/agnostic/common/vp/cm_fc_ld/media_srcs.cmake
++++ b/media_softlet/agnostic/common/vp/cm_fc_ld/media_srcs.cmake
+@@ -52,3 +52,5 @@ set (SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/vp/hal/bufferMgr/media_srcs.cmake b/media_softlet/agnostic/common/vp/hal/bufferMgr/media_srcs.cmake
+index 5ac1ca5ae..296d9c14b 100644
+--- a/media_softlet/agnostic/common/vp/hal/bufferMgr/media_srcs.cmake
++++ b/media_softlet/agnostic/common/vp/hal/bufferMgr/media_srcs.cmake
+@@ -47,4 +47,5 @@ set(TMP_HEADERS_ "")
+ set (SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/vp/hal/feature_manager/media_srcs.cmake b/media_softlet/agnostic/common/vp/hal/feature_manager/media_srcs.cmake
+index e2b60d58d..da0d19d6b 100644
+--- a/media_softlet/agnostic/common/vp/hal/feature_manager/media_srcs.cmake
++++ b/media_softlet/agnostic/common/vp/hal/feature_manager/media_srcs.cmake
+@@ -59,4 +59,5 @@ set(TMP_HEADERS_ "")
+ set (SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/vp/hal/features/media_srcs.cmake b/media_softlet/agnostic/common/vp/hal/features/media_srcs.cmake
+index ddc05dbbb..b30f24503 100644
+--- a/media_softlet/agnostic/common/vp/hal/features/media_srcs.cmake
++++ b/media_softlet/agnostic/common/vp/hal/features/media_srcs.cmake
+@@ -66,4 +66,5 @@ set(TMP_HEADERS_ "")
+ set (SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/vp/hal/mmc/media_srcs.cmake b/media_softlet/agnostic/common/vp/hal/mmc/media_srcs.cmake
+index 1ec208dba..a00ab32b4 100644
+--- a/media_softlet/agnostic/common/vp/hal/mmc/media_srcs.cmake
++++ b/media_softlet/agnostic/common/vp/hal/mmc/media_srcs.cmake
+@@ -42,4 +42,5 @@ set(TMP_HEADERS_ "")
+ set (SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/vp/hal/packet/media_srcs.cmake b/media_softlet/agnostic/common/vp/hal/packet/media_srcs.cmake
+index 34139ed46..c84e08a06 100644
+--- a/media_softlet/agnostic/common/vp/hal/packet/media_srcs.cmake
++++ b/media_softlet/agnostic/common/vp/hal/packet/media_srcs.cmake
+@@ -71,4 +71,5 @@ set(TMP_HEADERS_ "")
+ set (SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/vp/hal/pipeline/media_srcs.cmake b/media_softlet/agnostic/common/vp/hal/pipeline/media_srcs.cmake
+index 0464e1a49..b4fcbe20a 100644
+--- a/media_softlet/agnostic/common/vp/hal/pipeline/media_srcs.cmake
++++ b/media_softlet/agnostic/common/vp/hal/pipeline/media_srcs.cmake
+@@ -53,4 +53,5 @@ set(TMP_HEADERS_ "")
+ set(SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/vp/hal/platform_interface/media_srcs.cmake b/media_softlet/agnostic/common/vp/hal/platform_interface/media_srcs.cmake
+index ad5aecfd1..d7159398c 100644
+--- a/media_softlet/agnostic/common/vp/hal/platform_interface/media_srcs.cmake
++++ b/media_softlet/agnostic/common/vp/hal/platform_interface/media_srcs.cmake
+@@ -41,4 +41,5 @@ set(TMP_HEADERS_ "")
+ set (SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/vp/hal/scalability/media_srcs.cmake b/media_softlet/agnostic/common/vp/hal/scalability/media_srcs.cmake
+index f5c0d6976..0dbde114d 100644
+--- a/media_softlet/agnostic/common/vp/hal/scalability/media_srcs.cmake
++++ b/media_softlet/agnostic/common/vp/hal/scalability/media_srcs.cmake
+@@ -49,4 +49,5 @@ set(TMP_HEADERS_ "")
+ set (SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/vp/hal/shared/scalability/media_srcs.cmake b/media_softlet/agnostic/common/vp/hal/shared/scalability/media_srcs.cmake
+index 816be9790..88363ee82 100644
+--- a/media_softlet/agnostic/common/vp/hal/shared/scalability/media_srcs.cmake
++++ b/media_softlet/agnostic/common/vp/hal/shared/scalability/media_srcs.cmake
+@@ -54,3 +54,5 @@ set (SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/vp/hal/statusreport/media_srcs.cmake b/media_softlet/agnostic/common/vp/hal/statusreport/media_srcs.cmake
+index e03c24c2f..7d01392b7 100644
+--- a/media_softlet/agnostic/common/vp/hal/statusreport/media_srcs.cmake
++++ b/media_softlet/agnostic/common/vp/hal/statusreport/media_srcs.cmake
+@@ -42,4 +42,5 @@ set(TMP_HEADERS_ "")
+ set (SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/vp/hal/utils/hal_ddi_share/media_srcs.cmake b/media_softlet/agnostic/common/vp/hal/utils/hal_ddi_share/media_srcs.cmake
+index 478d8355c..4b9b1fcc9 100644
+--- a/media_softlet/agnostic/common/vp/hal/utils/hal_ddi_share/media_srcs.cmake
++++ b/media_softlet/agnostic/common/vp/hal/utils/hal_ddi_share/media_srcs.cmake
+@@ -60,4 +60,5 @@ set(SOFTLET_VP_HAL_DDI_SHARED_INCLUDE_DIRS_
+ 
+ source_group( VpHalNext\\Shared FILES ${TMP_SOURCES_} ${TMP_HEADERS_})
+ set(TMP_SOURCES_ "")
+-set(TMP_HEADERS_ "")
+\ No newline at end of file
++set(TMP_HEADERS_ "")
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/agnostic/common/vp/hal/utils/media_srcs.cmake b/media_softlet/agnostic/common/vp/hal/utils/media_srcs.cmake
+index ae20dcc2f..66065349f 100644
+--- a/media_softlet/agnostic/common/vp/hal/utils/media_srcs.cmake
++++ b/media_softlet/agnostic/common/vp/hal/utils/media_srcs.cmake
+@@ -57,4 +57,5 @@ set(TMP_HEADERS_ "")
+ set (SOFTLET_VP_PRIVATE_INCLUDE_DIRS_
+     ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/cmake/linux/media_include_paths_linux.cmake b/media_softlet/cmake/linux/media_include_paths_linux.cmake
+index 69fe141e6..a72e4971f 100644
+--- a/media_softlet/cmake/linux/media_include_paths_linux.cmake
++++ b/media_softlet/cmake/linux/media_include_paths_linux.cmake
+@@ -26,7 +26,7 @@ elseif(DEFINED ENV{LIBVA_INSTALL_PATH} AND NOT "$ENV{LIBVA_INSTALL_PATH}" STREQU
+     include_directories(BEFORE $ENV{LIBVA_INSTALL_PATH})
+ else()
+     include(FindPkgConfig)
+-    pkg_check_modules(LIBVA REQUIRED libva>=1.8.0)
++    pkg_check_modules(LIBVA REQUIRED libva>=1.7.0)
+     if(LIBVA_FOUND)
+         include_directories(BEFORE ${LIBVA_INCLUDE_DIRS})
+         if("${LIBVA_DRIVERS_PATH}" STREQUAL "")
+diff --git a/media_softlet/linux/Xe_M_plus/ddi/media_srcs.cmake b/media_softlet/linux/Xe_M_plus/ddi/media_srcs.cmake
+index 6868edc28..84234d616 100644
+--- a/media_softlet/linux/Xe_M_plus/ddi/media_srcs.cmake
++++ b/media_softlet/linux/Xe_M_plus/ddi/media_srcs.cmake
+@@ -33,4 +33,5 @@ set(SOFTLET_DDI_SOURCES_
+ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/common/codec/ddi/dec/media_srcs.cmake b/media_softlet/linux/common/codec/ddi/dec/media_srcs.cmake
+index e693d6d53..22020bd63 100644
+--- a/media_softlet/linux/common/codec/ddi/dec/media_srcs.cmake
++++ b/media_softlet/linux/common/codec/ddi/dec/media_srcs.cmake
+@@ -120,4 +120,5 @@ set(SOFTLET_DDI_HEADERS_
+ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/common/codec/ddi/enc/media_srcs.cmake b/media_softlet/linux/common/codec/ddi/enc/media_srcs.cmake
+index 532b1125a..bd9093544 100644
+--- a/media_softlet/linux/common/codec/ddi/enc/media_srcs.cmake
++++ b/media_softlet/linux/common/codec/ddi/enc/media_srcs.cmake
+@@ -55,3 +55,5 @@ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/common/codec/ddi/shared/media_srcs.cmake b/media_softlet/linux/common/codec/ddi/shared/media_srcs.cmake
+index ab1b9707a..270a0692c 100644
+--- a/media_softlet/linux/common/codec/ddi/shared/media_srcs.cmake
++++ b/media_softlet/linux/common/codec/ddi/shared/media_srcs.cmake
+@@ -48,4 +48,5 @@ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+-endif()
+\ No newline at end of file
++endif()
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/common/cp/ddi/media_srcs.cmake b/media_softlet/linux/common/cp/ddi/media_srcs.cmake
+index b3fb45fad..55818920b 100644
+--- a/media_softlet/linux/common/cp/ddi/media_srcs.cmake
++++ b/media_softlet/linux/common/cp/ddi/media_srcs.cmake
+@@ -47,3 +47,5 @@ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/common/cp/media_srcs.cmake b/media_softlet/linux/common/cp/media_srcs.cmake
+index 6ea27109b..61516b3c0 100644
+--- a/media_softlet/linux/common/cp/media_srcs.cmake
++++ b/media_softlet/linux/common/cp/media_srcs.cmake
+@@ -43,3 +43,5 @@ set(CP_INTERFACE_DIRECTORIES_
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+ media_include_subdirectory(ddi)
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/common/ddi/media_srcs.cmake b/media_softlet/linux/common/ddi/media_srcs.cmake
+index 5c488766f..f7c33ebc1 100644
+--- a/media_softlet/linux/common/ddi/media_srcs.cmake
++++ b/media_softlet/linux/common/ddi/media_srcs.cmake
+@@ -54,4 +54,5 @@ set(SOFTLET_DDI_HEADERS_
+ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/common/os/i915/include/media_srcs.cmake b/media_softlet/linux/common/os/i915/include/media_srcs.cmake
+index 6b5cb8efd..fc0bec88d 100644
+--- a/media_softlet/linux/common/os/i915/include/media_srcs.cmake
++++ b/media_softlet/linux/common/os/i915/include/media_srcs.cmake
+@@ -43,3 +43,5 @@ set (SOFTLET_MOS_PREPEND_INCLUDE_DIRS_
+     ${CMAKE_CURRENT_LIST_DIR}
+     ${SOFTLET_MOS_PREPEND_INCLUDE_DIRS_}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/common/os/i915/include/uapi/media_srcs.cmake b/media_softlet/linux/common/os/i915/include/uapi/media_srcs.cmake
+index 7f2dbc2f0..13eae053e 100644
+--- a/media_softlet/linux/common/os/i915/include/uapi/media_srcs.cmake
++++ b/media_softlet/linux/common/os/i915/include/uapi/media_srcs.cmake
+@@ -39,3 +39,5 @@ set (SOFTLET_MOS_PREPEND_INCLUDE_DIRS_
+     ${SOFTLET_MOS_PREPEND_INCLUDE_DIRS_}
+ )
+ 
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/common/os/i915_production/include/media_srcs.cmake b/media_softlet/linux/common/os/i915_production/include/media_srcs.cmake
+index e1870dafc..8123893b4 100644
+--- a/media_softlet/linux/common/os/i915_production/include/media_srcs.cmake
++++ b/media_softlet/linux/common/os/i915_production/include/media_srcs.cmake
+@@ -31,4 +31,5 @@ set(SOFTLET_MOS_COMMON_HEADERS_
+ set (SOFTLET_MOS_PREPEND_INCLUDE_DIRS_
+     ${CMAKE_CURRENT_LIST_DIR}
+     ${SOFTLET_MOS_PREPEND_INCLUDE_DIRS_}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/common/os/i915_production/media_srcs.cmake b/media_softlet/linux/common/os/i915_production/media_srcs.cmake
+index a610f569f..81895f825 100644
+--- a/media_softlet/linux/common/os/i915_production/media_srcs.cmake
++++ b/media_softlet/linux/common/os/i915_production/media_srcs.cmake
+@@ -41,3 +41,5 @@ set(SOFTLET_MOS_COMMON_SOURCES_
+  )
+ 
+ #Do not add this dir to include dir
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/common/os/media_srcs.cmake b/media_softlet/linux/common/os/media_srcs.cmake
+index 3d0858ea4..b871297c0 100644
+--- a/media_softlet/linux/common/os/media_srcs.cmake
++++ b/media_softlet/linux/common/os/media_srcs.cmake
+@@ -106,3 +106,5 @@ endif()
+ source_group( "mos_softlet" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
+ 
+ endif() # CMAKE_WDDM_LINUX
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/common/os/osservice/media_srcs.cmake b/media_softlet/linux/common/os/osservice/media_srcs.cmake
+index 4e8aad1d8..7b35f37cf 100644
+--- a/media_softlet/linux/common/os/osservice/media_srcs.cmake
++++ b/media_softlet/linux/common/os/osservice/media_srcs.cmake
+@@ -46,3 +46,5 @@ set(SOFTLET_MOS_PUBLIC_INCLUDE_DIRS_
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
+ source_group( "mos_softlet" FILES ${TMP_SOURCES_} ${TMP_HEADERS_} )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/common/vp/ddi/media_srcs.cmake b/media_softlet/linux/common/vp/ddi/media_srcs.cmake
+index bf57d3277..768417137 100644
+--- a/media_softlet/linux/common/vp/ddi/media_srcs.cmake
++++ b/media_softlet/linux/common/vp/ddi/media_srcs.cmake
+@@ -42,3 +42,5 @@ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/xe_lpm_plus_r0/ddi/media_srcs.cmake b/media_softlet/linux/xe_lpm_plus_r0/ddi/media_srcs.cmake
+index 996feb4c3..6daf4e52c 100644
+--- a/media_softlet/linux/xe_lpm_plus_r0/ddi/media_srcs.cmake
++++ b/media_softlet/linux/xe_lpm_plus_r0/ddi/media_srcs.cmake
+@@ -30,4 +30,5 @@ set(SOFTLET_DDI_HEADERS_
+ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/xe_lpm_plus_r0/encode/av1/ddi/media_srcs.cmake b/media_softlet/linux/xe_lpm_plus_r0/encode/av1/ddi/media_srcs.cmake
+index a4de5a6e0..08798487f 100644
+--- a/media_softlet/linux/xe_lpm_plus_r0/encode/av1/ddi/media_srcs.cmake
++++ b/media_softlet/linux/xe_lpm_plus_r0/encode/av1/ddi/media_srcs.cmake
+@@ -31,3 +31,5 @@ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/xe_lpm_plus_r0/encode/avc/ddi/media_srcs.cmake b/media_softlet/linux/xe_lpm_plus_r0/encode/avc/ddi/media_srcs.cmake
+index cde7f976a..3cf98ef92 100644
+--- a/media_softlet/linux/xe_lpm_plus_r0/encode/avc/ddi/media_srcs.cmake
++++ b/media_softlet/linux/xe_lpm_plus_r0/encode/avc/ddi/media_srcs.cmake
+@@ -30,4 +30,5 @@ set (SOFTLET_DDI_HEADERS_
+ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/xe_lpm_plus_r0/encode/hevc/ddi/media_srcs.cmake b/media_softlet/linux/xe_lpm_plus_r0/encode/hevc/ddi/media_srcs.cmake
+index 474f57d53..4532eae53 100644
+--- a/media_softlet/linux/xe_lpm_plus_r0/encode/hevc/ddi/media_srcs.cmake
++++ b/media_softlet/linux/xe_lpm_plus_r0/encode/hevc/ddi/media_srcs.cmake
+@@ -30,4 +30,5 @@ set (SOFTLET_DDI_HEADERS_
+ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/xe_lpm_plus_r0/encode/jpeg/ddi/media_srcs.cmake b/media_softlet/linux/xe_lpm_plus_r0/encode/jpeg/ddi/media_srcs.cmake
+index bdf7b50b1..c441960b7 100644
+--- a/media_softlet/linux/xe_lpm_plus_r0/encode/jpeg/ddi/media_srcs.cmake
++++ b/media_softlet/linux/xe_lpm_plus_r0/encode/jpeg/ddi/media_srcs.cmake
+@@ -31,3 +31,5 @@ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+ )
++
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/xe_lpm_plus_r0/encode/vp9/ddi/media_srcs.cmake b/media_softlet/linux/xe_lpm_plus_r0/encode/vp9/ddi/media_srcs.cmake
+index cd3c3530b..48bcbcf53 100644
+--- a/media_softlet/linux/xe_lpm_plus_r0/encode/vp9/ddi/media_srcs.cmake
++++ b/media_softlet/linux/xe_lpm_plus_r0/encode/vp9/ddi/media_srcs.cmake
+@@ -30,4 +30,5 @@ set (SOFTLET_DDI_HEADERS_
+ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+diff --git a/media_softlet/linux/xe_lpm_plus_r0/vp/ddi/media_srcs.cmake b/media_softlet/linux/xe_lpm_plus_r0/vp/ddi/media_srcs.cmake
+index 60d8dd454..d8618386a 100644
+--- a/media_softlet/linux/xe_lpm_plus_r0/vp/ddi/media_srcs.cmake
++++ b/media_softlet/linux/xe_lpm_plus_r0/vp/ddi/media_srcs.cmake
+@@ -30,4 +30,5 @@ set(SOFTLET_DDI_HEADERS_
+ set(SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_
+     ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_}
+     ${CMAKE_CURRENT_LIST_DIR}
+-)
+\ No newline at end of file
++)
++media_add_curr_to_include_path()
+\ No newline at end of file
+-- 
+2.34.1
+


### PR DESCRIPTION
Add new error code KM_ERROR_KEYBOX_ALREADY_PROVISIONED to indicate error type of trying to provision device which has been already provisioned.

Tracked-On: OAM-95939