### PR TITLE
Avoid HIGH_ACCURACY request from stationary throttling

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/57_0057-Avoid-HIGH_ACCURACY-request-from-stationary-throttli.patch
+++ b/aosp_diff/preliminary/frameworks/base/57_0057-Avoid-HIGH_ACCURACY-request-from-stationary-throttli.patch
@@ -1,0 +1,72 @@
+From d80992c115c6c4af39a4434a53434dee2aef2081 Mon Sep 17 00:00:00 2001
+From: Yu-Han Yang <yuhany@google.com>
+Date: Thu, 11 Jul 2024 04:34:06 +0000
+Subject: [PATCH 1/2] Avoid HIGH_ACCURACY request from stationary throttling
+
+Bug: 319054085
+Test: atest StationThrottlingLocationProviderTest
+Change-Id: I33e945b62c660db7e0ecce45ca6959213cd64bf4
+---
+ .../StationaryThrottlingLocationProvider.java  |  2 ++
+ ...ationaryThrottlingLocationProviderTest.java | 18 ++++++++++++++++++
+ 2 files changed, 20 insertions(+)
+
+diff --git a/services/core/java/com/android/server/location/provider/StationaryThrottlingLocationProvider.java b/services/core/java/com/android/server/location/provider/StationaryThrottlingLocationProvider.java
+index 5e38bca78a7c..da7c65ab2611 100644
+--- a/services/core/java/com/android/server/location/provider/StationaryThrottlingLocationProvider.java
++++ b/services/core/java/com/android/server/location/provider/StationaryThrottlingLocationProvider.java
+@@ -27,6 +27,7 @@ import static java.lang.Math.max;
+ 
+ import android.annotation.Nullable;
+ import android.location.Location;
++import android.location.LocationRequest;
+ import android.location.LocationResult;
+ import android.location.provider.ProviderRequest;
+ import android.os.SystemClock;
+@@ -179,6 +180,7 @@ public final class StationaryThrottlingLocationProvider extends DelegateLocation
+     private void onThrottlingChangedLocked(boolean deliverImmediate) {
+         long throttlingIntervalMs = INTERVAL_DISABLED;
+         if (mDeviceStationary && mDeviceIdle && !mIncomingRequest.isLocationSettingsIgnored()
++		&& mIncomingRequest.getQuality() != LocationRequest.QUALITY_HIGH_ACCURACY
+                 && mLastLocation != null
+                 && mLastLocation.getElapsedRealtimeAgeMillis(mDeviceStationaryRealtimeMs)
+                 <= MAX_STATIONARY_LOCATION_AGE_MS) {
+diff --git a/services/tests/mockingservicestests/src/com/android/server/location/provider/StationaryThrottlingLocationProviderTest.java b/services/tests/mockingservicestests/src/com/android/server/location/provider/StationaryThrottlingLocationProviderTest.java
+index 4eba21934a4e..82afaba96031 100644
+--- a/services/tests/mockingservicestests/src/com/android/server/location/provider/StationaryThrottlingLocationProviderTest.java
++++ b/services/tests/mockingservicestests/src/com/android/server/location/provider/StationaryThrottlingLocationProviderTest.java
+@@ -29,6 +29,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
+ 
+ import android.content.Context;
+ import android.location.Location;
++import android.location.LocationRequest;
+ import android.location.LocationResult;
+ import android.location.provider.ProviderRequest;
+ import android.platform.test.annotations.Presubmit;
+@@ -213,6 +214,23 @@ public class StationaryThrottlingLocationProviderTest {
+         mDelegateProvider.reportLocation(loc);
+         verify(mListener, times(1)).onReportLocation(loc);
+ 
++        mInjector.getDeviceStationaryHelper().setStationary(true);
++        mInjector.getDeviceIdleHelper().setIdle(true);
++        verify(mDelegate, never()).onSetRequest(ProviderRequest.EMPTY_REQUEST);
++        verify(mListener, after(75).times(1)).onReportLocation(any(LocationResult.class));
++    }
++    @Test
++    public void testNoThrottle_highAccuracy() {
++        ProviderRequest request = new ProviderRequest.Builder().setIntervalMillis(
++                50).setQuality(LocationRequest.QUALITY_HIGH_ACCURACY).build();
++
++        mProvider.getController().setRequest(request);
++        verify(mDelegate).onSetRequest(request);
++
++        LocationResult loc = createLocationResult("test_provider", mRandom);
++        mDelegateProvider.reportLocation(loc);
++        verify(mListener, times(1)).onReportLocation(loc);
++
+         mInjector.getDeviceStationaryHelper().setStationary(true);
+         mInjector.getDeviceIdleHelper().setIdle(true);
+         verify(mDelegate, never()).onSetRequest(ProviderRequest.EMPTY_REQUEST);
+-- 
+2.34.1
+

--- a/aosp_diff/preliminary/frameworks/base/58_0058-Apply-pending-transactions-always.patch
+++ b/aosp_diff/preliminary/frameworks/base/58_0058-Apply-pending-transactions-always.patch
@@ -1,0 +1,38 @@
+From 5765b54e8590aea70bbd51652e96e8d8293a08bd Mon Sep 17 00:00:00 2001
+From: John Reck <jreck@google.com>
+Date: Fri, 12 Jul 2024 09:20:37 +0000
+Subject: [PATCH 2/2] Apply pending transactions always
+
+Test: repro in bug
+Bug: 334901521
+
+Change-Id: I8f856e7be5917a1d01f0ee2bdbe613bf37045646
+(cherry picked from commit 54526e9b29556ede6c22a07fad83cc6cc8163915)
+---
+ core/java/android/view/ViewRootImpl.java | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/core/java/android/view/ViewRootImpl.java b/core/java/android/view/ViewRootImpl.java
+index cd2d36c60ade..f47932fd32c3 100644
+--- a/core/java/android/view/ViewRootImpl.java
++++ b/core/java/android/view/ViewRootImpl.java
+@@ -4024,7 +4024,15 @@ public final class ViewRootImpl implements ViewParent,
+             mReportNextDraw = false;
+             mLastReportNextDrawReason = null;
+             mActiveSurfaceSyncGroup = null;
+-            mSyncBuffer = false;
++            if (mHasPendingTransactions) {
++                // TODO: We shouldn't ever actually hit this, it means mPendingTransaction wasn't
++                // merged with a sync group or BLASTBufferQueue before making it to this point
++                // But better a one or two frame flicker than steady-state broken from dropping
++                // whatever is in this transaction
++                mPendingTransaction.apply();
++                mHasPendingTransactions = false;
++            }            
++	    mSyncBuffer = false;
+             if (isInWMSRequestedSync()) {
+                 mWmsRequestSyncGroup.markSyncReady();
+                 mWmsRequestSyncGroup = null;
+-- 
+2.34.1
+


### PR DESCRIPTION
    Applying High Security patches from Google
    
    Avoid HIGH_ACCURACY request from stationary throttling
    Bug: 319054085
    Apply pending transactions always
    Bug: 334901521
    
    Test Done: Build and Boot success
               Basic sanity test pass successfully
    
    Tracked-On: OAM-122204
