### PR TITLE
Add patch which modifies evs HAL API version to 2

### DIFF
--- a/aosp_diff/base_aaos/packages/services/Car/0002-Modify-evs-HAL-API-version-to-2.patch
+++ b/aosp_diff/base_aaos/packages/services/Car/0002-Modify-evs-HAL-API-version-to-2.patch
@@ -1,0 +1,29 @@
+From e3409445334a49cad313331ae9f3c51475841676 Mon Sep 17 00:00:00 2001
+From: "Liu, Kai1" <kai1.liu@intel.com>
+Date: Fri, 5 Jul 2024 12:33:03 +0800
+Subject: [PATCH] Modify evs HAL API version to 2
+
+V2 version of evs HAL API has been used, so modify the version
+to 2 in the manifest files.
+
+Tracked-On: OAM-122020
+Signed-off-by: Liu, Kai1 <kai1.liu@intel.com>
+---
+ .../aidl/manifest_android.hardware.automotive.evs-default.xml    | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/cpp/evs/sampleDriver/aidl/manifest_android.hardware.automotive.evs-default.xml b/cpp/evs/sampleDriver/aidl/manifest_android.hardware.automotive.evs-default.xml
+index ae37ad3f6b..78a32a6273 100644
+--- a/cpp/evs/sampleDriver/aidl/manifest_android.hardware.automotive.evs-default.xml
++++ b/cpp/evs/sampleDriver/aidl/manifest_android.hardware.automotive.evs-default.xml
+@@ -1,6 +1,7 @@
+ <manifest version="1.0" type="device">
+     <hal format="aidl">
+         <name>android.hardware.automotive.evs</name>
++        <version>2</version>
+         <fqname>IEvsEnumerator/hw/1</fqname>
+     </hal>
+ </manifest>
+-- 
+2.34.1
+


### PR DESCRIPTION
V2 version of evs HAL API has been used, so modify the version to 2 in the manifest files.

Test Done:
vts -m vts_treble_vintf_vendor_test

Tracked-On: OAM-122020