### PR TITLE
[VTS FIX] wifi hal: fix VtsHalWifiStaIfaceTargetTest vts test

### DIFF
--- a/aosp_diff/preliminary/hardware/intel/wlan/libwifihal/open/0001-wifi-hal-fix-VtsHalWifiStaIfaceTargetTest-vts-test.patch
+++ b/aosp_diff/preliminary/hardware/intel/wlan/libwifihal/open/0001-wifi-hal-fix-VtsHalWifiStaIfaceTargetTest-vts-test.patch
@@ -1,0 +1,47 @@
+From a49a4f9ee5902ba24ada61d9117bdb88aa2985ef Mon Sep 17 00:00:00 2001
+From: "Ye, Zhao" <zhao.ye@intel.com>
+Date: Wed, 5 Jun 2024 04:57:19 +0000
+Subject: [PATCH] wifi hal: fix VtsHalWifiStaIfaceTargetTest vts test
+
+this patch can fix below vts fail:
+wifi_sta_iface_->getApfPacketFilterCapabilities(&apf_caps).isOk()
+
+Test:
+after put on this patch
+VtsHalWifiStaIfaceTargetTest will pass
+
+Tracked-On: OAM-120203
+Signed-off-by: Ye, Zhao <zhao.ye@intel.com>
+---
+ lib/wifi_hal.cpp | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/lib/wifi_hal.cpp b/lib/wifi_hal.cpp
+index 52470e0..1483176 100644
+--- a/lib/wifi_hal.cpp
++++ b/lib/wifi_hal.cpp
+@@ -560,6 +560,14 @@ wifi_error wifi_set_scanning_mac_oui(wifi_interface_handle iface, unsigned char
+ 	return WIFI_SUCCESS;
+ }
+ 
++wifi_error wifi_get_packet_filter_capabilities(
++		wifi_interface_handle handle, u32 *version, u32 *max_len)
++{
++    *version = 4;
++    *max_len = 4096;
++    return WIFI_SUCCESS;
++}
++
+ wifi_error init_wifi_vendor_hal_func_table(wifi_hal_fn *hal_fn) {
+ 	if (hal_fn == NULL) {
+ 		return WIFI_ERROR_UNINITIALIZED;
+@@ -597,5 +605,6 @@ wifi_error init_wifi_vendor_hal_func_table(wifi_hal_fn *hal_fn) {
+ 	hal_fn->wifi_is_epr_supported = wifi_is_epr_supported;
+ 	hal_fn->wifi_reset_iface_event_handler = wifi_reset_iface_event_handler;
+ 	hal_fn->wifi_set_scanning_mac_oui = wifi_set_scanning_mac_oui;
++	hal_fn->wifi_get_packet_filter_capabilities = wifi_get_packet_filter_capabilities;
+ 	return WIFI_SUCCESS;
+ }
+-- 
+2.34.1
+


### PR DESCRIPTION
this patch can fix below vts fail:
wifi_sta_iface_->getApfPacketFilterCapabilities(&apf_caps).isOk()

Test:
after put on this patch
VtsHalWifiStaIfaceTargetTest will pass

Tracked-On: OAM-120203