### PR TITLE
Fix for coverity issue for memtrack_module

### DIFF
--- a/aosp_diff/preliminary/hardware/interfaces/15_0015-Fix-for-coverity-issue-for-memtrack_module.patch
+++ b/aosp_diff/preliminary/hardware/interfaces/15_0015-Fix-for-coverity-issue-for-memtrack_module.patch
@@ -1,0 +1,32 @@
+From 7712038563e5463392f7805385f9fe4f3192a1e0 Mon Sep 17 00:00:00 2001
+From: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+Date: Thu, 5 Sep 2024 04:15:29 +0000
+Subject: [PATCH] Fix for coverity issue for memtrack_module
+
+The memtrack_module variable was going out of scope and
+function was exiting without freeing it. Free memtrack_module
+if return nullptr.
+
+Tests Done: Build and boot.
+
+Tracked-On: OAM-122303
+Signed-off-by: Tanuj Tekriwal <tanuj.tekriwal@intel.com>
+---
+ memtrack/aidl/default/Memtrack.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/memtrack/aidl/default/Memtrack.cpp b/memtrack/aidl/default/Memtrack.cpp
+index dbf9a5cc92..8b4a58cf23 100644
+--- a/memtrack/aidl/default/Memtrack.cpp
++++ b/memtrack/aidl/default/Memtrack.cpp
+@@ -99,6 +99,7 @@ memtrack_module_t* AIDL_FETCH_IMemtrack(const char* /* name */) {
+                 reinterpret_cast<hw_device_t**>(reinterpret_cast<memtrack_module_t**>(&memtrack_module)));
+         if (err) {
+             ALOGE("Passthrough failed to load legacy HAL.");
++            free(memtrack_module);
+             return nullptr;
+         }
+     }
+-- 
+2.34.1
+


### PR DESCRIPTION
The memtrack_module variable was going out of scope and function was exiting without freeing it. Free memtrack_module if return nullptr.

Tests Done: Build and boot.

Tracked-On: OAM-122303