### PR TITLE
Removing support for 32bit since Android removed it

### DIFF
--- a/bsp_diff/caas/device/intel/mixins/0004-Remove-32bit-support-in-AOSP14.patch
+++ b/bsp_diff/caas/device/intel/mixins/0004-Remove-32bit-support-in-AOSP14.patch
@@ -1,0 +1,59 @@
+From dc16edb223befbed426e07eb81a508afe0468277 Mon Sep 17 00:00:00 2001
+From: "Shi, Qiming" <qiming.shi@intel.com>
+Date: Thu, 11 Apr 2024 23:08:13 +0800
+Subject: [PATCH] Remove 32bit support in AOSP14
+
+Signed-off-by: Shi, Qiming <qiming.shi@intel.com>
+---
+ groups/cpu-arch/x86/BoardConfig.mk | 5 -----
+ groups/houdini/true/BoardConfig.mk | 8 ++------
+ 2 files changed, 2 insertions(+), 11 deletions(-)
+
+diff --git a/groups/cpu-arch/x86/BoardConfig.mk b/groups/cpu-arch/x86/BoardConfig.mk
+index c38eead..955e7b4 100644
+--- a/groups/cpu-arch/x86/BoardConfig.mk
++++ b/groups/cpu-arch/x86/BoardConfig.mk
+@@ -1,7 +1,6 @@
+ BUILD_CPU_ARCH ?= silvermont
+ 
+ # Items that are common between slm 32b and 64b:
+-TARGET_CPU_ABI_LIST_32_BIT := x86
+ TARGET_ARCH_VARIANT := $(if $(BUILD_CPU_ARCH),$(BUILD_CPU_ARCH),x86)
+ TARGET_CPU_VARIANT := generic
+ TARGET_CPU_SMP := true
+@@ -10,10 +9,6 @@ ifeq ($(BOARD_USE_64BIT_USERSPACE),true)
+ # 64b-specific items:
+ TARGET_ARCH := x86_64
+ TARGET_CPU_ABI := x86_64
+-TARGET_2ND_CPU_ABI := x86
+-TARGET_2ND_ARCH := x86
+-TARGET_2ND_ARCH_VARIANT := $(if $(BUILD_CPU_ARCH),$(BUILD_CPU_ARCH))
+-TARGET_2ND_CPU_VARIANT := generic
+ else
+ # 32b-specific items:
+ TARGET_ARCH := x86
+diff --git a/groups/houdini/true/BoardConfig.mk b/groups/houdini/true/BoardConfig.mk
+index cd080a1..7435e3b 100644
+--- a/groups/houdini/true/BoardConfig.mk
++++ b/groups/houdini/true/BoardConfig.mk
+@@ -1,15 +1,11 @@
+ # Native Bridge ABI List
+-NB_ABI_LIST_32_BIT := armeabi-v7a armeabi
+ NB_ABI_LIST_64_BIT := arm64-v8a
+ # Support 64 Bit Apps
+ TARGET_CPU_ABI_LIST_64_BIT ?= $(TARGET_CPU_ABI) $(TARGET_CPU_ABI2)
+-TARGET_CPU_ABI_LIST_32_BIT ?= $(TARGET_2ND_CPU_ABI) $(TARGET_2ND_CPU_ABI2)
+ TARGET_CPU_ABI_LIST := \
+     $(TARGET_CPU_ABI_LIST_64_BIT) \
+-    $(TARGET_CPU_ABI_LIST_32_BIT) \
+-    $(NB_ABI_LIST_64_BIT) \
+-    $(NB_ABI_LIST_32_BIT)
+-TARGET_CPU_ABI_LIST_32_BIT += $(NB_ABI_LIST_32_BIT)
++    $(NB_ABI_LIST_64_BIT) 
++
+ TARGET_CPU_ABI_LIST_64_BIT += $(NB_ABI_LIST_64_BIT)
+ 
+ BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/houdini
+-- 
+2.34.1
+


### PR DESCRIPTION
This patch will remove support for 32bit from the apilist

Tests Done: #getprop | grep abilist
	    This should not show 32bit support

Tracked-On: OAM-118704