### PR TITLE
Fixed crash in Gallery during monkey test run.

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Gallery2/0010-Fixed-crash-in-Gallery-during-monkey-test-run.patch
+++ b/aosp_diff/base_aaos/packages/apps/Gallery2/0010-Fixed-crash-in-Gallery-during-monkey-test-run.patch
@@ -1,0 +1,134 @@
+From d2915c08d3fdc8d57e8fd65eb16992e4c3dae0d2 Mon Sep 17 00:00:00 2001
+From: Ankit Agarwal <ankit.agarwal@intel.com>
+Date: Mon, 24 Jun 2024 10:00:07 +0530
+Subject: [PATCH] Fixed crash in Gallery during monkey test run.
+
+Observed following crash during monkey test run
+android.os.FileUriExposedException: file:///storage/emulated/14/Movies
+/MUTE_20240606_225943.mp4 exposed beyond app through Intent.getData()
+
+Porting fix from open source-
+fix b/218791647 [AOSP] Gallery app crash when press on Mute button and
+saving trimmed video reason for crash was an api change in sdk 24
+https://developer.android.com/google/play/requirements/target-sdk
+fixed thi issue following https://developer.android.com/training/secure
+-file-sharing/setup-sharing
+    + Specify file provider in manifest
+    + Specify shareable directories
+    + Generate uri with FileProvider
+
+ChangeId- I34190720790e0b69d6695474461e461b9c6f61e5
+
+Tests: Compiled and launched Gallery app successfully.
+
+Tracked-On: OAM-120512
+Signed-off-by: Ankit Agarwal <ankit.agarwal@intel.com>
+---
+ AndroidManifest.xml                          | 10 ++++++++++
+ res/xml/provider_paths.xml                   | 19 +++++++++++++++++++
+ src/com/android/gallery3d/app/MuteVideo.java |  8 +++++++-
+ src/com/android/gallery3d/app/TrimVideo.java |  8 +++++++-
+ 4 files changed, 43 insertions(+), 2 deletions(-)
+ create mode 100644 res/xml/provider_paths.xml
+
+diff --git a/AndroidManifest.xml b/AndroidManifest.xml
+index 57db4e89f..d761f8725 100644
+--- a/AndroidManifest.xml
++++ b/AndroidManifest.xml
+@@ -248,6 +248,16 @@
+                 android:name=".filtershow.pipeline.ProcessingService"
+                 android:exported="false" />
+ 
++        <provider
++            android:name="androidx.core.content.FileProvider"
++            android:authorities="${applicationId}.provider"
++            android:exported="false"
++            android:grantUriPermissions="true">
++            <meta-data
++                android:name="android.support.FILE_PROVIDER_PATHS"
++                android:resource="@xml/provider_paths" />
++        </provider>
++
+         <activity
+             android:name="com.android.gallery3d.filtershow.FilterShowActivity"
+             android:label="@string/title_activity_filter_show"
+diff --git a/res/xml/provider_paths.xml b/res/xml/provider_paths.xml
+new file mode 100644
+index 000000000..9b9c4cda0
+--- /dev/null
++++ b/res/xml/provider_paths.xml
+@@ -0,0 +1,19 @@
++<?xml version="1.0" encoding="utf-8"?>
++<!-- Copyright (C) 2008 The Android Open Source Project
++
++     Licensed under the Apache License, Version 2.0 (the "License");
++     you may not use this file except in compliance with the License.
++     You may obtain a copy of the License at
++
++          http://www.apache.org/licenses/LICENSE-2.0
++
++     Unless required by applicable law or agreed to in writing, software
++     distributed under the License is distributed on an "AS IS" BASIS,
++     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++     See the License for the specific language governing permissions and
++     limitations under the License.
++-->
++
++<paths>
++    <external-path name="external_files" path="."/>
++</paths>
+diff --git a/src/com/android/gallery3d/app/MuteVideo.java b/src/com/android/gallery3d/app/MuteVideo.java
+index d3f3aa594..8fc42f154 100644
+--- a/src/com/android/gallery3d/app/MuteVideo.java
++++ b/src/com/android/gallery3d/app/MuteVideo.java
+@@ -24,6 +24,8 @@ import android.os.Handler;
+ import android.provider.MediaStore;
+ import android.widget.Toast;
+ 
++import androidx.core.content.FileProvider;
++
+ import com.android.gallery3d.R;
+ import com.android.gallery3d.data.MediaItem;
+ import com.android.gallery3d.util.SaveVideoFileInfo;
+@@ -83,7 +85,11 @@ public class MuteVideo {
+                             // Show the result only when the activity not
+                             // stopped.
+                             Intent intent = new Intent(android.content.Intent.ACTION_VIEW);
+-                            intent.setDataAndType(Uri.fromFile(mDstFileInfo.mFile), "video/*");
++                            Uri videoUri = FileProvider.getUriForFile(
++                                    mActivity,
++                                    mActivity.getApplicationContext().getPackageName()
++                                            + ".provider", mDstFileInfo.mFile);
++                            intent.setDataAndType(videoUri, "video/*");
+                             intent.putExtra(MediaStore.EXTRA_FINISH_ON_COMPLETION, false);
+                             mActivity.startActivity(intent);
+                         }
+diff --git a/src/com/android/gallery3d/app/TrimVideo.java b/src/com/android/gallery3d/app/TrimVideo.java
+index b0ed8e635..a064e6039 100644
+--- a/src/com/android/gallery3d/app/TrimVideo.java
++++ b/src/com/android/gallery3d/app/TrimVideo.java
+@@ -33,6 +33,8 @@ import android.widget.TextView;
+ import android.widget.Toast;
+ import android.widget.VideoView;
+ 
++import androidx.core.content.FileProvider;
++
+ import com.android.gallery3d.R;
+ import com.android.gallery3d.util.SaveVideoFileInfo;
+ import com.android.gallery3d.util.SaveVideoFileUtils;
+@@ -261,7 +263,11 @@ public class TrimVideo extends Activity implements
+                             mProgress = null;
+                             // Show the result only when the activity not stopped.
+                             Intent intent = new Intent(android.content.Intent.ACTION_VIEW);
+-                            intent.setDataAndType(Uri.fromFile(mDstFileInfo.mFile), "video/*");
++                            Uri videoUri = FileProvider.getUriForFile(
++                                    TrimVideo.this,
++                                    getApplicationContext().getPackageName()
++                                            + ".provider", mDstFileInfo.mFile);
++                            intent.setDataAndType(videoUri, "video/*");
+                             intent.putExtra(MediaStore.EXTRA_FINISH_ON_COMPLETION, false);
+                             startActivity(intent);
+                             finish();
+-- 
+2.34.1
+


### PR DESCRIPTION
Observed following crash during monkey test run
android.os.FileUriExposedException: file:///storage/emulated/14/Movies /MUTE_20240606_225943.mp4 exposed beyond app through Intent.getData()

Porting fix from open source-
fix b/218791647 [AOSP] Gallery app crash when press on Mute button and saving trimmed video reason for crash was an api change in sdk 24 https://developer.android.com/google/play/requirements/target-sdk fixed thi issue following https://developer.android.com/training/secure -file-sharing/setup-sharing
    + Specify file provider in manifest
    + Specify shareable directories
    + Generate uri with FileProvider

ChangeId- I34190720790e0b69d6695474461e461b9c6f61e5

Tests: Compiled and launched Gallery app successfully.

Tracked-On: OAM-120512