### PR TITLE
Skip print job if print feature is not defined

### DIFF
--- a/aosp_diff/aaos_iasw/packages/services/BuiltInPrintService/0001-Skip-print-job-if-print-feature-is-not-defined.patch
+++ b/aosp_diff/aaos_iasw/packages/services/BuiltInPrintService/0001-Skip-print-job-if-print-feature-is-not-defined.patch
@@ -1,0 +1,41 @@
+From 48ba1532a69d4f867a996d464ee89addfba930ed Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Mon, 19 Aug 2024 14:35:57 +0800
+Subject: [PATCH] Skip print job if print feature is not defined
+
+System doesn't enabel the feature "android.software.print",
+so we skip the print job.
+
+Test: run monkey test, no crash happen
+
+Tracked-On: OAM-123126
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ src/com/android/bips/ImagePrintActivity.java | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/bips/ImagePrintActivity.java b/src/com/android/bips/ImagePrintActivity.java
+index 75e4d2f..5ff35a8 100644
+--- a/src/com/android/bips/ImagePrintActivity.java
++++ b/src/com/android/bips/ImagePrintActivity.java
+@@ -19,6 +19,7 @@ package com.android.bips;
+ import android.app.Activity;
+ import android.content.Context;
+ import android.content.Intent;
++import android.content.pm.PackageManager;
+ import android.graphics.Bitmap;
+ import android.graphics.BitmapFactory;
+ import android.graphics.Canvas;
+@@ -145,7 +146,8 @@ public class ImagePrintActivity extends Activity {
+             boolean isPortrait = values[0];
+             if (DEBUG) Log.d(TAG, "startPrint(portrait=" + isPortrait + ")");
+             PrintManager printManager = (PrintManager) getSystemService(Context.PRINT_SERVICE);
+-            if (printManager == null) {
++            boolean isSupportPrinting = getPackageManager().hasSystemFeature("android.software.print");
++            if (printManager == null || !isSupportPrinting) {
+                 finish();
+                 return;
+             }
+-- 
+2.34.1
+


### PR DESCRIPTION
System doesn't enabel the feature "android.software.print", so we skip the print job.

Test: run monkey test, no crash happen

Tracked-On: OAM-123126