### PR TITLE
Enable BT HFP for AX210 card

### DIFF
--- a/aosp_diff/base_aaos/packages/modules/Bluetooth/0001-Disabling-WBS-in-the-BT-stack.patch
+++ b/aosp_diff/base_aaos/packages/modules/Bluetooth/0001-Disabling-WBS-in-the-BT-stack.patch
@@ -1,0 +1,33 @@
+From 1e6cc7f502b2a3bbc66fde040a2557053266e94b Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Thu, 27 Jun 2024 11:01:26 +0530
+Subject: [PATCH] Disabling WBS in the BT stack.
+
+Workaround to support NB
+
+Tracked-On: OAM-121423
+Signed-off-by: Deepa K G <g.k.deepa@intel.com>
+Signed-off-by: Aiswarya Cyriac <aiswarya.cyriac@intel.com>
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ system/bta/hf_client/bta_hf_client_at.cc | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/system/bta/hf_client/bta_hf_client_at.cc b/system/bta/hf_client/bta_hf_client_at.cc
+index da37a07cad..6d67a5e6cd 100644
+--- a/system/bta/hf_client/bta_hf_client_at.cc
++++ b/system/bta/hf_client/bta_hf_client_at.cc
+@@ -1782,7 +1782,9 @@ void bta_hf_client_send_at_bac(tBTA_HF_CLIENT_CB* client_cb) {
+ 
+   APPL_TRACE_DEBUG("%s", __func__);
+ 
+-  buf = "AT+BAC=1,2\r";
++  //Disable WBS and support only NB, as sco driver supports only NB.
++  //buf = "AT+BAC=1,2\r";
++  buf = "AT+BAC=1\r";
+ 
+   bta_hf_client_send_at(client_cb, BTA_HF_CLIENT_AT_BAC, buf, strlen(buf));
+ }
+-- 
+2.17.1
+

--- a/bsp_diff/base_aaos/vendor/intel/hardware/interfaces/0001-Add-BT-HFP-support-for-TyP2.patch
+++ b/bsp_diff/base_aaos/vendor/intel/hardware/interfaces/0001-Add-BT-HFP-support-for-TyP2.patch
@@ -1,0 +1,39 @@
+From d702b3b574a65a8eeb0e6091f8a73ac7a3b97ae3 Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Wed, 6 Mar 2024 16:55:31 +0530
+Subject: [PATCH] Add BT HFP support for TyP2
+
+Send sco handle during BT HFP sco call for Intel Bluetooth AX210
+bt card (TyphoonPeak - Typ2)
+
+Tracked-On: OAM-121421
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ bluetooth/h4_protocol.cc | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/bluetooth/h4_protocol.cc b/bluetooth/h4_protocol.cc
+index 1b29117..4463518 100644
+--- a/bluetooth/h4_protocol.cc
++++ b/bluetooth/h4_protocol.cc
+@@ -40,6 +40,7 @@
+ #define INTEL_PID_9560 0x0aaa // 9460/9560 also know as Jefferson Peak (JfP)
+ #define INTEL_PID_AX201 0x0026 // AX201 also know as Harrison Peak (HrP)
+ #define INTEL_PID_AX211 0x0033 // AX211 also know as GarfieldPeak (Gfp)
++#define INTEL_PID_AX210 0x0032 // AX210 also know as TyphoonPeak (TyP2)
+ 
+ #include <errno.h>
+ #include <fcntl.h>
+@@ -88,7 +89,8 @@ bool H4Protocol::IsIntelController(uint16_t vid, uint16_t pid) {
+                                 (pid == INTEL_PID_9260)||
+                                 (pid == INTEL_PID_9560)||
+                                 (pid == INTEL_PID_AX201)||
+-                                (pid == INTEL_PID_AX211)))
++                                (pid == INTEL_PID_AX211)||
++                                (pid == INTEL_PID_AX210)))
+         return true;
+     else
+ 	return false;
+-- 
+2.17.1
+


### PR DESCRIPTION
btusb_sco_snd_card not listing for AX210 card.

Add the vendor id and product id to list the sound card.

Tests done:
1. Flash BM
2. Check cat /proc/asound/cards
3. It should list btaudio sound card

Tracked-On: OAM-121421