### PR TITLE
Fixed for crash in Gallery during monkey test.

### DIFF
--- a/aosp_diff/preliminary/packages/apps/Gallery2/0002-Fixed-for-crash-in-Gallery-during-monkey-test.patch
+++ b/aosp_diff/preliminary/packages/apps/Gallery2/0002-Fixed-for-crash-in-Gallery-during-monkey-test.patch
@@ -1,0 +1,194 @@
+From e4a2d22324792b43164398476877e1cbf231b9ff Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Thu, 17 Aug 2023 19:22:55 +0530
+Subject: [PATCH] Fixed for crash in Gallery during monkey test.
+
+Fragment Activity does not support action bar by default. Adding
+toolbar in layout to create custom action bar.
+
+Crash log snippet looks like below:
+java.lang.NullPointerException: Attempt to invoke virtual method
+'void android.app.ActionBar.setDisplayOptions(int)' on a null object reference
+at com.android.gallery3d.filtershow.FilterShowActivity.loadXML(FilterShowActivity.java:352)
+
+Test: run monkey test, no crash happen.
+
+Tracked-On: OAM-122773
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ res/layout-land/filtershow_activity.xml       | 11 +++++--
+ res/layout/crop_activity.xml                  | 10 ++++++-
+ res/layout/filtershow_activity.xml            | 10 ++++++-
+ .../filtershow/FilterShowActivity.java        | 29 +++++++++++--------
+ .../filtershow/crop/CropActivity.java         |  3 ++
+ 5 files changed, 47 insertions(+), 16 deletions(-)
+
+diff --git a/res/layout-land/filtershow_activity.xml b/res/layout-land/filtershow_activity.xml
+index f4380126e..38984aa1d 100644
+--- a/res/layout-land/filtershow_activity.xml
++++ b/res/layout-land/filtershow_activity.xml
+@@ -19,7 +19,8 @@
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:id="@+id/mainView"
+-             android:background="@drawable/filtershow_tiled_background">
++             android:background="@drawable/filtershow_tiled_background"
++             xmlns:app="http://schemas.android.com/apk/res-auto">
+ 
+     <LinearLayout
+             android:layout_width="match_parent"
+@@ -27,7 +28,6 @@
+             android:orientation="horizontal"
+             android:animateLayoutChanges="true">
+ 
+-
+         <FrameLayout
+                 android:layout_width="wrap_content"
+                 android:layout_height="match_parent"
+@@ -95,10 +95,17 @@
+                 android:orientation="vertical"
+                 android:animateLayoutChanges="true">
+ 
++            <Toolbar
++                android:id="@+id/my_toolbar"
++                android:layout_width="match_parent"
++                android:layout_height="wrap_content"
++                android:minHeight="?android:attr/actionBarSize"/>
++
+             <FrameLayout
+                     android:id="@+id/main_panel_container"
+                     android:layout_width="350dip"
+                     android:layout_height="0dip"
++                    android:layout_below="@id/my_toolbar"
+                     android:layout_weight="1"/>
+ 
+         </LinearLayout>
+diff --git a/res/layout/crop_activity.xml b/res/layout/crop_activity.xml
+index 0620cf4d9..5d72f686b 100644
+--- a/res/layout/crop_activity.xml
++++ b/res/layout/crop_activity.xml
+@@ -18,7 +18,8 @@
+ <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+     android:layout_width="match_parent"
+     android:layout_height="match_parent"
+-    android:id="@+id/mainView">
++    android:id="@+id/mainView"
++    xmlns:app="http://schemas.android.com/apk/res-auto">
+ 
+     <LinearLayout
+         android:id="@+id/mainPanel"
+@@ -27,9 +28,16 @@
+         android:layout_weight="1"
+         android:orientation="vertical" >
+ 
++        <Toolbar
++            android:id="@+id/my_toolbar"
++            android:layout_width="match_parent"
++            android:layout_height="wrap_content"
++            android:minHeight="?android:attr/actionBarSize"/>
++
+         <FrameLayout
+             android:layout_width="match_parent"
+             android:layout_height="wrap_content"
++            android:layout_below="@id/my_toolbar"
+             android:layout_weight="1" >
+ 
+             <com.android.gallery3d.filtershow.crop.CropView
+diff --git a/res/layout/filtershow_activity.xml b/res/layout/filtershow_activity.xml
+index 79c315b7b..10c57818e 100644
+--- a/res/layout/filtershow_activity.xml
++++ b/res/layout/filtershow_activity.xml
+@@ -19,11 +19,19 @@
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:id="@+id/mainView"
+-             android:background="@drawable/filtershow_tiled_background">
++             android:background="@drawable/filtershow_tiled_background"
++             xmlns:app="http://schemas.android.com/apk/res-auto">
++
++    <Toolbar
++            android:id="@+id/my_toolbar"
++            android:layout_width="match_parent"
++            android:layout_height="wrap_content"
++            android:minHeight="?android:attr/actionBarSize"/>
+ 
+     <LinearLayout
+             android:layout_width="match_parent"
+             android:layout_height="match_parent"
++            android:layout_below="@id/my_toolbar"
+             android:orientation="vertical">
+ 
+         <FrameLayout
+diff --git a/src/com/android/gallery3d/filtershow/FilterShowActivity.java b/src/com/android/gallery3d/filtershow/FilterShowActivity.java
+index 4542c1972..d07a01d13 100644
+--- a/src/com/android/gallery3d/filtershow/FilterShowActivity.java
++++ b/src/com/android/gallery3d/filtershow/FilterShowActivity.java
+@@ -65,6 +65,7 @@ import android.widget.ShareActionProvider;
+ import android.widget.ShareActionProvider.OnShareTargetSelectedListener;
+ import android.widget.Spinner;
+ import android.widget.Toast;
++import android.widget.Toolbar;
+ 
+ import com.android.gallery3d.R;
+ import com.android.gallery3d.app.PhotoPage;
+@@ -348,19 +349,23 @@ public class FilterShowActivity extends FragmentActivity implements OnItemClickL
+     private void loadXML() {
+         setContentView(R.layout.filtershow_activity);
+ 
++        Toolbar myToolbar = findViewById(R.id.my_toolbar);
++        setActionBar(myToolbar);
+         ActionBar actionBar = getActionBar();
+-        actionBar.setDisplayOptions(ActionBar.DISPLAY_SHOW_CUSTOM);
+-        actionBar.setCustomView(R.layout.filtershow_actionbar);
+-        actionBar.setBackgroundDrawable(new ColorDrawable(
+-                getResources().getColor(R.color.background_screen)));
+-
+-        mSaveButton = actionBar.getCustomView();
+-        mSaveButton.setOnClickListener(new OnClickListener() {
+-            @Override
+-            public void onClick(View view) {
+-                saveImage();
+-            }
+-        });
++        if(actionBar != null) {
++            actionBar.setDisplayOptions(ActionBar.DISPLAY_SHOW_CUSTOM);
++            actionBar.setCustomView(R.layout.filtershow_actionbar);
++            actionBar.setBackgroundDrawable(new ColorDrawable(
++                    getResources().getColor(R.color.background_screen)));
++
++            mSaveButton = actionBar.getCustomView();
++            mSaveButton.setOnClickListener(new OnClickListener() {
++                @Override
++                public void onClick(View view) {
++                    saveImage();
++                }
++            });
++        }
+ 
+         mImageShow = (ImageShow) findViewById(R.id.imageShow);
+         mImageViews.add(mImageShow);
+diff --git a/src/com/android/gallery3d/filtershow/crop/CropActivity.java b/src/com/android/gallery3d/filtershow/crop/CropActivity.java
+index 3a7829681..1552b15c2 100644
+--- a/src/com/android/gallery3d/filtershow/crop/CropActivity.java
++++ b/src/com/android/gallery3d/filtershow/crop/CropActivity.java
+@@ -41,6 +41,7 @@ import android.view.View;
+ import android.view.View.OnClickListener;
+ import android.view.WindowManager;
+ import android.widget.Toast;
++import android.widget.Toolbar;
+ 
+ import com.android.gallery3d.R;
+ import com.android.gallery3d.common.Utils;
+@@ -105,6 +106,8 @@ public class CropActivity extends Activity {
+         setContentView(R.layout.crop_activity);
+         mCropView = (CropView) findViewById(R.id.cropView);
+ 
++        Toolbar myToolbar = findViewById(R.id.my_toolbar);
++        setActionBar(myToolbar);
+         ActionBar actionBar = getActionBar();
+         if (actionBar != null) {
+             actionBar.setDisplayOptions(ActionBar.DISPLAY_SHOW_CUSTOM);
+-- 
+2.34.1
+


### PR DESCRIPTION
Fragment Activity does not support action bar by default. Adding toolbar in layout to create custom action bar.

Crash log snippet looks like below:
java.lang.NullPointerException: Attempt to invoke virtual method 'void android.app.ActionBar.setDisplayOptions(int)' on a null object reference at com.android.gallery3d.filtershow.FilterShowActivity.loadXML(FilterShowActivity.java:352)

Tracked-On: OAM-122773