### PR TITLE
Fixed for crash during Monkey test run.

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/DeskClock/0004-Fixed-for-crash-during-Monkey-test-run.patch
+++ b/aosp_diff/base_aaos/packages/apps/DeskClock/0004-Fixed-for-crash-during-Monkey-test-run.patch
@@ -1,0 +1,43 @@
+From 0978e6f867be92f450c6f3c2969e00925ba1204b Mon Sep 17 00:00:00 2001
+From: Ankit Agarwal <ankit.agarwal@intel.com>
+Date: Mon, 15 Apr 2024 17:30:19 +0530
+Subject: [PATCH] Fixed for crash during Monkey test run.
+
+Following crash was observed in com.android.deskclock during monkey as
+android.app.RemoteServiceException$CannotPostForegroundService
+NotificationException: Bad notification for startForeground.
+
+Create the notification channel with same channel id before creating
+the notification.
+
+Tests:
+Run monkey test and observe, test is pass.
+
+Tracked-On: OAM-117151
+Signed-off-by: Ankit Agarwal <ankit.agarwal@intel.com>
+---
+ src/com/android/deskclock/data/TimerModel.kt | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/deskclock/data/TimerModel.kt b/src/com/android/deskclock/data/TimerModel.kt
+index 08f6fb1ef..f09819249 100644
+--- a/src/com/android/deskclock/data/TimerModel.kt
++++ b/src/com/android/deskclock/data/TimerModel.kt
+@@ -758,6 +758,7 @@ internal class TimerModel(
+         }
+ 
+         // Otherwise build and post a foreground notification reflecting the latest expired timers.
++        mNotificationBuilder.buildChannel(mContext, mNotificationManager)
+         val notification: Notification = mNotificationBuilder.buildHeadsUp(mContext, expired)
+         val notificationId = mNotificationModel.expiredTimerNotificationId
+         mService!!.startForeground(notificationId, notification)
+@@ -806,4 +807,4 @@ internal class TimerModel(
+             }
+         }
+     }
+-}
+\ No newline at end of file
++}
+-- 
+2.34.1
+


### PR DESCRIPTION
Following crash was observed in com.android.deskclock during monkey as android.app.RemoteServiceException$CannotPostForegroundService NotificationException: Bad notification for startForeground.

Create the notification channel with same channel id before creating the notification. Also context will be used of service, as this is service notification.

Tests:
Run monkey test and observe, test is pass.

Tracked-On: OAM-117151