### PR TITLE
Add patch to return HWC2_ERROR_NONE to pass vts

### DIFF
--- a/aosp_diff/preliminary/hardware/interfaces/0013-Return-HWC2_ERROR_NONE-to-pass-vts.patch
+++ b/aosp_diff/preliminary/hardware/interfaces/0013-Return-HWC2_ERROR_NONE-to-pass-vts.patch
@@ -1,0 +1,37 @@
+From 2c4fa29714bdb051a4abbf080f117992cbf6ae6b Mon Sep 17 00:00:00 2001
+From: "Liu, Kai1" <kai1.liu@intel.com>
+Date: Fri, 17 May 2024 01:02:49 +0800
+Subject: [PATCH] Return HWC2_ERROR_NONE to pass vts
+
+Our HWC does not support set display brightness and function
+flushDisplayBrightnessChange returns HWC2_ERROR_UNSUPPORTED,
+which results in vts case SetDisplayBrightness failed.
+
+Let flushDisplayBrightnessChange return HWC2_ERROR_NONE to pass
+the vts test.
+
+Test Done:
+run vts -m VtsHalGraphicsComposer3_TargetTest
+
+Tracked-On: OAM-118706
+Signed-off-by: Liu, Kai1 <kai1.liu@intel.com>
+---
+ graphics/composer/aidl/default/impl/HalImpl.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/graphics/composer/aidl/default/impl/HalImpl.cpp b/graphics/composer/aidl/default/impl/HalImpl.cpp
+index 15dcefe912..4d16d49a11 100644
+--- a/graphics/composer/aidl/default/impl/HalImpl.cpp
++++ b/graphics/composer/aidl/default/impl/HalImpl.cpp
+@@ -680,7 +680,7 @@ int32_t HalImpl::getSupportedContentTypes(int64_t display, std::vector<ContentTy
+ }
+ 
+ int32_t HalImpl::flushDisplayBrightnessChange([[maybe_unused]] int64_t display) {
+-    return HWC2_ERROR_UNSUPPORTED;
++    return HWC2_ERROR_NONE;
+ }
+ 
+ int32_t HalImpl::presentDisplay(int64_t display, ndk::ScopedFileDescriptor& fence,
+-- 
+2.34.1
+


### PR DESCRIPTION
Our HWC does not support set display brightness and function flushDisplayBrightnessChange returns HWC2_ERROR_UNSUPPORTED, which results in vts case SetDisplayBrightness failed.

Let flushDisplayBrightnessChange return HWC2_ERROR_NONE to pass the vts test.

Test Done:
run vts -m VtsHalGraphicsComposer3_TargetTest

Tracked-On: OAM-118706