### PR TITLE
Solve the 32-bit Integer Multiplication Overflow Issue

### DIFF
--- a/aosp_diff/base_aaos/build/soong/0001-solve-pahole-is-not-allowed-to-be-used-in-build-issu.patch
+++ b/aosp_diff/base_aaos/build/soong/0001-solve-pahole-is-not-allowed-to-be-used-in-build-issu.patch
@@ -1,0 +1,26 @@
+From 7d64ba96c347c1adaadc0d43bcb5b7641d710bab Mon Sep 17 00:00:00 2001
+From: "Chen, Gang G" <gang.g.chen@intel.com>
+Date: Fri, 21 Jun 2024 14:02:22 +0800
+Subject: [PATCH] solve "pahole" is not allowed to be used in build issue
+
+Tracked-On: OAM-121144
+Signed-off-by: Chen, Gang G <gang.g.chen@intel.com>
+---
+ ui/build/paths/config.go | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/ui/build/paths/config.go b/ui/build/paths/config.go
+index 14ae9af5a..0fd774f44 100644
+--- a/ui/build/paths/config.go
++++ b/ui/build/paths/config.go
+@@ -115,6 +115,7 @@ var Configuration = map[string]PathConfig{
+        "mmd":     Allowed,
+        "sgdisk":  Allowed,
+        "split":   Allowed,
++       "pahol":   Allowed,
+        "mkisofs":   Allowed,
+        "isohybrid":   Allowed,
+        "xorriso":   Allowed,
+-- 
+2.25.1
+

--- a/bsp_diff/base_aaos/hardware/intel/kernelflinger/0055-Solve-the-32-bit-Integer-Multiplication-Overflow-Iss.patch
+++ b/bsp_diff/base_aaos/hardware/intel/kernelflinger/0055-Solve-the-32-bit-Integer-Multiplication-Overflow-Iss.patch
@@ -1,0 +1,30 @@
+From b1b697812be773f02012900eedd07087ad241b55 Mon Sep 17 00:00:00 2001
+From: "Chen, Gang G" <gang.g.chen@intel.com>
+Date: Fri, 14 Jun 2024 16:10:00 +0800
+Subject: [PATCH 1/2] Solve the 32-bit Integer Multiplication Overflow Issue
+
+Call pause_us() to sleep 1S doesn't take effect, the reason
+is that multiply overflow
+
+Tracked-On: OAM-120825
+Signed-off-by: Chen, Gang G <gang.g.chen@intel.com>
+---
+ libkernelflinger/lib.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libkernelflinger/lib.c b/libkernelflinger/lib.c
+index 4eeb6c3..6c3e6fc 100644
+--- a/libkernelflinger/lib.c
++++ b/libkernelflinger/lib.c
+@@ -1309,7 +1309,7 @@ VOID pause_us(UINTN microseconds)
+         if (microseconds > 10 * 1000000)
+                 microseconds = 10 * 1000000;
+ 
+-        total_tick = rdtsc() + get_cpu_freq() * microseconds;
++        total_tick = rdtsc() + (UINT64)get_cpu_freq() * microseconds;
+         while (rdtsc() < total_tick) {
+                 asm volatile ("pause");
+         }
+-- 
+2.25.1
+


### PR DESCRIPTION
Call pause_us() to sleep 1S doesn't take effect, the reason is that multiply overflow

Tracked-On: OAM-121142