### PR TITLE
Enable HID and OPP profiles for aaos

### DIFF
--- a/aosp_diff/base_aaos/packages/services/Car/0001-Enable-HID-and-OPP-profiles-for-aaos.patch
+++ b/aosp_diff/base_aaos/packages/services/Car/0001-Enable-HID-and-OPP-profiles-for-aaos.patch
@@ -1,0 +1,39 @@
+From 61c819296cf1df80064cb2ea3cf9bebebd4460dc Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Mon, 10 Jun 2024 20:51:16 +0530
+Subject: [PATCH] Enable HID and OPP profiles for aaos
+
+HID and OPP profiles were not enabled in car-service.
+
+Enable HID and OPP profiles in bluetooth.prop car-service.
+
+Tests done:
+1. Flash Bare Metal
+2. BT on success
+3. Connect HID sony joystick
+4. Hover the mouse pointer and press keys
+5. Connect Pixel reference device
+6. Validate Bluetooth file transfer from both side
+
+Tracked-On: OAM-120401
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ car_product/properties/bluetooth.prop | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/car_product/properties/bluetooth.prop b/car_product/properties/bluetooth.prop
+index 05a4e95d32..6561e9495b 100644
+--- a/car_product/properties/bluetooth.prop
++++ b/car_product/properties/bluetooth.prop
+@@ -17,6 +17,8 @@ bluetooth.profile.map.client.enabled=true
+ bluetooth.profile.pan.nap.enabled=true
+ bluetooth.profile.pan.panu.enabled=true
+ bluetooth.profile.pbap.client.enabled=true
++bluetooth.profile.opp.enabled=true
++bluetooth.profile.hid.host.enabled=true
+ 
+ # This property disables checking for link encryption when using an LE link
+ # that doesn't immediaely require it. It typically results in redundant
+-- 
+2.17.1
+


### PR DESCRIPTION
HID and OPP profiles were not enabled in car-service.

Enable HID and OPP profiles in bluetooth.prop car-service.

Tests done:
1. Flash Bare Metal
2. BT on success
3. Connect HID sony joystick
4. Hover the mouse pointer and press keys
5. Connect Pixel reference device
6. Validate Bluetooth file transfer from both side

Tracked-On: OAM-120401