### PR TITLE
InputDevice: Use location for idc file

### DIFF
--- a/aosp_diff/preliminary/frameworks/native/03_0003-InputDevice-Use-location-for-idc-file.patch
+++ b/aosp_diff/preliminary/frameworks/native/03_0003-InputDevice-Use-location-for-idc-file.patch
@@ -1,0 +1,120 @@
+From 27dcfe366362a4eed6b06c86a9d3ffd54fa8f460 Mon Sep 17 00:00:00 2001
+From: Ankit Agarwal <ankit.agarwal@intel.com>
+Date: Mon, 24 Jun 2024 17:38:04 +0530
+Subject: [PATCH] InputDevice: Use location for idc file
+
+Devices that have multiple usb touchpanels attached that are all using
+the same product, vendor, and version ids do not have a good way to use
+different idc files to allow the touchpanels to be configured
+differently as matching is done either by product, vendor, and version
+ids or device name which will be the same for all of the touchpanels.
+
+This updates the logic to search for idc files to add searching by
+InputDeviceIdentifier.location if no existing matches are found. The
+location is an identifier such as usb-xhci-hcd.1.auto-1/input1 which
+contains a bus id to allow configuration by which usb port the
+touchpanel is attached to. This will use the canonical location which
+replaces anything other than A-Z, a-z, 0-9, -, and _ with the _
+character similar to what is done for the canonical name to allow it
+to be used in a path.
+
+Tests: Verified 2 touch display by mapping location based idc files to
+display.
+
+Type: New Feature
+Change-Id: I30db47889f4925e8eb6522640bd8316af20ca572
+
+Tracked-On: OAM-104623
+Signed-off-by: Vilas R K <vilas.r.k@intel.com>
+---
+ include/input/InputDevice.h           | 10 ++++++++++
+ libs/input/InputDevice.cpp            | 25 +++++++++++++++++++++++--
+ libs/input/tests/InputDevice_test.cpp |  6 ++++++
+ 3 files changed, 39 insertions(+), 2 deletions(-)
+
+diff --git a/include/input/InputDevice.h b/include/input/InputDevice.h
+index b7751f704a..2296f8396b 100644
+--- a/include/input/InputDevice.h
++++ b/include/input/InputDevice.h
+@@ -71,8 +71,18 @@ struct InputDeviceIdentifier {
+      */
+     std::string getCanonicalName() const;
+ 
++    /**
++     * Return InputDeviceIdentifier.location that has been adjusted as follows:
++     *     - all characters besides alphanumerics, dash,
++     *       and underscore have been replaced with underscores.
++     * This helps in situations where a file that matches the device location is needed,
++     * while conforming to the filename limitations.
++     */
++    std::string getCanonicalLocation() const;
++
+     bool operator==(const InputDeviceIdentifier&) const = default;
+     bool operator!=(const InputDeviceIdentifier&) const = default;
++
+ };
+ 
+ /* Types of input device sensors. Keep sync with core/java/android/hardware/Sensor.java */
+diff --git a/libs/input/InputDevice.cpp b/libs/input/InputDevice.cpp
+index 9c7c0c19ed..a4cfa19d81 100644
+--- a/libs/input/InputDevice.cpp
++++ b/libs/input/InputDevice.cpp
+@@ -85,8 +85,20 @@ std::string getInputDeviceConfigurationFilePathByDeviceIdentifier(
+     }
+ 
+     // Try device name.
+-    return getInputDeviceConfigurationFilePathByName(deviceIdentifier.getCanonicalName() + suffix,
+-                                                     type);
++    std::string productPath =
++    getInputDeviceConfigurationFilePathByName(deviceIdentifier.getCanonicalName(),
++                                              type);
++    if (!productPath.empty()) {
++        return productPath;
++    }
++
++    // Try device location.
++    if (!deviceIdentifier.getCanonicalLocation().empty()) {
++        productPath = getInputDeviceConfigurationFilePathByName(
++            deviceIdentifier.getCanonicalLocation(), type);
++    }
++    return productPath;
++
+ }
+ 
+ std::string getInputDeviceConfigurationFilePathByName(
+@@ -163,6 +175,15 @@ std::string InputDeviceIdentifier::getCanonicalName() const {
+     return replacedName;
+ }
+ 
++std::string InputDeviceIdentifier::getCanonicalLocation() const {
++    std::string replacedLocation = location;
++    for (char& ch : replacedLocation) {
++        if (!isValidNameChar(ch)) {
++            ch = '_';
++        }
++    }
++    return replacedLocation;
++}
+ 
+ // --- InputDeviceInfo ---
+ 
+diff --git a/libs/input/tests/InputDevice_test.cpp b/libs/input/tests/InputDevice_test.cpp
+index ee961f0ffc..d0a0535de1 100644
+--- a/libs/input/tests/InputDevice_test.cpp
++++ b/libs/input/tests/InputDevice_test.cpp
+@@ -35,6 +35,12 @@ TEST(InputDeviceIdentifierTest, getCanonicalName) {
+     ASSERT_EQ(std::string("deviceName-123_version_C_"), identifier.getCanonicalName());
+ }
+ 
++TEST(InputDeviceIdentifierTest, getCanonicalLocation) {
++    InputDeviceIdentifier identifier;
++    identifier.location = "usb-xhci-hcd.1.auto-1.1/input1";
++    ASSERT_EQ(std::string("usb-xhci-hcd_1_auto-1_1_input1"), identifier.getCanonicalLocation());
++}
++
+ class InputDeviceKeyMapTest : public testing::Test {
+ protected:
+     void loadKeyLayout(const char* name) {
+-- 
+2.34.1
+


### PR DESCRIPTION
Devices that have multiple usb touchpanels attached that are all using the same product, vendor, and version ids do not have a good way to use different idc files to allow the touchpanels to be configured differently as matching is done either by product, vendor, and version ids or device name which will be the same for all of the touchpanels.

This updates the logic to search for idc files to add searching by InputDeviceIdentifier.location if no existing matches are found. The location is an identifier such as usb-xhci-hcd.1.auto-1/input1 which contains a bus id to allow configuration by which usb port the touchpanel is attached to. This will use the canonical location which replaces anything other than A-Z, a-z, 0-9, -, and _ with the _ character similar to what is done for the canonical name to allow it to be used in a path.

Tests: Verified 2 touch display by mapping location based idc files to display.

Type: New Feature
Change-Id: I30db47889f4925e8eb6522640bd8316af20ca572

Tracked-On: OAM-120439