### PR TITLE
Fixed for SystemUI crash in Passenger Display.

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Car/SystemUI/0001-Fixed-for-SystemUI-crash-in-Passenger-Display.patch
+++ b/aosp_diff/base_aaos/packages/apps/Car/SystemUI/0001-Fixed-for-SystemUI-crash-in-Passenger-Display.patch
@@ -1,0 +1,42 @@
+From 56379b3c7d25dfddfe31fc17f5cbe1b45aa0fe87 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Tue, 8 Oct 2024 09:02:08 +0530
+Subject: [PATCH] Fixed for SystemUI crash in Passenger Display.
+
+In concurrent multi-user mode, SystemUI crash has seen for passenger
+display. It was crashing due to missing audio configuration for
+passenger zone.
+
+If audio configuartion is not present for any of zone, then it should
+always use PRIMARY_AUDIO_ZONE.
+
+Tests: Enabled concurrent multi-user feature and passenger display is
+working fine. it is showing system ui components.
+
+Tracked-On: OAM-126129
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ .../car/statusicon/ui/MediaVolumeStatusIconController.java | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/com/android/systemui/car/statusicon/ui/MediaVolumeStatusIconController.java b/src/com/android/systemui/car/statusicon/ui/MediaVolumeStatusIconController.java
+index 6263ca14..e2f2c890 100644
+--- a/src/com/android/systemui/car/statusicon/ui/MediaVolumeStatusIconController.java
++++ b/src/com/android/systemui/car/statusicon/ui/MediaVolumeStatusIconController.java
+@@ -77,8 +77,11 @@ public class MediaVolumeStatusIconController extends StatusIconViewController {
+                     if (carOccupantZoneManager != null) {
+                         occupantZoneInfo = carOccupantZoneManager.getMyOccupantZone();
+                     }
+-                    mZoneId =
+-                            occupantZoneInfo != null ? occupantZoneInfo.zoneId : PRIMARY_AUDIO_ZONE;
++                    int audioZoneId = PRIMARY_AUDIO_ZONE;
++                    if (occupantZoneInfo != null) {
++                        audioZoneId = carOccupantZoneManager.getAudioZoneIdForOccupant(occupantZoneInfo);
++                    }
++                    mZoneId = audioZoneId != CarAudioManager.INVALID_AUDIO_ZONE ? audioZoneId : PRIMARY_AUDIO_ZONE;
+ 
+                     mCarAudioManager = (CarAudioManager) car.getCarManager(Car.AUDIO_SERVICE);
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
In concurrent multi-user mode, SystemUI crash has seen for passenger display. It was crashing due to missing audio configuration for passenger zone.

If audio configuartion is not present for any of zone, then it should always use PRIMARY_AUDIO_ZONE.

Tests: Enabled concurrent multi-user feature and passenger display is working fine. it is showing system ui components.

Tracked-On: OAM-126129