### PR TITLE
AAOS14 does not support 32bit any more. So change hwcodec2.0 to 64bit.

### DIFF
--- a/bsp_diff/caas/device/intel/mixins/0005-Remove-omx-interface-in-AAOS14.patch
+++ b/bsp_diff/caas/device/intel/mixins/0005-Remove-omx-interface-in-AAOS14.patch
@@ -1,0 +1,38 @@
+From 2c38b97b3072872044ea6324f7895b27a52c03b6 Mon Sep 17 00:00:00 2001
+From: "Shi, Qiming" <qiming.shi@intel.com>
+Date: Fri, 2 Aug 2024 04:43:58 +0000
+Subject: [PATCH] Remove omx interface in AAOS14
+
+Change-Id: Iae2ed19f2f1ffb3e3f3b2f384a0e3c01ed4e3599
+Signed-off-by: Shi, Qiming <qiming.shi@intel.com>
+---
+ groups/device-specific/caas/framework_manifest.xml | 13 -------------
+ 1 file changed, 13 deletions(-)
+
+diff --git a/groups/device-specific/caas/framework_manifest.xml b/groups/device-specific/caas/framework_manifest.xml
+index 055afcd..851c120 100644
+--- a/groups/device-specific/caas/framework_manifest.xml
++++ b/groups/device-specific/caas/framework_manifest.xml
+@@ -97,19 +97,6 @@
+             <instance>default</instance>
+         </interface>
+     </hal>
+-    <hal format="hidl">
+-        <name>android.hardware.media.omx</name>
+-        <transport>hwbinder</transport>
+-        <version>1.0</version>
+-        <interface>
+-            <name>IOmx</name>
+-            <instance>default</instance>
+-        </interface>
+-        <interface>
+-            <name>IOmxStore</name>
+-            <instance>default</instance>
+-        </interface>
+-    </hal>
+     <!--hal format="hidl">
+         <name>android.hardware.drm</name>
+         <transport>hwbinder</transport>
+-- 
+2.34.1
+

--- a/bsp_diff/caas/vendor/intel/mediasdk_c2/0001-Make-c2-service-64bit.patch
+++ b/bsp_diff/caas/vendor/intel/mediasdk_c2/0001-Make-c2-service-64bit.patch
@@ -1,0 +1,25 @@
+From 92c267cb68772ad90abba41a8617acf14a74ff46 Mon Sep 17 00:00:00 2001
+From: "Shi, Qiming" <qiming.shi@intel.com>
+Date: Fri, 2 Aug 2024 05:06:13 +0000
+Subject: [PATCH] Make c2 service 64bit
+
+Signed-off-by: Shi, Qiming <qiming.shi@intel.com>
+---
+ c2_store/Android.bp | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/c2_store/Android.bp b/c2_store/Android.bp
+index 64c044e..9926ea9 100644
+--- a/c2_store/Android.bp
++++ b/c2_store/Android.bp
+@@ -63,7 +63,6 @@ cc_binary {
+ 
+     required: ["android.hardware.media.c2@1.0-vendor.policy"],
+ 
+-    compile_multilib: "32",
+ }
+ 
+ prebuilt_etc {
+-- 
+2.34.1
+


### PR DESCRIPTION
Remove obsolete omx interface declaration in manifest file

Test Done: Build and boot successfully.
	sdcard file pushing supporting.

Tracked-On: OAM-123433