### PR TITLE
Fix java crash when Bluetooth MAP profile connects

### DIFF
--- a/aosp_diff/base_aaos/packages/services/Telephony/0001-Fix-java-crash-when-Bluetooth-MAP-profile-connects.patch
+++ b/aosp_diff/base_aaos/packages/services/Telephony/0001-Fix-java-crash-when-Bluetooth-MAP-profile-connects.patch
@@ -1,0 +1,57 @@
+From 358d1f8a33b808e6214991e5b0f706c949eb8258 Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Mon, 10 Jun 2024 22:29:44 +0530
+Subject: [PATCH] Fix java crash when Bluetooth MAP profile connects
+
+When Bluetooth MAP profile connects, Persistent bundle is accessed
+even before its being populated in the constructor resulting in
+ArrayIndexOutOfBoundsException.
+
+Add a proper check for bundle initialization before querying for
+its configuration.
+
+Tests done:
+1. Flash Bare Metal
+2. BT on success
+3. Connect Pixel reference phone
+4. Connect MAP
+5. Disconnect/Connect MAP profile 20 times
+6. No crash observed
+
+Tracked-On: OAM-119041
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ src/com/android/phone/CarrierConfigLoader.java | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/phone/CarrierConfigLoader.java b/src/com/android/phone/CarrierConfigLoader.java
+index fa85f27cf..c4e76ef11 100644
+--- a/src/com/android/phone/CarrierConfigLoader.java
++++ b/src/com/android/phone/CarrierConfigLoader.java
+@@ -1327,8 +1327,22 @@ public class CarrierConfigLoader extends ICarrierConfigLoader.Stub {
+         }
+ 
+         int phoneId = SubscriptionManager.getPhoneId(subscriptionId);
++        boolean carrierConfigInitialized = true;
++
+         PersistableBundle retConfig = CarrierConfigManager.getDefaultConfig();
+-        if (SubscriptionManager.isValidPhoneId(phoneId)) {
++
++        /* CarrierConfigLoader constructor is intializing the mConfigFromDefaultApp
++         * bundle. Sometimes the getConfigForSubIdWithFeature is called even before
++         * this constructor gets called, resulting in ArrayIndexOutOfBoundsException.
++         * Always check the mConfigFromDefaultApp bundle is populated before querying
++         * for various configs.
++         */
++        if (mConfigFromDefaultApp.length <= phoneId) {
++            logd("Constructor not called yet");
++            carrierConfigInitialized = false;
++        }
++
++        if (SubscriptionManager.isValidPhoneId(phoneId) && carrierConfigInitialized) {
+             PersistableBundle config = mConfigFromDefaultApp[phoneId];
+             if (config != null) {
+                 retConfig.putAll(config);
+-- 
+2.17.1
+


### PR DESCRIPTION
When Bluetooth MAP profile connects, Persistent bundle is accessed even before its being populated in the constructor resulting in ArrayIndexOutOfBoundsException.

Add a proper check for bundle initialization before querying for its configuration.

Tests done:
1. Flash Bare Metal
2. BT on success
3. Connect Pixel reference phone
4. Connect MAP
5. Disconnect/Connect MAP profile 20 times
6. No crash observed

Tracked-On: OAM-119041