### PR TITLE
Fix android boot issue in SRIOV mode

### DIFF
--- a/bsp_diff/caas/hardware/intel/external/minigbm-intel/0001-Fix-android-boot-issue-in-SRIOV-mode.patch
+++ b/bsp_diff/caas/hardware/intel/external/minigbm-intel/0001-Fix-android-boot-issue-in-SRIOV-mode.patch
@@ -1,0 +1,408 @@
+From b5afd1b4a2009b9634998f7ee19aa03114c8b378 Mon Sep 17 00:00:00 2001
+From: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+Date: Thu, 4 Jul 2024 11:47:32 +0000
+Subject: [PATCH] Fix android boot issue in SRIOV mode
+
+Following commits are reverted due to boot isse in SRIOV mode:
+b5053aa2 Fix android VM boot issue
+47523529 Remove drv_kms_
+5d6cdab9 Refine the init function and fix issue
+
+Tests done:
+- caas boot in GVT-d and SRIOV mode
+- aaos boot in GVT-d and SRIOV mode
+- dGPU GVT-d boot
+- Wi-Fi, Bluetooth on/off/connect/disconnect
+- adb reboot
+- adb remount
+- CtsDeqpTestCases with 0 failures in GVT-d mode
+
+Tracked-On: OAM-123080
+Signed-off-by: Jeevaka Prabu Badrappan <jeevaka.badrappan@intel.com>
+---
+ cros_gralloc/cros_gralloc_driver.cc | 142 ++++++++++++++++++++--------
+ cros_gralloc/cros_gralloc_driver.h  |   5 +
+ drv.c                               |   6 +-
+ gbm.c                               |   6 --
+ i915.c                              |  39 --------
+ 5 files changed, 106 insertions(+), 92 deletions(-)
+
+diff --git a/cros_gralloc/cros_gralloc_driver.cc b/cros_gralloc/cros_gralloc_driver.cc
+index 8a0dd12..8dfee13 100644
+--- a/cros_gralloc/cros_gralloc_driver.cc
++++ b/cros_gralloc/cros_gralloc_driver.cc
+@@ -110,7 +110,6 @@ cros_gralloc_driver::cros_gralloc_driver()
+ 	int fd;
+ 	drmVersionPtr version;
+ 	const int render_num = 10;
+-	const int name_length = 50;
+ 	int node_fd[render_num];
+ 	char *node_name[render_num] = {};
+ 	int availabe_node = 0;
+@@ -122,6 +121,16 @@ cros_gralloc_driver::cros_gralloc_driver()
+ 	mt8183_camera_quirk_ = !strncmp(buf, "kukui", strlen("kukui"));
+ 
+ 	// destroy drivers if exist before re-initializing them
++	if (drv_kms_) {
++		int fd = drv_get_fd(drv_kms_);
++		drv_destroy(drv_kms_);
++		if (!is_kmsro_enabled()) {
++			drv_render_ = nullptr;
++		}
++		drv_kms_ = nullptr;
++		close(fd);
++	}
++
+ 	if (drv_render_) {
+ 		int fd = drv_get_fd(drv_render_);
+ 		drv_destroy(drv_render_);
+@@ -175,41 +184,60 @@ cros_gralloc_driver::cros_gralloc_driver()
+ 		if (!drv_render_) {
+ 			drv_loge("Failed to create driver for the 1st device\n");
+ 			close(node_fd[0]);
+-		}
+-		switch (availabe_node) {
+-		// only have one render node, is GVT-d/BM/VirtIO
+-		case 1:
+-			gpu_grp_type = (virtio_node_idx != -1)? ONE_GPU_VIRTIO: ONE_GPU_INTEL;
+-			break;
+-		// is SR-IOV or iGPU + dGPU
+-		case 2:
+-			close(node_fd[1]);
+-			if (virtio_node_idx != -1) {
+-				gpu_grp_type = TWO_GPU_IGPU_VIRTIO;
+-			} else {
+-				gpu_grp_type = TWO_GPU_IGPU_DGPU;
+-			}
+-			break;
+-		// is SR-IOV + dGPU
+-		case 3:
+-			if (!strcmp(node_name[1], "i915")) {
+-				close(node_fd[1]);
++		} else {
++			switch (availabe_node) {
++			// only have one render node, is GVT-d/BM/VirtIO
++			case 1:
++				if (drv_render_) {
++					drv_kms_ = drv_render_;
++				} else
++					break;
++				gpu_grp_type = (virtio_node_idx != -1)? ONE_GPU_VIRTIO: ONE_GPU_INTEL;
++				break;
++			// is SR-IOV or iGPU + dGPU
++			case 2:
++				if (virtio_node_idx != -1) {
++					drv_kms_ = drv_create(node_fd[virtio_node_idx]);
++					if (!drv_kms_) {
++						drv_loge("Failed to create driver for virtio device\n");
++						close(node_fd[virtio_node_idx]);
++						break;
++					}
++					gpu_grp_type = TWO_GPU_IGPU_VIRTIO;
++				} else {
++					close(node_fd[1]);
++					drv_kms_ = drv_render_;
++					gpu_grp_type = TWO_GPU_IGPU_DGPU;
++				}
++				break;
++			// is SR-IOV + dGPU
++			case 3:
++				if (!strcmp(node_name[1], "i915")) {
++					close(node_fd[1]);
++				}
++				if (virtio_node_idx != -1) {
++					drv_kms_ = drv_create(node_fd[virtio_node_idx]);
++					if (!drv_kms_) {
++						drv_loge("Failed to create driver for virtio device\n");
++						close(node_fd[virtio_node_idx]);
++						break;
++					}
++				}
++				gpu_grp_type = THREE_GPU_IGPU_VIRTIO_DGPU;
++				// TO-DO: the 3rd node is i915 or others.
++				break;
+ 			}
+-			if (virtio_node_idx != -1) {
+-				close(node_fd[virtio_node_idx]);
++
++			if (drv_render_) {
++				if (drv_init(drv_render_, gpu_grp_type)) {
++					drv_loge("Failed to init render driver\n");
++				}
+ 			}
+-			gpu_grp_type = THREE_GPU_IGPU_VIRTIO_DGPU;
+-			// TO-DO: the 3rd node is i915 or others.
+-			break;
+-		}
+ 
+-		if (drv_render_) {
+-			if (drv_init(drv_render_, gpu_grp_type)) {
+-				drv_loge("Failed to init driver\n");
+-				fd = drv_get_fd(drv_render_);
+-				drv_destroy(drv_render_);
+-				close(fd);
+-				drv_render_ = nullptr;
++			if (drv_kms_ && (drv_kms_ != drv_render_)) {
++				if (drv_init(drv_kms_, gpu_grp_type)) {
++					drv_loge("Failed to init kms driver\n");
++				}
+ 			}
+ 		}
+ 	}
+@@ -224,6 +252,16 @@ cros_gralloc_driver::~cros_gralloc_driver()
+ 	buffers_.clear();
+ 	handles_.clear();
+ 
++	if (drv_kms_) {
++		int fd = drv_get_fd(drv_kms_);
++		drv_destroy(drv_kms_);
++		if (!is_kmsro_enabled()) {
++			drv_render_ = nullptr;
++		}
++		drv_kms_ = nullptr;
++		close(fd);
++	}
++
+ 	if (drv_render_) {
+ 		int fd = drv_get_fd(drv_render_);
+ 		drv_destroy(drv_render_);
+@@ -235,7 +273,7 @@ cros_gralloc_driver::~cros_gralloc_driver()
+ 
+ bool cros_gralloc_driver::is_initialized()
+ {
+-	return (drv_render_ != nullptr);
++	return (drv_render_ != nullptr && drv_kms_ != nullptr);
+ }
+ 
+ bool cros_gralloc_driver::get_resolved_format_and_use_flags(
+@@ -246,7 +284,7 @@ bool cros_gralloc_driver::get_resolved_format_and_use_flags(
+ 	uint64_t resolved_use_flags;
+ 	struct combination *combo;
+ 
+-	struct driver *drv = drv_render_;
++	struct driver *drv = (descriptor->use_flags & BO_USE_SCANOUT) ? drv_kms_ : drv_render_;
+ 	if (mt8183_camera_quirk_ && (descriptor->use_flags & BO_USE_CAMERA_READ) &&
+ 	    !(descriptor->use_flags & BO_USE_SCANOUT) &&
+ 	    descriptor->drm_format == DRM_FORMAT_FLEX_IMPLEMENTATION_DEFINED) {
+@@ -260,8 +298,21 @@ bool cros_gralloc_driver::get_resolved_format_and_use_flags(
+ 
+ 	combo = drv_get_combination(drv, resolved_format, resolved_use_flags);
+ 	if (!combo && (descriptor->use_flags & BO_USE_SCANOUT)) {
+-		resolved_use_flags &= ~BO_USE_SCANOUT;
+-		combo = drv_get_combination(drv, resolved_format, descriptor->use_flags);
++		if (is_kmsro_enabled()) {
++			/* if kmsro is enabled, it is scanout buffer and not used for video,
++			 * don't need remove scanout flag */
++			if (!IsSupportedYUVFormat(descriptor->droid_format)) {
++				combo = drv_get_combination(drv, resolved_format,
++					    (descriptor->use_flags) & (~BO_USE_SCANOUT));
++			} else {
++				drv = drv_render_;
++				resolved_use_flags &= ~BO_USE_SCANOUT;
++				combo = drv_get_combination(drv, resolved_format, descriptor->use_flags);
++			}
++		} else {
++			resolved_use_flags &= ~BO_USE_SCANOUT;
++			combo = drv_get_combination(drv, resolved_format, descriptor->use_flags);
++		}
+ 	}
+ 	if (!combo && (descriptor->droid_usage & GRALLOC_USAGE_HW_VIDEO_ENCODER) &&
+ 	    descriptor->droid_format != HAL_PIXEL_FORMAT_YCbCr_420_888) {
+@@ -289,10 +340,11 @@ bool cros_gralloc_driver::is_supported(const struct cros_gralloc_buffer_descript
+ {
+ 	uint32_t resolved_format;
+ 	uint64_t resolved_use_flags;
+-	struct driver *drv = drv_render_;
++	struct driver *drv = (descriptor->use_flags & BO_USE_SCANOUT) ? drv_kms_ : drv_render_;
+ 	uint32_t max_texture_size = drv_get_max_texture_2d_size(drv);
+ 	if (!get_resolved_format_and_use_flags(descriptor, &resolved_format, &resolved_use_flags))
+ 		return false;
++
+ 	// Allow blob buffers to go beyond the limit.
+ 	if (descriptor->droid_format == HAL_PIXEL_FORMAT_BLOB)
+ 		return true;
+@@ -335,10 +387,16 @@ int32_t cros_gralloc_driver::allocate(const struct cros_gralloc_buffer_descripto
+ 	struct bo *bo;
+ 	struct cros_gralloc_handle *hnd;
+ 	std::unique_ptr<cros_gralloc_buffer> buffer;
++	bool from_kms = false;
+ 
+ 	struct driver *drv;
+ 
+-	drv = drv_render_;
++        if ((descriptor->use_flags & BO_USE_SCANOUT)) {
++                from_kms = true;
++                drv = drv_kms_;
++        } else {
++                drv = drv_render_;
++        }
+ 
+ 	if (!get_resolved_format_and_use_flags(descriptor, &resolved_format, &resolved_use_flags)) {
+ 		ALOGE("Failed to resolve format and use_flags.");
+@@ -402,7 +460,7 @@ int32_t cros_gralloc_driver::allocate(const struct cros_gralloc_buffer_descripto
+ 		hnd->fds[i] = -1;
+ 
+ 	hnd->num_planes = num_planes;
+-	hnd->from_kms = false; // not used, just set a default value. keep this member to be backward compatible.
++	hnd->from_kms = from_kms;
+ 	for (size_t plane = 0; plane < num_planes; plane++) {
+ 		ret = drv_bo_get_plane_fd(bo, plane);
+ 		if (ret < 0)
+@@ -488,7 +546,7 @@ int32_t cros_gralloc_driver::retain(buffer_handle_t handle)
+ 		return -EINVAL;
+ 	}
+ 
+-	drv = drv_render_;
++	drv = (hnd->from_kms) ? drv_kms_ : drv_render_;
+ 
+ 	auto hnd_it = handles_.find(hnd);
+ 	if (hnd_it != handles_.end()) {
+@@ -752,7 +810,7 @@ uint32_t cros_gralloc_driver::get_resolved_drm_format(uint32_t drm_format, uint6
+ {
+ 	uint32_t resolved_format;
+ 	uint64_t resolved_use_flags;
+-	struct driver *drv = drv_render_;
++	struct driver *drv = (use_flags & BO_USE_SCANOUT) ? drv_kms_ : drv_render_;
+ 
+ 	drv_resolve_format_and_use_flags(drv, drm_format, use_flags, &resolved_format,
+ 					 &resolved_use_flags);
+diff --git a/cros_gralloc/cros_gralloc_driver.h b/cros_gralloc/cros_gralloc_driver.h
+index be9c596..06ae517 100644
+--- a/cros_gralloc/cros_gralloc_driver.h
++++ b/cros_gralloc/cros_gralloc_driver.h
+@@ -55,6 +55,10 @@ class cros_gralloc_driver
+ 			 const std::function<void(cros_gralloc_buffer *)> &function);
+ 	void with_each_buffer(const std::function<void(cros_gralloc_buffer *)> &function);
+ 	uint32_t get_resolved_common_drm_format(uint32_t drm_format);
++	bool is_kmsro_enabled()
++	{
++		return drv_kms_ != drv_render_;
++	};
+ 
+       private:
+ 	cros_gralloc_driver();
+@@ -83,6 +87,7 @@ class cros_gralloc_driver
+ 		int32_t refcount = 1;
+ 	};
+ 
++	struct driver *drv_kms_ = nullptr;
+ 	struct driver *drv_render_ = nullptr;
+ 	std::mutex mutex_;
+ 	std::unordered_map<uint32_t, std::unique_ptr<cros_gralloc_buffer>> buffers_;
+diff --git a/drv.c b/drv.c
+index 206df16..a2f4146 100644
+--- a/drv.c
++++ b/drv.c
+@@ -105,7 +105,6 @@ static const struct backend *drv_get_backend(int fd)
+ struct driver *drv_create(int fd)
+ {
+ 	struct driver *drv;
+-	int ret;
+ 
+ 	drv = (struct driver *)calloc(1, sizeof(*drv));
+ 
+@@ -162,12 +161,9 @@ int drv_init(struct driver * drv, uint32_t grp_type)
+ 	assert(drv->backend);
+ 
+ 	drv->gpu_grp_type = grp_type;
++
+ 	if (drv->backend->init) {
+ 		ret = drv->backend->init(drv);
+-		if (ret) {
+-			drv_array_destroy(drv->combos);
+-			drv_array_destroy(drv->mappings);
+-		}
+ 	}
+ 	return ret;
+ }
+diff --git a/gbm.c b/gbm.c
+index 69ddb7b..190347e 100644
+--- a/gbm.c
++++ b/gbm.c
+@@ -62,12 +62,6 @@ PUBLIC struct gbm_device *gbm_create_device(int fd)
+ 		return NULL;
+ 	}
+ 
+-	if (drv_init(gbm->drv, 0) != 0) {
+-		drv_destroy(gbm->drv);
+-		free(gbm);
+-		return NULL;
+-	}
+-
+ 	return gbm;
+ }
+ 
+diff --git a/i915.c b/i915.c
+index a8a237a..9f60cd5 100644
+--- a/i915.c
++++ b/i915.c
+@@ -7,7 +7,6 @@
+ #ifdef DRV_I915
+ 
+ #include <assert.h>
+-#include <cpuid.h>
+ #include <errno.h>
+ #include <stdbool.h>
+ #include <stdio.h>
+@@ -19,7 +18,6 @@
+ 
+ #include "drv_helpers.h"
+ #include "drv_priv.h"
+-// #include "external/i915_drm.h"
+ #include "util.h"
+ #include "i915_prelim.h"
+ 
+@@ -298,42 +296,6 @@ static uint64_t unset_flags(uint64_t current_flags, uint64_t mask)
+ 	return value;
+ }
+ 
+-/*
+- * Check virtual machine type, by checking cpuid
+- */
+-enum {
+-	HYPERTYPE_NONE 	    = 0,
+-	HYPERTYPE_ANY       = 0x1,
+-	HYPERTYPE_TYPE_ACRN = 0x2,
+-	HYPERTYPE_TYPE_KVM  = 0x4
+-};
+-static inline int vm_type()
+-{
+-	int type = HYPERTYPE_NONE;
+-	union {
+-		uint32_t sig32[3];
+-		char text[13];
+-	} sig = {};
+-
+-	uint32_t eax=0, ebx=0, ecx=0, edx=0;
+-	if(__get_cpuid(1, &eax, &ebx, &ecx, &edx)) {
+-		if (((ecx >> 31) & 1) == 1) {
+-			type |= HYPERTYPE_ANY;
+-
+-			__cpuid(0x40000000U, eax, ebx, ecx, edx);
+-			sig.sig32[0] = ebx;
+-			sig.sig32[1] = ecx;
+-			sig.sig32[2] = edx;
+-			if (!strncmp(sig.text, "ACRNACRNACRN", 12))
+-				type |= HYPERTYPE_TYPE_ACRN;
+-			else if ((!strncmp(sig.text, "KVMKVMKVM", 9)) ||
+-				 (!strncmp(sig.text, "EVMMEVMMEVMM", 12)))
+-				type |= HYPERTYPE_TYPE_KVM;
+-		}
+-	}
+-	return type;
+-}
+-
+ static int i915_add_combinations(struct driver *drv)
+ {
+ 	struct i915_device *i915 = drv->priv;
+@@ -343,7 +305,6 @@ static int i915_add_combinations(struct driver *drv)
+ 	const uint64_t texture_only = BO_USE_TEXTURE_MASK;
+ 	uint64_t render_flags = BO_USE_RENDER_MASK;
+ 	uint64_t texture_flags = BO_USE_TEXTURE_MASK;
+-	bool is_kvm = vm_type() & HYPERTYPE_TYPE_KVM;
+ 
+ 	// HW protected buffers also need to be scanned out.
+ 	const uint64_t hw_protected =
+-- 
+2.45.2
+


### PR DESCRIPTION
Reverted minigbm patches that causes android boot issue in SRIOV mode.

Tests done:
- caas boot in GVT-d and SRIOV mode
- aaos boot in GVT-d and SRIOV mode
- dGPU GVT-d boot
- Wi-Fi, Bluetooth on/off/connect/disconnect
- adb reboot
- adb remount
- CtsDeqpTestCases with 0 failures in GVT-d mode

Tracked-On: OAM-123080