### PR TITLE
Fix crash in Webview Browser during MonkeyTest

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Browser2/0001-Fix-crash-in-Webview-Browser-during-MonkeyTest.patch
+++ b/aosp_diff/base_aaos/packages/apps/Browser2/0001-Fix-crash-in-Webview-Browser-during-MonkeyTest.patch
@@ -1,0 +1,33 @@
+From 1ccd2cbfe8c614db485ea5731e4cc88f2abab4e4 Mon Sep 17 00:00:00 2001
+From: Salini Venate <salini.venate@intel.com>
+Date: Fri, 14 Jun 2024 10:40:01 +0530
+Subject: [PATCH] Fix crash in Webview Browser during MonkeyTest
+
+Getting below crash when running monkey test:
+  java.lang.RuntimeException: StrictMode ThreadPolicy violation
+  Caused by: android.os.strictmode.UnbufferedIoViolation
+
+Allow UnbufferedIo in StrictMode builder.
+
+Test Dome: Boot check
+Tracked-On: OAM-118786
+Signed-off-by: Salini Venate <salini.venate@intel.com>
+---
+ src/org/chromium/webview_shell/WebViewBrowserActivity.java | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/org/chromium/webview_shell/WebViewBrowserActivity.java b/src/org/chromium/webview_shell/WebViewBrowserActivity.java
+index 0a7b637..eaa63e9 100644
+--- a/src/org/chromium/webview_shell/WebViewBrowserActivity.java
++++ b/src/org/chromium/webview_shell/WebViewBrowserActivity.java
+@@ -244,6 +244,7 @@ public class WebViewBrowserActivity extends Activity implements PopupMenu.OnMenu
+         StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
+                 .detectAll()
+                 .penaltyLog()
++                .permitUnbufferedIo()
+                 .penaltyDeath()
+                 .build());
+         // Conspicuously omitted: detectCleartextNetwork() and detectFileUriExposure() to permit
+-- 
+2.43.0
+


### PR DESCRIPTION
Getting below crash when running monkey test:
 java.lang.RuntimeException: StrictMode ThreadPolicy violation
 Caused by: android.os.strictmode.UnbufferedIoViolation

Allow UnbufferedIo in StrictMode builder.

Test Dome: Boot check
Tracked-On: OAM-118786
Signed-off-by: Salini Venate <salini.venate@intel.com>