### PR TITLE
Fix BT profile initialization by multiple tasks

### DIFF
--- a/aosp_diff/base_aaos/frameworks/base/99_0259-Fix-BT-profile-initialization-by-multiple-tasks.patch
+++ b/aosp_diff/base_aaos/frameworks/base/99_0259-Fix-BT-profile-initialization-by-multiple-tasks.patch
@@ -1,0 +1,41 @@
+From f28bdf6d8dca96bb29f9f2896d56290a95976593 Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Tue, 2 Apr 2024 20:29:40 +0530
+Subject: [PATCH] Fix BT profile initialization by multiple tasks
+
+[Problem]
+During stability cycle tests, below error is observed.
+java.lang.IllegalStateException: Task appeared more than once: #1
+
+BT profile initiatlization done twice because of timing issue, causing
+FATAL exception and systemUI is crashing.
+
+[Solution]
+Make the profile initialization code synchronized, so that one task
+can execute at a time.
+
+Tests done:
+Flash apollo-ivi image and verify BT on/off.
+
+Tracked-On: OAM-115576
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ .../settingslib/bluetooth/LocalBluetoothProfileManager.java     | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/packages/SettingsLib/src/com/android/settingslib/bluetooth/LocalBluetoothProfileManager.java b/packages/SettingsLib/src/com/android/settingslib/bluetooth/LocalBluetoothProfileManager.java
+index 63cb38153d8d..ebc8c9d8877d 100644
+--- a/packages/SettingsLib/src/com/android/settingslib/bluetooth/LocalBluetoothProfileManager.java
++++ b/packages/SettingsLib/src/com/android/settingslib/bluetooth/LocalBluetoothProfileManager.java
+@@ -125,7 +125,7 @@ public class LocalBluetoothProfileManager {
+     /**
+      * create profile instance according to bluetooth supported profile list
+      */
+-    void updateLocalProfiles() {
++    synchronized void updateLocalProfiles() {
+         List<Integer> supportedList = BluetoothAdapter.getDefaultAdapter().getSupportedProfiles();
+         if (CollectionUtils.isEmpty(supportedList)) {
+             if (DEBUG) Log.d(TAG, "supportedList is null");
+-- 
+2.17.1
+


### PR DESCRIPTION
[Problem]
During stability cycle tests, below error is observed. java.lang.IllegalStateException: Task appeared more than once: #1

BT profile initiatlization done twice because of timing issue, causing FATAL exception and systemUI is crashing.

[Solution]
Make the profile initialization code synchronized, so that one task can execute at a time.

Tests done:
Flash apollo-ivi image and verify BT on/off.

Tracked-On: OAM-115576