### PR TITLE
ACPI/PM:Propagate power button event to user space

### DIFF
--- a/bsp_diff/common/kernel/lts2022-chromium/0008-ACPI-PM-Propagate-power-button-event-to-user-space-w.patch
+++ b/bsp_diff/common/kernel/lts2022-chromium/0008-ACPI-PM-Propagate-power-button-event-to-user-space-w.patch
@@ -1,0 +1,72 @@
+From e9c361475af8edd1578fa82988990d704a6b4415 Mon Sep 17 00:00:00 2001
+From: Kaushlendra Kumar <kaushlendra.kumar@intel.com>
+Date: Mon, 15 Apr 2024 16:33:38 +0530
+Subject: [PATCH] ACPI/PM: Propagate power button event to user space when
+ device wakes up
+
+Sometimes power button does not wake up the systemm and we get suspends
+event right after that. Here Android needs to see KEY_POWER at resume.
+Otherwise, its opportunistic suspend will kick in shortly.
+
+However, other OS such as Ubuntu doesn't like KEY_POWER at resume.
+So add a knob "/sys/module/button/parameters/key_power_at_resume" for
+users to select.
+
+Signed-off-by: Kaushlendra Kumar <kaushlendra.kumar@intel.com>
+---
+ drivers/acpi/button.c | 6 +++++-
+ drivers/acpi/sleep.c  | 7 +++++++
+ 2 files changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/acpi/button.c b/drivers/acpi/button.c
+index 1f9b9a4c38c7..812bd349bfc6 100644
+--- a/drivers/acpi/button.c
++++ b/drivers/acpi/button.c
+@@ -38,6 +38,10 @@
+ #define ACPI_BUTTON_DEVICE_NAME_LID	"Lid Switch"
+ #define ACPI_BUTTON_TYPE_LID		0x05
+ 
++/* does userspace want to see KEY_POWER at resume? */
++static bool __read_mostly key_power_at_resume = true;
++module_param(key_power_at_resume, bool, 0644);
++
+ enum {
+ 	ACPI_BUTTON_LID_INIT_IGNORE,
+ 	ACPI_BUTTON_LID_INIT_OPEN,
+@@ -418,7 +422,7 @@ static void acpi_button_notify(struct acpi_device *device, u32 event)
+ 			int keycode;
+ 
+ 			acpi_pm_wakeup_event(&device->dev);
+-			if (button->suspended)
++			if (button->suspended && !key_power_at_resume)
+ 				break;
+ 
+ 			keycode = test_bit(KEY_SLEEP, input->keybit) ?
+diff --git a/drivers/acpi/sleep.c b/drivers/acpi/sleep.c
+index 5e7a05014dea..2ba1c55e055d 100644
+--- a/drivers/acpi/sleep.c
++++ b/drivers/acpi/sleep.c
+@@ -466,6 +466,12 @@ static int acpi_pm_prepare(void)
+ 	return error;
+ }
+ 
++static void pwr_btn_notify(struct acpi_device *device)
++{
++	struct acpi_driver *acpi_drv = to_acpi_driver(device->dev.driver);
++	acpi_drv->ops.notify(device, ACPI_FIXED_HARDWARE_EVENT);
++}
++
+ /**
+  *	acpi_pm_finish - Instruct the platform to leave a sleep state.
+  *
+@@ -508,6 +514,7 @@ static void acpi_pm_finish(void)
+ 						    NULL, -1);
+ 	if (pwr_btn_adev) {
+ 		pm_wakeup_event(&pwr_btn_adev->dev, 0);
++		pwr_btn_notify(pwr_btn_adev);
+ 		acpi_dev_put(pwr_btn_adev);
+ 	}
+ }
+-- 
+2.43.0
+


### PR DESCRIPTION
Sometimes power button does not wake up the systemm and we get suspends event right after that. Here Android needs to see KEY_POWER at resume. Otherwise, its opportunistic suspend will kick in shortly.

However, other OS such as Ubuntu doesn't like KEY_POWER at resume. So add a knob "/sys/module/button/parameters/key_power_at_resume" for users to select.

Tests Done:
1. Check guest standalone suspend/resume with input keyevent 26
2. Use telnet qmp capabilities to wake the device so that android screen is up

Tracked-On: OAM-117467