### PR TITLE
Enable AX210 and AX201 Bluetooth for Android Automotive

### DIFF
--- a/aosp_diff/base_aaos/frameworks/base/99_0258-Enable-AX210-and-AX201-Bluetooth-for-Android-Automot.patch
+++ b/aosp_diff/base_aaos/frameworks/base/99_0258-Enable-AX210-and-AX201-Bluetooth-for-Android-Automot.patch
@@ -1,0 +1,156 @@
+From be118bb56d62f2478748d7cb642de7510aa7d844 Mon Sep 17 00:00:00 2001
+From: "Ye, Zhao" <zhao.ye@intel.com>
+Date: Sun, 28 Apr 2024 02:32:34 +0000
+Subject: [PATCH] Enable AX210 and AX201 Bluetooth for Android Automotive
+
+    The BT chip is loaded as USB interface as hci0, the UsbHostManager
+    is taking control of hci0 interface and doing initialization.
+    Because of which Bluetooth-HAL is not able to send HCI cmds via
+    hci0 interface, causing the hci_timeout_abort() crash.
+    So BT is not enabled.
+
+    Add BT chip vendor id and product id in config deny list, so that
+    UsbHostManager skips the USB interface intialization for hci0.
+Tests:
+Open bluetooth in Settings app,
+bluetooth device can be found.
+
+Tracked-On:OAM-118006
+
+Signed-off-by: Ye, Zhao <zhao.ye@intel.com>
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Signed-off-by: Bharat B Panda <bharat.b.panda@intel.com>
+---
+ core/res/res/values/config.xml                |  3 +
+ .../android/server/usb/UsbHostManager.java    | 57 +++++++++++++++----
+ 2 files changed, 49 insertions(+), 11 deletions(-)
+
+diff --git a/core/res/res/values/config.xml b/core/res/res/values/config.xml
+index 5b0f0befcf16..9dcb76040883 100644
+--- a/core/res/res/values/config.xml
++++ b/core/res/res/values/config.xml
+@@ -1245,6 +1245,9 @@
+          to this list.  If this is empty, no parts of the host USB bus will be excluded.
+     -->
+     <string-array name="config_usbHostDenylist" translatable="false">
++        <item>"8087:0032"</item>
++        <item>"8087:0033"</item>
++        <item>"8087:0026"</item>
+     </string-array>
+ 
+     <!-- List of paths to serial ports that are available to the serial manager.
+diff --git a/services/usb/java/com/android/server/usb/UsbHostManager.java b/services/usb/java/com/android/server/usb/UsbHostManager.java
+index b3eb28552796..af049dbb620c 100644
+--- a/services/usb/java/com/android/server/usb/UsbHostManager.java
++++ b/services/usb/java/com/android/server/usb/UsbHostManager.java
+@@ -242,6 +242,16 @@ public class UsbHostManager {
+         }
+     }
+ 
++    private static class VendorIdProductId {
++        public int vendorId;
++        public int productId;
++
++        public VendorIdProductId(int vendorId, int productId) {
++            vendorId = vendorId;
++            productId = productId;
++        }
++    }
++
+     /*
+      * UsbHostManager
+      */
+@@ -297,14 +307,24 @@ public class UsbHostManager {
+     }
+ 
+     /* returns true if the USB device should not be accessible by applications */
+-    private boolean isDenyListed(int clazz, int subClass) {
++    private boolean isDenyListed(int clazz, int subClass, int vendorID, int productID) {
+         // deny hubs
+         if (clazz == UsbConstants.USB_CLASS_HUB) return true;
+ 
+         // deny HID boot devices (mouse and keyboard)
+-        return clazz == UsbConstants.USB_CLASS_HID
+-                && subClass == UsbConstants.USB_INTERFACE_SUBCLASS_BOOT;
++        if (clazz == UsbConstants.USB_CLASS_HID
++                && subClass == UsbConstants.USB_INTERFACE_SUBCLASS_BOOT) {
++            return true;
++        }
+ 
++        int count = mHostDenyList.length;
++        String vid_pid = String.format("%04x:%04x", vendorID, productID);
++        for (int i = 0; i < count; i++) {
++            if (vid_pid.equals(mHostDenyList[i])) {
++                return true;
++            }
++        }
++        return false;
+     }
+ 
+     private void addConnectionRecord(String deviceAddress, int mode, byte[] rawDescriptors) {
+@@ -366,6 +386,9 @@ public class UsbHostManager {
+     @SuppressWarnings("unused")
+     private boolean usbDeviceAdded(String deviceAddress, int deviceClass, int deviceSubclass,
+             byte[] descriptors) {
++        int vendorId = 0;
++        int productId = 0;
++
+         if (DEBUG) {
+             Slog.d(TAG, "usbDeviceAdded(" + deviceAddress + ") - start");
+         }
+@@ -377,19 +400,23 @@ public class UsbHostManager {
+             return false;
+         }
+ 
+-        if (isDenyListed(deviceClass, deviceSubclass)) {
+-            if (DEBUG) {
+-                Slog.d(TAG, "device class is deny listed");
+-            }
+-            return false;
+-        }
+-
+         UsbDescriptorParser parser = new UsbDescriptorParser(deviceAddress, descriptors);
+         if (deviceClass == UsbConstants.USB_CLASS_PER_INTERFACE
+                 && !checkUsbInterfacesDenyListed(parser)) {
+             return false;
+         }
++        UsbDeviceDescriptor deviceDescriptor = parser.getDeviceDescriptor();
++        if (deviceDescriptor != null) {
++            vendorId  = deviceDescriptor.getVendorID();
++            productId = deviceDescriptor.getProductID();
++        }
+ 
++        if (isDenyListed(deviceClass, deviceSubclass, vendorId, productId)) {
++            if (DEBUG) {
++                Slog.d(TAG, "device class is black listed");
++            }
++            return false;
++        }
+         // Potentially can block as it may read data from the USB device.
+         logUsbDevice(parser);
+ 
+@@ -629,12 +656,20 @@ public class UsbHostManager {
+         // Device class needs to be obtained through the device interface.  Ignore device only
+         // if ALL interfaces are deny-listed.
+         boolean shouldIgnoreDevice = false;
++        int vendorId = 0;
++        int productId = 0;
++
+         for (UsbDescriptor descriptor: parser.getDescriptors()) {
+             if (!(descriptor instanceof UsbInterfaceDescriptor)) {
+                 continue;
+             }
++            UsbDeviceDescriptor deviceDescriptor = parser.getDeviceDescriptor();
++            if (deviceDescriptor != null) {
++                vendorId  = deviceDescriptor.getVendorID();
++                productId = deviceDescriptor.getProductID();
++            }
+             UsbInterfaceDescriptor iface = (UsbInterfaceDescriptor) descriptor;
+-            shouldIgnoreDevice = isDenyListed(iface.getUsbClass(), iface.getUsbSubclass());
++            shouldIgnoreDevice = isDenyListed(iface.getUsbClass(), iface.getUsbSubclass(), vendorId, productId);
+             if (!shouldIgnoreDevice) {
+                 break;
+             }
+-- 
+2.34.1
+


### PR DESCRIPTION
    The BT chip is loaded as USB interface as hci0, the UsbHostManager
    is taking control of hci0 interface and doing initialization.
    Because of which Bluetooth-HAL is not able to send HCI cmds via
    hci0 interface, causing the hci_timeout_abort() crash.
    So BT is not enabled.

    Add BT chip vendor id and product id in config deny list, so that
    UsbHostManager skips the USB interface intialization for hci0.

    Tests:
    Open bluetooth in Settings app,
    bluetooth device can be found.

    Tracked-On:  OAM-118006