### PR TITLE
LocalMediaPlayer: fix sound is still output when focus is lost

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Car/LocalMediaPlayer/0003-LocalMediaPlayer-fix-sound-is-still-output-when-focu.patch
+++ b/aosp_diff/base_aaos/packages/apps/Car/LocalMediaPlayer/0003-LocalMediaPlayer-fix-sound-is-still-output-when-focu.patch
@@ -1,0 +1,110 @@
+From 856e6a05ba39b8a05b696294a5a293beacda24cf Mon Sep 17 00:00:00 2001
+From: Libin Yang <libin.yang@intel.com>
+Date: Sun, 14 Apr 2024 21:45:52 +0800
+Subject: [PATCH] LocalMediaPlayer: fix sound is still output when focus is
+ lost
+
+Sometimes, playing audio with local media player in background,
+switch to video play in photos, audio and video sound will be mixed.
+
+Steps to reproduce:
+-----------------------
+
+1. Push 48Kbps CBR &VBR, videos to dut folder /mnt/user/emulated/10
+   and restart android
+2. Install attached photos.apk
+3. Launch local media player(System default app) and play audio files
+   in circle.
+4. Put local media player in back ground
+5. Go to Files->Video->choose a video->open with photos.
+6. During video playing, choose another video to play with photos.
+
+This is because there is contest between audio playback pause and
+audio playback switching to next song.
+
+Tests done: smoke test Pass
+
+Tracked-On: OAM-115548
+Signed-off-by: Libin Yang <libin.yang@intel.com>
+---
+ .../car/media/localmediaplayer/Player.java    | 25 +++++++++++++------
+ 1 file changed, 18 insertions(+), 7 deletions(-)
+
+diff --git a/src/com/android/car/media/localmediaplayer/Player.java b/src/com/android/car/media/localmediaplayer/Player.java
+index 4508c30..48db5c8 100644
+--- a/src/com/android/car/media/localmediaplayer/Player.java
++++ b/src/com/android/car/media/localmediaplayer/Player.java
+@@ -85,6 +85,7 @@ public class Player extends MediaSession.Callback {
+     private final CustomAction mShuffle;
+ 
+     private List<QueueItem> mQueue;
++    private int mHasFocus = 0;
+     private int mCurrentQueueIdx = 0;
+     private final SharedPreferences mSharedPrefs;
+ 
+@@ -159,10 +160,12 @@ public class Player extends MediaSession.Callback {
+         int result = mAudioManager.requestAudioFocus(mAudioFocusListener, AudioManager.STREAM_MUSIC,
+                 AudioManager.AUDIOFOCUS_GAIN);
+         if (result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
++            mHasFocus = 1;
+             onSuccess.run();
+             return true;
+         }
+         Log.e(TAG, "Failed to acquire audio focus");
++        mHasFocus = 0;
+         return false;
+     }
+ 
+@@ -536,6 +539,8 @@ public class Player extends MediaSession.Callback {
+             Log.d(TAG, "play path=" + path + " metadata=" + metadata);
+         }
+ 
++        boolean wasGrantedAudio = false;
++
+         mMediaPlayer.reset();
+         mMediaPlayer.setDataSource(path);
+         mMediaPlayer.prepare();
+@@ -543,15 +548,19 @@ public class Player extends MediaSession.Callback {
+         if (metadata != null) {
+             mSession.setMetadata(metadata);
+         }
+-        boolean wasGrantedAudio = requestAudioFocus(() -> {
++        if (mHasFocus == 0) {
++            pausePlayback();
++        } else {
++            wasGrantedAudio = requestAudioFocus(() -> {
+             mMediaPlayer.start();
+             updatePlaybackStatePlaying();
+-        });
+-        if (!wasGrantedAudio) {
+-            // player.pause() isn't needed since it should not actually be playing, the
+-            // other steps like, updating the notification and play state are needed, thus we
+-            // call the pause method.
+-            pausePlayback();
++                });
++            if (!wasGrantedAudio) {
++                // player.pause() isn't needed since it should not actually be playing, the
++                // other steps like, updating the notification and play state are needed, thus we
++                // call the pause method.
++                pausePlayback();
++            }
+         }
+     }
+ 
+@@ -652,11 +661,13 @@ public class Player extends MediaSession.Callback {
+             switch (focus) {
+                 case AudioManager.AUDIOFOCUS_GAIN:
+                     resumePlayback();
++                    mHasFocus = 1;
+                     break;
+                 case AudioManager.AUDIOFOCUS_LOSS:
+                 case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
+                 case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
+                     pausePlayback();
++                    mHasFocus = 0;
+                     break;
+                 default:
+                     Log.e(TAG, "Unhandled audio focus type: " + focus);
+-- 
+2.34.1
+


### PR DESCRIPTION
Sometimes, playing audio with local media player in background, switch to video play in photos, audio and video sound will be mixed.

This is because there is contest between audio playback pause and audio playback switching to next song.

Tests done: smoke test Pass

Tracked-On: OAM-115548