### PR TITLE
Disable VP9 HDR support by default

### DIFF
--- a/aosp_diff/preliminary/frameworks/av/0009-By-default-disable-HDR-support-for-VP9-codec.patch
+++ b/aosp_diff/preliminary/frameworks/av/0009-By-default-disable-HDR-support-for-VP9-codec.patch
@@ -1,0 +1,32 @@
+From 695fa89a4552a52498e92151440848aa4a968eed Mon Sep 17 00:00:00 2001
+From: Lina Sun <lina.sun@intel.com>
+Date: Mon, 29 Jul 2024 08:06:16 +0000
+Subject: [PATCH] By default disable HDR support for VP9 codec
+
+The change is because current mediasdk_c2 doesn't support HDR for
+VP9 codec, but in framework VP9 HDR is supported by default.
+
+Will need to remove this patch when VP9 is supported in
+mediasdk_c2.
+---
+ media/codec2/sfplugin/Codec2InfoBuilder.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/media/codec2/sfplugin/Codec2InfoBuilder.cpp b/media/codec2/sfplugin/Codec2InfoBuilder.cpp
+index 453a0d2f59..3e00dc5ee5 100644
+--- a/media/codec2/sfplugin/Codec2InfoBuilder.cpp
++++ b/media/codec2/sfplugin/Codec2InfoBuilder.cpp
+@@ -154,7 +154,9 @@ bool addSupportedProfileLevels(
+     // VP9 does not support HDR metadata in the bitstream and static metadata
+     // can always be carried by the framework. (The framework does not propagate
+     // dynamic metadata as that needs to be frame accurate.)
+-    supportsHdr |= (mediaType == MIMETYPE_VIDEO_VP9);
++    // TODO: comment out this line for now as VP9 HDR is not supported in SDK yet
++    // will need uncomment it when adding VP9 HDR support in SDK.
++    //supportsHdr |= (mediaType == MIMETYPE_VIDEO_VP9);
+ 
+     // HDR support implies 10-bit support. AV1 codecs are also required to
+     // support 10-bit per CDD.
+-- 
+2.34.1
+


### PR DESCRIPTION
Currently VP9 HDR is not supported in mediasdk_c2, but in framework VP9 HDR is set to supported by default and caused some cts tests run failed.

Will need to revert this patch when VP9 HDR support is added in mediasdk_c2.

Tracked-On: OAM-122909