### PR TITLE
Fixed for crash in QuickSearchBox.

### DIFF
--- a/aosp_diff/preliminary/packages/apps/QuickSearchBox/0001-Fixed-for-crash-in-QuickSearchBox.patch
+++ b/aosp_diff/preliminary/packages/apps/QuickSearchBox/0001-Fixed-for-crash-in-QuickSearchBox.patch
@@ -1,0 +1,40 @@
+From 45e51c54638156b8b27ff4c7242694efcd25949f Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Wed, 6 Nov 2024 08:59:02 +0530
+Subject: [PATCH] Fixed for crash in QuickSearchBox.
+
+Observed NullPointerException in QuickSearchBox app
+Caused by: java.lang.NullPointerException
+at com.android.quicksearchbox.ui.SuggestionsAdapterBase
+.getSuggestions(SuggestionsAdapterBase.kt:63)
+at com.android.quicksearchbox.ui.DelayingSuggestionsAdapter
+.getSuggestions(DelayingSuggestionsAdapter.kt:98)
+
+Removing null assert condition as it is already handled by further null
+check condition.
+
+Tests: Launch QuickSearchBox app and type something in search box.
+Press Home button. There is no crash.
+
+Tracked-On: OAM-126864
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+---
+ src/com/android/quicksearchbox/ui/SuggestionsAdapterBase.kt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/com/android/quicksearchbox/ui/SuggestionsAdapterBase.kt b/src/com/android/quicksearchbox/ui/SuggestionsAdapterBase.kt
+index 25218a5..8004c00 100644
+--- a/src/com/android/quicksearchbox/ui/SuggestionsAdapterBase.kt
++++ b/src/com/android/quicksearchbox/ui/SuggestionsAdapterBase.kt
+@@ -60,7 +60,7 @@ protected constructor(private val mViewFactory: SuggestionViewFactory) : Suggest
+   @get:Override
+   @set:Override
+   override var suggestions: Suggestions?
+-    get() = mSuggestions!!
++    get() = mSuggestions
+     set(suggestions) {
+       if (mSuggestions === suggestions) {
+         return
+-- 
+2.34.1
+


### PR DESCRIPTION
Observed NullPointerException in QuickSearchBox app Caused by: java.lang.NullPointerException
at com.android.quicksearchbox.ui.SuggestionsAdapterBase .getSuggestions(SuggestionsAdapterBase.kt:63)
at com.android.quicksearchbox.ui.DelayingSuggestionsAdapter .getSuggestions(DelayingSuggestionsAdapter.kt:98)

Removing null assert condition as it is already handled by further null check condition.

Tests: Launch QuickSearchBox app and type something in search box. Press Home button. There is no crash.

Tracked-On: OAM-126864