### PR TITLE
fix for OTA update through script failure

### DIFF
--- a/bsp_diff/common/device/intel/sepolicy/0007-fix-for-OTA-update-through-script-failure.patch
+++ b/bsp_diff/common/device/intel/sepolicy/0007-fix-for-OTA-update-through-script-failure.patch
@@ -1,0 +1,57 @@
+From 30888e99257a8f07dda5b6ebe5042935a9d946e3 Mon Sep 17 00:00:00 2001
+From: "Unnithan, Balakrishnan" <balakrishnan.unnithan@intel.com>
+Date: Wed, 18 Sep 2024 15:41:51 +0530
+Subject: [PATCH] fix for OTA update through script failure
+
+OTA update was failing due to sepolicy permission denial.
+Added file context for vendor_boot_a|b partition.
+
+Tests done: Run command ./update_device.py caas-ota-CR0000094.zip
+
+Tracked-On: OAM-123102
+Signed-off-by: Unnithan, Balakrishnan <balakrishnan.unnithan@intel.com>
+---
+ ...or-OTA-update-through-script-failure.patch | 31 +++++++++++++++++++
+ 1 file changed, 31 insertions(+)
+ create mode 100644 bsp_diff/common/device/intel/sepolicy/0002-fix-for-OTA-update-through-script-failure.patch
+
+diff --git a/bsp_diff/common/device/intel/sepolicy/0002-fix-for-OTA-update-through-script-failure.patch b/bsp_diff/common/device/intel/sepolicy/0002-fix-for-OTA-update-through-script-failure.patch
+new file mode 100644
+index 0000000..0f2ccaa
+--- /dev/null
++++ b/bsp_diff/common/device/intel/sepolicy/0002-fix-for-OTA-update-through-script-failure.patch
+@@ -0,0 +1,31 @@
++From a544b007a96f5797c759305883943ed915102c79 Mon Sep 17 00:00:00 2001
++From: "Unnithan, Balakrishnan" <balakrishnan.unnithan@intel.com>
++Date: Wed, 18 Sep 2024 15:31:00 +0530
++Subject: [PATCH] fix for OTA update through script failure
++
++OTA update was failing due to sepolicy permission denial.
++Added file context for vendor_boot_a|b partition.
++
++Tests done: Run command ./update_device.py caas-ota-CR0000094.zip
++
++Tracked-On: OAM-123102
++Signed-off-by: Unnithan, Balakrishnan <balakrishnan.unnithan@intel.com>
++---
++ boot-arch/generic/file_contexts | 1 +
++ 1 file changed, 1 insertion(+)
++
++diff --git a/boot-arch/generic/file_contexts b/boot-arch/generic/file_contexts
++index 4984f6c..1c70c45 100644
++--- a/boot-arch/generic/file_contexts
+++++ b/boot-arch/generic/file_contexts
++@@ -2,6 +2,7 @@
++ # Block Devices
++ #
++ /dev/block/by-name/boot(_(a|b))?	u:object_r:boot_block_device:s0
+++/dev/block/by-name/vendor_boot(_(a|b))? u:object_r:boot_block_device:s0
++ /dev/block/by-name/bootloader(_(a|b))?	u:object_r:boot_block_device:s0
++ /dev/block/by-name/multiboot(_(a|b))?	u:object_r:boot_block_device:s0
++ /dev/block/by-name/system(_(a|b))?	u:object_r:system_block_device:s0
++-- 
++2.25.1
++
+-- 
+2.34.1
+


### PR DESCRIPTION
OTA update was failing due to sepolicy permission denial. Added file context for vendor_boot_a|b partition.

Tests done: Run command ./update_device.py caas-ota-xxx.zip

Tracked-On: OAM-126630