### PR TITLE
Update default KeyMint version to 3

### DIFF
--- a/aosp_diff/base_aaos/hardware/interfaces/0001-Update-default-KeyMint-version-to-3.patch
+++ b/aosp_diff/base_aaos/hardware/interfaces/0001-Update-default-KeyMint-version-to-3.patch
@@ -1,0 +1,38 @@
+From 8417708fe467f786608e8caf13552132b06e640a Mon Sep 17 00:00:00 2001
+From: Eran Messeri <eranm@google.com>
+Date: Wed, 21 Jun 2023 16:11:25 +0100
+Subject: [PATCH] Update default KeyMint version to 3
+
+Update the default KeyMint version to v3.
+Note this affects the pure software implementation of KeyMint that is
+not used for anything that tests currently run against.
+
+Bug: 275982952
+Test: m (that it builds)
+Change-Id: I6ab10329af590bd2a045710dfff47c6e78740464
+---
+ .../default/android.hardware.security.keymint-service.xml     | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/security/keymint/aidl/default/android.hardware.security.keymint-service.xml b/security/keymint/aidl/default/android.hardware.security.keymint-service.xml
+index a4d0302065..0568ae6436 100644
+--- a/security/keymint/aidl/default/android.hardware.security.keymint-service.xml
++++ b/security/keymint/aidl/default/android.hardware.security.keymint-service.xml
+@@ -1,12 +1,12 @@
+ <manifest version="1.0" type="device">
+     <hal format="aidl">
+         <name>android.hardware.security.keymint</name>
+-        <version>2</version>
++        <version>3</version>
+         <fqname>IKeyMintDevice/default</fqname>
+     </hal>
+     <hal format="aidl">
+         <name>android.hardware.security.keymint</name>
+-        <version>2</version>
++        <version>3</version>
+         <fqname>IRemotelyProvisionedComponent/default</fqname>
+     </hal>
+ </manifest>
+-- 
+2.34.1
+


### PR DESCRIPTION
Backport Google's patch to update default KeyMint version to 3 to fix vts issue.

Test Done:
run vts -m vts_treble_vintf_vendor_test

Tracked-On: OAM-118540