### PR TITLE
Refactor UsbHostManager denylist for BT USB devices

### DIFF
--- a/aosp_diff/base_aaos/frameworks/base/99_0259-Refactor-UsbHostManager-denylist-for-BT-USB-devices.patch
+++ b/aosp_diff/base_aaos/frameworks/base/99_0259-Refactor-UsbHostManager-denylist-for-BT-USB-devices.patch
@@ -1,0 +1,114 @@
+From e0c3f8e06661214482e266d0d8c80d87d2e6c09a Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Mon, 29 Apr 2024 21:13:07 +0530
+Subject: [PATCH] Refactor UsbHostManager denylist for BT USB devices
+
+AOSP API is modified to block BT USB devices during initialization.
+This will not be accepted by VTS and CTS on GSI.
+
+Refactor the code to not modify the existing AOSP API.
+
+Tests done:
+1. Build and flash aaos 14 on MTL
+2. Check BT on success
+3. Connect phone and play music
+4. Validated on AX210, AX211 cards
+
+Tracked-On: OAM-118057
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Signed-off-by: Aman Bhadouria <aman.bhadouria@intel.com>
+---
+ .../android/server/usb/UsbHostManager.java    | 42 ++++++++++---------
+ 1 file changed, 22 insertions(+), 20 deletions(-)
+
+diff --git a/services/usb/java/com/android/server/usb/UsbHostManager.java b/services/usb/java/com/android/server/usb/UsbHostManager.java
+index af049dbb620c..2bc039276d81 100644
+--- a/services/usb/java/com/android/server/usb/UsbHostManager.java
++++ b/services/usb/java/com/android/server/usb/UsbHostManager.java
+@@ -307,16 +307,18 @@ public class UsbHostManager {
+     }
+ 
+     /* returns true if the USB device should not be accessible by applications */
+-    private boolean isDenyListed(int clazz, int subClass, int vendorID, int productID) {
++    private boolean isDenyListed(int clazz, int subClass) {
+         // deny hubs
+         if (clazz == UsbConstants.USB_CLASS_HUB) return true;
+ 
+         // deny HID boot devices (mouse and keyboard)
+-        if (clazz == UsbConstants.USB_CLASS_HID
+-                && subClass == UsbConstants.USB_INTERFACE_SUBCLASS_BOOT) {
+-            return true;
+-        }
++        return clazz == UsbConstants.USB_CLASS_HID
++                && subClass == UsbConstants.USB_INTERFACE_SUBCLASS_BOOT;
++
++    }
+ 
++    /* returns true if the USB device should not be accessible by applications */
++    private boolean isCustomUsbDenyListed(int vendorID, int productID) {
+         int count = mHostDenyList.length;
+         String vid_pid = String.format("%04x:%04x", vendorID, productID);
+         for (int i = 0; i < count; i++) {
+@@ -400,23 +402,31 @@ public class UsbHostManager {
+             return false;
+         }
+ 
++        if (isDenyListed(deviceClass, deviceSubclass)) {
++            if (DEBUG) {
++                Slog.d(TAG, "device class is deny listed");
++            }
++            return false;
++        }
++
+         UsbDescriptorParser parser = new UsbDescriptorParser(deviceAddress, descriptors);
+         if (deviceClass == UsbConstants.USB_CLASS_PER_INTERFACE
+                 && !checkUsbInterfacesDenyListed(parser)) {
+             return false;
+         }
++
+         UsbDeviceDescriptor deviceDescriptor = parser.getDeviceDescriptor();
+         if (deviceDescriptor != null) {
+             vendorId  = deviceDescriptor.getVendorID();
+             productId = deviceDescriptor.getProductID();
+-        }
+-
+-        if (isDenyListed(deviceClass, deviceSubclass, vendorId, productId)) {
+-            if (DEBUG) {
+-                Slog.d(TAG, "device class is black listed");
++            if (isCustomUsbDenyListed(vendorId, productId)) {
++                if (DEBUG) {
++                    Slog.d(TAG, "Device class is deny listed");
++                }
++                return false;
+             }
+-            return false;
+         }
++
+         // Potentially can block as it may read data from the USB device.
+         logUsbDevice(parser);
+ 
+@@ -656,20 +666,12 @@ public class UsbHostManager {
+         // Device class needs to be obtained through the device interface.  Ignore device only
+         // if ALL interfaces are deny-listed.
+         boolean shouldIgnoreDevice = false;
+-        int vendorId = 0;
+-        int productId = 0;
+-
+         for (UsbDescriptor descriptor: parser.getDescriptors()) {
+             if (!(descriptor instanceof UsbInterfaceDescriptor)) {
+                 continue;
+             }
+-            UsbDeviceDescriptor deviceDescriptor = parser.getDeviceDescriptor();
+-            if (deviceDescriptor != null) {
+-                vendorId  = deviceDescriptor.getVendorID();
+-                productId = deviceDescriptor.getProductID();
+-            }
+             UsbInterfaceDescriptor iface = (UsbInterfaceDescriptor) descriptor;
+-            shouldIgnoreDevice = isDenyListed(iface.getUsbClass(), iface.getUsbSubclass(), vendorId, productId);
++            shouldIgnoreDevice = isDenyListed(iface.getUsbClass(), iface.getUsbSubclass());
+             if (!shouldIgnoreDevice) {
+                 break;
+             }
+-- 
+2.17.1
+


### PR DESCRIPTION
AOSP API is modified to block BT USB devices during initialization. This will not be accepted by VTS and CTS on GSI.

Refactor the code to not modify the existing AOSP API.

Tests done:
1. Build and flash aaos 14 on MTL
2. Check BT on success
3. Connect phone and play music
4. Validated on AX210, AX211 cards

Tracked-On: OAM-118057