### PR TITLE
Fix "MTL RVP reboots continuously with latest host kernel"

### DIFF
--- a/host/kernel/lts2022-chromium/0002-Revert-FIXUP-drm-i915-display-Fix-phys_base-in-MTL.patch
+++ b/host/kernel/lts2022-chromium/0002-Revert-FIXUP-drm-i915-display-Fix-phys_base-in-MTL.patch
@@ -1,0 +1,29 @@
+From babb86eb7b14c170b70ce8e4605268497a1c6806 Mon Sep 17 00:00:00 2001
+From: sgnanase <sundar.gnanasekaran@intel.com>
+Date: Tue, 2 Apr 2024 22:00:10 +0530
+Subject: [PATCH] Revert "FIXUP: drm/i915/display: Fix phys_base in MTL"
+
+This reverts commit fa0cbf244c0aeaf7f509f5f0b3d57572dda446b5.
+---
+ drivers/gpu/drm/i915/display/intel_plane_initial.c | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/display/intel_plane_initial.c b/drivers/gpu/drm/i915/display/intel_plane_initial.c
+index 55851fba914a..736072a8b2b0 100644
+--- a/drivers/gpu/drm/i915/display/intel_plane_initial.c
++++ b/drivers/gpu/drm/i915/display/intel_plane_initial.c
+@@ -89,10 +89,7 @@ initial_plane_vma(struct drm_i915_private *i915,
+ 			"Using phys_base=%pa, based on initial plane programming\n",
+ 			&phys_base);
+ 	} else {
+-		if (IS_METEORLAKE_P(i915))
+-			phys_base = 0;
+-		else
+-			phys_base = base;
++		phys_base = base;
+ 		mem = i915->mm.stolen_region;
+ 	}
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
Test Done:
- Host Kernel Boot successfully
- i915 loaded
- Able to launch android guest successfully
- Reboot issue not seen

Tracked-On: OAM-116753