### PR TITLE
Reset default value for display white balance.

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Car/Settings/06_0006-Reset-all-display-hardware-settings-to-default-value.patch
+++ b/aosp_diff/base_aaos/packages/apps/Car/Settings/06_0006-Reset-all-display-hardware-settings-to-default-value.patch
@@ -1,4 +1,4 @@
-From 354c4a0c17034df30c9aba17eae058410b927f9f Mon Sep 17 00:00:00 2001
+From 65fc5b54f97d873680624fc9bd17b3ec1297c49e Mon Sep 17 00:00:00 2001
 From: xubing <bing.xu@intel.com>
 Date: Fri, 22 Mar 2024 08:59:21 +0800
 Subject: [PATCH] Reset all display hardware settings to default value
@@ -24,10 +24,10 @@ Signed-off-by: xubing <bing.xu@intel.com>
  create mode 100644 src/com/android/car/settings/display/DisplayActionButtonsPreferenceController.java
 
 diff --git a/res/values/preference_keys.xml b/res/values/preference_keys.xml
-index bcf93e274..c76f5763a 100644
+index 425f89a7e..16767b81c 100644
 --- a/res/values/preference_keys.xml
 +++ b/res/values/preference_keys.xml
-@@ -349,6 +349,7 @@
+@@ -343,6 +343,7 @@
      <string name="pk_saturation_level" translatable="false">saturation_level</string>
      <string name="pk_whitebalance_level" translatable="false">whitebalance_level</string>
      <string name="pk_luminance_level" translatable="false">luminance_level</string>
@@ -36,7 +36,7 @@ index bcf93e274..c76f5763a 100644
      <!-- DateTime Settings -->
      <string name="pk_auto_datetime_switch" translatable="false">auto_datetime_switch</string>
 diff --git a/res/values/strings.xml b/res/values/strings.xml
-index 1115c78c8..f0e3511b1 100644
+index 1a5eabe7f..57aa52c97 100644
 --- a/res/values/strings.xml
 +++ b/res/values/strings.xml
 @@ -680,6 +680,9 @@
@@ -435,15 +435,15 @@ index 74ce3c6ee..46daa7792 100644
          return gamma;
      }
 diff --git a/src/com/android/car/settings/display/WhitebalanceLevelPreferenceController.java b/src/com/android/car/settings/display/WhitebalanceLevelPreferenceController.java
-index a20320000..233c3f830 100644
+index a20320000..09232cb35 100644
 --- a/src/com/android/car/settings/display/WhitebalanceLevelPreferenceController.java
 +++ b/src/com/android/car/settings/display/WhitebalanceLevelPreferenceController.java
 @@ -53,6 +53,9 @@ public class WhitebalanceLevelPreferenceController extends PreferenceController<
      private ColorDisplayManager mColorDisplayManager;
      private final int mMaximumWhitebalance = 65535;
      private final int mMinimumWhitebalance = 0;
-+    private final int mDefaultWhitebalanceLevel = 255;
-+    private final int mMaxWhitebalanceLevel = 255;
++    private final int mDefaultWhitebalanceLevel = 100;
++    private final int mMaxWhitebalanceLevel = 200;
 +    public static WhitebalanceLevelPreferenceController mWhitebalanceInstance;
      private final Handler mHandler = new Handler(Looper.getMainLooper());
  
@@ -478,7 +478,7 @@ index a20320000..233c3f830 100644
  
      private int getSeekbarValue() {
 -        int gamma = GAMMA_SPACE_MAX;
-+        int gamma = mMaximumWhitebalance;
++        int gamma = mMaximumWhitebalance / 2;
          try {
              int linear = Settings.System.getIntForUser(getContext().getContentResolver(),
                      Settings.System.SCREEN_WHITEBALANCE, UserHandle.myUserId());


### PR DESCRIPTION
Reset default value for display white balance as the design doc is changed. Refer to:
https://jira.devtools.intel.com/secure/Tests.jspa#/testCase/OATV-T61955

Test: Reset to default value and check it, test OK.

Tracked-On: OAM-117067