### PR TITLE
Set car_data_subscription_status Global Setting in AAOS14 to pass ATS

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/41_0041-Add-car_data_subscription_status-to-global-settings.patch
+++ b/aosp_diff/preliminary/frameworks/base/41_0041-Add-car_data_subscription_status-to-global-settings.patch
@@ -1,0 +1,123 @@
+From 4f00e69b12ff9cfa00ff0e9697be313c69e01f96 Mon Sep 17 00:00:00 2001
+From: "Zhang, Weixiong" <weixiong.zhang@intel.com>
+Date: Thu, 30 May 2024 16:20:43 +0800
+Subject: [PATCH] [Patch] Add car_data_subscription_status to Settings.Global
+ default to 1
+
+This setting is required to be set to 1, 2, or 3 to pass ATS.
+1 means no subscription, 2 means on trial, 3 means active subscription.
+An data plan subscription feature should be provided to manage this settings.
+
+Signed-off-by: Zhang, Weixiong <weixiong.zhang@intel.com>
+---
+ boot/hiddenapi/hiddenapi-max-target-o.txt                 | 1 +
+ core/java/android/provider/Settings.java                  | 8 ++++++++
+ core/proto/android/providers/settings/global.proto        | 3 +++
+ packages/SettingsProvider/res/values/defaults.xml         | 4 ++++
+ .../com/android/providers/settings/DatabaseHelper.java    | 3 +++
+ .../android/providers/settings/SettingsProtoDumpUtil.java | 4 ++++
+ .../test/src/android/provider/SettingsBackupTest.java     | 1 +
+ 7 files changed, 24 insertions(+)
+
+diff --git a/boot/hiddenapi/hiddenapi-max-target-o.txt b/boot/hiddenapi/hiddenapi-max-target-o.txt
+index 3c16915cf71f..08447d4d8e29 100644
+--- a/boot/hiddenapi/hiddenapi-max-target-o.txt
++++ b/boot/hiddenapi/hiddenapi-max-target-o.txt
+@@ -42192,6 +42192,7 @@ Landroid/provider/Settings$Global;->CDMA_CELL_BROADCAST_SMS:Ljava/lang/String;
+ Landroid/provider/Settings$Global;->CDMA_ROAMING_MODE:Ljava/lang/String;
+ Landroid/provider/Settings$Global;->CDMA_SUBSCRIPTION_MODE:Ljava/lang/String;
+ Landroid/provider/Settings$Global;->CELL_ON:Ljava/lang/String;
++Landroid/provider/Settings$Global;->CAR_DATA_SUBSCRIPTION_STATUS:Ljava/lang/String;
+ Landroid/provider/Settings$Global;->CERT_PIN_UPDATE_CONTENT_URL:Ljava/lang/String;
+ Landroid/provider/Settings$Global;->CERT_PIN_UPDATE_METADATA_URL:Ljava/lang/String;
+ Landroid/provider/Settings$Global;->CHAINED_BATTERY_ATTRIBUTION_ENABLED:Ljava/lang/String;
+diff --git a/core/java/android/provider/Settings.java b/core/java/android/provider/Settings.java
+index a55183c0f7c5..2a8ea87a5c01 100644
+--- a/core/java/android/provider/Settings.java
++++ b/core/java/android/provider/Settings.java
+@@ -17424,6 +17424,14 @@ public final class Settings {
+         @Readable
+         public static final String CELL_ON = "cell_on";
+ 
++        /**
++         * Status of car data subscription.
++         * @hide
++         */
++        @Readable
++        public static final String CAR_DATA_SUBSCRIPTION_STATUS = "car_data_subscription_status";
++
++
+         /**
+          * Global settings which can be accessed by instant apps.
+          * @hide
+diff --git a/core/proto/android/providers/settings/global.proto b/core/proto/android/providers/settings/global.proto
+index 052e2f20a313..c0bb5b4d86d0 100644
+--- a/core/proto/android/providers/settings/global.proto
++++ b/core/proto/android/providers/settings/global.proto
+@@ -1087,4 +1087,7 @@ message GlobalSettingsProto {
+     // Please insert fields in alphabetical order and group them into messages
+     // if possible (to avoid reaching the method limit).
+     // Next tag = 160;
++
++    optional SettingProto car_data_subscription_status = 160 [ (android.privacy).dest = DEST_AUTOMATIC ];
++
+ }
+diff --git a/packages/SettingsProvider/res/values/defaults.xml b/packages/SettingsProvider/res/values/defaults.xml
+index 159e9ad8a0cf..41cf1b364316 100644
+--- a/packages/SettingsProvider/res/values/defaults.xml
++++ b/packages/SettingsProvider/res/values/defaults.xml
+@@ -228,6 +228,10 @@
+         0: cellular off; 1: cellular on. -->
+     <integer name="def_cell_on">1</integer>
+ 
++    <!-- Default for Settings.Global.car_data_subscription_status.
++        1: no subscription; 2: on trail; 3: active subscription. -->
++    <integer name="def_car_data_subscription_status">1</integer>
++
+     <!-- Default for Settings.Global.APPLY_RAMPING_RINGER -->
+     <bool name="def_apply_ramping_ringer">false</bool>
+ 
+diff --git a/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java b/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
+index 61b2a6437fbe..b2d2eaaee52a 100644
+--- a/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
++++ b/packages/SettingsProvider/src/com/android/providers/settings/DatabaseHelper.java
+@@ -2460,6 +2460,9 @@ class DatabaseHelper extends SQLiteOpenHelper {
+             loadIntegerSetting(stmt, Settings.Global.CELL_ON,
+                     R.integer.def_cell_on);
+ 
++            loadIntegerSetting(stmt, Settings.Global.CAR_DATA_SUBSCRIPTION_STATUS,
++                    R.integer.def_car_data_subscription_status);
++
+             // Enable or disable Cell Broadcast SMS
+             loadSetting(stmt, Settings.Global.CDMA_CELL_BROADCAST_SMS,
+                     RILConstants.CDMA_CELL_BROADCAST_SMS_DISABLED);
+diff --git a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProtoDumpUtil.java b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProtoDumpUtil.java
+index 5c6729529fa8..39495ac69259 100644
+--- a/packages/SettingsProvider/src/com/android/providers/settings/SettingsProtoDumpUtil.java
++++ b/packages/SettingsProvider/src/com/android/providers/settings/SettingsProtoDumpUtil.java
+@@ -447,6 +447,10 @@ class SettingsProtoDumpUtil {
+                 Settings.Global.CELL_ON,
+                 GlobalSettingsProto.CELL_ON);
+ 
++        dumpSetting(s, p,
++                Settings.Global.CAR_DATA_SUBSCRIPTION_STATUS,
++                GlobalSettingsProto.CAR_DATA_SUBSCRIPTION_STATUS);
++
+         final long certPinToken = p.start(GlobalSettingsProto.CERT_PIN);
+         dumpSetting(s, p,
+                 Settings.Global.CERT_PIN_UPDATE_CONTENT_URL,
+diff --git a/packages/SettingsProvider/test/src/android/provider/SettingsBackupTest.java b/packages/SettingsProvider/test/src/android/provider/SettingsBackupTest.java
+index 91c72b543cc4..44ec8cfc353b 100644
+--- a/packages/SettingsProvider/test/src/android/provider/SettingsBackupTest.java
++++ b/packages/SettingsProvider/test/src/android/provider/SettingsBackupTest.java
+@@ -199,6 +199,7 @@ public class SettingsBackupTest {
+                     Settings.Global.CDMA_ROAMING_MODE,
+                     Settings.Global.CDMA_SUBSCRIPTION_MODE,
+                     Settings.Global.CELL_ON,
++                    Settings.Global.CAR_DATA_SUBSCRIPTION_STATUS,
+                     Settings.Global.CERT_PIN_UPDATE_CONTENT_URL,
+                     Settings.Global.CERT_PIN_UPDATE_METADATA_URL,
+                     Settings.Global.COMPATIBILITY_MODE,
+-- 
+2.34.1
+


### PR DESCRIPTION
The ATS testcase AtsConnectivityDeviceTests failed since car_data_subscription_status is not set

The setting needs to be valid as 1 - no subscription, 2 - on trial, 3 - active subscription

Added a patch to set it to 1 by default to pass the ATS.

Tracked-On: OAM-119802