### PR TITLE
WA for compatibility mode apk resource load failed

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/70_0070-WA-for-compatibility-mode-apk-resource-load-failed.patch
+++ b/aosp_diff/preliminary/frameworks/base/70_0070-WA-for-compatibility-mode-apk-resource-load-failed.patch
@@ -1,0 +1,40 @@
+From d989f3dbab9e8e79aaedff1b359493b309caa0ce Mon Sep 17 00:00:00 2001
+From: tingli <ting.li@intel.com>
+Date: Fri, 27 Sep 2024 18:36:40 +0800
+Subject: [PATCH] WA for compatibility mode apk resource load failed
+
+  Apps that don't support car mode may run in compatibility window mode.
+  If they integrate system compomnets, they might fail to load
+  certain resources upon creation.
+  So, we bypass the configuration to try and locate the appropriate resources.
+
+Tracked-On: OAM-124544
+Signed-off-by: tingli <ting.li@intel.com>
+---
+ libs/androidfw/AssetManager2.cpp | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/libs/androidfw/AssetManager2.cpp b/libs/androidfw/AssetManager2.cpp
+index d33b592bddc6..d69d57ed454e 100644
+--- a/libs/androidfw/AssetManager2.cpp
++++ b/libs/androidfw/AssetManager2.cpp
+@@ -1019,7 +1019,15 @@ base::expected<AssetManager2::SelectedValue, NullOrIOError> AssetManager2::GetRe
+   auto result = FindEntry(resid, density_override, false /* stop_at_first_match */,
+                           false /* ignore_configuration */);
+   if (!result.has_value()) {
+-    return base::unexpected(result.error());
++    /* WORKAROUND, apps that don't support car mode may run in compatibility window mode.
++       If they integrate system compomnets, they might fail to load certain resources upon creation.
++       So, we bypass the configuration to try and locate the appropriate resources. */
++
++    ALOGW("FindEntry error on resid:0x%x retry with ignore_configuration = true\n", resid);
++    result = FindEntry(resid, density_override, false /* stop_at_first_match */, true /* ignore_configuration */);
++    if (!result.has_value()) {
++      return base::unexpected(result.error());
++    }
+   }
+ 
+   auto result_map_entry = std::get_if<incfs::verified_map_ptr<ResTable_map_entry>>(&result->entry);
+-- 
+2.34.1
+


### PR DESCRIPTION
  Apps that don't support car mode may run in compatibility window mode.
  If they integrate system compomnets, they might fail to load
    certain resources upon creation.
  So, we bypass the configuration to try and locate the appropriate resources.

Tracked-On: OAM-124544