### PR TITLE
Fix error of setting new action bar in Gallery app.

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Gallery2/0002-Fix-error-of-setting-new-action-bar-in-Gallery-app.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Gallery2/0002-Fix-error-of-setting-new-action-bar-in-Gallery-app.patch
@@ -1,0 +1,63 @@
+From 31b4b705ac2c5bac9caef9e477c92602ae28d400 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Thu, 23 Nov 2023 08:47:34 +0530
+Subject: [PATCH] Fix error of setting new action bar in Gallery app.
+
+When try to crop or edit the image in gallery app, sometime app is
+crashing as it try to set new action bar which already has an action
+bar.
+
+Check for action bar before creating new action bar.
+
+Tests:
+Launch Gallery app and try to edit/crop image and it should work fine.
+
+Tracked-On: OAM-125981
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ .../android/gallery3d/filtershow/FilterShowActivity.java   | 7 +++++--
+ .../android/gallery3d/filtershow/crop/CropActivity.java    | 7 +++++--
+ 2 files changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/src/com/android/gallery3d/filtershow/FilterShowActivity.java b/src/com/android/gallery3d/filtershow/FilterShowActivity.java
+index dbe0edd24..63e7ba7b2 100644
+--- a/src/com/android/gallery3d/filtershow/FilterShowActivity.java
++++ b/src/com/android/gallery3d/filtershow/FilterShowActivity.java
+@@ -349,9 +349,12 @@ public class FilterShowActivity extends FragmentActivity implements OnItemClickL
+     private void loadXML() {
+         setContentView(R.layout.filtershow_activity);
+ 
+-        Toolbar myToolbar = findViewById(R.id.my_toolbar);
+-        setActionBar(myToolbar);
+         ActionBar actionBar = getActionBar();
++        if (actionBar == null) {
++            Toolbar myToolbar = findViewById(R.id.my_toolbar);
++            setActionBar(myToolbar);
++            actionBar = getActionBar();
++        }
+         if(actionBar != null) {
+             actionBar.setDisplayOptions(ActionBar.DISPLAY_SHOW_CUSTOM);
+             actionBar.setCustomView(R.layout.filtershow_actionbar);
+diff --git a/src/com/android/gallery3d/filtershow/crop/CropActivity.java b/src/com/android/gallery3d/filtershow/crop/CropActivity.java
+index 1552b15c2..6566cd9f2 100644
+--- a/src/com/android/gallery3d/filtershow/crop/CropActivity.java
++++ b/src/com/android/gallery3d/filtershow/crop/CropActivity.java
+@@ -106,9 +106,12 @@ public class CropActivity extends Activity {
+         setContentView(R.layout.crop_activity);
+         mCropView = (CropView) findViewById(R.id.cropView);
+ 
+-        Toolbar myToolbar = findViewById(R.id.my_toolbar);
+-        setActionBar(myToolbar);
+         ActionBar actionBar = getActionBar();
++        if (actionBar == null) {
++            Toolbar myToolbar = findViewById(R.id.my_toolbar);
++            setActionBar(myToolbar);
++            actionBar = getActionBar();
++        }
+         if (actionBar != null) {
+             actionBar.setDisplayOptions(ActionBar.DISPLAY_SHOW_CUSTOM);
+             actionBar.setCustomView(R.layout.filtershow_actionbar);
+-- 
+2.34.1
+


### PR DESCRIPTION
When try to crop or edit the image in gallery app, sometime app is crashing as it try to set new action bar which already has an action bar.

Check for action bar before creating new action bar.

Tests:
Launch Gallery app and try to edit/crop image and it should work fine.

Tracked-On: OAM-125981