### PR TITLE
Fixed for crash in Contacts app during Monkey test run.

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/70_0070-Fixed-for-crash-in-Contacts-app-during-Monkey-test-r.patch
+++ b/aosp_diff/preliminary/frameworks/base/70_0070-Fixed-for-crash-in-Contacts-app-during-Monkey-test-r.patch
@@ -1,0 +1,46 @@
+From 41d8e532de16a350f106d7efc312e0aa60e415a9 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Tue, 24 Sep 2024 10:41:29 +0530
+Subject: [PATCH] Fixed for crash in Contacts app during Monkey test run.
+
+Observed below crash-
+java.lang.RuntimeException: android.os.DeadObjectException: Transaction
+failed on small parcel; remote process probably died, but this could
+also be caused by running out of binder buffer space
+    at android.provider.ContactsContract.nullSafeCall
+(ContactsContract.java:10310)
+    at android.provider.ContactsContract.-$$Nest$smnullSafeCall
+(Unknown Source:0)
+    at android.provider.ContactsContract$SimContacts.getSimAccounts
+(ContactsContract.java:8472)
+    at com.android.contacts.util.DeviceLocalAccountTypeFactory$Default
+.classifyAccount(DeviceLocalAccountTypeFactory.java:74)
+    at com.android.contacts.util.DeviceLocalAccountTypeFactory$Default
+.getAccountType(DeviceLocalAccountTypeFactory.java:88)
+
+Release the provider if there is no other reason for keeping it active.
+
+Tests: Run monkey test. There no crash has observed.
+
+Tracked-On: OAM-122770
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ core/java/android/provider/ContactsContract.java | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/core/java/android/provider/ContactsContract.java b/core/java/android/provider/ContactsContract.java
+index 4bfff16d973f..e6f183d3ba65 100644
+--- a/core/java/android/provider/ContactsContract.java
++++ b/core/java/android/provider/ContactsContract.java
+@@ -10308,6 +10308,8 @@ public final class ContactsContract {
+             return client.call(method, arg, extras);
+         } catch (RemoteException e) {
+             throw e.rethrowAsRuntimeException();
++        } finally {
++            client.close();
+         }
+     }
+ }
+-- 
+2.34.1
+


### PR DESCRIPTION
Observed below crash-
java.lang.RuntimeException: android.os.DeadObjectException: Transaction failed on small parcel; remote process probably died, but this could also be caused by running out of binder buffer space
    at android.provider.ContactsContract.nullSafeCall
(ContactsContract.java:10310)
    at android.provider.ContactsContract.-$$Nest$smnullSafeCall
(Unknown Source:0)
    at android.provider.ContactsContract$SimContacts.getSimAccounts
(ContactsContract.java:8472)
    at com.android.contacts.util.DeviceLocalAccountTypeFactory$Default
.classifyAccount(DeviceLocalAccountTypeFactory.java:74)
    at com.android.contacts.util.DeviceLocalAccountTypeFactory$Default
.getAccountType(DeviceLocalAccountTypeFactory.java:88)

Release the provider if there is no other reason for keeping it active.

Tests: Run monkey test. There no crash has observed.

Tracked-On: OAM-122770