### PR TITLE
Enable capture capabilities

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/73_0073-Enable-capture-capapbilities.patch
+++ b/aosp_diff/preliminary/frameworks/base/73_0073-Enable-capture-capapbilities.patch
@@ -1,0 +1,34 @@
+From f63c6b947aff2183aa6d4d4af066920d70a8280b Mon Sep 17 00:00:00 2001
+From: padmashree mandri <padmashree.mandri@intel.com>
+Date: Fri, 18 Oct 2024 13:20:38 +0000
+Subject: [PATCH] Enable capture capapbilities
+
+This patch adds permission of capture audio output,
+which is required by echo-reference device to capture
+output for looopback purpose.
+
+Tracked-On: OAM-126457
+Signed-off-by: padmashree mandri <padmashree.mandri@intel.com>
+Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>
+---
+ data/etc/privapp-permissions-platform.xml | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/data/etc/privapp-permissions-platform.xml b/data/etc/privapp-permissions-platform.xml
+index b6771b7aa855..8e83b25dc327 100644
+--- a/data/etc/privapp-permissions-platform.xml
++++ b/data/etc/privapp-permissions-platform.xml
+@@ -582,6 +582,10 @@ applications that come with the platform
+         <permission name="com.android.voicemail.permission.READ_VOICEMAIL"/>
+     </privapp-permissions>
+ 
++    <privapp-permissions package="com.google.android.car.kitchensink">
++        <permission name="android.permission.CAPTURE_AUDIO_OUTPUT"/>
++    </privapp-permissions>
++
+     <privapp-permissions package="com.intel.clipboardagent">
+         <permission name="android.permission.INTERNAL_SYSTEM_WINDOW"/>
+         <permission name="android.permission.INTERNET"/>
+-- 
+2.34.1
+

--- a/aosp_diff/preliminary/packages/services/Car/0001-Enable-capture-capapbilities.patch
+++ b/aosp_diff/preliminary/packages/services/Car/0001-Enable-capture-capapbilities.patch
@@ -1,0 +1,29 @@
+From b435a8dc923d9a7a03493b0ac787a08a18007a09 Mon Sep 17 00:00:00 2001
+From: padmashree mandri <padmashree.mandri@intel.com>
+Date: Wed, 16 Oct 2024 09:58:43 +0000
+Subject: [PATCH] Enable capture capapbilities
+
+This patch adds permission of capture audio output,
+which is required by echo-reference device to capture
+output for looopback purpose.
+
+Signed-off-by: padmashree mandri <padmashree.mandri@intel.com>
+---
+ tests/EmbeddedKitchenSinkApp/AndroidManifest.xml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tests/EmbeddedKitchenSinkApp/AndroidManifest.xml b/tests/EmbeddedKitchenSinkApp/AndroidManifest.xml
+index 695678f996..bfbf9a621a 100644
+--- a/tests/EmbeddedKitchenSinkApp/AndroidManifest.xml
++++ b/tests/EmbeddedKitchenSinkApp/AndroidManifest.xml
+@@ -127,6 +127,7 @@
+     <uses-permission android:name="android.permission.MODIFY_AUDIO_ROUTING"/>
+     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+     <uses-permission android:name="android.permission.RECORD_AUDIO" />
++    <uses-permission android:name="android.permission.CAPTURE_AUDIO_OUTPUT" />
+     <uses-permission android:name="android.permission.READ_PRIVILEGED_PHONE_STATE"/>
+     <uses-permission android:name="android.permission.MODIFY_DAY_NIGHT_MODE"/>
+     <uses-permission android:name="android.permission.MODIFY_PHONE_STATE"/>
+-- 
+2.34.1
+


### PR DESCRIPTION
This patch adds permission of capture audio output, which is required by echo-reference device to capture output for looopback purpose.

Tracked-On: OAM-126457