### PR TITLE
Fix error when playback can't be resumed on LocalMediaPlayer

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Car/LocalMediaPlayer/0001-Fix-error-when-playback-can-t-be-resumed-on-LocalMed.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Car/LocalMediaPlayer/0001-Fix-error-when-playback-can-t-be-resumed-on-LocalMed.patch
@@ -1,0 +1,45 @@
+From 2df55c363762dd39dd3d0dcda88c399604938d94 Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Mon, 9 Sep 2024 05:50:50 +0800
+Subject: [PATCH] Fix error when playback can't be resumed on LocalMediaPlayer
+
+Do not check permission during playback every time, permissions
+have been checked when APP start, and system don't pregrant
+some permissions for LocalMediaPlayer, can't resume playback
+if the permission check failed.
+
+Test: play music on LocalMediaPlayer then pause and resume.
+
+Tracked-On: OAM-123021
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ .../android/car/media/localmediaplayer/Player.java   | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/src/com/android/car/media/localmediaplayer/Player.java b/src/com/android/car/media/localmediaplayer/Player.java
+index 5c5cab2..bb4b621 100644
+--- a/src/com/android/car/media/localmediaplayer/Player.java
++++ b/src/com/android/car/media/localmediaplayer/Player.java
+@@ -177,12 +177,14 @@ public class Player extends MediaSession.Callback {
+         if (Log.isLoggable(TAG, Log.DEBUG)) {
+             Log.d(TAG, "onPlay");
+         }
++
++        requestAudioFocus(() -> resumePlayback());
+         // Check permissions every time we try to play
+-        if (!Utils.hasRequiredPermissions(mContext)) {
+-            setMissingPermissionError();
+-        } else {
+-            requestAudioFocus(() -> resumePlayback());
+-        }
++        //if (!Utils.hasRequiredPermissions(mContext)) {
++        //    setMissingPermissionError();
++        //} else {
++        //    requestAudioFocus(() -> resumePlayback());
++        //}
+     }
+ 
+     @Override
+-- 
+2.34.1
+


### PR DESCRIPTION
Do not check permission during playback every time, permissions have been checked when APP start, and system don't pregrant some permissions for LocalMediaPlayer, can't resume playback if the permission check failed.

Test: play music on LocalMediaPlayer then pause and resume.

Tracked-On: OAM-123021