### PR TITLE
Add some permissions for Local Media Player

### DIFF
--- a/aosp_diff/preliminary/packages/apps/Car/LocalMediaPlayer/0001-Add-some-permissions-for-Local-Media-Player.patch
+++ b/aosp_diff/preliminary/packages/apps/Car/LocalMediaPlayer/0001-Add-some-permissions-for-Local-Media-Player.patch
@@ -1,0 +1,36 @@
+From 447c56f2f88a6d4a6d773eae878a8523eba87d2f Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Wed, 31 Jul 2024 09:36:23 +0800
+Subject: [PATCH] Add some permissions for Local Media Player
+
+Local Media Player can't play audio and videos as the app has not
+some permissions, add them to fix the issues.
+
+Test: Open Local Media Player and play audio and video files.
+
+Tracked-On: OAM-122382
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ AndroidManifest.xml | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/AndroidManifest.xml b/AndroidManifest.xml
+index 00dce55..e1d588d 100644
+--- a/AndroidManifest.xml
++++ b/AndroidManifest.xml
+@@ -18,7 +18,12 @@
+     package="com.android.car.media.localmediaplayer"
+     android:sharedUserId="com.android.car.media" >
+ 
++    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
++    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
++    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
++    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
++    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+ 
+     <application
+-- 
+2.34.1
+


### PR DESCRIPTION
Local Media Player can't play audio and videos as the app has not some permissions, add them to fix the issues.

Test: Open Local Media Player and play audio and video files.

Tracked-On: OAM-122382