### PR TITLE
[DO NOT MERGE] Enable F2FS for metadata partition

### DIFF
--- a/bsp_diff/caas/device/intel/mixins/0001-DO-NOT-MERGE-Enable-F2FS-for-metadata-partition.patch
+++ b/bsp_diff/caas/device/intel/mixins/0001-DO-NOT-MERGE-Enable-F2FS-for-metadata-partition.patch
@@ -1,0 +1,162 @@
+From 44fe77c5c0847ed66e366be03ab6fce24d0a8656 Mon Sep 17 00:00:00 2001
+From: "Unnithan, Balakrishnan" <balakrishnan.unnithan@intel.com>
+Date: Thu, 20 Jun 2024 14:25:30 +0530
+Subject: [PATCH] [DO NOT MERGE] Enable F2FS for metadata partition
+
+The Intel Android Platform must support MUST use EROFS, EXT4, or F2FS
+for all read-only dynamic partitions. EROFS is STRONGLY RECOMMENDED.
+MUST use F2FS for /metadata and /data partitions.
+MUST use the /metadata partition of a minimum of 64 MiB.
+Note: F2FS read-only partitions are not optimized for OTA.
+
+Increased size of /metadata partition to 64MB (from 16MB).
+Set /metadata partition to F2FS.
+
+Ref: https://source.android.com/docs/security/features/encryption/metadata
+
+Tests done: vts-tradefed run vts -m vts_kernel_encryption_test
+            df -h
+            mount | grep metadata
+
+Tracked-On: OAM-115910
+Signed-off-by: Unnithan, Balakrishnan <balakrishnan.unnithan@intel.com>
+---
+ groups/boot-arch/project-celadon/fstab        | 32 +++++++++----------
+ .../boot-arch/project-celadon/fstab.recovery  | 32 +++++++++----------
+ groups/boot-arch/project-celadon/gpt.ini      |  2 +-
+ 3 files changed, 33 insertions(+), 33 deletions(-)
+
+diff --git a/groups/boot-arch/project-celadon/fstab b/groups/boot-arch/project-celadon/fstab
+index 40cba4f..36e368b 100644
+--- a/groups/boot-arch/project-celadon/fstab
++++ b/groups/boot-arch/project-celadon/fstab
+@@ -1,38 +1,38 @@
+ {{^use_cic}}
+ # Android fstab file.
+-# <src>                   <mnt_point> <type>  <mnt_flags and options>  <fs_mgr_flags>
++# <src>			<mnt_point>	<type>	<mnt_flags and options>			<fs_mgr_flags>
+ # The filesystem that contains the filesystem checker binary (typically /system) cannot
+ # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
+ {{#dynamic-partitions}}
+-system   /system  {{system_fs}} ro{{#system_fs_ext4}},barrier=1{{/system_fs_ext4}} wait{{#slot-ab}},slotselect{{/slot-ab}},avb_keys=/avb/q-gsi.avbpubkey:/avb/r-gsi.avbpubkey:/avb/s-gsi.avbpubkey,avb=vbmeta,logical,first_stage_mount
++system				/system		{{system_fs}}	ro{{#system_fs_ext4}},barrier=1{{/system_fs_ext4}}						wait{{#slot-ab}},slotselect{{/slot-ab}},avb_keys=/avb/q-gsi.avbpubkey:/avb/r-gsi.avbpubkey:/avb/s-gsi.avbpubkey,avb=vbmeta,logical,first_stage_mount
+ {{/dynamic-partitions}}
+ {{^dynamic-partitions}}
+-/dev/block/by-name/system       /{{^slot-ab}}system{{/slot-ab}}         {{system_fs}}    ro                                                          wait{{#slot-ab}},slotselect{{/slot-ab}},avb
++/dev/block/by-name/system	/{{^slot-ab}}system{{/slot-ab}}		{{system_fs}}	ro	wait{{#slot-ab}},slotselect{{/slot-ab}},avb
+ {{/dynamic-partitions}}
+-/dev/block/by-name/vbmeta       /vbmeta         emmc    defaults                                                   defaults{{#slot-ab}},slotselect,avb{{/slot-ab}}
++/dev/block/by-name/vbmeta	/vbmeta         emmc    defaults					defaults{{#slot-ab}},slotselect,avb{{/slot-ab}}
+ {{^slot-ab}}
+-/dev/block/by-name/cache        /cache          ext4    noatime,nosuid,nodev,errors=panic                           wait,check
++/dev/block/by-name/cache	/cache		ext4    noatime,nosuid,nodev,errors=panic		wait,check
+ {{/slot-ab}}
+ {{#multi_user_support}}
+-/dev/block/vdb         /data           {{^data_use_f2fs}}ext4{{/data_use_f2fs}}{{#data_use_f2fs}}f2fs{{/data_use_f2fs}}    noatime,nosuid,nodev{{^data_use_f2fs}},noauto_da_alloc,errors=panic{{/data_use_f2fs}}   wait,check,formattable{{#disk_encryption}},forceencrypt=/dev/block/by-name/metadata{{/disk_encryption}}{{#file_encryption}},fileencryption=aes-256-xts:aes-256-cts{{/file_encryption}},quota,reservedsize=50m{{#fsverity}},fsverity{{/fsverity}}{{#metadata_encryption}},latemount,keydirectory=/metadata/vold/metadata_encryption{{#userdata_checkpoint}}{{^data_use_f2fs}},checkpoint=block{{/data_use_f2fs}}{{#data_use_f2fs}},checkpoint=fs{{/data_use_f2fs}}{{/userdata_checkpoint}}{{/metadata_encryption}}
++/dev/block/vdb			/data		{{^data_use_f2fs}}ext4{{/data_use_f2fs}}{{#data_use_f2fs}}f2fs{{/data_use_f2fs}}	noatime,nosuid,nodev{{^data_use_f2fs}},noauto_da_alloc,errors=panic{{/data_use_f2fs}}				wait,check,formattable{{#disk_encryption}},forceencrypt=/dev/block/by-name/metadata{{/disk_encryption}}{{#file_encryption}},fileencryption=aes-256-xts:aes-256-cts{{/file_encryption}},quota,reservedsize=50m{{#fsverity}},fsverity{{/fsverity}}{{#metadata_encryption}},latemount,keydirectory=/metadata/vold/metadata_encryption{{#userdata_checkpoint}}{{^data_use_f2fs}},checkpoint=block{{/data_use_f2fs}}{{#data_use_f2fs}},checkpoint=fs{{/data_use_f2fs}}{{/userdata_checkpoint}}{{/metadata_encryption}}
+ {{/multi_user_support}}
+ {{^multi_user_support}}
+-/dev/block/by-name/{{#dynamic-partitions}}user{{/dynamic-partitions}}data         /data           {{^data_use_f2fs}}ext4{{/data_use_f2fs}}{{#data_use_f2fs}}f2fs{{/data_use_f2fs}}    noatime,nosuid,nodev{{^data_use_f2fs}},noauto_da_alloc,errors=panic{{/data_use_f2fs}}   wait,check,formattable{{#disk_encryption}},forceencrypt=/dev/block/by-name/metadata{{/disk_encryption}}{{#file_encryption}},fileencryption=aes-256-xts:aes-256-cts{{/file_encryption}},quota,reservedsize=50m{{#fsverity}},fsverity{{/fsverity}}{{#metadata_encryption}},latemount,keydirectory=/metadata/vold/metadata_encryption{{#userdata_checkpoint}}{{^data_use_f2fs}},checkpoint=block{{/data_use_f2fs}}{{#data_use_f2fs}},checkpoint=fs{{/data_use_f2fs}}{{/userdata_checkpoint}}{{/metadata_encryption}}
++/dev/block/by-name/{{#dynamic-partitions}}user{{/dynamic-partitions}}data	/data		{{^data_use_f2fs}}ext4{{/data_use_f2fs}}{{#data_use_f2fs}}f2fs{{/data_use_f2fs}}	noatime,nosuid,nodev{{^data_use_f2fs}},noauto_da_alloc,errors=panic{{/data_use_f2fs}}				wait,check,formattable{{#disk_encryption}},forceencrypt=/dev/block/by-name/metadata{{/disk_encryption}}{{#file_encryption}},fileencryption=aes-256-xts:aes-256-cts{{/file_encryption}},quota,reservedsize=50m{{#fsverity}},fsverity{{/fsverity}}{{#metadata_encryption}},latemount,keydirectory=/metadata/vold/metadata_encryption{{#userdata_checkpoint}}{{^data_use_f2fs}},checkpoint=block{{/data_use_f2fs}}{{#data_use_f2fs}},checkpoint=fs{{/data_use_f2fs}}{{/userdata_checkpoint}}{{/metadata_encryption}}
+ {{/multi_user_support}}
+-/dev/block/by-name/boot         /boot           emmc    defaults                                                    defaults{{#slot-ab}},slotselect,avb{{/slot-ab}}
++/dev/block/by-name/boot		/boot		emmc	defaults					defaults{{#slot-ab}},slotselect,avb{{/slot-ab}}
+ {{^slot-ab}}
+-/dev/block/by-name/recovery     /recovery       emmc    defaults                                                    defaults
++/dev/block/by-name/recovery		/recovery       emmc	defaults					defaults
+ {{/slot-ab}}
+-/dev/block/by-name/misc         /misc           emmc    defaults                                                    defaults
++/dev/block/by-name/misc		/misc           emmc	defaults					defaults
+ {{#trusty}}
+-/dev/block/by-name/tos          /tos            emmc    defaults                                                    defaults{{#slot-ab}},slotselect,avb{{/slot-ab}}
++/dev/block/by-name/tos		/tos            emmc	defaults					defaults{{#slot-ab}},slotselect,avb{{/slot-ab}}
+ {{/trusty}}
+ {{#bootloader_slot_ab}}
+-/dev/block/by-name/esp          /esp            emmc    defaults                                                    recoveryonly
++/dev/block/by-name/esp		/esp            emmc	defaults					recoveryonly
+ {{/bootloader_slot_ab}}
+-/dev/block/by-name/bootloader   /bootloader     emmc    defaults                                                    recoveryonly{{#bootloader_slot_ab}},slotselect{{/bootloader_slot_ab}}
+-/dev/block/by-name/bootloader2  /bootloader2    emmc    defaults                                                    recoveryonly
+-/dev/block/by-name/persistent   /persistent     emmc    defaults                                                    defaults
+-/dev/block/by-name/metadata     /metadata       ext4    noatime,nosuid,nodev,errors=panic{{#metadata_encryption}},discard{{/metadata_encryption}}                           wait,check,formattable,first_stage_mount
++/dev/block/by-name/bootloader	/bootloader     emmc	defaults					recoveryonly{{#bootloader_slot_ab}},slotselect{{/bootloader_slot_ab}}
++/dev/block/by-name/bootloader2	/bootloader2	emmc	defaults					recoveryonly
++/dev/block/by-name/persistent	/persistent     emmc	defaults					defaults
++/dev/block/by-name/metadata	/metadata       f2fs	noatime,nosuid,nodev				wait,formattable,first_stage_mount,fileencryption=aes-256-xts:aes-256-cts
+ {{/use_cic}}
+ 
+diff --git a/groups/boot-arch/project-celadon/fstab.recovery b/groups/boot-arch/project-celadon/fstab.recovery
+index 9c7dfb7..4eb4f48 100644
+--- a/groups/boot-arch/project-celadon/fstab.recovery
++++ b/groups/boot-arch/project-celadon/fstab.recovery
+@@ -1,38 +1,38 @@
+ {{^use_cic}}
+ # Android fstab file.
+-# <src>                   <mnt_point> <type>  <mnt_flags and options>  <fs_mgr_flags>
++# <src>			<mnt_point>	<type>	<mnt_flags and options>			<fs_mgr_flags>
+ # The filesystem that contains the filesystem checker binary (typically /system) cannot
+ # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
+ {{#dynamic-partitions}}
+-system   /system  {{system_fs}} ro{{#system_fs_ext4}},barrier=1{{/system_fs_ext4}} wait{{#slot-ab}},slotselect{{/slot-ab}},avb_keys=/avb/q-gsi.avbpubkey:/avb/r-gsi.avbpubkey:/avb/s-gsi.avbpubkey,avb=vbmeta,logical,first_stage_mount
++system				/system		{{system_fs}}	ro{{#system_fs_ext4}},barrier=1{{/system_fs_ext4}}						wait{{#slot-ab}},slotselect{{/slot-ab}},avb_keys=/avb/q-gsi.avbpubkey:/avb/r-gsi.avbpubkey:/avb/s-gsi.avbpubkey,avb=vbmeta,logical,first_stage_mount
+ {{/dynamic-partitions}}
+ {{^dynamic-partitions}}
+-/dev/block/by-name/system               /{{^slot-ab}}system{{/slot-ab}}         {{system_fs}}    ro                 wait,avb{{#slot-ab}},slotselect{{/slot-ab}}
++/dev/block/by-name/system	/{{^slot-ab}}system{{/slot-ab}}		{{system_fs}}	ro	wait{{#slot-ab}},slotselect{{/slot-ab}},avb
+ {{/dynamic-partitions}}
+-/dev/block/by-name/vbmeta               /vbmeta         emmc    defaults                                            defaults{{#slot-ab}},slotselect,avb{{/slot-ab}}
++/dev/block/by-name/vbmeta	/vbmeta         emmc    defaults					defaults{{#slot-ab}},slotselect,avb{{/slot-ab}}
+ {{^slot-ab}}
+-/dev/block/by-name/cache        /cache          ext4    noatime,nosuid,nodev,errors=panic                           wait,check
++/dev/block/by-name/cache	/cache		ext4    noatime,nosuid,nodev,errors=panic		wait,check
+ {{/slot-ab}}
+ {{#multi_user_support}}
+-/dev/block/vdb         /data           {{^data_use_f2fs}}ext4{{/data_use_f2fs}}{{#data_use_f2fs}}f2fs{{/data_use_f2fs}}     noatime,nosuid,nodev{{^data_use_f2fs}},noauto_da_alloc,errors=panic{{/data_use_f2fs}}   wait,check,formattable{{#disk_encryption}},forceencrypt=/dev/block/by-name/metadata{{/disk_encryption}}{{#file_encryption}},fileencryption=aes-256-xts:aes-256-cts{{/file_encryption}}
++/dev/block/vdb			/data		{{^data_use_f2fs}}ext4{{/data_use_f2fs}}{{#data_use_f2fs}}f2fs{{/data_use_f2fs}}	noatime,nosuid,nodev{{^data_use_f2fs}},noauto_da_alloc,errors=panic{{/data_use_f2fs}}				wait,check,formattable{{#disk_encryption}},forceencrypt=/dev/block/by-name/metadata{{/disk_encryption}}{{#file_encryption}},fileencryption=aes-256-xts:aes-256-cts{{/file_encryption}}
+ {{/multi_user_support}}
+ {{^multi_user_support}}
+-/dev/block/by-name/{{#dynamic-partitions}}user{{/dynamic-partitions}}data         /data           {{^data_use_f2fs}}ext4{{/data_use_f2fs}}{{#data_use_f2fs}}f2fs{{/data_use_f2fs}}     noatime,nosuid,nodev{{^data_use_f2fs}},noauto_da_alloc,errors=panic{{/data_use_f2fs}}   wait,check,formattable{{#disk_encryption}},forceencrypt=/dev/block/by-name/metadata{{/disk_encryption}}{{#file_encryption}},fileencryption=aes-256-xts:aes-256-cts{{/file_encryption}}
++/dev/block/by-name/{{#dynamic-partitions}}user{{/dynamic-partitions}}data	/data		{{^data_use_f2fs}}ext4{{/data_use_f2fs}}{{#data_use_f2fs}}f2fs{{/data_use_f2fs}}	noatime,nosuid,nodev{{^data_use_f2fs}},noauto_da_alloc,errors=panic{{/data_use_f2fs}}				wait,check,formattable{{#disk_encryption}},forceencrypt=/dev/block/by-name/metadata{{/disk_encryption}}{{#file_encryption}},fileencryption=aes-256-xts:aes-256-cts{{/file_encryption}}
+ {{/multi_user_support}}
+-/dev/block/by-name/boot         /boot           emmc    defaults                                                    defaults
++/dev/block/by-name/boot		/boot		emmc	defaults					defaults
+ {{^slot-ab}}
+-/dev/block/by-name/recovery     /recovery       emmc    defaults                                                    defaults
++/dev/block/by-name/recovery		/recovery       emmc	defaults					defaults
+ {{/slot-ab}}
+-/dev/block/by-name/misc         /misc           emmc    defaults                                                    defaults
++/dev/block/by-name/misc		/misc           emmc	defaults					defaults
+ {{#trusty}}
+-/dev/block/by-name/tos          /tos            emmc    defaults                                                    defaults{{#slot-ab}},slotselect{{/slot-ab}}
++/dev/block/by-name/tos		/tos            emmc	defaults					defaults{{#slot-ab}},slotselect{{/slot-ab}}
+ {{/trusty}}
+ {{#bootloader_slot_ab}}
+-/dev/block/by-name/esp          /esp            emmc    defaults                                                    recoveryonly
++/dev/block/by-name/esp		/esp            emmc	defaults					recoveryonly
+ {{/bootloader_slot_ab}}
+-/dev/block/by-name/bootloader   /bootloader     emmc    defaults                                                    recoveryonly{{#bootloader_slot_ab}},slotselect{{/bootloader_slot_ab}}
+-/dev/block/by-name/bootloader2  /bootloader2    emmc    defaults                                                    recoveryonly
+-/dev/block/by-name/persistent   /persistent     emmc    defaults                                                    defaults
+-/dev/block/by-name/metadata     /metadata       ext4    noatime,nosuid,nodev,errors=panic                           wait,check
++/dev/block/by-name/bootloader	/bootloader     emmc	defaults					recoveryonly{{#bootloader_slot_ab}},slotselect{{/bootloader_slot_ab}}
++/dev/block/by-name/bootloader2	/bootloader2	emmc	defaults					recoveryonly
++/dev/block/by-name/persistent	/persistent     emmc	defaults					defaults
++/dev/block/by-name/metadata	/metadata       f2fs	noatime,nosuid,nodev				wait,check,formattable,fileencryption=aes-256-xts:aes-256-cts
+ {{/use_cic}}
+ 
+diff --git a/groups/boot-arch/project-celadon/gpt.ini b/groups/boot-arch/project-celadon/gpt.ini
+index 56c6904..6920914 100644
+--- a/groups/boot-arch/project-celadon/gpt.ini
++++ b/groups/boot-arch/project-celadon/gpt.ini
+@@ -84,7 +84,7 @@ type = misc
+ 
+ [partition.metadata]
+ label = metadata
+-len = 16
++len = 64
+ type = metadata
+ 
+ [partition.system]
+-- 
+2.25.1
+


### PR DESCRIPTION
The Intel Android Platform must support MUST use EROFS, EXT4, or F2FS for all read-only dynamic partitions. EROFS is STRONGLY RECOMMENDED. MUST use F2FS for /metadata and /data partitions.
MUST use the /metadata partition of a minimum of 64 MiB. Note: F2FS read-only partitions are not optimized for OTA.

Increased size of /metadata partition to 64MB (from 16MB). Set /metadata partition to F2FS.

Ref: https://source.android.com/docs/security/features/encryption/metadata

Verification: vts-tradefed run vts -m vts_kernel_encryption_test

Tracked-On: OAM-115910