### PR TITLE
[WA] Fixed for Soft Keyboard Color & key size.

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Car/LatinIME/0001-WA-Fixed-for-Soft-Keyboard-Color-key-size.patch
+++ b/aosp_diff/base_aaos/packages/apps/Car/LatinIME/0001-WA-Fixed-for-Soft-Keyboard-Color-key-size.patch
@@ -1,0 +1,44 @@
+From 1dcb72d74e79e393e086cfad6ee67b7155a876ae Mon Sep 17 00:00:00 2001
+From: Ankit Agarwal <ankit.agarwal@intel.com>
+Date: Thu, 11 Jul 2024 11:40:21 +0530
+Subject: [PATCH] [WA] Fixed for Soft Keyboard Color & key size.
+
+Currently soft keyboard keys are dark and not visible properly due to
+dark background and also key size is small.
+
+Changed the key color and size.
+
+Tests:
+Open any Editor, it pop up soft keyboard. it has key visible
+poperly.
+
+Tracked-On: OAM-121431
+Signed-off-by: Ankit Agarwal <ankit.agarwal@intel.com>
+---
+ src/com/android/inputmethod/latin/car/KeyboardView.java | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/com/android/inputmethod/latin/car/KeyboardView.java b/src/com/android/inputmethod/latin/car/KeyboardView.java
+index 974b3af..0e5581c 100644
+--- a/src/com/android/inputmethod/latin/car/KeyboardView.java
++++ b/src/com/android/inputmethod/latin/car/KeyboardView.java
+@@ -322,13 +322,13 @@ public class KeyboardView extends View implements View.OnClickListener {
+                     mPreviewHeight = a.getDimensionPixelSize(attr, 80);
+                     break; */
+                 case R.styleable.KeyboardView_keyTextSize:
+-                    mKeyTextSize = a.getDimensionPixelSize(attr, 18);
++                    mKeyTextSize = 40;// a.getDimensionPixelSize(attr, 18);
+                     break;
+                 case R.styleable.KeyboardView_keyTextColorPrimary:
+-                    mKeyTextColorPrimary = a.getColor(attr, 0xFF000000);
++                    mKeyTextColorPrimary = 0xFFffffff;//a.getColor(attr, 0xFF000000);
+                     break;
+                 case R.styleable.KeyboardView_keyTextColorSecondary:
+-                    mKeyTextColorSecondary = a.getColor(attr, 0x99000000);
++                    mKeyTextColorSecondary = 0x99ffffff;//a.getColor(attr, 0x99000000);
+                     break;
+                 case R.styleable.KeyboardView_labelTextSize:
+                     mLabelTextSize = a.getDimensionPixelSize(attr, 14);
+-- 
+2.34.1
+


### PR DESCRIPTION
Currently soft keyboard keys are dark and not visible properly due to dark background and also key size is small.

Changed the key color and size.

Tests:
Open any Editor, it pop up soft keyboard. it has key visible poperly.

Tracked-On: OAM-121431