### PR TITLE
Add graphics related sepolicy for hal_sensors_default

### DIFF
--- a/bsp_diff/common/device/intel/sepolicy/0001-Add-graphics-related-sepolicy-for-hal_sensors_defaul.patch
+++ b/bsp_diff/common/device/intel/sepolicy/0001-Add-graphics-related-sepolicy-for-hal_sensors_defaul.patch
@@ -1,0 +1,29 @@
+From 7ef6e0e8ab8fea13300c6923d40f0609b3f51ae5 Mon Sep 17 00:00:00 2001
+From: RajaniRanjan <rajani.ranjan@intel.com>
+Date: Fri, 5 Jul 2024 10:56:01 +0530
+Subject: [PATCH] Add graphics related sepolicy for hal_sensors_default
+
+Fix VTS sensors issues.
+-DirectChannelGralloc/0_android_hardware_sensors_ISensors_default
+
+Test Done:
+run vts -m VtsAidlHalSensorsTargetTest
+
+Tracked-On: OAM-118440
+Signed-off-by: RajaniRanjan <rajani.ranjan@intel.com>
+---
+ sensors/mediation/sensor_hal_default.te | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/sensors/mediation/sensor_hal_default.te b/sensors/mediation/sensor_hal_default.te
+index bc2c23b..a85a7e7 100644
+--- a/sensors/mediation/sensor_hal_default.te
++++ b/sensors/mediation/sensor_hal_default.te
+@@ -5,3 +5,4 @@ allowxperm hal_sensors_default self:socket ioctl unpriv_sock_ioctls;
+ allow hal_sensors_default serial_device:chr_file rw_file_perms;
+ 
+ allow hal_sensors_default self:vsock_socket { create read write connect getopt setopt };
++allow hal_sensors_default hal_graphics_allocator_default_tmpfs:file { read write };
+-- 
+2.43.2
+


### PR DESCRIPTION
Fix VTS sensors issues.
-DirectChannelGralloc/0_android_hardware_sensors_ISensors_default

Test Done:
run vts -m VtsAidlHalSensorsTargetTest

Tracked-On: OAM-118440