### PR TITLE
 Removed DocumentsUIStub and DocumentsUIStubWithResult

### DIFF
--- a/aosp_diff/base_aaos/packages/services/Car/0001-Removed-DocumentsUIStub-and-DocumentsUIStubWithResul.patch
+++ b/aosp_diff/base_aaos/packages/services/Car/0001-Removed-DocumentsUIStub-and-DocumentsUIStubWithResul.patch
@@ -1,0 +1,93 @@
+From f9226d5c5fb4cde5c1863a53096d40d27123897f Mon Sep 17 00:00:00 2001
+From: RaghulXRamar <raghulx.ramar@gmail.com>
+Date: Mon, 2 Sep 2024 11:46:55 +0000
+Subject: [PATCH] Removed DocumentsUIStub and DocumentsUIStubWithResult
+
+Fix for android.permission.cts.ProviderPermissionTest#testManageDocuments
+
+Only 1 package is allowed to implement/enable these intents.
+Currently, it is in "com.android.car.frameworkpackagestubs" and "com.android.documentsui"
+
+Removing from frameworkpackagestubs since we are having file management enabled.
+
+Tracked-On: OAM-121898
+Signed-off-by: RaghulXRamar <raghulx.ramar@intel.com>
+---
+ FrameworkPackageStubs/AndroidManifest.xml | 62 -----------------------
+ 1 file changed, 62 deletions(-)
+
+diff --git a/FrameworkPackageStubs/AndroidManifest.xml b/FrameworkPackageStubs/AndroidManifest.xml
+index 9317d21637..8f41ab2a08 100644
+--- a/FrameworkPackageStubs/AndroidManifest.xml
++++ b/FrameworkPackageStubs/AndroidManifest.xml
+@@ -265,67 +265,5 @@
+                 <data android:mimeType="vnd.android.cursor.dir/contact"/>
+             </intent-filter>
+         </activity>
+-
+-        <!-- DocumentsUI stub to handle app file access requests.
+-             For devices planning to properly support File Management,
+-             DocumentsUIStubWithResult & DocumentsUIStub should be removed. -->
+-        <activity
+-            android:name=".Stubs$DocumentsUIStubWithResult"
+-            android:label="@string/stub_name"
+-            android:excludeFromRecents="true"
+-            android:visibleToInstantApps="true"
+-            android:exported="true">
+-            <!-- .picker.PickActivity
+-                 set android:priority="101" to avoid other apps to take the priority,
+-                 and in case of conflicting with DocumentsUI's 100. -->
+-            <intent-filter android:priority="101">
+-                <action android:name="android.intent.action.OPEN_DOCUMENT" />
+-                <category android:name="android.intent.category.DEFAULT" />
+-                <category android:name="android.intent.category.OPENABLE" />
+-                <data android:mimeType="*/*" />
+-            </intent-filter>
+-            <intent-filter android:priority="101">
+-                <action android:name="android.intent.action.CREATE_DOCUMENT" />
+-                <category android:name="android.intent.category.DEFAULT" />
+-                <category android:name="android.intent.category.OPENABLE" />
+-                <data android:mimeType="*/*" />
+-            </intent-filter>
+-            <intent-filter android:priority="101">
+-                <action android:name="android.intent.action.GET_CONTENT" />
+-                <category android:name="android.intent.category.DEFAULT" />
+-                <category android:name="android.intent.category.OPENABLE" />
+-                <data android:mimeType="*/*" />
+-            </intent-filter>
+-            <intent-filter android:priority="101">
+-                <action android:name="android.intent.action.OPEN_DOCUMENT_TREE" />
+-                <category android:name="android.intent.category.DEFAULT" />
+-            </intent-filter>
+-        </activity>
+-
+-        <activity
+-            android:name=".Stubs$DocumentsUIStub"
+-            android:label="@string/stub_name"
+-            android:excludeFromRecents="true"
+-            android:exported="true">
+-            <!-- .files.FilesActivity
+-                 For VIEW actions, ComponentResolver always adjustPriority to 0. -->
+-            <intent-filter>
+-                <action android:name="android.intent.action.VIEW" />
+-                <category android:name="android.intent.category.DEFAULT" />
+-                <data android:mimeType="vnd.android.document/root" />
+-            </intent-filter>
+-            <intent-filter>
+-                <action android:name="android.intent.action.VIEW" />
+-                <category android:name="android.intent.category.DEFAULT" />
+-                <data android:mimeType="vnd.android.document/directory" />
+-            </intent-filter>
+-            <!-- .ViewDownloadsActivity
+-                 Set android:priority="101" to avoid other apps to take the priority,
+-                 nor conflicting with DocumentsUI's 0. -->
+-            <intent-filter android:priority="101">
+-                <action android:name="android.intent.action.VIEW_DOWNLOADS" />
+-                <category android:name="android.intent.category.DEFAULT" />
+-            </intent-filter>
+-        </activity>
+     </application>
+ </manifest>
+-- 
+2.34.1
+


### PR DESCRIPTION
Fix for android.permission.cts.ProviderPermissionTest#testManageDocuments

Only 1 package is allowed to implement/enable these intents. Currently, it is in "com.android.car.frameworkpackagestubs" and "com.android.documentsui"

Removing from frameworkpackagestubs since we are having file management enabled.

Tracked-On: OAM-121898