### PR TITLE
Fix metadata issue when reconnect pixel

### DIFF
--- a/aosp_diff/base_aaos/packages/modules/Bluetooth/0002-Fix-metadata-issue-when-reconnect-pixel.patch
+++ b/aosp_diff/base_aaos/packages/modules/Bluetooth/0002-Fix-metadata-issue-when-reconnect-pixel.patch
@@ -1,0 +1,51 @@
+From e90398f298828ef752e3fafbb94ee3375905b923 Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Tue, 20 Aug 2024 22:32:22 +0530
+Subject: [PATCH] Fix metadata issue when reconnect pixel
+
+When reconnecting pixel some times metadata is not synced.
+bt-stack issuing two AVRC browse channel, one as acceptor,
+other as initiator, which is causing collision in lcid and resulting
+in l2cap disconnection of avrc browse channel, resulting in metadata
+sync issue.
+
+Don't initiate avrc browse channel as initiator, open only
+as acceptor. Now browse channel is always success and metadata is
+seen everytime.
+
+Tests-done:
+1. Flash BM
+2. Connect Pixel
+3. Play Music and do adb reboot
+4. Everytime the metadata should sync on home screen
+5. Trail 20 times
+
+Tracked-On: OAM-123252
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ system/bta/av/bta_av_act.cc | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/system/bta/av/bta_av_act.cc b/system/bta/av/bta_av_act.cc
+index c639502852..9db796164f 100644
+--- a/system/bta/av/bta_av_act.cc
++++ b/system/bta/av/bta_av_act.cc
+@@ -587,8 +587,13 @@ void bta_av_rc_opened(tBTA_AV_CB* p_cb, tBTA_AV_DATA* p_data) {
+   if ((p_cb->features & BTA_AV_FEAT_BROWSE) &&
+       (rc_open.peer_features & BTA_AV_FEAT_BROWSE) &&
+       ((p_cb->rcb[i].status & BTA_AV_RC_ROLE_MASK) == BTA_AV_RC_ROLE_INT)) {
+-    APPL_TRACE_DEBUG("%s: opening AVRC Browse channel", __func__);
+-    AVRC_OpenBrowse(p_data->rc_conn_chg.handle, AVCT_INT);
++    APPL_TRACE_DEBUG("%s: Not opening AVRC Browse channel as INT", __func__);
++    /* Commenting the below line as for IVI use case, for A2DP SNK, we dont
++     * support browsing channel. So no need to open browsing channel as
++     * INITIATOR. Revert this when have logic to resolve this conflict in
++     * stack/avct.
++     */
++    //AVRC_OpenBrowse(p_data->rc_conn_chg.handle, AVCT_INT);
+   }
+ }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
When reconnecting pixel some times metadata is not synced. bt-stack issuing two AVRC browse channel, one as acceptor, other as initator, which is causing collision in lcid and resulting in l2cap disconnection of avrc browse channel, resulting in metadata sync issue.

Don't initiate avrc browse channel as initiator, open only as acceptor. Now browse channel is always success and metadata is seen everytime.

Tests-done:
1. Flash BM
2. Connect Pixel
3. Play Music and do adb reboot
4. Everytime the metadata should sync on home screen
5. Trail 20 times

Tracked-On: OAM-123252