### PR TITLE
Dynamically disable audio codes

### DIFF
--- a/aosp_diff/preliminary/frameworks/av/0007-Dynamically-disable-audio-codes.patch
+++ b/aosp_diff/preliminary/frameworks/av/0007-Dynamically-disable-audio-codes.patch
@@ -1,0 +1,91 @@
+From 3c98f06168b3cce52dad42897d6ed7cf67930898 Mon Sep 17 00:00:00 2001
+From: "zhepeng.xu" <zhepengx.xu@intel.com>
+Date: Wed, 15 May 2024 20:39:21 +0800
+Subject: [PATCH] Dynamically disable audio codes
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+set a property in Nuplayer to dynamically disable the audio codec.
+In order to quickly eliminate the audio cause when video freezes occur in the future.
+
+Tests Done
+Disable audio decoding:
+-setprop persist.sys.disable.audio true
+-reboot
+Enable audio decoding:
+-setprop persist.sys.disable.audio false
+-reboot
+
+Tracked-On:OAM-116765
+Signed-off-by: zhepeng.xu <zhepengx.xu@intel.com>
+---
+ .../nuplayer/NuPlayer.cpp                      | 18 +++++++++++++-----
+ .../nuplayer/include/nuplayer/NuPlayer.h       |  1 +
+ 2 files changed, 14 insertions(+), 5 deletions(-)
+
+diff --git a/media/libmediaplayerservice/nuplayer/NuPlayer.cpp b/media/libmediaplayerservice/nuplayer/NuPlayer.cpp
+index e5f2b2b696..2923977a17 100644
+--- a/media/libmediaplayerservice/nuplayer/NuPlayer.cpp
++++ b/media/libmediaplayerservice/nuplayer/NuPlayer.cpp
+@@ -211,6 +211,7 @@ NuPlayer::NuPlayer(pid_t pid, const sp<MediaClock> &mediaClock)
+       mDataSourceType(DATA_SOURCE_TYPE_NONE) {
+     CHECK(mediaClock != NULL);
+     clearFlushComplete();
++    mDisableAudio = property_get_bool("persist.sys.disable.audio", false);
+ }
+ 
+ NuPlayer::~NuPlayer() {
+@@ -1040,9 +1041,11 @@ void NuPlayer::onMessageReceived(const sp<AMessage> &msg) {
+             }
+ 
+             // Don't try to re-open audio sink if there's an existing decoder.
+-            if (mAudioSink != NULL && mAudioDecoder == NULL) {
+-                if (instantiateDecoder(true, &mAudioDecoder) == -EWOULDBLOCK) {
+-                    rescan = true;
++            if (!mDisableAudio) {
++                if (mAudioSink != NULL && mAudioDecoder == NULL) {
++                    if (instantiateDecoder(true, &mAudioDecoder) == -EWOULDBLOCK) {
++                        rescan = true;
++                    }
+                 }
+             }
+ 
+@@ -1510,7 +1513,9 @@ void NuPlayer::onResume() {
+     // |mAudioDecoder| may have been released due to the pause timeout, so re-create it if
+     // needed.
+     if (audioDecoderStillNeeded() && mAudioDecoder == NULL) {
+-        instantiateDecoder(true /* audio */, &mAudioDecoder);
++        if (!mDisableAudio) {
++            instantiateDecoder(true /* audio */, &mAudioDecoder);
++        }
+     }
+     if (mRenderer != NULL) {
+         mRenderer->resume();
+@@ -1887,7 +1892,10 @@ void NuPlayer::restartAudio(
+         mOffloadAudio = false;
+     }
+     if (needsToCreateAudioDecoder) {
+-        instantiateDecoder(true /* audio */, &mAudioDecoder, !forceNonOffload);
++        if (!mDisableAudio) {
++            ALOGD("enable instantiateDecoder");
++            instantiateDecoder(true /* audio */, &mAudioDecoder, !forceNonOffload);
++        }
+     }
+ }
+ 
+diff --git a/media/libmediaplayerservice/nuplayer/include/nuplayer/NuPlayer.h b/media/libmediaplayerservice/nuplayer/include/nuplayer/NuPlayer.h
+index 7dc97ea029..1c5fe728fb 100644
+--- a/media/libmediaplayerservice/nuplayer/include/nuplayer/NuPlayer.h
++++ b/media/libmediaplayerservice/nuplayer/include/nuplayer/NuPlayer.h
+@@ -114,6 +114,7 @@ protected:
+ public:
+     struct NuPlayerStreamListener;
+     struct Source;
++    bool mDisableAudio;
+ 
+ private:
+     struct Decoder;
+-- 
+2.34.1
+


### PR DESCRIPTION
set a property in Nuplayer to dynamically disable the audio codec. 
In order to quickly eliminate the audio cause when video freezes occur in the future.

Tests Done
Disable audio decoding:
-setprop persist.sys.disable.audio true
-reboot
Enable audio decoding:
-setprop persist.sys.disable.audio false
-reboot

Tracked-On:OAM-116765