### PR TITLE
Disable audio codec

### DIFF
--- a/aosp_diff/preliminary/frameworks/av/0007-Without-considering-online-video-set-a-property-in-N.patch
+++ b/aosp_diff/preliminary/frameworks/av/0007-Without-considering-online-video-set-a-property-in-N.patch
@@ -1,0 +1,73 @@
+From 4273b2b7245ef669453f1143954fb73c75f0ca20 Mon Sep 17 00:00:00 2001
+From: "zhepeng.xu" <zhepengx.xu@intel.com>
+Date: Wed, 15 May 2024 00:25:13 +0800
+Subject: [PATCH] Without considering online-video, set a property in Nuplayer
+ to dynamically disable the audio codec. In order to quickly eliminate the
+ audio cause when video freezes occur in the future. Tracked-On:OAM-116765
+
+Signed-off-by: zhepeng.xu <zhepengx.xu@intel.com>
+---
+ media/libmediaplayerservice/nuplayer/NuPlayer.cpp         | 8 ++++++++
+ .../nuplayer/include/nuplayer/NuPlayer.h                  | 1 +
+ 2 files changed, 9 insertions(+)
+
+diff --git a/media/libmediaplayerservice/nuplayer/NuPlayer.cpp b/media/libmediaplayerservice/nuplayer/NuPlayer.cpp
+index e5f2b2b696..18d251403e 100644
+--- a/media/libmediaplayerservice/nuplayer/NuPlayer.cpp
++++ b/media/libmediaplayerservice/nuplayer/NuPlayer.cpp
+@@ -211,6 +211,7 @@ NuPlayer::NuPlayer(pid_t pid, const sp<MediaClock> &mediaClock)
+       mDataSourceType(DATA_SOURCE_TYPE_NONE) {
+     CHECK(mediaClock != NULL);
+     clearFlushComplete();
++    mDisableAudio = property_get_bool("persist.sys.disable.audio", false);
+ }
+ 
+ NuPlayer::~NuPlayer() {
+@@ -1040,9 +1041,11 @@ void NuPlayer::onMessageReceived(const sp<AMessage> &msg) {
+             }
+ 
+             // Don't try to re-open audio sink if there's an existing decoder.
++            if (!mDisableAudio) {
+             if (mAudioSink != NULL && mAudioDecoder == NULL) {
+                 if (instantiateDecoder(true, &mAudioDecoder) == -EWOULDBLOCK) {
+                     rescan = true;
++                    }
+                 }
+             }
+ 
+@@ -1510,7 +1513,9 @@ void NuPlayer::onResume() {
+     // |mAudioDecoder| may have been released due to the pause timeout, so re-create it if
+     // needed.
+     if (audioDecoderStillNeeded() && mAudioDecoder == NULL) {
++        if (!mDisableAudio) {
+         instantiateDecoder(true /* audio */, &mAudioDecoder);
++        }
+     }
+     if (mRenderer != NULL) {
+         mRenderer->resume();
+@@ -1887,7 +1892,10 @@ void NuPlayer::restartAudio(
+         mOffloadAudio = false;
+     }
+     if (needsToCreateAudioDecoder) {
++        if (!mDisableAudio) {
++            ALOGD("enable instantiateDecoder");
+         instantiateDecoder(true /* audio */, &mAudioDecoder, !forceNonOffload);
++        }
+     }
+ }
+ 
+diff --git a/media/libmediaplayerservice/nuplayer/include/nuplayer/NuPlayer.h b/media/libmediaplayerservice/nuplayer/include/nuplayer/NuPlayer.h
+index 7dc97ea029..1c5fe728fb 100644
+--- a/media/libmediaplayerservice/nuplayer/include/nuplayer/NuPlayer.h
++++ b/media/libmediaplayerservice/nuplayer/include/nuplayer/NuPlayer.h
+@@ -114,6 +114,7 @@ protected:
+ public:
+     struct NuPlayerStreamListener;
+     struct Source;
++    bool mDisableAudio;
+ 
+ private:
+     struct Decoder;
+-- 
+2.34.1
+


### PR DESCRIPTION
Without considering online-video, set a property in Nuplayer to dynamically disable the audio codec. In order to quickly eliminate the audio cause when video freezes occur in the future. 
Tracked-On:OAM-116765
