### PR TITLE
Allow modification of Vehicle HAL properties.

### DIFF
--- a/aosp_diff/base_aaos/hardware/interfaces/0001-Allow-modification-of-Vehicle-HAL-properties.patch
+++ b/aosp_diff/base_aaos/hardware/interfaces/0001-Allow-modification-of-Vehicle-HAL-properties.patch
@@ -1,0 +1,64 @@
+From 0c46aa24f341248888daeb56e222d814d8a72e69 Mon Sep 17 00:00:00 2001
+From: Vilas R K <vilas.r.k@intel.com>
+Date: Mon, 26 Aug 2024 10:31:37 +0530
+Subject: [PATCH] Allow modification of Vehicle HAL properties.
+
+- When "persist.vendor.emulate.vehiclehal" is set to false, the code
+checks the access permissions. If the property does not have write
+access, it returns an ACCESS_DENIED status.
+
+- When persist.vendor.emulate.vehiclehal is set to true, the code
+allows writing to Vehicle HAL properties.
+
+Test
+  Ex: adb shell setprop persist.vendor.emulate.vehiclehal true
+      dumpsys car_service set-property-value <prop-Id> <area Id> value.
+      dumpsys car_service set-property-value 0x11400400 0x11400400 4
+
+Signed-off-by: Vilas R K <vilas.r.k@intel.com>
+---
+ .../aidl/impl/vhal/src/DefaultVehicleHal.cpp  | 19 ++++++++++++++-----
+ 1 file changed, 14 insertions(+), 5 deletions(-)
+
+diff --git a/automotive/vehicle/aidl/impl/vhal/src/DefaultVehicleHal.cpp b/automotive/vehicle/aidl/impl/vhal/src/DefaultVehicleHal.cpp
+index 0d5c070c54..ef9c2f160b 100644
+--- a/automotive/vehicle/aidl/impl/vhal/src/DefaultVehicleHal.cpp
++++ b/automotive/vehicle/aidl/impl/vhal/src/DefaultVehicleHal.cpp
+@@ -31,6 +31,8 @@
+ #include <utils/SystemClock.h>
+ #include <utils/Trace.h>
+ 
++#include <cutils/properties.h>
++
+ #include <inttypes.h>
+ #include <set>
+ #include <unordered_set>
+@@ -752,13 +754,20 @@ VhalResult<void> DefaultVehicleHal::checkWritePermission(const VehiclePropValue&
+     if (!result.ok()) {
+         return StatusError(StatusCode::INVALID_ARG) << getErrorMsg(result);
+     }
+-    const VehiclePropConfig* config = result.value();
++    if(!property_get_bool("persist.vendor.emulate.vehiclehal", false)) {
++        ALOGE("Vehicle HAL Properties  Not allowed to write");
++        const VehiclePropConfig* config = result.value();
+ 
+-    if (config->access != VehiclePropertyAccess::WRITE &&
+-        config->access != VehiclePropertyAccess::READ_WRITE) {
+-        return StatusError(StatusCode::ACCESS_DENIED)
+-               << StringPrintf("Property %" PRId32 " has no write access", propId);
++        if (config->access != VehiclePropertyAccess::WRITE &&
++            config->access != VehiclePropertyAccess::READ_WRITE) {
++            return StatusError(StatusCode::ACCESS_DENIED)
++                << StringPrintf("Property %" PRId32 " has no write access", propId);
++        }
+     }
++    else {
++        ALOGE("Vehicle HAL Properties allowd to write");
++    }
++
+     return {};
+ }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
- When "persist.vendor.emulate.vehiclehal" is set to false, the code checks the access permissions. If the property does not have write access, it returns an ACCESS_DENIED status.

- When persist.vendor.emulate.vehiclehal is set to true, the code allows writing to Vehicle HAL properties.

Test
  Ex: adb shell setprop persist.vendor.emulate.vehiclehal true dumpsys car_service set-property-value <prop-Id> <area Id> value. dumpsys car_service set-property-value 0x11400400 0x11400400 4

Tracked-On: OAM-123892