### PR TITLE
[VTS FIX] Wifi: iwlmvm: enable vendor-cmd for vts test

### DIFF
--- a/bsp_diff/common/kernel/lts2022-chromium/0009-Wifi-iwlmvm-enable-vendor-cmd-for-vts-test.patch
+++ b/bsp_diff/common/kernel/lts2022-chromium/0009-Wifi-iwlmvm-enable-vendor-cmd-for-vts-test.patch
@@ -1,0 +1,71 @@
+From 4a9dc82c8eae26b477bb75d53c313a572d7bf458 Mon Sep 17 00:00:00 2001
+From: "Ye, Zhao" <zhao.ye@intel.com>
+Date: Wed, 5 Jun 2024 02:53:15 +0000
+Subject: [PATCH] Wifi: iwlmvm: enable vendor-cmd for vts test
+
+for VtsHalWifiChipTargetTest
+wifi_chip_->requestChipDebugInfo(&debug_info).isOk()
+will failed
+
+Test:
+After put on this patch,
+VtsHalWifiChipTargetTest can pass
+
+Tracked-On: OAM-120202
+Change-Id: Ic345a75ef08ff07dd96164fe8d13011208b57a2a
+Signed-off-by: Ye, Zhao <zhao.ye@intel.com>
+---
+ drivers/net/wireless/intel/iwlwifi/mvm/Makefile     | 2 +-
+ drivers/net/wireless/intel/iwlwifi/mvm/mvm.h        | 8 --------
+ drivers/net/wireless/intel/iwlwifi/mvm/vendor-cmd.c | 1 +
+ 3 files changed, 2 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/net/wireless/intel/iwlwifi/mvm/Makefile b/drivers/net/wireless/intel/iwlwifi/mvm/Makefile
+index 11e814b7cad0..83751856a887 100644
+--- a/drivers/net/wireless/intel/iwlwifi/mvm/Makefile
++++ b/drivers/net/wireless/intel/iwlwifi/mvm/Makefile
+@@ -10,6 +10,6 @@ iwlmvm-y += rfi.o
+ iwlmvm-$(CONFIG_IWLWIFI_DEBUGFS) += debugfs.o debugfs-vif.o
+ iwlmvm-$(CONFIG_IWLWIFI_LEDS) += led.o
+ iwlmvm-$(CONFIG_PM) += d3.o
+-iwlmvm-$(CONFIG_IWLMEI) += vendor-cmd.o
++iwlmvm-y += vendor-cmd.o
+ 
+ ccflags-y += -I $(srctree)/$(src)/../
+diff --git a/drivers/net/wireless/intel/iwlwifi/mvm/mvm.h b/drivers/net/wireless/intel/iwlwifi/mvm/mvm.h
+index f5c921c41be5..e2b58080b46d 100644
+--- a/drivers/net/wireless/intel/iwlwifi/mvm/mvm.h
++++ b/drivers/net/wireless/intel/iwlwifi/mvm/mvm.h
+@@ -1951,17 +1951,9 @@ void iwl_mvm_enter_ctkill(struct iwl_mvm *mvm);
+ int iwl_mvm_send_temp_report_ths_cmd(struct iwl_mvm *mvm);
+ int iwl_mvm_ctdp_command(struct iwl_mvm *mvm, u32 op, u32 budget);
+ 
+-#if IS_ENABLED(CONFIG_IWLMEI)
+-
+ /* vendor commands */
+ void iwl_mvm_vendor_cmds_register(struct iwl_mvm *mvm);
+ 
+-#else
+-
+-static inline void iwl_mvm_vendor_cmds_register(struct iwl_mvm *mvm) {}
+-
+-#endif
+-
+ /* Location Aware Regulatory */
+ struct iwl_mcc_update_resp *
+ iwl_mvm_update_mcc(struct iwl_mvm *mvm, const char *alpha2,
+diff --git a/drivers/net/wireless/intel/iwlwifi/mvm/vendor-cmd.c b/drivers/net/wireless/intel/iwlwifi/mvm/vendor-cmd.c
+index f7ad1c895b85..b2643a12156d 100644
+--- a/drivers/net/wireless/intel/iwlwifi/mvm/vendor-cmd.c
++++ b/drivers/net/wireless/intel/iwlwifi/mvm/vendor-cmd.c
+@@ -5,6 +5,7 @@
+ #include "mvm.h"
+ #include <linux/nl80211-vnd-intel.h>
+ #include <net/netlink.h>
++#include <linux/utsname.h>
+ 
+ static const struct nla_policy
+ iwl_mvm_vendor_attr_policy[NUM_IWL_MVM_VENDOR_ATTR] = {
+-- 
+2.34.1
+


### PR DESCRIPTION
for VtsHalWifiChipTargetTest
wifi_chip_->requestChipDebugInfo(&debug_info).isOk() will fail

Test:
After put on this patch,
VtsHalWifiChipTargetTest will pass

Tracked-On: OAM-120202