### PR TITLE
Add test kernel module for system and odm DLKM partition

### DIFF
--- a/bsp_diff/base_aaos/device/intel/mixins/0003-Add-test-kernel-module-for-system-and-odm-DLKM-parti.patch
+++ b/bsp_diff/base_aaos/device/intel/mixins/0003-Add-test-kernel-module-for-system-and-odm-DLKM-parti.patch
@@ -1,0 +1,39 @@
+From 3fed5abf7a4cce965959e07455b73c9fdfd51d05 Mon Sep 17 00:00:00 2001
+From: "Chen, Gang G" <gang.g.chen@intel.com>
+Date: Sun, 22 Sep 2024 10:00:35 +0800
+Subject: [PATCH 3/3] Add test kernel module for system and odm DLKM partition
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The vts_dlkm_partition_test vts test case will check if
+ “/<system/odm>/lib/modules” is a symlink to
+ “/<system/odm>_dlkm/lib/modules. If there is no module
+in the partition, symlink will not be created.
+So this is a WA patch to pass the VTS. The WA patch can
+be removed if enable GKI on X86 platform.
+
+Test Done:
+Boot
+vts_dlkm_partition_test
+
+Tracked-On: OAM-118469
+Signed-off-by: Chen, Gang G <gang.g.chen@intel.com>
+---
+ groups/boot-arch/project-celadon/BoardConfig.mk | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/groups/boot-arch/project-celadon/BoardConfig.mk b/groups/boot-arch/project-celadon/BoardConfig.mk
+index db83fc47..f72f881a 100644
+--- a/groups/boot-arch/project-celadon/BoardConfig.mk
++++ b/groups/boot-arch/project-celadon/BoardConfig.mk
+@@ -201,3 +201,6 @@ ENABLE_GRUB_INSTALLER ?= true
+ {{/use_cic}}
+ 
+ BOARD_SEPOLICY_DIRS += $(INTEL_PATH_SEPOLICY)/soc
++
++BOARD_SYSTEM_KERNEL_MODULES := kernel/prebuilts/6.1/x86_64/pppox.ko
++BOARD_ODM_KERNEL_MODULES  := kernel/prebuilts/6.1/x86_64/pppox.ko
+-- 
+2.45.2
+


### PR DESCRIPTION
The vts_dlkm_partition_test vts test case will check if
 “/<system/odm>/lib/modules” is a symlink to
 “/<system/odm>_dlkm/lib/modules. If there is no module
in the partition, symlink will not be created.
So this is a WA patch to pass the VTS. The WA patch can be removed if enable GKI on X86 platform.

Test Done:
Boot
vts_dlkm_partition_test

Tracked-On: OAM-118469