### PR TITLE
Fix a2dp state machine java crash

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Bluetooth/07_0007-Fix-a2dp-state-machine-java-crash.patch
+++ b/aosp_diff/base_aaos/packages/apps/Bluetooth/07_0007-Fix-a2dp-state-machine-java-crash.patch
@@ -1,0 +1,42 @@
+From fa5dbc6f7ec1451c6e29f30cc05e36fb2811bbd2 Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Wed, 29 May 2024 19:07:57 +0530
+Subject: [PATCH] Fix a2dp state machine java crash
+
+Multiple threads trying to execute the a2dp state machine block,
+where the message is sent even before starting the state machine,
+resulting in FATAL exception on com.android.bluetooth.
+
+Make the state machine block synchronized to avoid multiple threads
+accessing the same resource at a time.
+
+Tests done:
+1. Flash bare metal
+2. Check BT on success
+3. Connect Pixel
+4. Toggle A2DP media profile 20 times
+5. With Pixel connected, toggle BT on/off 20 times
+6. No crash observed, no hang observed
+
+Tracked-On: OAM-116660
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ src/com/android/bluetooth/a2dpsink/A2dpSinkService.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/com/android/bluetooth/a2dpsink/A2dpSinkService.java b/src/com/android/bluetooth/a2dpsink/A2dpSinkService.java
+index b5d3ab2cd..68e8f4abd 100644
+--- a/src/com/android/bluetooth/a2dpsink/A2dpSinkService.java
++++ b/src/com/android/bluetooth/a2dpsink/A2dpSinkService.java
+@@ -376,7 +376,7 @@ public class A2dpSinkService extends ProfileService {
+         return getDevicesMatchingConnectionStates(new int[]{BluetoothAdapter.STATE_CONNECTED});
+     }
+ 
+-    protected A2dpSinkStateMachine getOrCreateStateMachine(BluetoothDevice device) {
++    protected synchronized A2dpSinkStateMachine getOrCreateStateMachine(BluetoothDevice device) {
+         A2dpSinkStateMachine newStateMachine = new A2dpSinkStateMachine(device, this);
+         A2dpSinkStateMachine existingStateMachine =
+                 mDeviceStateMap.putIfAbsent(device, newStateMachine);
+-- 
+2.17.1
+


### PR DESCRIPTION
Multiple threads trying to execute the a2dp state machine block, where the message is sent even before starting the state machine, resulting in FATAL exception on com.android.bluetooth.

Make the state machine block synchronized to avoid multiple threads accessing the same resource at a time.

Tests done:
1. Flash bare metal
2. Check BT on success
3. Connect Pixel
4. Toggle A2DP media profile 20 times
5. With Pixel connected, toggle BT on/off 20 times
6. No crash observed, no hang observed
7. Every time BT ON and A2DP connect success

Tracked-On: OAM-116660
Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>