### PR TITLE
Fix for default notification sound.

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/69_0069-Fix-for-default-notification-sound.patch
+++ b/aosp_diff/preliminary/frameworks/base/69_0069-Fix-for-default-notification-sound.patch
@@ -1,0 +1,35 @@
+From 79ab1cded23e01cf5477f5bea01deb6de57cdf19 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Thu, 19 Sep 2024 17:59:56 +0530
+Subject: [PATCH] Fix for default notification sound.
+
+"Default notification sound" value is set 'none' in Settings->Sound
+option. this was due to missing file Tethys.ogg.
+
+Added Tethys.ogg file for audio notification.
+
+Test:
+Open Settings->Sound option in Settings app and check for
+"Default notification sound" value. it should not be none.
+
+Tracked-On: OAM-124058
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ data/sounds/AllAudio.mk | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/data/sounds/AllAudio.mk b/data/sounds/AllAudio.mk
+index a3495209fba0..366a35e8f25a 100644
+--- a/data/sounds/AllAudio.mk
++++ b/data/sounds/AllAudio.mk
+@@ -93,6 +93,7 @@ PRODUCT_COPY_FILES += \
+     $(LOCAL_PATH)/notifications/TaDa.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/notifications/TaDa.ogg \
+     $(LOCAL_PATH)/notifications/ogg/Talitha.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/notifications/Talitha.ogg \
+     $(LOCAL_PATH)/notifications/ogg/Tejat.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/notifications/Tejat.ogg \
++    $(LOCAL_PATH)/notifications/ogg/Tethys.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/notifications/Tethys.ogg \
+     $(LOCAL_PATH)/notifications/ogg/Thallium.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/notifications/Thallium.ogg \
+     $(LOCAL_PATH)/notifications/Tinkerbell.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/notifications/Tinkerbell.ogg \
+     $(LOCAL_PATH)/notifications/ogg/Upsilon.ogg:$(TARGET_COPY_OUT_PRODUCT)/media/audio/notifications/Upsilon.ogg \
+-- 
+2.34.1
+


### PR DESCRIPTION
"Default notification sound" value is set 'none' in Settings->Sound option. this was due to missing file Tethys.ogg.

Added Tethys.ogg file for audio notification.

Test:
Open Settings->Sound option in Settings app and check for "Default notification sound" value. it should not be none.

Tracked-On: OAM-124058