### PR TITLE
Enable wifi RTT and NAN features

### DIFF
--- a/bsp_diff/caas/device/intel/mixins/0001-Enable-wifi-RTT-and-NAN-features.patch
+++ b/bsp_diff/caas/device/intel/mixins/0001-Enable-wifi-RTT-and-NAN-features.patch
@@ -1,0 +1,49 @@
+From cd243d10478446177a83d1d72ec789627d046c52 Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Tue, 4 Jun 2024 18:13:43 +0530
+Subject: [PATCH] Enable wifi RTT and NAN features
+
+RTT and NAN features are not enabled in caas.
+
+Enabled RTT and NAN for caas.
+
+Tests done:
+1. Flash BM
+2. In adb shell #>pm list features | grep wifi
+3. Verify RTT and wifi aware service is running from logcat
+
+Tracked-On: OAM-120503
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Signed-off-by: Aman Bhadouria <aman.bhadouria@intel.com>
+---
+ groups/wlan/iwlwifi/BoardConfig.mk | 1 +
+ groups/wlan/iwlwifi/product.mk     | 4 +++-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/groups/wlan/iwlwifi/BoardConfig.mk b/groups/wlan/iwlwifi/BoardConfig.mk
+index b17098a..74bb579 100644
+--- a/groups/wlan/iwlwifi/BoardConfig.mk
++++ b/groups/wlan/iwlwifi/BoardConfig.mk
+@@ -12,3 +12,4 @@ BOARD_WPA_SUPPLICANT_PRIVATE_LIB ?= lib_driver_cmd_intc
+ BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/wlan/load_iwl_modules
+ BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/wlan/iwlwifi
+ WIFI_HIDL_UNIFIED_SUPPLICANT_SERVICE_RC_ENTRY := true
++WIFI_HIDL_FEATURE_AWARE := true
+diff --git a/groups/wlan/iwlwifi/product.mk b/groups/wlan/iwlwifi/product.mk
+index e973e7b..3844942 100644
+--- a/groups/wlan/iwlwifi/product.mk
++++ b/groups/wlan/iwlwifi/product.mk
+@@ -19,7 +19,9 @@ PRODUCT_COPY_FILES += \
+     $(INTEL_PATH_COMMON)/wlan/iwlwifi/p2p_supplicant_overlay.conf:vendor/etc/wifi/p2p_supplicant_overlay.conf \
+     frameworks/native/data/etc/android.hardware.wifi.xml:vendor/etc/permissions/android.hardware.wifi.xml \
+     frameworks/native/data/etc/android.hardware.wifi.direct.xml:vendor/etc/permissions/android.hardware.wifi.direct.xml \
+-    frameworks/native/data/etc/android.software.ipsec_tunnels.xml:vendor/etc/permissions/android.software.ipsec_tunnels.xml
++    frameworks/native/data/etc/android.software.ipsec_tunnels.xml:vendor/etc/permissions/android.software.ipsec_tunnels.xml \
++    frameworks/native/data/etc/android.hardware.wifi.rtt.xml:vendor/etc/permissions/android.hardware.wifi.rtt.xml \
++    frameworks/native/data/etc/android.hardware.wifi.aware.xml:vendor/etc/permissions/android.hardware.wifi.aware.xml
+ 
+ PRODUCT_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/wlan/overlay-disable_keepalive_offload
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
RTT and NAN features are not enabled in caas.

Enabled RTT and NAN for caas.

Tests done:
1. Flash BM
2. In adb shell #>pm list features | grep wifi
3. Verify RTT and wifi aware service is running from logcat

Tracked-On: OAM-120503