### PR TITLE
Ported CTS fixes from Google QPR1 Release.

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/53_0053-Ported-CTS-fixes-from-Google-QPR1-Release.patch
+++ b/aosp_diff/preliminary/frameworks/base/53_0053-Ported-CTS-fixes-from-Google-QPR1-Release.patch
@@ -1,0 +1,65 @@
+From f92937e44d26a20f87d0868a019ec5bf2d181469 Mon Sep 17 00:00:00 2001
+From: Ankit Agarwal <ankit.agarwal@intel.com>
+Date: Fri, 7 Jun 2024 11:37:13 +0530
+Subject: [PATCH] Ported CTS fixes from Google QPR1 Release.
+
+Porting below CTS fixes-
+
+https://android-review.googlesource.com/c/platform/frameworks/base/+/2855186
+https://android-review.googlesource.com/c/platform/frameworks/base/+/2855185
+https://android-review.googlesource.com/c/platform/frameworks/base/+/2855166
+
+Disable `sync_disabled_mode` in `DeviceConfigTest` runs.
+Fix HorizontalScrollViewFunctionsTest
+Ensure that DebuggerWindow is shown on headless systems.
+
+Ensure that DebuggerWindow is shown on headless systems.
+
+on headless systems, user-0 is invisible. And hence windows started by
+user-0 process are not visible.
+
+Tests: Build EB is successfull and booting to home screen.
+
+Tracked-On: OAM-120405
+Signed-off-by: Ankit Agarwal <ankit.agarwal@intel.com>
+---
+ .../tests/coretests/src/android/provider/DeviceConfigTest.java | 1 +
+ .../com/android/server/am/AppWaitingForDebuggerDialog.java     | 3 +++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/core/tests/coretests/src/android/provider/DeviceConfigTest.java b/core/tests/coretests/src/android/provider/DeviceConfigTest.java
+index 1ea20f162680..a68833c974e4 100644
+--- a/core/tests/coretests/src/android/provider/DeviceConfigTest.java
++++ b/core/tests/coretests/src/android/provider/DeviceConfigTest.java
+@@ -67,6 +67,7 @@ public class DeviceConfigTest {
+         deleteViaContentProvider(NAMESPACE, KEY);
+         deleteViaContentProvider(NAMESPACE, KEY2);
+         deleteViaContentProvider(NAMESPACE, KEY3);
++        DeviceConfig.setSyncDisabledMode(DeviceConfig.SYNC_DISABLED_MODE_NONE);
+     }
+ 
+     @Test
+diff --git a/services/core/java/com/android/server/am/AppWaitingForDebuggerDialog.java b/services/core/java/com/android/server/am/AppWaitingForDebuggerDialog.java
+index 9b5f18caf71a..710278d6b3c6 100644
+--- a/services/core/java/com/android/server/am/AppWaitingForDebuggerDialog.java
++++ b/services/core/java/com/android/server/am/AppWaitingForDebuggerDialog.java
+@@ -16,6 +16,8 @@
+ 
+ package com.android.server.am;
+ 
++import static android.view.WindowManager.LayoutParams.SYSTEM_FLAG_SHOW_FOR_ALL_USERS;
++
+ import android.content.Context;
+ import android.content.DialogInterface;
+ import android.os.Handler;
+@@ -54,6 +56,7 @@ final class AppWaitingForDebuggerDialog extends BaseErrorDialog {
+         setButton(DialogInterface.BUTTON_POSITIVE, "Force Close", mHandler.obtainMessage(1, app));
+         setTitle("Waiting For Debugger");
+         WindowManager.LayoutParams attrs = getWindow().getAttributes();
++        attrs.privateFlags |= SYSTEM_FLAG_SHOW_FOR_ALL_USERS;
+         attrs.setTitle("Waiting For Debugger: " + app.info.processName);
+         getWindow().setAttributes(attrs);
+     }
+-- 
+2.34.1
+


### PR DESCRIPTION
Porting below CTS fixes-
https://android-review.googlesource.com/c/platform/frameworks/base/+/2855186 https://android-review.googlesource.com/c/platform/frameworks/base/+/2855185 https://android-review.googlesource.com/c/platform/frameworks/base/+/2855166

Disable `sync_disabled_mode` in `DeviceConfigTest` runs. Fix HorizontalScrollViewFunctionsTest
Ensure that DebuggerWindow is shown on headless systems.

on headless systems, user-0 is invisible. And hence windows started by user-0 process are not visible.

Tests: Build EB is successfull and booting to home screen.

Tracked-On: OAM-120405