### PR TITLE
fix for OTA update through script failure

### DIFF
--- a/aosp_diff/caas/system/sepolicy/0001-fix-for-OTA-update-through-script-failure-1.patch
+++ b/aosp_diff/caas/system/sepolicy/0001-fix-for-OTA-update-through-script-failure-1.patch
@@ -1,0 +1,117 @@
+From fa9bda163d16291ed80ce24757913a2558e0289f Mon Sep 17 00:00:00 2001
+From: "Unnithan, Balakrishnan" <balakrishnan.unnithan@intel.com>
+Date: Wed, 18 Sep 2024 11:41:20 +0530
+Subject: [PATCH] fix for OTA update through script failure-1
+
+OTA update was failing due to sepolicy permission denial.
+
+Added sepolicy to open-read-write block-device block-file.
+
+Tests done: Run command ./update_device.py caas-ota-CR0000094.zip
+
+Tracked-On: OAM-123102
+Signed-off-by: Unnithan, Balakrishnan <balakrishnan.unnithan@intel.com>
+---
+ prebuilts/api/29.0/public/domain.te | 2 +-
+ prebuilts/api/30.0/public/domain.te | 2 +-
+ prebuilts/api/31.0/public/domain.te | 2 +-
+ prebuilts/api/32.0/public/domain.te | 2 +-
+ prebuilts/api/33.0/public/domain.te | 2 +-
+ prebuilts/api/34.0/public/domain.te | 2 +-
+ public/domain.te                    | 2 +-
+ 7 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/prebuilts/api/29.0/public/domain.te b/prebuilts/api/29.0/public/domain.te
+index 1a9e0e1c2..5d1a5bcca 100644
+--- a/prebuilts/api/29.0/public/domain.te
++++ b/prebuilts/api/29.0/public/domain.te
+@@ -430,7 +430,7 @@ neverallow * vendor_init:binder *;
+ 
+ # Don't allow raw read/write/open access to block_device
+ # Rather force a relabel to a more specific type
+-neverallow { domain -kernel -init -recovery } block_device:blk_file { open read write };
++neverallow { domain -kernel -init -recovery -update_engine } block_device:blk_file { open read write };
+ 
+ # Do not allow renaming of block files or character files
+ # Ability to do so can lead to possible use in an exploit chain
+diff --git a/prebuilts/api/30.0/public/domain.te b/prebuilts/api/30.0/public/domain.te
+index c151b9528..c3553dec0 100644
+--- a/prebuilts/api/30.0/public/domain.te
++++ b/prebuilts/api/30.0/public/domain.te
+@@ -428,7 +428,7 @@ neverallow * vendor_init:binder *;
+ 
+ # Don't allow raw read/write/open access to block_device
+ # Rather force a relabel to a more specific type
+-neverallow { domain -kernel -init -recovery } block_device:blk_file { open read write };
++neverallow { domain -kernel -init -recovery -update_engine } block_device:blk_file { open read write };
+ 
+ # Do not allow renaming of block files or character files
+ # Ability to do so can lead to possible use in an exploit chain
+diff --git a/prebuilts/api/31.0/public/domain.te b/prebuilts/api/31.0/public/domain.te
+index 799a2f1c5..7bb8c1b0a 100644
+--- a/prebuilts/api/31.0/public/domain.te
++++ b/prebuilts/api/31.0/public/domain.te
+@@ -453,7 +453,7 @@ neverallow * vendor_init:binder *;
+ 
+ # Don't allow raw read/write/open access to block_device
+ # Rather force a relabel to a more specific type
+-neverallow { domain -kernel -init -recovery } block_device:blk_file { open read write };
++neverallow { domain -kernel -init -recovery -update_engine } block_device:blk_file { open read write };
+ 
+ # Do not allow renaming of block files or character files
+ # Ability to do so can lead to possible use in an exploit chain
+diff --git a/prebuilts/api/32.0/public/domain.te b/prebuilts/api/32.0/public/domain.te
+index 799a2f1c5..7bb8c1b0a 100644
+--- a/prebuilts/api/32.0/public/domain.te
++++ b/prebuilts/api/32.0/public/domain.te
+@@ -453,7 +453,7 @@ neverallow * vendor_init:binder *;
+ 
+ # Don't allow raw read/write/open access to block_device
+ # Rather force a relabel to a more specific type
+-neverallow { domain -kernel -init -recovery } block_device:blk_file { open read write };
++neverallow { domain -kernel -init -recovery -update_engine } block_device:blk_file { open read write };
+ 
+ # Do not allow renaming of block files or character files
+ # Ability to do so can lead to possible use in an exploit chain
+diff --git a/prebuilts/api/33.0/public/domain.te b/prebuilts/api/33.0/public/domain.te
+index de529f5d8..dddae1e09 100644
+--- a/prebuilts/api/33.0/public/domain.te
++++ b/prebuilts/api/33.0/public/domain.te
+@@ -460,7 +460,7 @@ neverallow * vendor_init:binder *;
+ 
+ # Don't allow raw read/write/open access to block_device
+ # Rather force a relabel to a more specific type
+-neverallow { domain -kernel -init -recovery } block_device:blk_file { open read write };
++neverallow { domain -kernel -init -recovery -update_engine } block_device:blk_file { open read write };
+ 
+ # Do not allow renaming of block files or character files
+ # Ability to do so can lead to possible use in an exploit chain
+diff --git a/prebuilts/api/34.0/public/domain.te b/prebuilts/api/34.0/public/domain.te
+index 1da3f51a9..2121877c9 100644
+--- a/prebuilts/api/34.0/public/domain.te
++++ b/prebuilts/api/34.0/public/domain.te
+@@ -435,7 +435,7 @@ neverallow * vendor_init:binder *;
+ 
+ # Don't allow raw read/write/open access to block_device
+ # Rather force a relabel to a more specific type
+-neverallow { domain -kernel -init -recovery } block_device:blk_file { open read write };
++neverallow { domain -kernel -init -recovery -update_engine } block_device:blk_file { open read write };
+ 
+ # Do not allow renaming of block files or character files
+ # Ability to do so can lead to possible use in an exploit chain
+diff --git a/public/domain.te b/public/domain.te
+index 1da3f51a9..2121877c9 100644
+--- a/public/domain.te
++++ b/public/domain.te
+@@ -435,7 +435,7 @@ neverallow * vendor_init:binder *;
+ 
+ # Don't allow raw read/write/open access to block_device
+ # Rather force a relabel to a more specific type
+-neverallow { domain -kernel -init -recovery } block_device:blk_file { open read write };
++neverallow { domain -kernel -init -recovery -update_engine } block_device:blk_file { open read write };
+ 
+ # Do not allow renaming of block files or character files
+ # Ability to do so can lead to possible use in an exploit chain
+-- 
+2.25.1
+

--- a/bsp_diff/caas/device/intel/sepolicy/0001-fix-for-OTA-update-through-script-failure-2.patch
+++ b/bsp_diff/caas/device/intel/sepolicy/0001-fix-for-OTA-update-through-script-failure-2.patch
@@ -1,0 +1,40 @@
+From 142a7c8f128cedc42e09e8d2ed080712681ce48a Mon Sep 17 00:00:00 2001
+From: "Unnithan, Balakrishnan" <balakrishnan.unnithan@intel.com>
+Date: Wed, 18 Sep 2024 11:47:28 +0530
+Subject: [PATCH] fix for OTA update through script failure-2
+
+OTA update was failing due to sepolicy permission denial.
+Added sepolicy to open-read-write block-device block- file.
+
+Tests done: Run command ./update_device.py caas-ota-CR0000094.zip
+
+Tracked-On: OAM-123102
+Signed-off-by: Unnithan, Balakrishnan <balakrishnan.unnithan@intel.com>
+---
+ abota/generic/update_engine.te | 2 ++
+ virtual_ab/update_engine.te    | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/abota/generic/update_engine.te b/abota/generic/update_engine.te
+index bbc7000..20afcb5 100644
+--- a/abota/generic/update_engine.te
++++ b/abota/generic/update_engine.te
+@@ -15,3 +15,5 @@ allow update_engine mnt_media_rw_file:dir r_dir_perms;
+ allow update_engine sdcardfs:dir search;
+ allow update_engine sdcardfs:file { read getattr open };
+ allow update_engine storage_file:dir search;
++
++allow update_engine block_device:blk_file { open read write };
+diff --git a/virtual_ab/update_engine.te b/virtual_ab/update_engine.te
+index 1cf0f9b..81c1e1e 100644
+--- a/virtual_ab/update_engine.te
++++ b/virtual_ab/update_engine.te
+@@ -2,3 +2,5 @@ allow update_engine proc_bootconfig:file r_file_perms;
+ allow update_engine vd_device:blk_file rw_file_perms;
+ allowxperm update_engine vd_device:blk_file ioctl BLKROGET;
+ allow update_engine dm_user_device:chr_file r_file_perms;
++
++allow update_engine block_device:blk_file { open read write };
+-- 
+2.25.1
+


### PR DESCRIPTION
OTA update was failing due to sepolicy permission denial. 
Added sepolicy to open-read-write block-device block- file.

Tests done: Run command ./update_device.py caas-ota-CR0000094.zip

Tracked-On: OAM-123102