### PR TITLE
Handle auto-suspend for btusb_sco driver

### DIFF
--- a/bsp_diff/base_aaos/kernel/linux-intel-lts2021/0043-Handle-auto-suspend-for-btusb_sco-driver.patch
+++ b/bsp_diff/base_aaos/kernel/linux-intel-lts2021/0043-Handle-auto-suspend-for-btusb_sco-driver.patch
@@ -1,0 +1,118 @@
+From 5f0fa6fb0fa6d47035dd01a4c2c6f29fa1458f91 Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Tue, 2 Apr 2024 20:45:17 +0530
+Subject: [PATCH] Handle auto-suspend for btusb_sco driver
+
+Add support for auto-suspend in btusb sco driver, so that when the
+driver is not busy (no Tx/Rx), it goes to suspend state. When any
+Tx/Rx, its back to active.
+
+Tests done:
+Check the runtime power status of BT usb during below scenario.
+1. BT connection
+2. BT music streaming
+3. BT file transfer
+4. BT call
+
+Tracked-On: OAM-116918
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ sound/usb/btusb/btusb_sco_snd_card.c | 49 +++++++++++++++++++++++-----
+ 1 file changed, 40 insertions(+), 9 deletions(-)
+
+diff --git a/sound/usb/btusb/btusb_sco_snd_card.c b/sound/usb/btusb/btusb_sco_snd_card.c
+index 2034695c9086..85b59f88646b 100644
+--- a/sound/usb/btusb/btusb_sco_snd_card.c
++++ b/sound/usb/btusb/btusb_sco_snd_card.c
+@@ -89,6 +89,7 @@ struct btusb_data {
+ 
+ 	struct urb *tx_urb;
+ 	struct urb *rx_urb[MAX_URBS];
++	int suspend_count;
+ };
+ 
+ 
+@@ -527,7 +528,8 @@ static inline int __set_isoc_interface(struct snd_pcm_substream *substream,
+ 
+ static struct snd_pcm_hardware btsco_pcm_hardware = {
+ 	.info = SNDRV_PCM_INFO_INTERLEAVED | SNDRV_PCM_INFO_BLOCK_TRANSFER
+-		| SNDRV_PCM_INFO_MMAP | SNDRV_PCM_INFO_MMAP_VALID,
++		| SNDRV_PCM_INFO_MMAP | SNDRV_PCM_INFO_MMAP_VALID
++		| SNDRV_PCM_INFO_RESUME,
+ 	.rates = SNDRV_PCM_RATE_CONTINUOUS,
+ 	.buffer_bytes_max = BUFF_SIZE_MAX,
+ 	.period_bytes_min = MIN_PERIOD_SIZE,
+@@ -994,21 +996,49 @@ static void btusb_sco_disconnect(struct usb_interface *intf)
+ 	data = NULL; */
+ }
+ 
++#ifdef CONFIG_PM
+ static int btusb_sco_suspend(struct usb_interface *intf, pm_message_t message)
+ {
+-	// TODO: Do we need to call snd_pcm_suspend_all
+-	// snd_pcm_suspend_all(data->pcm);
++	struct btusb_data *data = usb_get_intfdata(intf);
++	struct device *dev;
++
++	if (data->suspend_count++)
++		return 0;
++
++	dev = &(data->udev->dev);
++	dev_dbg(dev, "%s", __func__);
++
++	/* During SCO call, we should not suspend btusb_sco driver.
++	 * Modify below condition if external/internal PM needs
++	 * to be handled.
++	 */
++	if (test_bit(BTUSB_ISOC_TX_START, &data->flags)
++		|| test_bit(BTUSB_ISOC_RX_START, &data->flags)) {
++		dev_dbg(dev, "%s SCO Tx/Rx active cannot suspend", __func__);
++		data->suspend_count--;
++		return -EBUSY;
++	}
++
++	snd_power_change_state(data->card, SNDRV_CTL_POWER_D3hot);
++	snd_pcm_suspend_all(data->pcm);
+ 	return 0;
+ }
+ 
+ static int btusb_sco_resume(struct usb_interface *intf)
+ {
+-	// TODO: Do we need to call snd_power_change_state
+-	// snd_power_change_state(data->card, SNDRV_CTL_POWER_D0);
++	struct btusb_data *data = usb_get_intfdata(intf);
++	struct device *dev;
+ 
+-	return 0;
++	if (--data->suspend_count)
++		return 0;
++
++	dev = &(data->udev->dev);
++	dev_dbg(dev, "%s", __func__);
+ 
+- }
++	snd_power_change_state(data->card, SNDRV_CTL_POWER_D0);
++	return 0;
++}
++#endif
+ 
+ static int btusb_sco_ioctl(struct usb_interface *intf, unsigned int code,
+ 		void *buf)
+@@ -1037,11 +1067,12 @@ static struct usb_driver btusb_sco_driver = {
+ 	.probe		= btusb_sco_probe,
+ 	.unlocked_ioctl = btusb_sco_ioctl,
+ 	.disconnect	= btusb_sco_disconnect,
++#ifdef CONFIG_PM
+ 	.suspend	= btusb_sco_suspend,
+ 	.resume		= btusb_sco_resume,
++#endif
+ 	.id_table	= btusb_sco_table,
+-	.supports_autosuspend = 0
+-
++	.supports_autosuspend = 1
+ };
+ 
+ module_usb_driver(btusb_sco_driver);
+-- 
+2.17.1
+


### PR DESCRIPTION
Add support for auto-suspend in btusb sco driver, so that when the driver is not busy (no Tx/Rx), it goes to suspend state. When any Tx/Rx, its back to active.

Tests done:
Check the runtime power status of BT usb during below scenario.
1. BT connection
2. BT music streaming
3. BT file transfer
4. BT call

Tracked-On: OAM-116918