### PR TITLE
Enable wifi RTT and NAN features

### DIFF
--- a/bsp_diff/caas/device/intel/mixins/0003-Enable-wifi-RTT-and-NAN-features.patch
+++ b/bsp_diff/caas/device/intel/mixins/0003-Enable-wifi-RTT-and-NAN-features.patch
@@ -1,0 +1,79 @@
+From 984fb57a5bd93b13c578198912b02a2a0615aeae Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Thu, 27 Jun 2024 13:06:17 +0530
+Subject: [PATCH] Enable wifi RTT and NAN features
+
+RTT and NAN features are not enabled in caas.
+
+Enabled RTT and NAN for caas. Since NAN and hotspot cannot work
+simultaneously, moved NAN to mixins options, whenever required
+can enable and validate.
+
+Tests done:
+[RTT]
+1. Flash BM
+2. In adb shell #>pm list features | grep wifi
+3. Check rtt is listing
+4. Verify RTT service is running in logcat
+5. Check wifi on success
+6. Check hotspot on success
+
+[NAN]
+1. Build with nan=true and flash BM
+2. In adb shell #>pm list features | grep wifi
+3. Check aware is listing
+4. Verify aware service is running in logcat
+5. Check wifi on success
+
+Tracked-On: OAM-121432
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Signed-off-by: Aman Bhadouria <aman.bhadouria@intel.com>
+---
+ groups/wlan/iwlwifi/BoardConfig.mk | 4 ++++
+ groups/wlan/iwlwifi/option.spec    | 1 +
+ groups/wlan/iwlwifi/product.mk     | 8 +++++++-
+ 3 files changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/groups/wlan/iwlwifi/BoardConfig.mk b/groups/wlan/iwlwifi/BoardConfig.mk
+index b17098a..8fc0ab0 100644
+--- a/groups/wlan/iwlwifi/BoardConfig.mk
++++ b/groups/wlan/iwlwifi/BoardConfig.mk
+@@ -12,3 +12,7 @@ BOARD_WPA_SUPPLICANT_PRIVATE_LIB ?= lib_driver_cmd_intc
+ BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/wlan/load_iwl_modules
+ BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/wlan/iwlwifi
+ WIFI_HIDL_UNIFIED_SUPPLICANT_SERVICE_RC_ENTRY := true
++
++{{#nan}}
++WIFI_HIDL_FEATURE_AWARE := true
++{{/nan}}
+diff --git a/groups/wlan/iwlwifi/option.spec b/groups/wlan/iwlwifi/option.spec
+index b37b6fb..733fba0 100644
+--- a/groups/wlan/iwlwifi/option.spec
++++ b/groups/wlan/iwlwifi/option.spec
+@@ -10,3 +10,4 @@ libwifi-hal = false
+ firmware =
+ nvm = true
+ iwl_upstream_drv = true
++nan = false
+diff --git a/groups/wlan/iwlwifi/product.mk b/groups/wlan/iwlwifi/product.mk
+index e973e7b..e827b29 100644
+--- a/groups/wlan/iwlwifi/product.mk
++++ b/groups/wlan/iwlwifi/product.mk
+@@ -19,7 +19,13 @@ PRODUCT_COPY_FILES += \
+     $(INTEL_PATH_COMMON)/wlan/iwlwifi/p2p_supplicant_overlay.conf:vendor/etc/wifi/p2p_supplicant_overlay.conf \
+     frameworks/native/data/etc/android.hardware.wifi.xml:vendor/etc/permissions/android.hardware.wifi.xml \
+     frameworks/native/data/etc/android.hardware.wifi.direct.xml:vendor/etc/permissions/android.hardware.wifi.direct.xml \
+-    frameworks/native/data/etc/android.software.ipsec_tunnels.xml:vendor/etc/permissions/android.software.ipsec_tunnels.xml
++    frameworks/native/data/etc/android.software.ipsec_tunnels.xml:vendor/etc/permissions/android.software.ipsec_tunnels.xml \
++    frameworks/native/data/etc/android.hardware.wifi.rtt.xml:vendor/etc/permissions/android.hardware.wifi.rtt.xml
++
++{{#nan}}
++PRODUCT_COPY_FILES += \
++    frameworks/native/data/etc/android.hardware.wifi.aware.xml:vendor/etc/permissions/android.hardware.wifi.aware.xml
++{{/nan}}
+ 
+ PRODUCT_PACKAGE_OVERLAYS += $(INTEL_PATH_COMMON)/wlan/overlay-disable_keepalive_offload
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
RTT and NAN features are not enabled in caas.

Enabled RTT and NAN for caas. Since NAN and hotspot cannot work simultaneously, moved NAN to mixins options, whenever required can enable and validate.

Tests done:
[RTT]
1. Flash BM
2. In adb shell #>pm list features | grep wifi
3. Check rtt is listing
4. Verify RTT service is running in logcat
5. Check wifi on success
6. Check hotspot on success

[NAN]
1. Build with nan=true and flash BM
2. In adb shell #>pm list features | grep wifi
3. Check aware is listing
4. Verify aware service is running in logcat
5. Check wifi on success

Tracked-On: OAM-121432