### PR TITLE
Fix for VtsHalLoudnessEnhancerTargetTest Case

### DIFF
--- a/bsp_diff/caas/device/intel/mixins/0002-Fix-for-VtsHalLoudnessEnhancerTargetTest-Case.patch
+++ b/bsp_diff/caas/device/intel/mixins/0002-Fix-for-VtsHalLoudnessEnhancerTargetTest-Case.patch
@@ -1,0 +1,45 @@
+From e349607a7321fd82c4608b9cc50401ad300e7b93 Mon Sep 17 00:00:00 2001
+From: Ankit Agarwal <ankit.agarwal@intel.com>
+Date: Tue, 18 Jun 2024 15:02:36 +0530
+Subject: [PATCH] Fix for VtsHalLoudnessEnhancerTargetTest Case.
+
+while running the vts module following fail to push error is occurring:
+Attempting to push dir 'VtsHalLoudnessEnhancerTargetTest' to an
+existing device file /data/local/tmp/.
+
+When it try to push directory, it always shows that dir already exists
+even if it is not there. this was checking dir using 'ls' command and
+check for 'No such file or directory' output. But 'ls' command was
+giving always 'Invalid argument' and in that case it was always
+returning showing dir exists. During 'ls' command syscall for 'prctrl'
+was assigning VMA name, but VMA feature was not enabled, so it was
+assigning default error code EINVAL. Enabling this feature by enabling
+this flag-: CONFIG_ANON_VMA_NAME
+
+Test:
+Run 'ls' command in adb shell for some file or directory which does not
+exists, it should give output "No such file or Directory" instead of
+"Invalid argument".
+
+Tracked-On: OAM-120995
+Signed-off-by: Ankit Agarwal <ankit.agarwal@intel.com>
+---
+ .../kernel/gmin64/config-lts/lts2022-chromium/x86_64_defconfig  | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/groups/kernel/gmin64/config-lts/lts2022-chromium/x86_64_defconfig b/groups/kernel/gmin64/config-lts/lts2022-chromium/x86_64_defconfig
+index 7c50462..3735cc9 100644
+--- a/groups/kernel/gmin64/config-lts/lts2022-chromium/x86_64_defconfig
++++ b/groups/kernel/gmin64/config-lts/lts2022-chromium/x86_64_defconfig
+@@ -973,7 +973,7 @@ CONFIG_VM_EVENT_COUNTERS=y
+ # GUP_TEST needs to have DEBUG_FS enabled
+ #
+ CONFIG_ARCH_HAS_PTE_SPECIAL=y
+-# CONFIG_ANON_VMA_NAME is not set
++CONFIG_ANON_VMA_NAME=y
+ CONFIG_USERFAULTFD=y
+ CONFIG_HAVE_ARCH_USERFAULTFD_WP=y
+ CONFIG_HAVE_ARCH_USERFAULTFD_MINOR=y
+-- 
+2.34.1
+


### PR DESCRIPTION
while running the vts module following fail to push error is occurring: Attempting to push dir 'VtsHalGraphicsComposerV2_4TargetTest' to an existing device file /data/local/tmp/.

When it try to push directory, it always shows that dir already exists even if it is not there. this was checking dir using 'ls' command and check for 'No such file or directory' output. But 'ls' command was giving always 'Invalid argument' and in that case it was always returning showing dir exists. During 'ls' command syscall for 'prctrl' was assigning VMA name, but VMA feature was not enabled, so it was assigning default error code EINVAL. Enabling this feature by enabling this flag-: CONFIG_ANON_VMA_NAME

Test:
Run 'ls' command in adb shell for some file or directory which does not exists, it should give output "No such file or Directory" instead of "Invalid argument".

Tracked-On: