### PR TITLE
Fix crashes in Webview Browser during MonkeyTest

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Browser2/0001-Fix-crashes-in-Webview-Browser-during-MonkeyTest.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Browser2/0001-Fix-crashes-in-Webview-Browser-during-MonkeyTest.patch
@@ -1,0 +1,36 @@
+From 3ef99242c9f0a9e87f04744cedcc9f16aaabea13 Mon Sep 17 00:00:00 2001
+From: Salini Venate <salini.venate@intel.com>
+Date: Tue, 27 Feb 2024 09:29:30 +0530
+Subject: [PATCH] Fix crashes in Webview Browser during MonkeyTest
+
+Getting below crash when running monkey test-:
+1) java.lang.RuntimeException: StrictMode ThreadPolicy violation
+   Caused by: android.os.strictmode.DiskReadViolation
+2) java.lang.RuntimeException: StrictMode ThreadPolicy violation
+   Caused by: android.os.strictmode.UnbufferedIoViolation
+
+Allow DiskRead and UnbufferedIo in StrictMode builder.
+
+Tracked-On: OAM-123134
+Signed-off-by: Salini Venate <salini.venate@intel.com>
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ src/org/chromium/webview_shell/WebViewBrowserActivity.java | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/org/chromium/webview_shell/WebViewBrowserActivity.java b/src/org/chromium/webview_shell/WebViewBrowserActivity.java
+index d39db6a..c8e95ab 100644
+--- a/src/org/chromium/webview_shell/WebViewBrowserActivity.java
++++ b/src/org/chromium/webview_shell/WebViewBrowserActivity.java
+@@ -243,6 +243,8 @@ public class WebViewBrowserActivity extends Activity implements PopupMenu.OnMenu
+ 
+         StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder()
+                 .detectAll()
++                .permitDiskReads()
++                .permitUnbufferedIo()
+                 .penaltyLog()
+                 .penaltyDeath()
+                 .build());
+-- 
+2.34.1
+


### PR DESCRIPTION
Getting below crash when running monkey test-:
1) java.lang.RuntimeException: StrictMode ThreadPolicy violation
   Caused by: android.os.strictmode.DiskReadViolation
2) java.lang.RuntimeException: StrictMode ThreadPolicy violation
   Caused by: android.os.strictmode.UnbufferedIoViolation

Allow DiskRead and UnbufferedIo in StrictMode builder.

Tracked-On: OAM-123134