### PR TITLE
Fix com.android.systemui crash during Monkey test

### DIFF
--- a/aosp_diff/base_aaos/frameworks/base/99_0267-Fixed-crash-for-com.android.systemui-during-Monkey.patch
+++ b/aosp_diff/base_aaos/frameworks/base/99_0267-Fixed-crash-for-com.android.systemui-during-Monkey.patch
@@ -1,0 +1,41 @@
+From bf4918ea31a306351c06e27c5cca8eb65ca630ce Mon Sep 17 00:00:00 2001
+From: "Gong, Pu" <pu.gong@intel.com>
+Date: Mon, 20 May 2024 01:34:55 +0000
+Subject: [PATCH] Fixed crash for com.android.systemui during Monkey test run
+
+Following crash were observed:
+java.lang.NullPointerException: Attempt to invoke interface method
+'void android.service.dreams.IDreamManager.awaken()' on a null object
+reference at com.android.systemui.statusbar.phone.StatusBar.lambda
+$awakenDreams$37(StatusBar.java:3901)
+
+Re-set mDreamManager in runtime to avoid the first null init conditon.
+
+Tests:
+Run monkey test and observe, test is pass.
+
+Tracked-On: OAM-118790
+Signed-off-by: Ankit Agarwal <ankit.agarwal@intel.com>
+Signed-off-by: Gong Pu <pu.gong@intel.com>
+---
+ .../src/com/android/systemui/statusbar/phone/StatusBar.java   | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+index 5188c8dc633e..005d669a91ec 100644
+--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
++++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+@@ -3895,8 +3895,8 @@ public class StatusBar extends SystemUI implements
+ 
+     public void awakenDreams() {
+         mUiBgExecutor.execute(() -> {
+-            IDreamManager dreamManager = getDreamManager();
+-            if (dreamManager != null) {
++            mDreamManager = getDreamManager();
++            if (mDreamManager != null) {
+                 try {
+                     mDreamManager.awaken();
+                 } catch (RemoteException e) {
+-- 
+2.34.1
+


### PR DESCRIPTION
Following crash were observed:
java.lang.NullPointerException: Attempt to invoke interface method 'void android.service.dreams.IDreamManager.awaken()' on a null object reference at com.android.systemui.statusbar.phone.StatusBar.lambda $awakenDreams$37(StatusBar.java:3901)

Re-set mDreamManager in runtime to avoid the first null init conditon.

Tests:
Run monkey test and observe, test is pass.

Tracked-On: OAM-118790