### PR TITLE
Fixed for crash during Monkey test run.

### DIFF
--- a/aosp_diff/base_aaos/frameworks/base/99_0260-Fixed-for-crashe-during-Monkey-test-run.patch
+++ b/aosp_diff/base_aaos/frameworks/base/99_0260-Fixed-for-crashe-during-Monkey-test-run.patch
@@ -1,0 +1,57 @@
+From e9d05820f7526f4c00b6add0fe4f0b511411a7dd Mon Sep 17 00:00:00 2001
+From: Ankit Agarwal <ankit.agarwal@intel.com>
+Date: Mon, 15 Apr 2024 09:17:32 +0530
+Subject: [PATCH] Fixed for crashe during Monkey test run.
+
+Following crash were observed
+java.lang.NullPointerException: Attempt to invoke interface method
+'void android.service.dreams.IDreamManager.awaken()' on a null object
+reference at com.android.systemui.statusbar.phone.StatusBar.lambda
+$awakenDreams$37(StatusBar.java:3899)
+
+Get dream service during api runtime & also check for null condition,
+so during monkey test run, then it can safely handle.
+
+Tests:
+Run monkey test and observe, test is pass.
+
+Tracked-On: OAM-117071
+Signed-off-by: Ankit Agarwal <ankit.agarwal@intel.com>
+---
+ .../systemui/statusbar/phone/StatusBar.java      | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+index a539564b831a..5188c8dc633e 100644
+--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
++++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+@@ -3895,14 +3895,22 @@ public class StatusBar extends SystemUI implements
+ 
+     public void awakenDreams() {
+         mUiBgExecutor.execute(() -> {
+-            try {
+-                mDreamManager.awaken();
+-            } catch (RemoteException e) {
+-                e.printStackTrace();
++            IDreamManager dreamManager = getDreamManager();
++            if (dreamManager != null) {
++                try {
++                    mDreamManager.awaken();
++                } catch (RemoteException e) {
++                    e.printStackTrace();
++                }
+             }
+         });
+     }
+ 
++    private IDreamManager getDreamManager() {
++        return IDreamManager.Stub.asInterface(
++                ServiceManager.checkService(DreamService.DREAM_SERVICE));
++    }
++
+     protected void toggleKeyboardShortcuts(int deviceId) {
+         KeyboardShortcuts.toggle(mContext, deviceId);
+     }
+-- 
+2.34.1
+


### PR DESCRIPTION
Following crash were observed
java.lang.NullPointerException: Attempt to invoke interface method 'void android.service.dreams.IDreamManager.awaken()' on a null object reference at com.android.systemui.statusbar.phone.StatusBar.lambda $awakenDreams$37(StatusBar.java:3899)

Get dream service during api runtime & also check for null condition, so during monkey test run, then it can safely handle.

Tests:
Run monkey test and observe, test is pass.

Tracked-On: OAM-117071