### PR TITLE
Remove the data violators for hal_graphics_composer

### DIFF
--- a/bsp_diff/common/device/intel/sepolicy/06_0001-Add-sepolicy-for-composer3-AIDL-HAL-service.patch
+++ b/bsp_diff/common/device/intel/sepolicy/06_0001-Add-sepolicy-for-composer3-AIDL-HAL-service.patch
@@ -1,4 +1,4 @@
-From 8e2c16f69a65b348e863f909031a9d00fcdb805f Mon Sep 17 00:00:00 2001
+From 902ea88a3e776802868751e284908d1f0c42e09b Mon Sep 17 00:00:00 2001
 From: manxiaoliang <xiaoliangx.man@intel.com>
 Date: Thu, 24 Aug 2023 00:57:08 +0000
 Subject: [PATCH] Add sepolicy for composer3 AIDL HAL service.
@@ -6,11 +6,9 @@ Subject: [PATCH] Add sepolicy for composer3 AIDL HAL service.
 Tracked-On: OAM-110596
 Signed-off-by: manxiaoliang <xiaoliangx.man@intel.com>
 ---
- graphics/composer3/file_contexts          | 2 ++
- graphics/composer3/violators_blacklist.te | 1 +
- 2 files changed, 3 insertions(+)
+ graphics/composer3/file_contexts | 2 ++
+ 1 file changed, 2 insertions(+)
  create mode 100644 graphics/composer3/file_contexts
- create mode 100644 graphics/composer3/violators_blacklist.te
 
 diff --git a/graphics/composer3/file_contexts b/graphics/composer3/file_contexts
 new file mode 100644
@@ -20,13 +18,6 @@ index 0000000..9ca63c0
 @@ -0,0 +1,2 @@
 +/(vendor|system/vendor)/bin/hw/android\.hardware\.graphics\.composer3-service\.intel u:object_r:hal_graphics_composer_default_exec:s0
 +
-diff --git a/graphics/composer3/violators_blacklist.te b/graphics/composer3/violators_blacklist.te
-new file mode 100644
-index 0000000..084022e
---- /dev/null
-+++ b/graphics/composer3/violators_blacklist.te
-@@ -0,0 +1 @@
-+typeattribute hal_graphics_composer_default data_between_core_and_vendor_violators;
 -- 
-2.17.1
+2.25.1
 


### PR DESCRIPTION
This is used to fix the failed case of GTS:
com.google.android.security.gts.SELinuxHostTest#testNoExemptionsForDataBetweenCoreAndVendor

Test done: testNoExemptionsForDataBetweenCoreAndVendor can pass with this patch.

Tracked-On: OAM-118907