### PR TITLE
Fix JavaCrash of android.car.usb.handler

### DIFF
--- a/aosp_diff/base_aaos/packages/services/Car/0021-Fix-JavaCrash-of-android.car.usb.handler.patch
+++ b/aosp_diff/base_aaos/packages/services/Car/0021-Fix-JavaCrash-of-android.car.usb.handler.patch
@@ -1,0 +1,51 @@
+From 7e7af7f0f6db0b59438585026cec87f0c4d8c7fc Mon Sep 17 00:00:00 2001
+From: xubing <bing.xu@intel.com>
+Date: Fri, 12 Apr 2024 10:37:02 +0800
+Subject: [PATCH] Fix JavaCrash of android.car.usb.handler
+
+Monkey test open two tasks of android.car.usb.handler at the same
+time, they use one sqlite database, one task has been destoried,
+database is closed meanwhile other task is using the database, so
+crash happen, add instance count to check if database is used.
+
+TEST: run monkey test, no crash happen.
+
+Tracked-On: OAM-116601
+Signed-off-by: xubing <bing.xu@intel.com>
+---
+ .../android/car/usb/handler/UsbSettingsStorage.java  | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/car-usb-handler/src/android/car/usb/handler/UsbSettingsStorage.java b/car-usb-handler/src/android/car/usb/handler/UsbSettingsStorage.java
+index b578161668..11f9dcea51 100644
+--- a/car-usb-handler/src/android/car/usb/handler/UsbSettingsStorage.java
++++ b/car-usb-handler/src/android/car/usb/handler/UsbSettingsStorage.java
+@@ -185,6 +185,7 @@ public final class UsbSettingsStorage {
+ 
+     private static class UsbSettingsDbHelper extends SQLiteOpenHelper {
+         private static final int DATABASE_VERSION = 2;
++        private static int databaseInstance = 0;
+         private static final String DATABASE_NAME = "usb_devices.db";
+ 
+         // we are using device protected storage because we may need to access the db before the
+@@ -201,6 +202,17 @@ public final class UsbSettingsStorage {
+         public void onCreate(SQLiteDatabase db) {
+             createTable(db, TABLE_USB_SETTINGS);
+             createSerialIndex(db);
++            databaseInstance++;
++            Log.w(TAG, "Create new usb handler databaseInstance: " + databaseInstance);
++        }
++
++        @Override
++        public void close() {
++            databaseInstance--;
++            Log.w(TAG, "Close usb handler databaseInstance: " + databaseInstance);
++            if( databaseInstance == 0){
++                super.close();
++            }
+         }
+ 
+         private void createTable(SQLiteDatabase db, String tableName) {
+-- 
+2.34.1
+


### PR DESCRIPTION
Monkey test open two tasks of android.car.usb.handler at the same time, they use one sqlite database, one task has been destoried, database is closed meanwhile other task is using the database, so crash happen, add instance count to check if database is used.

TEST: run monkey test, no crash happen.

Tracked-On: OAM-116601