### PR TITLE
Remove more than once task appeared check

### DIFF
--- a/aosp_diff/base_aaos/frameworks/base/99_0262-Remove-more-than-once-task-appeared-check.patch
+++ b/aosp_diff/base_aaos/frameworks/base/99_0262-Remove-more-than-once-task-appeared-check.patch
@@ -1,0 +1,56 @@
+From cf683509f6a2e0e1a7b22feb025d038b2b1ae5f0 Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Mon, 6 May 2024 13:36:58 +0530
+Subject: [PATCH] Remove more than once task appeared check
+
+Sometimes remove apk task, but framework did not real notify wmshell
+onTaskVanished success due to remoteException, if this task appeared
+again, should follow and grant this time appear.
+
+Cherry-pick: https://android-review.googlesource.com/c/platform/frameworks/base/+/2929814
+
+Tests done:
+1. Build and flash as BM
+2. Check BT on success
+3. Toggle BT 50 times
+4. Check BT on success everytime
+5. Connect pixel device from BT settings
+6. Disconnect/Connect 20 times
+7. Check pixel connection success everytime
+
+Tracked-On: OAM-118069
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ .../src/com/android/wm/shell/freeform/FreeformTaskListener.java | 2 +-
+ .../com/android/wm/shell/fullscreen/FullscreenTaskListener.java | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/libs/WindowManager/Shell/src/com/android/wm/shell/freeform/FreeformTaskListener.java b/libs/WindowManager/Shell/src/com/android/wm/shell/freeform/FreeformTaskListener.java
+index 52ff21bc3172..b731d7a2ee3b 100644
+--- a/libs/WindowManager/Shell/src/com/android/wm/shell/freeform/FreeformTaskListener.java
++++ b/libs/WindowManager/Shell/src/com/android/wm/shell/freeform/FreeformTaskListener.java
+@@ -58,7 +58,7 @@ public class FreeformTaskListener implements ShellTaskOrganizer.TaskListener {
+     @Override
+     public void onTaskAppeared(RunningTaskInfo taskInfo, SurfaceControl leash) {
+         if (mTasks.get(taskInfo.taskId) != null) {
+-            throw new RuntimeException("Task appeared more than once: #" + taskInfo.taskId);
++            mTasks.remove(taskInfo.taskId);
+         }
+         ProtoLog.v(ShellProtoLogGroup.WM_SHELL_TASK_ORG, "Freeform Task Appeared: #%d",
+                 taskInfo.taskId);
+diff --git a/libs/WindowManager/Shell/src/com/android/wm/shell/fullscreen/FullscreenTaskListener.java b/libs/WindowManager/Shell/src/com/android/wm/shell/fullscreen/FullscreenTaskListener.java
+index 6e38e421d4b6..f8cea1a4c420 100644
+--- a/libs/WindowManager/Shell/src/com/android/wm/shell/fullscreen/FullscreenTaskListener.java
++++ b/libs/WindowManager/Shell/src/com/android/wm/shell/fullscreen/FullscreenTaskListener.java
+@@ -70,7 +70,7 @@ public class FullscreenTaskListener implements ShellTaskOrganizer.TaskListener {
+     @Override
+     public void onTaskAppeared(RunningTaskInfo taskInfo, SurfaceControl leash) {
+         if (mDataByTaskId.get(taskInfo.taskId) != null) {
+-            throw new IllegalStateException("Task appeared more than once: #" + taskInfo.taskId);
++            mDataByTaskId.remove(taskInfo.taskId);
+         }
+         ProtoLog.v(ShellProtoLogGroup.WM_SHELL_TASK_ORG, "Fullscreen Task Appeared: #%d",
+                 taskInfo.taskId);
+-- 
+2.17.1
+


### PR DESCRIPTION
Sometimes remove apk task, but framework did not real notify wmshell onTaskVanished success due to remoteException, if this task appeared again, should follow and grant this time appear.

Cherry-pick: https://android-review.googlesource.com/c/platform/frameworks/base/+/2929814

Tracked-On: OAM-118069