### PR TITLE
Enable capture capapbilities

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/73_0073-Enable-capture-capapbilities.patch
+++ b/aosp_diff/preliminary/frameworks/base/73_0073-Enable-capture-capapbilities.patch
@@ -1,0 +1,34 @@
+From f63c6b947aff2183aa6d4d4af066920d70a8280b Mon Sep 17 00:00:00 2001
+From: padmashree mandri <padmashree.mandri@intel.com>
+Date: Fri, 18 Oct 2024 13:20:38 +0000
+Subject: [PATCH] Enable capture capapbilities
+
+This patch adds permission of capture audio output,
+which is required by echo-reference device to capture
+output for looopback purpose.
+
+Tracked-On: OAM-126457
+Signed-off-by: padmashree mandri <padmashree.mandri@intel.com>
+Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>
+---
+ data/etc/privapp-permissions-platform.xml | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/data/etc/privapp-permissions-platform.xml b/data/etc/privapp-permissions-platform.xml
+index b6771b7aa855..8e83b25dc327 100644
+--- a/data/etc/privapp-permissions-platform.xml
++++ b/data/etc/privapp-permissions-platform.xml
+@@ -582,6 +582,10 @@ applications that come with the platform
+         <permission name="com.android.voicemail.permission.READ_VOICEMAIL"/>
+     </privapp-permissions>
+ 
++    <privapp-permissions package="com.google.android.car.kitchensink">
++        <permission name="android.permission.CAPTURE_AUDIO_OUTPUT"/>
++    </privapp-permissions>
++
+     <privapp-permissions package="com.intel.clipboardagent">
+         <permission name="android.permission.INTERNAL_SYSTEM_WINDOW"/>
+         <permission name="android.permission.INTERNET"/>
+-- 
+2.34.1
+


### PR DESCRIPTION
This patch adds permission of capture audio output, which is required by echo-reference device to capture output for looopback purpose.

Tracked-On: OAM-126457