### PR TITLE
fix for OTA update through script failure

### DIFF
--- a/bsp_diff/base_aaos/device/intel/sepolicy/0006-fix-for-OTA-update-through-script-failure.patch
+++ b/bsp_diff/base_aaos/device/intel/sepolicy/0006-fix-for-OTA-update-through-script-failure.patch
@@ -1,0 +1,31 @@
+From 4e9c7a23553edadd83b730c296d8ca78e9f5e31e Mon Sep 17 00:00:00 2001
+From: "Unnithan, Balakrishnan" <balakrishnan.unnithan@intel.com>
+Date: Thu, 12 Sep 2024 16:35:48 +0530
+Subject: [PATCH] fix for OTA update through script failure
+
+OTA update was failing due to sepolicy permission denial.
+added sepolicy to read-write in tmpfs block file.
+
+Tests done: Run command ./update_device.py caas-ota-CR0000094.zip
+
+Tracked-On: OAM-123102
+Signed-off-by: Unnithan, Balakrishnan <balakrishnan.unnithan@intel.com>
+---
+ abota/generic/update_engine.te | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/abota/generic/update_engine.te b/abota/generic/update_engine.te
+index bbc7000..755c431 100644
+--- a/abota/generic/update_engine.te
++++ b/abota/generic/update_engine.te
+@@ -6,6 +6,7 @@ allow update_engine acpio_block_device:blk_file rw_file_perms;
+ allow update_engine tmpfs:dir r_dir_perms;
+ allow update_engine tmpfs:file r_file_perms;
+ allow update_engine tmpfs:lnk_file r_file_perms;
++allow update_engine tmpfs:blk_file rw_file_perms;
+ 
+ allow update_engine platform_app:binder call;
+ allow update_engine vfat:dir search;
+-- 
+2.25.1
+


### PR DESCRIPTION
OTA update was failing due to sepolicy permission denial. added sepolicy to read-write in tmpfs block file.

Tests done: Run command ./update_device.py caas-ota-CR0000094.zip

Tracked-On: OAM-123102