### PR TITLE
Add comment explaining the use of include_** files.

### DIFF
--- a/aosp_diff/caas/include_preliminary
+++ b/aosp_diff/caas/include_preliminary
@@ -1,0 +1,3 @@
+This file is to include vendor/intel/utils/aosp_diff/preliminary folder
+for this build target. It will include all the common patches which apply
+to all build targets whether it is embargoed or non-embargoed.

--- a/bsp_diff/caas/include_common
+++ b/bsp_diff/caas/include_common
@@ -1,0 +1,3 @@
+This file is to include vendor/intel/utils/bsp_diff/common folder
+for this build target. It will include all the common non-embargoed patches 
+which apply to all build targets whether it is embargoed or non-embargoed.


### PR DESCRIPTION
This patch will add comments explaining what will happen if we add include_common and include_preliminary files in a build target folder.

Tests Done: source and lunch

Tracked-On: OAM-126841