### PR TITLE
Add iacamera hal sepolicy

### DIFF
--- a/bsp_diff/base_aaos/device/intel/sepolicy/0002-Add-iacamera-hal-sepolicy.patch
+++ b/bsp_diff/base_aaos/device/intel/sepolicy/0002-Add-iacamera-hal-sepolicy.patch
@@ -1,0 +1,118 @@
+From 757bcf46dabdb6f87f0a097bf9734f363b54b3e5 Mon Sep 17 00:00:00 2001
+From: Neo Fang <neo.fang@intel.com>
+Date: Sun, 28 Apr 2024 12:36:16 +0000
+Subject: [PATCH] Add iacamera hal sepolicy
+
+Issue Detailed: No iacamera hal sepolicy.
+
+Fix Detailed: Enable iacamera hal sepolicy.
+
+Tested On: AOSP camera app preview successfully.
+
+Tracked-On: OAM-117417
+Signed-off-by: Neo Fang <neo.fang@intel.com>
+---
+ camera-ext/ivi/cameraserver.te       |  4 ++++
+ camera-ext/ivi/file_contexts         |  4 ++++
+ camera-ext/ivi/hal_camera_default.te | 10 ++++++++++
+ camera-ext/ivi/init.te               |  6 ++++++
+ camera-ext/ivi/logwrapper.te         |  1 +
+ camera-ext/ivi/property.te           |  1 +
+ camera-ext/ivi/property_contexts     |  8 ++++++++
+ camera-ext/ivi/vendor_init.te        |  1 +
+ 8 files changed, 35 insertions(+)
+ create mode 100644 camera-ext/ivi/cameraserver.te
+ create mode 100644 camera-ext/ivi/file_contexts
+ create mode 100644 camera-ext/ivi/hal_camera_default.te
+ create mode 100644 camera-ext/ivi/init.te
+ create mode 100644 camera-ext/ivi/logwrapper.te
+ create mode 100644 camera-ext/ivi/property.te
+ create mode 100644 camera-ext/ivi/property_contexts
+ create mode 100644 camera-ext/ivi/vendor_init.te
+
+diff --git a/camera-ext/ivi/cameraserver.te b/camera-ext/ivi/cameraserver.te
+new file mode 100644
+index 0000000..a24f9bb
+--- /dev/null
++++ b/camera-ext/ivi/cameraserver.te
+@@ -0,0 +1,4 @@
++#============= cameraserver ==============
++allow cameraserver gpu_device:dir search;
++allow cameraserver gpu_device:chr_file rw_file_perms;
++allow cameraserver hal_graphics_allocator_default_tmpfs:file { read write map};
+diff --git a/camera-ext/ivi/file_contexts b/camera-ext/ivi/file_contexts
+new file mode 100644
+index 0000000..b5f44fa
+--- /dev/null
++++ b/camera-ext/ivi/file_contexts
+@@ -0,0 +1,4 @@
++/dev/media[0-9]+          u:object_r:video_device:s0
++/(vendor|system/vendor)/bin/android\.hardware\.automotive\.evs@1\.[0-9]-sample  u:object_r:hal_evs_default_exec:s0
++/(vendor|system/vendor)/bin/hw/android\.vendor\.hardware\.camera\.provider@2\.[0-9]+-ivi-service       u:object_r:hal_camera_default_exec:s0
++/(vendor|system/vendor)/bin/hw/android\.iacamera\.provider@2\.[0-9]+-ivi-service u:object_r:hal_camera_default_exec:s0
+diff --git a/camera-ext/ivi/hal_camera_default.te b/camera-ext/ivi/hal_camera_default.te
+new file mode 100644
+index 0000000..aca2051
+--- /dev/null
++++ b/camera-ext/ivi/hal_camera_default.te
+@@ -0,0 +1,10 @@
++#============= hal_camera_default ==============
++vndbinder_use(hal_camera_default);
++
++allow hal_camera_default gpu_device:chr_file rw_file_perms;
++allow hal_camera_default gpu_device:dir search;
++allow hal_camera_default hal_graphics_allocator_default_tmpfs:file { map read write };
++allow hal_camera_default hal_graphics_mapper_hwservice:hwservice_manager find;
++allow hal_camera_default hal_graphics_composer_default:fd use;
++allow hal_camera_default self:{ socket vsock_socket } { create read write listen accept bind };
++set_prop(hal_camera_default, vendor_camera_default_prop)
+diff --git a/camera-ext/ivi/init.te b/camera-ext/ivi/init.te
+new file mode 100644
+index 0000000..60543c9
+--- /dev/null
++++ b/camera-ext/ivi/init.te
+@@ -0,0 +1,6 @@
++#
++# init
++#
++
++# wait on /dev/video0 a shared buffer used for camera processing
++allow init video_device:chr_file getattr;
+diff --git a/camera-ext/ivi/logwrapper.te b/camera-ext/ivi/logwrapper.te
+new file mode 100644
+index 0000000..0da1971
+--- /dev/null
++++ b/camera-ext/ivi/logwrapper.te
+@@ -0,0 +1 @@
++set_prop(logwrapper, vendor_camera_default_prop)
+diff --git a/camera-ext/ivi/property.te b/camera-ext/ivi/property.te
+new file mode 100644
+index 0000000..905e3af
+--- /dev/null
++++ b/camera-ext/ivi/property.te
+@@ -0,0 +1 @@
++vendor_internal_prop(vendor_camera_default_prop)
+diff --git a/camera-ext/ivi/property_contexts b/camera-ext/ivi/property_contexts
+new file mode 100644
+index 0000000..2a1f00c
+--- /dev/null
++++ b/camera-ext/ivi/property_contexts
+@@ -0,0 +1,8 @@
++ro.vendor.remote.sf.fake_camera                 u:object_r:vendor_camera_default_prop:s0
++ro.vendor.camera.in_frame_format.h264 u:object_r:vendor_camera_default_prop:s0
++ro.vendor.camera.in_frame_format.i420 u:object_r:vendor_camera_default_prop:s0
++ro.vendor.camera.decode.vaapi         u:object_r:vendor_camera_default_prop:s0
++ro.vendor.remote.sf.back_camera_hal             u:object_r:vendor_camera_default_prop:s0
++ro.vendor.remote.sf.front_camera_hal            u:object_r:vendor_camera_default_prop:s0
++ro.vendor.camera.transference         u:object_r:vendor_camera_default_prop:s0 
++vendor.camera.external         u:object_r:vendor_camera_default_prop:s0 
+diff --git a/camera-ext/ivi/vendor_init.te b/camera-ext/ivi/vendor_init.te
+new file mode 100644
+index 0000000..72ae654
+--- /dev/null
++++ b/camera-ext/ivi/vendor_init.te
+@@ -0,0 +1 @@
++set_prop(vendor_init, vendor_camera_default_prop)
+-- 
+2.25.1
+


### PR DESCRIPTION
Issue Detailed: No iacamera hal sepolicy.

Fix Detailed: Enable iacamera hal sepolicy.

Tested On: AOSP camera app preview successfully.

Tracked-On: OAM-117417
Signed-off-by: Neo Fang <neo.fang@intel.com>