### PR TITLE
Port art avx2 patches to A15

### DIFF
--- a/aosp_diff/preliminary/art/0004-Implement-AVX2-instructions-in-x64-assembler.patch
+++ b/aosp_diff/preliminary/art/0004-Implement-AVX2-instructions-in-x64-assembler.patch
@@ -1,0 +1,6114 @@
+From 0132013c98a1b70f9a0e94bd90f891d0e987a08d Mon Sep 17 00:00:00 2001
+From: Vinay Prasad Kompella <vinay.kompella@intel.com>
+Date: Mon, 4 Nov 2024 10:12:09 +0530
+Subject: [PATCH 4/6] Implement AVX2 instructions in x64 assembler
+
+This patch implements all the avx2 instructions required
+for supporting all the existing HVec instructions.
+Its a building block to enable AVX2 based 256-bit vectorization.
+
+x86 has overlapping FP and vector registers, so xmm/ymm is the same register
+Xmm registers now have vector length, to determine if it is Xmm/Ymm/Zmm.
+
+Test: art/test.py -b --host
+          Run the above test with and without "avx,avx2" features
+
+Tracked-On: OAM-126116
+Signed-off-by: Vinay Prasad Kompella <vinay.kompella@intel.com>
+---
+ compiler/utils/assembler_test.h               |   69 +-
+ compiler/utils/x86_64/assembler_x86_64.cc     | 2368 ++++++++++-------
+ compiler/utils/x86_64/assembler_x86_64.h      |  122 +-
+ .../utils/x86_64/assembler_x86_64_test.cc     |  983 ++++++-
+ compiler/utils/x86_64/constants_x86_64.h      |   12 +-
+ disassembler/disassembler_x86.cc              |  308 ++-
+ disassembler/disassembler_x86.h               |   26 +-
+ .../arch/x86/instruction_set_features_x86.h   |    2 +-
+ 8 files changed, 2803 insertions(+), 1087 deletions(-)
+
+diff --git a/compiler/utils/assembler_test.h b/compiler/utils/assembler_test.h
+index 05c79f3b21..846ed57e88 100644
+--- a/compiler/utils/assembler_test.h
++++ b/compiler/utils/assembler_test.h
+@@ -34,6 +34,10 @@
+ 
+ namespace art HIDDEN {
+ 
++typedef void (*DriverFnPtr)(const std::vector<uint8_t>& art_code,
++                            const std::string& assembly_text,
++                            const std::string& test_name);
++
+ // Helper for a constexpr string length.
+ constexpr size_t ConstexprStrLen(char const* str, size_t count = 0) {
+   return ('\0' == str[0]) ? count : ConstexprStrLen(str+1, count+1);
+@@ -72,6 +76,13 @@ class AssemblerTest : public AssemblerTestBase {
+     DriverWrapper(assembly_string, test_name);
+   }
+ 
++  // Since it's a string arg, the driver assumes assembler is already called.
++  void CustomDriverStr(DriverFnPtr custom_driver,
++                       const std::string& assembly_string,
++                       const std::string& test_name) {
++    DriverWrapper(assembly_string, test_name, custom_driver);
++  }
++
+   //
+   // Register repeats.
+   //
+@@ -760,6 +771,54 @@ class AssemblerTest : public AssemblerTestBase {
+         fmt);
+   }
+ 
++  // Repeats over addresses and vec-registers provided by fixture.
++  std::string RepeatAV(void (Ass::*f)(const Addr&, VecReg), const std::string& fmt) {
++    return RepeatAV(f, GetAddresses(), fmt);
++  }
++
++  // Variant that takes explicit vector of address
++  // (to test restricted addressing modes set).
++  std::string RepeatAV(void (Ass::*f)(const Addr&, VecReg),
++                       const std::vector<Addr>& a,
++                       const std::string& fmt) {
++    return RepeatTemplatedMemReg<Addr, VecReg>(f,
++                                               a,
++                                               GetVectorRegisters(),
++                                               &AssemblerTest::GetAddrName,
++                                               &AssemblerTest::GetVecRegName,
++                                               fmt);
++  }
++
++  // Repeats over vec-registers and addresses provided by fixture.
++  std::string RepeatVA(void (Ass::*f)(VecReg, const Addr&), const std::string& fmt) {
++    return RepeatVA(f, GetAddresses(), fmt);
++  }
++
++  // Variant that takes explicit vector of address
++  // (to test restricted addressing modes set).
++  std::string RepeatVA(void (Ass::*f)(VecReg, const Addr&),
++                       const std::vector<Addr>& a,
++                       const std::string& fmt) {
++    return RepeatTemplatedRegMem<VecReg, Addr>(f,
++                                               GetVectorRegisters(),
++                                               a,
++                                               &AssemblerTest::GetVecRegName,
++                                               &AssemblerTest::GetAddrName,
++                                               fmt);
++  }
++
++  std::string RepeatVVI(void (Ass::*f)(VecReg, VecReg, const Imm&),
++                        size_t imm_bytes,
++                        const std::string& fmt) {
++    return RepeatTemplatedRegistersImm<VecReg, VecReg>(f,
++                                                       GetVectorRegisters(),
++                                                       GetVectorRegisters(),
++                                                       &AssemblerTest::GetVecRegName,
++                                                       &AssemblerTest::GetVecRegName,
++                                                       imm_bytes,
++                                                       fmt);
++  }
++
+   template <typename ImmType>
+   std::string RepeatVIb(void (Ass::*f)(VecReg, ImmType),
+                         int imm_bits,
+@@ -1624,14 +1683,20 @@ class AssemblerTest : public AssemblerTestBase {
+   // Override this to pad the code with NOPs to a certain size if needed.
+   virtual void Pad([[maybe_unused]] std::vector<uint8_t>& data) {}
+ 
+-  void DriverWrapper(const std::string& assembly_text, const std::string& test_name) {
++  void DriverWrapper(const std::string& assembly_text,
++                     const std::string& test_name,
++                     DriverFnPtr custom_driver = nullptr) {
+     assembler_->FinalizeCode();
+     size_t cs = assembler_->CodeSize();
+     std::unique_ptr<std::vector<uint8_t>> data(new std::vector<uint8_t>(cs));
+     MemoryRegion code(&(*data)[0], data->size());
+     assembler_->CopyInstructions(code);
+     Pad(*data);
+-    Driver(*data, assembly_text, test_name);
++    if (custom_driver != nullptr) {
++      (*custom_driver)(*data, assembly_text, test_name);
++    } else {
++      Driver(*data, assembly_text, test_name);
++    }
+   }
+ 
+   static constexpr size_t kWarnManyCombinationsThreshold = 500;
+diff --git a/compiler/utils/x86_64/assembler_x86_64.cc b/compiler/utils/x86_64/assembler_x86_64.cc
+index 89a1d0923a..7b3f7caa62 100644
+--- a/compiler/utils/x86_64/assembler_x86_64.cc
++++ b/compiler/utils/x86_64/assembler_x86_64.cc
+@@ -24,12 +24,20 @@
+ namespace art HIDDEN {
+ namespace x86_64 {
+ 
++inline uint8_t GetEncodedVexLen(XmmRegister xmmReg) {
++  return (xmmReg.IsYMM() ? SET_VEX_L_256 : SET_VEX_L_128);
++}
++
+ std::ostream& operator<<(std::ostream& os, const CpuRegister& reg) {
+   return os << reg.AsRegister();
+ }
+ 
+ std::ostream& operator<<(std::ostream& os, const XmmRegister& reg) {
+-  return os << reg.AsFloatRegister();
++  if (reg.IsYMM()) {
++    return os << "ymm" << static_cast<int>(reg.AsFloatRegister());
++  } else {
++    return os << reg.AsFloatRegister();
++  }
+ }
+ 
+ std::ostream& operator<<(std::ostream& os, const X87Register& reg) {
+@@ -64,13 +72,8 @@ std::ostream& operator<<(std::ostream& os, const Address& addr) {
+   }
+ }
+ 
+-bool X86_64Assembler::CpuHasAVXorAVX2FeatureFlag() {
+-  if (has_AVX_ || has_AVX2_) {
+-    return true;
+-  }
+-  return false;
+-}
+-
++bool X86_64Assembler::CpuHasAVXFeatureFlag() { return has_AVX_; }
++bool X86_64Assembler::CpuHasAVX2FeatureFlag() { return has_AVX2_; }
+ 
+ void X86_64Assembler::call(CpuRegister reg) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -414,7 +417,7 @@ void X86_64Assembler::leal(CpuRegister dst, const Address& src) {
+ 
+ 
+ void X86_64Assembler::movaps(XmmRegister dst, XmmRegister src) {
+-  if (CpuHasAVXorAVX2FeatureFlag()) {
++  if (dst.IsYMM()) {
+     vmovaps(dst, src);
+     return;
+   }
+@@ -425,14 +428,26 @@ void X86_64Assembler::movaps(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++void X86_64Assembler::movups(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vmovups(dst, src);
++    return;
++  }
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  EmitOptionalRex32(dst, src);
++  EmitUint8(0x0F);
++  EmitUint8(0x10);
++  EmitXmmRegisterOperand(dst.LowBits(), src);
++}
+ 
+ /**VEX.128.0F.WIG 28 /r VMOVAPS xmm1, xmm2 */
+ void X86_64Assembler::vmovaps(XmmRegister dst, XmmRegister src) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVXFeatureFlag());
+   uint8_t byte_zero, byte_one, byte_two;
+   bool is_twobyte_form = true;
+   bool load = dst.NeedsRex();
+   bool store = !load;
++  uint8_t VEX_L = GetEncodedVexLen(dst);
+ 
+   if (src.NeedsRex()&& dst.NeedsRex()) {
+     is_twobyte_form = false;
+@@ -443,18 +458,13 @@ void X86_64Assembler::vmovaps(XmmRegister dst, XmmRegister src) {
+   X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
+   if (is_twobyte_form) {
+     bool rex_bit = (load) ? dst.NeedsRex() : src.NeedsRex();
+-    byte_one = EmitVexPrefixByteOne(rex_bit,
+-                                    vvvv_reg,
+-                                    SET_VEX_L_128,
+-                                    SET_VEX_PP_NONE);
++    byte_one = EmitVexPrefixByteOne(rex_bit, vvvv_reg, VEX_L, SET_VEX_PP_NONE);
+   } else {
+     byte_one = EmitVexPrefixByteOne(dst.NeedsRex(),
+                                     /*X=*/ false,
+                                     src.NeedsRex(),
+                                     SET_VEX_M_0F);
+-    byte_two = EmitVexPrefixByteTwo(/*W=*/ false,
+-                                    SET_VEX_L_128,
+-                                    SET_VEX_PP_NONE);
++    byte_two = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_NONE);
+   }
+   EmitUint8(byte_zero);
+   EmitUint8(byte_one);
+@@ -476,7 +486,7 @@ void X86_64Assembler::vmovaps(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::movaps(XmmRegister dst, const Address& src) {
+-  if (CpuHasAVXorAVX2FeatureFlag()) {
++  if (dst.IsYMM()) {
+     vmovaps(dst, src);
+     return;
+   }
+@@ -489,11 +499,12 @@ void X86_64Assembler::movaps(XmmRegister dst, const Address& src) {
+ 
+ /**VEX.128.0F.WIG 28 /r VMOVAPS xmm1, m128 */
+ void X86_64Assembler::vmovaps(XmmRegister dst, const Address& src) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVXFeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   uint8_t ByteZero, ByteOne, ByteTwo;
+   bool is_twobyte_form = false;
+   // Instruction VEX Prefix
++  uint8_t VEX_L = GetEncodedVexLen(dst);
+   uint8_t rex = src.rex();
+   bool Rex_x = rex & GET_REX_X;
+   bool Rex_b = rex & GET_REX_B;
+@@ -503,18 +514,13 @@ void X86_64Assembler::vmovaps(XmmRegister dst, const Address& src) {
+   ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+   if (is_twobyte_form) {
+     X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   vvvv_reg,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_NONE);
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, VEX_L, SET_VEX_PP_NONE);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_NONE);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_NONE);
+   }
+   EmitUint8(ByteZero);
+   EmitUint8(ByteOne);
+@@ -528,7 +534,7 @@ void X86_64Assembler::vmovaps(XmmRegister dst, const Address& src) {
+ }
+ 
+ void X86_64Assembler::movups(XmmRegister dst, const Address& src) {
+-  if (CpuHasAVXorAVX2FeatureFlag()) {
++  if (dst.IsYMM()) {
+     vmovups(dst, src);
+     return;
+   }
+@@ -541,11 +547,12 @@ void X86_64Assembler::movups(XmmRegister dst, const Address& src) {
+ 
+ /** VEX.128.0F.WIG 10 /r VMOVUPS xmm1, m128 */
+ void X86_64Assembler::vmovups(XmmRegister dst, const Address& src) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVXFeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   uint8_t ByteZero, ByteOne, ByteTwo;
+   bool is_twobyte_form = false;
+   // Instruction VEX Prefix
++  uint8_t VEX_L = GetEncodedVexLen(dst);
+   uint8_t rex = src.rex();
+   bool Rex_x = rex & GET_REX_X;
+   bool Rex_b = rex & GET_REX_B;
+@@ -555,18 +562,13 @@ void X86_64Assembler::vmovups(XmmRegister dst, const Address& src) {
+   ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+   if (is_twobyte_form) {
+     X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   vvvv_reg,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_NONE);
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, VEX_L, SET_VEX_PP_NONE);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_NONE);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_NONE);
+   }
+   EmitUint8(ByteZero);
+   EmitUint8(ByteOne);
+@@ -581,7 +583,7 @@ void X86_64Assembler::vmovups(XmmRegister dst, const Address& src) {
+ 
+ 
+ void X86_64Assembler::movaps(const Address& dst, XmmRegister src) {
+-  if (CpuHasAVXorAVX2FeatureFlag()) {
++  if (src.IsYMM()) {
+     vmovaps(dst, src);
+     return;
+   }
+@@ -594,12 +596,13 @@ void X86_64Assembler::movaps(const Address& dst, XmmRegister src) {
+ 
+ /** VEX.128.0F.WIG 29 /r VMOVAPS m128, xmm1 */
+ void X86_64Assembler::vmovaps(const Address& dst, XmmRegister src) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVXFeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   uint8_t ByteZero, ByteOne, ByteTwo;
+   bool is_twobyte_form = false;
+ 
+   // Instruction VEX Prefix
++  uint8_t VEX_L = GetEncodedVexLen(src);
+   uint8_t rex = dst.rex();
+   bool Rex_x = rex & GET_REX_X;
+   bool Rex_b = rex & GET_REX_B;
+@@ -609,18 +612,13 @@ void X86_64Assembler::vmovaps(const Address& dst, XmmRegister src) {
+   ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+   if (is_twobyte_form) {
+     X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
+-    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
+-                                   vvvv_reg,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_NONE);
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(), vvvv_reg, VEX_L, SET_VEX_PP_NONE);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_NONE);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_NONE);
+   }
+   EmitUint8(ByteZero);
+   EmitUint8(ByteOne);
+@@ -634,7 +632,7 @@ void X86_64Assembler::vmovaps(const Address& dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::movups(const Address& dst, XmmRegister src) {
+-  if (CpuHasAVXorAVX2FeatureFlag()) {
++  if (src.IsYMM()) {
+     vmovups(dst, src);
+     return;
+   }
+@@ -647,12 +645,13 @@ void X86_64Assembler::movups(const Address& dst, XmmRegister src) {
+ 
+ /** VEX.128.0F.WIG 11 /r VMOVUPS m128, xmm1 */
+ void X86_64Assembler::vmovups(const Address& dst, XmmRegister src) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVXFeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   uint8_t ByteZero, ByteOne, ByteTwo;
+   bool is_twobyte_form = false;
+ 
+   // Instruction VEX Prefix
++  uint8_t VEX_L = GetEncodedVexLen(src);
+   uint8_t rex = dst.rex();
+   bool Rex_x = rex & GET_REX_X;
+   bool Rex_b = rex & GET_REX_B;
+@@ -662,18 +661,13 @@ void X86_64Assembler::vmovups(const Address& dst, XmmRegister src) {
+   ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+   if (is_twobyte_form) {
+     X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
+-    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
+-                                   vvvv_reg,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_NONE);
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(), vvvv_reg, VEX_L, SET_VEX_PP_NONE);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_NONE);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_NONE);
+   }
+   EmitUint8(ByteZero);
+   EmitUint8(ByteOne);
+@@ -686,8 +680,52 @@ void X86_64Assembler::vmovups(const Address& dst, XmmRegister src) {
+   EmitOperand(src.LowBits(), dst);
+ }
+ 
++/** VEX.128.0F.WIG 10/11 /r VMOVUPS xmm1, xmm2
++    VEX.256.0F.WIG 10/11 /r VMOVUPS ymm1, ymm2 */
++void X86_64Assembler::vmovups(XmmRegister dst, XmmRegister src) {
++  DCHECK(CpuHasAVXFeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero, ByteOne, ByteTwo;
++  bool is_twobyte_form = true;
++  bool is_load = src.NeedsRex() && !dst.NeedsRex();
++  // Instruction VEX Prefix
++  uint8_t VEX_L = GetEncodedVexLen(dst);
++  if (dst.NeedsRex() && src.NeedsRex()) {
++    is_twobyte_form = false;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++    ByteOne = EmitVexPrefixByteOne(
++        is_load ? src.NeedsRex() : dst.NeedsRex(), vvvv_reg, VEX_L, SET_VEX_PP_NONE);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/false,
++                                   src.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_NONE);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  // Instruction Opcode
++  if (is_load) {
++    EmitUint8(0x11);
++    EmitXmmRegisterOperand(src.LowBits(), dst);
++  } else {
++    EmitUint8(0x10);
++    // Instruction Operands
++    EmitXmmRegisterOperand(dst.LowBits(), src);
++  }
++}
+ 
+ void X86_64Assembler::movss(XmmRegister dst, const Address& src) {
++  if (dst.IsYMM()) {
++    vmovss(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0xF3);
+   EmitOptionalRex32(dst, src);
+@@ -698,6 +736,10 @@ void X86_64Assembler::movss(XmmRegister dst, const Address& src) {
+ 
+ 
+ void X86_64Assembler::movss(const Address& dst, XmmRegister src) {
++  if (src.IsYMM()) {
++    vmovss(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0xF3);
+   EmitOptionalRex32(src, dst);
+@@ -708,6 +750,10 @@ void X86_64Assembler::movss(const Address& dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::movss(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vmovss(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0xF3);
+   EmitOptionalRex32(src, dst);  // Movss is MR encoding instead of the usual RM.
+@@ -716,6 +762,116 @@ void X86_64Assembler::movss(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(src.LowBits(), dst);
+ }
+ 
++/* VEX.LIG.F3.0F.WIG 10 /r VMOVSS xmm1, m32
++   Since LIG VEX.L = 0 and WIG => VEX.W = 0
++*/
++void X86_64Assembler::vmovss(XmmRegister dst, const Address& src) {
++  DCHECK(CpuHasAVXFeatureFlag());
++  uint8_t byte_zero, byte_one, byte_two;
++  bool is_twobyte_form = false;
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++
++  uint8_t rex = src.rex();
++  bool Rex_x = rex & GET_REX_X;
++  bool Rex_b = rex & GET_REX_B;
++  if (!Rex_b && !Rex_x) {
++    is_twobyte_form = true;
++  }
++  // Instruction VEX Prefix
++  byte_zero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++  if (is_twobyte_form) {
++    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_F3);
++  } else {
++    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(), Rex_x, Rex_b, SET_VEX_M_0F);
++    byte_two = EmitVexPrefixByteTwo(/*W=*/false, SET_VEX_L_128, SET_VEX_PP_F3);
++  }
++  EmitUint8(byte_zero);
++  EmitUint8(byte_one);
++  if (!is_twobyte_form) {
++    EmitUint8(byte_two);
++  }
++  // Instruction Opcode
++  EmitUint8(0x10);
++
++  // Instruction Operands
++  EmitOperand(dst.LowBits(), src);
++}
++
++/* VEX.LIG.F3.0F.WIG 11 /r VMOVSS m32, xmm1 */
++void X86_64Assembler::vmovss(const Address& dst, XmmRegister src) {
++  DCHECK(CpuHasAVXFeatureFlag());
++  uint8_t byte_zero, byte_one, byte_two;
++  bool is_twobyte_form = false;
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++
++  uint8_t rex = dst.rex();
++  bool Rex_x = rex & GET_REX_X;
++  bool Rex_b = rex & GET_REX_B;
++  if (!Rex_b && !Rex_x) {
++    is_twobyte_form = true;
++  }
++  // Instruction VEX Prefix
++  byte_zero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++  if (is_twobyte_form) {
++    byte_one = EmitVexPrefixByteOne(src.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_F3);
++  } else {
++    byte_one = EmitVexPrefixByteOne(src.NeedsRex(), Rex_x, Rex_b, SET_VEX_M_0F);
++    byte_two = EmitVexPrefixByteTwo(/*W=*/false, SET_VEX_L_128, SET_VEX_PP_F3);
++  }
++  EmitUint8(byte_zero);
++  EmitUint8(byte_one);
++  if (!is_twobyte_form) {
++    EmitUint8(byte_two);
++  }
++  // Instruction Opcode
++  EmitUint8(0x11);
++
++  // Instruction Operands
++  EmitOperand(src.LowBits(), dst);
++}
++
++/* VEX.LIG.F3.0F.WIG 10/11 /r VMOVSS xmm1, xmm2, xmm3 */
++void X86_64Assembler::vmovss(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXFeatureFlag());
++  uint8_t byte_zero, byte_one, byte_two;
++  bool is_twobyte_form = true;
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++
++  if (dst.NeedsRex() && src2.NeedsRex()) {
++    is_twobyte_form = false;
++  }
++  // Instruction VEX Prefix
++  byte_zero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg = X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  bool is_store = src2.NeedsRex() && !dst.NeedsRex();
++  if (is_twobyte_form) {
++    byte_one = EmitVexPrefixByteOne(
++        is_store ? src2.NeedsRex() : dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_F3);
++  } else {
++    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                    /*X=*/false,
++                                    src2.NeedsRex(),
++                                    SET_VEX_M_0F);
++    byte_two = EmitVexPrefixByteTwo(/*W=*/false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_F3);
++  }
++  EmitUint8(byte_zero);
++  EmitUint8(byte_one);
++  if (!is_twobyte_form) {
++    EmitUint8(byte_two);
++  }
++
++  // Instruction Opcode
++  if (is_store) {
++    // Special opcode only when src2 needs rex
++    EmitUint8(0x11);
++    EmitXmmRegisterOperand(src2.LowBits(), dst);
++  } else {
++    EmitUint8(0x10);
++    EmitXmmRegisterOperand(dst.LowBits(), src2);
++  }
++}
+ 
+ void X86_64Assembler::movsxd(CpuRegister dst, CpuRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -742,6 +898,10 @@ void X86_64Assembler::movd(CpuRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::movd(XmmRegister dst, CpuRegister src, bool is64bit) {
++  if (dst.IsYMM()) {
++    vmovd(dst, src, is64bit);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex(false, is64bit, dst.NeedsRex(), false, src.NeedsRex());
+@@ -751,6 +911,10 @@ void X86_64Assembler::movd(XmmRegister dst, CpuRegister src, bool is64bit) {
+ }
+ 
+ void X86_64Assembler::movd(CpuRegister dst, XmmRegister src, bool is64bit) {
++  if (src.IsYMM()) {
++    vmovd(dst, src, is64bit);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex(false, is64bit, src.NeedsRex(), false, dst.NeedsRex());
+@@ -759,6 +923,70 @@ void X86_64Assembler::movd(CpuRegister dst, XmmRegister src, bool is64bit) {
+   EmitOperand(src.LowBits(), Operand(dst));
+ }
+ 
++void X86_64Assembler::vmovq(XmmRegister dst, CpuRegister src) { vmovd(dst, src, true); }
++
++void X86_64Assembler::vmovq(CpuRegister dst, XmmRegister src) { vmovd(dst, src, true); }
++
++void X86_64Assembler::vmovd(XmmRegister dst, CpuRegister src, bool is64bit) {
++  DCHECK(CpuHasAVXFeatureFlag());
++  uint8_t byte_zero, byte_one, byte_two;
++  bool is_twobyte_form = !(is64bit || src.NeedsRex());
++
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  // Instruction VEX Prefix
++  byte_zero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++  if (is_twobyte_form) {
++    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                    /*X=*/false,
++                                    src.NeedsRex(),
++                                    SET_VEX_M_0F);
++    byte_two = EmitVexPrefixByteTwo(/*W=*/is64bit, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(byte_zero);
++  EmitUint8(byte_one);
++  if (!is_twobyte_form) {
++    EmitUint8(byte_two);
++  }
++  // Instruction Opcode
++  EmitUint8(0x6E);
++
++  // Instruction Operands
++  EmitOperand(dst.LowBits(), Operand(src));
++}
++
++void X86_64Assembler::vmovd(CpuRegister dst, XmmRegister src, bool is64bit) {
++  DCHECK(CpuHasAVXFeatureFlag());
++  uint8_t byte_zero, byte_one, byte_two;
++  bool is_twobyte_form = !(is64bit || dst.NeedsRex());
++
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  // Instruction VEX Prefix
++  byte_zero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++  if (is_twobyte_form) {
++    byte_one = EmitVexPrefixByteOne(src.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  } else {
++    byte_one = EmitVexPrefixByteOne(src.NeedsRex(),
++                                    /*X=*/false,
++                                    dst.NeedsRex(),
++                                    SET_VEX_M_0F);
++    byte_two = EmitVexPrefixByteTwo(/*W=*/is64bit, SET_VEX_L_128, SET_VEX_PP_66);
++  }
++  EmitUint8(byte_zero);
++  EmitUint8(byte_one);
++  if (!is_twobyte_form) {
++    EmitUint8(byte_two);
++  }
++  // Instruction Opcode
++  EmitUint8(0x7E);
++
++  // Instruction Operands
++  EmitOperand(src.LowBits(), Operand(dst));
++}
++
+ void X86_64Assembler::addss(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0xF3);
+@@ -839,6 +1067,10 @@ void X86_64Assembler::divss(XmmRegister dst, const Address& src) {
+ 
+ 
+ void X86_64Assembler::addps(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vaddps(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitOptionalRex32(dst, src);
+   EmitUint8(0x0F);
+@@ -848,6 +1080,10 @@ void X86_64Assembler::addps(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::subps(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vsubps(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitOptionalRex32(dst, src);
+   EmitUint8(0x0F);
+@@ -856,63 +1092,20 @@ void X86_64Assembler::subps(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::vaddps(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!add_right.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!add_left.NeedsRex()) {
+-    return vaddps(dst, add_right, add_left);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   add_right.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0x58);
+-  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++  EmitVecArithAndLogicalOperation(
++      dst, add_left, add_right, 0x58, SET_VEX_PP_NONE, /*is_commutative*/ true);
+ }
+ 
+ void X86_64Assembler::vsubps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  bool is_twobyte_form = false;
+-  uint8_t byte_zero = 0x00, byte_one = 0x00, byte_two = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  }
+-  byte_zero = EmitVexPrefixByteZero(is_twobyte_form);
+-  X86_64ManagedRegister vvvv_reg = X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  if (is_twobyte_form) {
+-    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
+-  } else {
+-    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(), /*X=*/ false, src2.NeedsRex(), SET_VEX_M_0F);
+-    byte_two = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
+-  }
+-  EmitUint8(byte_zero);
+-  EmitUint8(byte_one);
+-  if (!is_twobyte_form) {
+-    EmitUint8(byte_two);
+-  }
+-  EmitUint8(0x5C);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0x5C, SET_VEX_PP_NONE);
+ }
+ 
+ 
+ void X86_64Assembler::mulps(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vmulps(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitOptionalRex32(dst, src);
+   EmitUint8(0x0F);
+@@ -921,37 +1114,14 @@ void X86_64Assembler::mulps(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::vmulps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!src1.NeedsRex()) {
+-    return vmulps(dst, src2, src1);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0x59);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0x59, SET_VEX_PP_NONE, /*is_commutative*/ true);
+ }
+ 
+ void X86_64Assembler::divps(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vdivps(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitOptionalRex32(dst, src);
+   EmitUint8(0x0F);
+@@ -960,39 +1130,14 @@ void X86_64Assembler::divps(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::vdivps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0x5E, SET_VEX_PP_NONE);
++}
++
++void X86_64Assembler::vfmadd213ss(XmmRegister acc, XmmRegister left, XmmRegister right) {
++  DCHECK(CpuHasAVX2FeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  bool is_twobyte_form = false;
+   uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  }
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0x5E);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
+-}
+-
+-void X86_64Assembler::vfmadd213ss(XmmRegister acc, XmmRegister left, XmmRegister right) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ false);
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/false);
+   X86_64ManagedRegister vvvv_reg =
+       X86_64ManagedRegister::FromXmmRegister(left.AsFloatRegister());
+   ByteOne = EmitVexPrefixByteOne(acc.NeedsRex(),
+@@ -1008,7 +1153,7 @@ void X86_64Assembler::vfmadd213ss(XmmRegister acc, XmmRegister left, XmmRegister
+ }
+ 
+ void X86_64Assembler::vfmadd213sd(XmmRegister acc, XmmRegister left, XmmRegister right) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVX2FeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+   ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form=*/ false);
+@@ -1047,7 +1192,7 @@ void X86_64Assembler::fstps(const Address& dst) {
+ 
+ 
+ void X86_64Assembler::movapd(XmmRegister dst, XmmRegister src) {
+-  if (CpuHasAVXorAVX2FeatureFlag()) {
++  if (dst.IsYMM()) {
+     vmovapd(dst, src);
+     return;
+   }
+@@ -1061,10 +1206,11 @@ void X86_64Assembler::movapd(XmmRegister dst, XmmRegister src) {
+ 
+ /** VEX.128.66.0F.WIG 28 /r VMOVAPD xmm1, xmm2 */
+ void X86_64Assembler::vmovapd(XmmRegister dst, XmmRegister src) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVXFeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   uint8_t ByteZero, ByteOne, ByteTwo;
+   bool is_twobyte_form = true;
++  uint8_t VEX_L = GetEncodedVexLen(dst);
+ 
+   if (src.NeedsRex() && dst.NeedsRex()) {
+     is_twobyte_form = false;
+@@ -1075,18 +1221,13 @@ void X86_64Assembler::vmovapd(XmmRegister dst, XmmRegister src) {
+   if (is_twobyte_form) {
+     X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
+     bool rex_bit = load ? dst.NeedsRex() : src.NeedsRex();
+-    ByteOne = EmitVexPrefixByteOne(rex_bit,
+-                                   vvvv_reg,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_66);
++    ByteOne = EmitVexPrefixByteOne(rex_bit, vvvv_reg, VEX_L, SET_VEX_PP_66);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+                                    /*X=*/ false,
+                                    src.NeedsRex(),
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_66);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_66);
+   }
+   EmitUint8(ByteZero);
+   EmitUint8(ByteOne);
+@@ -1108,7 +1249,7 @@ void X86_64Assembler::vmovapd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::movapd(XmmRegister dst, const Address& src) {
+-  if (CpuHasAVXorAVX2FeatureFlag()) {
++  if (dst.IsYMM()) {
+     vmovapd(dst, src);
+     return;
+   }
+@@ -1122,10 +1263,11 @@ void X86_64Assembler::movapd(XmmRegister dst, const Address& src) {
+ 
+ /** VEX.128.66.0F.WIG 28 /r VMOVAPD xmm1, m128 */
+ void X86_64Assembler::vmovapd(XmmRegister dst, const Address& src) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVXFeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   uint8_t ByteZero, ByteOne, ByteTwo;
+   bool is_twobyte_form = false;
++  uint8_t VEX_L = GetEncodedVexLen(dst);
+ 
+   // Instruction VEX Prefix
+   uint8_t rex = src.rex();
+@@ -1137,18 +1279,13 @@ void X86_64Assembler::vmovapd(XmmRegister dst, const Address& src) {
+   ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+   if (is_twobyte_form) {
+     X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   vvvv_reg,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_66);
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, VEX_L, SET_VEX_PP_66);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_66);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_66);
+   }
+   EmitUint8(ByteZero);
+   EmitUint8(ByteOne);
+@@ -1162,7 +1299,7 @@ void X86_64Assembler::vmovapd(XmmRegister dst, const Address& src) {
+ }
+ 
+ void X86_64Assembler::movupd(XmmRegister dst, const Address& src) {
+-  if (CpuHasAVXorAVX2FeatureFlag()) {
++  if (dst.IsYMM()) {
+     vmovupd(dst, src);
+     return;
+   }
+@@ -1176,10 +1313,11 @@ void X86_64Assembler::movupd(XmmRegister dst, const Address& src) {
+ 
+ /** VEX.128.66.0F.WIG 10 /r VMOVUPD xmm1, m128 */
+ void X86_64Assembler::vmovupd(XmmRegister dst, const Address& src) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVXFeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   bool is_twobyte_form = false;
+   uint8_t ByteZero, ByteOne, ByteTwo;
++  uint8_t VEX_L = GetEncodedVexLen(dst);
+ 
+   // Instruction VEX Prefix
+   uint8_t rex = src.rex();
+@@ -1191,18 +1329,13 @@ void X86_64Assembler::vmovupd(XmmRegister dst, const Address& src) {
+   ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+   if (is_twobyte_form) {
+     X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   vvvv_reg,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_66);
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, VEX_L, SET_VEX_PP_66);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_66);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_66);
+   }
+   EmitUint8(ByteZero);
+   EmitUint8(ByteOne);
+@@ -1215,7 +1348,7 @@ void X86_64Assembler::vmovupd(XmmRegister dst, const Address& src) {
+ }
+ 
+ void X86_64Assembler::movapd(const Address& dst, XmmRegister src) {
+-  if (CpuHasAVXorAVX2FeatureFlag()) {
++  if (src.IsYMM()) {
+     vmovapd(dst, src);
+     return;
+   }
+@@ -1229,10 +1362,12 @@ void X86_64Assembler::movapd(const Address& dst, XmmRegister src) {
+ 
+ /** VEX.128.66.0F.WIG 29 /r VMOVAPD m128, xmm1 */
+ void X86_64Assembler::vmovapd(const Address& dst, XmmRegister src) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVXFeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   bool is_twobyte_form = false;
+   uint8_t ByteZero, ByteOne, ByteTwo;
++  uint8_t VEX_L = GetEncodedVexLen(src);
++
+   // Instruction VEX Prefix
+   uint8_t rex = dst.rex();
+   bool Rex_x = rex & GET_REX_X;
+@@ -1243,18 +1378,13 @@ void X86_64Assembler::vmovapd(const Address& dst, XmmRegister src) {
+   ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+   if (is_twobyte_form) {
+     X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
+-    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
+-                                   vvvv_reg,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_66);
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(), vvvv_reg, VEX_L, SET_VEX_PP_66);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_66);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_66);
+   }
+   EmitUint8(ByteZero);
+   EmitUint8(ByteOne);
+@@ -1268,7 +1398,7 @@ void X86_64Assembler::vmovapd(const Address& dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::movupd(const Address& dst, XmmRegister src) {
+-  if (CpuHasAVXorAVX2FeatureFlag()) {
++  if (src.IsYMM()) {
+     vmovupd(dst, src);
+     return;
+   }
+@@ -1282,10 +1412,11 @@ void X86_64Assembler::movupd(const Address& dst, XmmRegister src) {
+ 
+ /** VEX.128.66.0F.WIG 11 /r VMOVUPD m128, xmm1 */
+ void X86_64Assembler::vmovupd(const Address& dst, XmmRegister src) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVXFeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   bool is_twobyte_form = false;
+   uint8_t ByteZero, ByteOne, ByteTwo;
++  uint8_t VEX_L = GetEncodedVexLen(src);
+ 
+   // Instruction VEX Prefix
+   uint8_t rex = dst.rex();
+@@ -1297,18 +1428,13 @@ void X86_64Assembler::vmovupd(const Address& dst, XmmRegister src) {
+   ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+   if (is_twobyte_form) {
+     X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
+-    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
+-                                   vvvv_reg,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_66);
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(), vvvv_reg, VEX_L, SET_VEX_PP_66);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_66);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_66);
+   }
+   EmitUint8(ByteZero);
+   EmitUint8(ByteOne);
+@@ -1323,6 +1449,10 @@ void X86_64Assembler::vmovupd(const Address& dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::movsd(XmmRegister dst, const Address& src) {
++  if (dst.IsYMM()) {
++    vmovsd(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0xF2);
+   EmitOptionalRex32(dst, src);
+@@ -1333,6 +1463,10 @@ void X86_64Assembler::movsd(XmmRegister dst, const Address& src) {
+ 
+ 
+ void X86_64Assembler::movsd(const Address& dst, XmmRegister src) {
++  if (src.IsYMM()) {
++    vmovsd(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0xF2);
+   EmitOptionalRex32(src, dst);
+@@ -1343,6 +1477,10 @@ void X86_64Assembler::movsd(const Address& dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::movsd(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vmovsd(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0xF2);
+   EmitOptionalRex32(src, dst);  // Movsd is MR encoding instead of the usual RM.
+@@ -1351,6 +1489,114 @@ void X86_64Assembler::movsd(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(src.LowBits(), dst);
+ }
+ 
++/* VEX.LIG.F2.0F.WIG 10 /r VMOVSD xmm1, m32 */
++void X86_64Assembler::vmovsd(XmmRegister dst, const Address& src) {
++  DCHECK(CpuHasAVXFeatureFlag());
++  uint8_t byte_zero, byte_one, byte_two;
++  bool is_twobyte_form = false;
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++
++  uint8_t rex = src.rex();
++  bool Rex_x = rex & GET_REX_X;
++  bool Rex_b = rex & GET_REX_B;
++  if (!Rex_b && !Rex_x) {
++    is_twobyte_form = true;
++  }
++  // Instruction VEX Prefix
++  byte_zero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++  if (is_twobyte_form) {
++    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_F2);
++  } else {
++    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(), Rex_x, Rex_b, SET_VEX_M_0F);
++    byte_two = EmitVexPrefixByteTwo(/*W=*/false, SET_VEX_L_128, SET_VEX_PP_F2);
++  }
++  EmitUint8(byte_zero);
++  EmitUint8(byte_one);
++  if (!is_twobyte_form) {
++    EmitUint8(byte_two);
++  }
++  // Instruction Opcode
++  EmitUint8(0x10);
++
++  // Instruction Operands
++  EmitOperand(dst.LowBits(), src);
++}
++
++/* VEX.LIG.F2.0F.WIG 11 /r VMOVSD m32, xmm1 */
++void X86_64Assembler::vmovsd(const Address& dst, XmmRegister src) {
++  DCHECK(CpuHasAVXFeatureFlag());
++  uint8_t byte_zero, byte_one, byte_two;
++  bool is_twobyte_form = false;
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++
++  uint8_t rex = dst.rex();
++  bool Rex_x = rex & GET_REX_X;
++  bool Rex_b = rex & GET_REX_B;
++  if (!Rex_b && !Rex_x) {
++    is_twobyte_form = true;
++  }
++  // Instruction VEX Prefix
++  byte_zero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++  if (is_twobyte_form) {
++    byte_one = EmitVexPrefixByteOne(src.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_F2);
++  } else {
++    byte_one = EmitVexPrefixByteOne(src.NeedsRex(), Rex_x, Rex_b, SET_VEX_M_0F);
++    byte_two = EmitVexPrefixByteTwo(/*W=*/false, SET_VEX_L_128, SET_VEX_PP_F2);
++  }
++  EmitUint8(byte_zero);
++  EmitUint8(byte_one);
++  if (!is_twobyte_form) {
++    EmitUint8(byte_two);
++  }
++  // Instruction Opcode
++  EmitUint8(0x11);
++
++  // Instruction Operands
++  EmitOperand(src.LowBits(), dst);
++}
++
++/* VEX.LIG.F2.0F.WIG 10/11 /r VMOVSD xmm1, xmm2, xmm3 */
++void X86_64Assembler::vmovsd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVXFeatureFlag());
++  uint8_t byte_zero, byte_one, byte_two;
++  bool is_twobyte_form = true;
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++
++  if (dst.NeedsRex() && src2.NeedsRex()) {
++    is_twobyte_form = false;
++  }
++  // Instruction VEX Prefix
++  byte_zero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg = X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  bool is_store = src2.NeedsRex() && !dst.NeedsRex();
++  if (is_twobyte_form) {
++    byte_one = EmitVexPrefixByteOne(
++        is_store ? src2.NeedsRex() : dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_F2);
++  } else {
++    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                    /*X=*/false,
++                                    src2.NeedsRex(),
++                                    SET_VEX_M_0F);
++    byte_two = EmitVexPrefixByteTwo(/*W=*/false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_F2);
++  }
++  EmitUint8(byte_zero);
++  EmitUint8(byte_one);
++  if (!is_twobyte_form) {
++    EmitUint8(byte_two);
++  }
++
++  // Instruction Opcode && Instruction Operands
++  if (is_store) {
++    // Opcode only when src2 needs rex
++    EmitUint8(0x11);
++    EmitXmmRegisterOperand(src2.LowBits(), dst);
++  } else {
++    EmitUint8(0x10);
++    EmitXmmRegisterOperand(dst.LowBits(), src2);
++  }
++}
+ 
+ void X86_64Assembler::addsd(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -1433,6 +1679,10 @@ void X86_64Assembler::divsd(XmmRegister dst, const Address& src) {
+ 
+ 
+ void X86_64Assembler::addpd(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vaddpd(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -1443,37 +1693,16 @@ void X86_64Assembler::addpd(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::vaddpd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!add_right.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!add_left.NeedsRex()) {
+-    return vaddpd(dst, add_right, add_left);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   add_right.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0x58);
+-  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++  EmitVecArithAndLogicalOperation(
++      dst, add_left, add_right, 0x58, SET_VEX_PP_66, /*is_commutative*/ true);
+ }
+ 
+ 
+ void X86_64Assembler::subpd(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vsubpd(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -1484,35 +1713,15 @@ void X86_64Assembler::subpd(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::vsubpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  }
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0x5C);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0x5C, SET_VEX_PP_66);
+ }
+ 
+ 
+ void X86_64Assembler::mulpd(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vmulpd(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -1522,37 +1731,14 @@ void X86_64Assembler::mulpd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::vmulpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!src1.NeedsRex()) {
+-    return vmulpd(dst, src2, src1);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0x59);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0x59, SET_VEX_PP_66, /*is_commutative*/ true);
+ }
+ 
+ void X86_64Assembler::divpd(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vdivpd(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -1563,37 +1749,12 @@ void X86_64Assembler::divpd(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::vdivpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  }
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0x5E);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0x5E, SET_VEX_PP_66);
+ }
+ 
+ 
+ void X86_64Assembler::movdqa(XmmRegister dst, XmmRegister src) {
+-  if (CpuHasAVXorAVX2FeatureFlag()) {
++  if (dst.IsYMM()) {
+     vmovdqa(dst, src);
+     return;
+   }
+@@ -1607,10 +1768,11 @@ void X86_64Assembler::movdqa(XmmRegister dst, XmmRegister src) {
+ 
+ /** VEX.128.66.0F.WIG 6F /r VMOVDQA xmm1, xmm2 */
+ void X86_64Assembler::vmovdqa(XmmRegister dst, XmmRegister src) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVXFeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   uint8_t ByteZero, ByteOne, ByteTwo;
+   bool is_twobyte_form = true;
++  uint8_t VEX_L = GetEncodedVexLen(dst);
+ 
+   // Instruction VEX Prefix
+   if (src.NeedsRex() && dst.NeedsRex()) {
+@@ -1621,18 +1783,13 @@ void X86_64Assembler::vmovdqa(XmmRegister dst, XmmRegister src) {
+   if (is_twobyte_form) {
+     X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
+     bool rex_bit = load ? dst.NeedsRex() : src.NeedsRex();
+-    ByteOne = EmitVexPrefixByteOne(rex_bit,
+-                                   vvvv_reg,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_66);
++    ByteOne = EmitVexPrefixByteOne(rex_bit, vvvv_reg, VEX_L, SET_VEX_PP_66);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+                                    /*X=*/ false,
+                                    src.NeedsRex(),
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_66);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_66);
+   }
+   EmitUint8(ByteZero);
+   EmitUint8(ByteOne);
+@@ -1654,7 +1811,7 @@ void X86_64Assembler::vmovdqa(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::movdqa(XmmRegister dst, const Address& src) {
+-  if (CpuHasAVXorAVX2FeatureFlag()) {
++  if (dst.IsYMM()) {
+     vmovdqa(dst, src);
+     return;
+   }
+@@ -1668,10 +1825,11 @@ void X86_64Assembler::movdqa(XmmRegister dst, const Address& src) {
+ 
+ /** VEX.128.66.0F.WIG 6F /r VMOVDQA xmm1, m128 */
+ void X86_64Assembler::vmovdqa(XmmRegister dst, const Address& src) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVXFeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   uint8_t  ByteZero, ByteOne, ByteTwo;
+   bool is_twobyte_form = false;
++  uint8_t VEX_L = GetEncodedVexLen(dst);
+ 
+   // Instruction VEX Prefix
+   uint8_t rex = src.rex();
+@@ -1683,18 +1841,13 @@ void X86_64Assembler::vmovdqa(XmmRegister dst, const Address& src) {
+   ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+   if (is_twobyte_form) {
+     X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   vvvv_reg,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_66);
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, VEX_L, SET_VEX_PP_66);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_66);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_66);
+   }
+   EmitUint8(ByteZero);
+   EmitUint8(ByteOne);
+@@ -1708,7 +1861,7 @@ void X86_64Assembler::vmovdqa(XmmRegister dst, const Address& src) {
+ }
+ 
+ void X86_64Assembler::movdqu(XmmRegister dst, const Address& src) {
+-  if (CpuHasAVXorAVX2FeatureFlag()) {
++  if (dst.IsYMM()) {
+     vmovdqu(dst, src);
+     return;
+   }
+@@ -1723,10 +1876,11 @@ void X86_64Assembler::movdqu(XmmRegister dst, const Address& src) {
+ /** VEX.128.F3.0F.WIG 6F /r VMOVDQU xmm1, m128
+ Load Unaligned */
+ void X86_64Assembler::vmovdqu(XmmRegister dst, const Address& src) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVXFeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   uint8_t ByteZero, ByteOne, ByteTwo;
+   bool is_twobyte_form = false;
++  uint8_t VEX_L = GetEncodedVexLen(dst);
+ 
+   // Instruction VEX Prefix
+   uint8_t rex = src.rex();
+@@ -1738,18 +1892,13 @@ void X86_64Assembler::vmovdqu(XmmRegister dst, const Address& src) {
+   ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+   if (is_twobyte_form) {
+     X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   vvvv_reg,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_F3);
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, VEX_L, SET_VEX_PP_F3);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_F3);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_F3);
+   }
+   EmitUint8(ByteZero);
+   EmitUint8(ByteOne);
+@@ -1763,7 +1912,7 @@ void X86_64Assembler::vmovdqu(XmmRegister dst, const Address& src) {
+ }
+ 
+ void X86_64Assembler::movdqa(const Address& dst, XmmRegister src) {
+-  if (CpuHasAVXorAVX2FeatureFlag()) {
++  if (src.IsYMM()) {
+     vmovdqa(dst, src);
+     return;
+   }
+@@ -1777,10 +1926,12 @@ void X86_64Assembler::movdqa(const Address& dst, XmmRegister src) {
+ 
+ /** VEX.128.66.0F.WIG 7F /r VMOVDQA m128, xmm1 */
+ void X86_64Assembler::vmovdqa(const Address& dst, XmmRegister src) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVXFeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   bool is_twobyte_form = false;
+   uint8_t ByteZero, ByteOne, ByteTwo;
++  uint8_t VEX_L = GetEncodedVexLen(src);
++
+   // Instruction VEX Prefix
+   uint8_t rex = dst.rex();
+   bool Rex_x = rex & GET_REX_X;
+@@ -1791,18 +1942,13 @@ void X86_64Assembler::vmovdqa(const Address& dst, XmmRegister src) {
+   ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+   if (is_twobyte_form) {
+     X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
+-    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
+-                                   vvvv_reg,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_66);
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(), vvvv_reg, VEX_L, SET_VEX_PP_66);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_66);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_66);
+   }
+   EmitUint8(ByteZero);
+   EmitUint8(ByteOne);
+@@ -1816,7 +1962,7 @@ void X86_64Assembler::vmovdqa(const Address& dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::movdqu(const Address& dst, XmmRegister src) {
+-  if (CpuHasAVXorAVX2FeatureFlag()) {
++  if (src.IsYMM()) {
+     vmovdqu(dst, src);
+     return;
+   }
+@@ -1830,10 +1976,11 @@ void X86_64Assembler::movdqu(const Address& dst, XmmRegister src) {
+ 
+ /** VEX.128.F3.0F.WIG 7F /r VMOVDQU m128, xmm1 */
+ void X86_64Assembler::vmovdqu(const Address& dst, XmmRegister src) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVXFeatureFlag());
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   uint8_t ByteZero, ByteOne, ByteTwo;
+   bool is_twobyte_form = false;
++  uint8_t VEX_L = GetEncodedVexLen(src);
+ 
+   // Instruction VEX Prefix
+   uint8_t rex = dst.rex();
+@@ -1845,18 +1992,13 @@ void X86_64Assembler::vmovdqu(const Address& dst, XmmRegister src) {
+   ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+   if (is_twobyte_form) {
+     X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
+-    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
+-                                   vvvv_reg,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_F3);
++    ByteOne = EmitVexPrefixByteOne(src.NeedsRex(), vvvv_reg, VEX_L, SET_VEX_PP_F3);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(src.NeedsRex(),
+                                    Rex_x,
+                                    Rex_b,
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false,
+-                                   SET_VEX_L_128,
+-                                   SET_VEX_PP_F3);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_F3);
+   }
+   EmitUint8(ByteZero);
+   EmitUint8(ByteOne);
+@@ -1870,6 +2012,10 @@ void X86_64Assembler::vmovdqu(const Address& dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::paddb(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpaddb(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -1880,38 +2026,17 @@ void X86_64Assembler::paddb(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::vpaddb(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  uint8_t ByteOne = 0x00, ByteZero = 0x00, ByteTwo = 0x00;
+-  bool is_twobyte_form = false;
+-  if (!add_right.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!add_left.NeedsRex()) {
+-    return vpaddb(dst, add_right, add_left);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   add_right.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0xFC);
+-  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(
++      dst, add_left, add_right, 0xFC, SET_VEX_PP_66, /*is_commutative*/ true);
+ }
+ 
+ 
+ void X86_64Assembler::psubb(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpsubb(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -1922,36 +2047,16 @@ void X86_64Assembler::psubb(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::vpsubb(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!add_right.NeedsRex()) {
+-    is_twobyte_form = true;
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, add_left, add_right, 0xF8, SET_VEX_PP_66);
++}
++
++
++void X86_64Assembler::paddw(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpaddw(dst, dst, src);
++    return;
+   }
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   add_right.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0xF8);
+-  EmitXmmRegisterOperand(dst.LowBits(), add_right);
+-}
+-
+-
+-void X86_64Assembler::paddw(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -1961,38 +2066,16 @@ void X86_64Assembler::paddw(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::vpaddw(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!add_right.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!add_left.NeedsRex()) {
+-    return vpaddw(dst, add_right, add_left);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   add_right.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0xFD);
+-  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(
++      dst, add_left, add_right, 0xFD, SET_VEX_PP_66, /*is_commutative*/ true);
+ }
+ 
+-
+ void X86_64Assembler::psubw(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpsubw(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2002,36 +2085,16 @@ void X86_64Assembler::psubw(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::vpsubw(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!add_right.NeedsRex()) {
+-    is_twobyte_form = true;
+-  }
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   add_right.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0xF9);
+-  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, add_left, add_right, 0xF9, SET_VEX_PP_66);
+ }
+ 
+ 
+ void X86_64Assembler::pmullw(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpmullw(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2041,37 +2104,15 @@ void X86_64Assembler::pmullw(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::vpmullw(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!src1.NeedsRex()) {
+-    return vpmullw(dst, src2, src1);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0xD5);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0xD5, SET_VEX_PP_66, /*is_commutative*/ true);
+ }
+ 
+ void X86_64Assembler::paddd(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpaddd(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2081,37 +2122,16 @@ void X86_64Assembler::paddd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::vpaddd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!add_right.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!add_left.NeedsRex()) {
+-    return vpaddd(dst, add_right, add_left);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   add_right.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0xFE);
+-  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(
++      dst, add_left, add_right, 0xFE, SET_VEX_PP_66, /*is_commutative*/ true);
+ }
+ 
+ void X86_64Assembler::psubd(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpsubd(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2122,6 +2142,10 @@ void X86_64Assembler::psubd(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::pmulld(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpmulld(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2132,9 +2156,10 @@ void X86_64Assembler::pmulld(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::vpmulld(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  uint8_t VEX_L = GetEncodedVexLen(dst);
+   ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form*/ false);
+   X86_64ManagedRegister vvvv_reg =
+       X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+@@ -2142,7 +2167,7 @@ void X86_64Assembler::vpmulld(XmmRegister dst, XmmRegister src1, XmmRegister src
+                                    /*X=*/ false,
+                                    src2.NeedsRex(),
+                                    SET_VEX_M_0F_38);
+-  ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++  ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, vvvv_reg, VEX_L, SET_VEX_PP_66);
+   EmitUint8(ByteZero);
+   EmitUint8(ByteOne);
+   EmitUint8(ByteTwo);
+@@ -2151,6 +2176,10 @@ void X86_64Assembler::vpmulld(XmmRegister dst, XmmRegister src1, XmmRegister src
+ }
+ 
+ void X86_64Assembler::paddq(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpaddq(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2161,38 +2190,17 @@ void X86_64Assembler::paddq(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::vpaddq(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!add_right.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!add_left.NeedsRex()) {
+-    return vpaddq(dst, add_right, add_left);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   add_right.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0xD4);
+-  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(
++      dst, add_left, add_right, 0xD4, SET_VEX_PP_66, /*is_commutative*/ true);
+ }
+ 
+ 
+ void X86_64Assembler::psubq(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpsubq(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2202,36 +2210,16 @@ void X86_64Assembler::psubq(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::vpsubq(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!add_right.NeedsRex()) {
+-    is_twobyte_form = true;
+-  }
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   add_right.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0xFB);
+-  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, add_left, add_right, 0xFB, SET_VEX_PP_66);
+ }
+ 
+ 
+ void X86_64Assembler::paddusb(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpaddusb(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2242,6 +2230,10 @@ void X86_64Assembler::paddusb(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::paddsb(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpaddsb(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2252,6 +2244,10 @@ void X86_64Assembler::paddsb(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::paddusw(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpaddusw(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2262,6 +2258,10 @@ void X86_64Assembler::paddusw(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::paddsw(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpaddsw(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2272,6 +2272,10 @@ void X86_64Assembler::paddsw(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::psubusb(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpsubusb(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2282,6 +2286,10 @@ void X86_64Assembler::psubusb(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::psubsb(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpsubsb(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2292,36 +2300,16 @@ void X86_64Assembler::psubsb(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::vpsubd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!add_right.NeedsRex()) {
+-    is_twobyte_form = true;
+-  }
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(add_left.AsFloatRegister());
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   add_right.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0xFA);
+-  EmitXmmRegisterOperand(dst.LowBits(), add_right);
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, add_left, add_right, 0xFA, SET_VEX_PP_66);
+ }
+ 
+ 
+ void X86_64Assembler::psubusw(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpsubusw(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2332,6 +2320,10 @@ void X86_64Assembler::psubusw(XmmRegister dst, XmmRegister src) {
+ 
+ 
+ void X86_64Assembler::psubsw(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpsubsw(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2340,6 +2332,61 @@ void X86_64Assembler::psubsw(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++/*VEX.128.66.0F.WIG DC /r VPADDUSB xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F.WIG DC /r VPADDUSB ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpaddusb(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0xDC, SET_VEX_PP_66, /*is_commutative*/ true);
++}
++
++/*VEX.128.66.0F.WIG EC /r VPADDSB xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F.WIG EC /r VPADDSB ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpaddsb(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0xEC, SET_VEX_PP_66, /*is_commutative*/ true);
++}
++
++/*VEX.128.66.0F.WIG DD /r VPADDUSW xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F.WIG DD /r VPADDUSW ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpaddusw(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0xDD, SET_VEX_PP_66, /*is_commutative*/ true);
++}
++
++/*VEX.128.66.0F.WIG ED /r VPADDSW xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F.WIG ED /r VPADDSW ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpaddsw(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0xED, SET_VEX_PP_66, /*is_commutative*/ true);
++}
++
++/*VEX.128.66.0F.WIG D8 /r VPSUBUSB xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F.WIG D8 /r VPSUBUSB ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpsubusb(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0xD8, SET_VEX_PP_66);
++}
++
++/*VEX.128.66.0F.WIG E8 /r VPSUBSB xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F.WIG E8 /r VPSUBSB ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpsubsb(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0xE8, SET_VEX_PP_66);
++}
++
++/*VEX.128.66.0F.WIG D9 /r VPSUBUSW xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F.WIG D9 /r VPSUBUSW ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpsubusw(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0xD9, SET_VEX_PP_66);
++}
++
++/*VEX.128.66.0F.WIG E9 /r VPSUBSW xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F.WIG E9 /r VPSUBSW ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpsubsw(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0xE9, SET_VEX_PP_66);
++}
+ 
+ void X86_64Assembler::cvtsi2ss(XmmRegister dst, CpuRegister src) {
+   cvtsi2ss(dst, src, false);
+@@ -2512,6 +2559,10 @@ void X86_64Assembler::cvtsd2ss(XmmRegister dst, const Address& src) {
+ 
+ 
+ void X86_64Assembler::cvtdq2ps(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vcvtdq2ps(dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitOptionalRex32(dst, src);
+   EmitUint8(0x0F);
+@@ -2519,6 +2570,34 @@ void X86_64Assembler::cvtdq2ps(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++void X86_64Assembler::vcvtdq2ps(XmmRegister dst, XmmRegister src) {
++  DCHECK(CpuHasAVXFeatureFlag());
++  uint8_t VEX_L = GetEncodedVexLen(dst);
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  if (!src.NeedsRex()) {
++    is_twobyte_form = true;
++  }
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, VEX_L, SET_VEX_PP_NONE);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/false,
++                                   src.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_NONE);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(0x5B);
++  EmitXmmRegisterOperand(dst.LowBits(), src);
++}
+ 
+ void X86_64Assembler::cvtdq2pd(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -2661,6 +2740,10 @@ void X86_64Assembler::xorpd(XmmRegister dst, const Address& src) {
+ 
+ 
+ void X86_64Assembler::xorpd(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vxorpd(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2680,6 +2763,10 @@ void X86_64Assembler::xorps(XmmRegister dst, const Address& src) {
+ 
+ 
+ void X86_64Assembler::xorps(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vxorps(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitOptionalRex32(dst, src);
+   EmitUint8(0x0F);
+@@ -2688,6 +2775,10 @@ void X86_64Assembler::xorps(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pxor(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpxor(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2698,98 +2789,18 @@ void X86_64Assembler::pxor(XmmRegister dst, XmmRegister src) {
+ 
+ /* VEX.128.66.0F.WIG EF /r VPXOR xmm1, xmm2, xmm3/m128 */
+ void X86_64Assembler::vpxor(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!src1.NeedsRex()) {
+-    return vpxor(dst, src2, src1);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0xEF);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0xEF, SET_VEX_PP_66, /*is_commutative*/ true);
+ }
+ 
+ /* VEX.128.0F.WIG 57 /r VXORPS xmm1,xmm2, xmm3/m128 */
+ void X86_64Assembler::vxorps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!src1.NeedsRex()) {
+-    return vxorps(dst, src2, src1);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0x57);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0x57, SET_VEX_PP_NONE, /*is_commutative*/ true);
+ }
+ 
+ /* VEX.128.66.0F.WIG 57 /r VXORPD xmm1,xmm2, xmm3/m128 */
+ void X86_64Assembler::vxorpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!src1.NeedsRex()) {
+-    return vxorpd(dst, src2, src1);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0x57);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0x57, SET_VEX_PP_66, /*is_commutative*/ true);
+ }
+ 
+ void X86_64Assembler::andpd(XmmRegister dst, const Address& src) {
+@@ -2802,6 +2813,10 @@ void X86_64Assembler::andpd(XmmRegister dst, const Address& src) {
+ }
+ 
+ void X86_64Assembler::andpd(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vandpd(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2811,6 +2826,10 @@ void X86_64Assembler::andpd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::andps(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vandps(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitOptionalRex32(dst, src);
+   EmitUint8(0x0F);
+@@ -2819,6 +2838,10 @@ void X86_64Assembler::andps(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pand(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpand(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2829,98 +2852,18 @@ void X86_64Assembler::pand(XmmRegister dst, XmmRegister src) {
+ 
+ /* VEX.128.66.0F.WIG DB /r VPAND xmm1, xmm2, xmm3/m128 */
+ void X86_64Assembler::vpand(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!src1.NeedsRex()) {
+-    return vpand(dst, src2, src1);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0xDB);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0xDB, SET_VEX_PP_66, /*is_commutative*/ true);
+ }
+ 
+ /* VEX.128.0F 54 /r VANDPS xmm1,xmm2, xmm3/m128 */
+ void X86_64Assembler::vandps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!src1.NeedsRex()) {
+-    return vandps(dst, src2, src1);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0x54);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0x54, SET_VEX_PP_NONE, /*is_commutative*/ true);
+ }
+ 
+ /* VEX.128.66.0F 54 /r VANDPD xmm1, xmm2, xmm3/m128 */
+ void X86_64Assembler::vandpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!src1.NeedsRex()) {
+-    return vandpd(dst, src2, src1);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0x54);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0x54, SET_VEX_PP_66, /*is_commutative*/ true);
+ }
+ 
+ void X86_64Assembler::andn(CpuRegister dst, CpuRegister src1, CpuRegister src2) {
+@@ -2943,6 +2886,10 @@ void X86_64Assembler::andn(CpuRegister dst, CpuRegister src1, CpuRegister src2)
+ }
+ 
+ void X86_64Assembler::andnpd(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vandnpd(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2952,6 +2899,10 @@ void X86_64Assembler::andnpd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::andnps(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vandnps(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitOptionalRex32(dst, src);
+   EmitUint8(0x0F);
+@@ -2960,6 +2911,10 @@ void X86_64Assembler::andnps(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pandn(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpandn(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -2970,95 +2925,25 @@ void X86_64Assembler::pandn(XmmRegister dst, XmmRegister src) {
+ 
+ /* VEX.128.66.0F.WIG DF /r VPANDN xmm1, xmm2, xmm3/m128 */
+ void X86_64Assembler::vpandn(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  }
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0xDF);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0xDF, SET_VEX_PP_66);
+ }
+ 
+ /* VEX.128.0F 55 /r VANDNPS xmm1, xmm2, xmm3/m128 */
+ void X86_64Assembler::vandnps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  }
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0x55);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0x55, SET_VEX_PP_NONE);
+ }
+ 
+ /* VEX.128.66.0F 55 /r VANDNPD xmm1, xmm2, xmm3/m128 */
+ void X86_64Assembler::vandnpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  }
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0x55);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0x55, SET_VEX_PP_66);
+ }
+ 
+ void X86_64Assembler::orpd(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vorpd(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3068,6 +2953,10 @@ void X86_64Assembler::orpd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::orps(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vorps(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitOptionalRex32(dst, src);
+   EmitUint8(0x0F);
+@@ -3076,6 +2965,10 @@ void X86_64Assembler::orps(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::por(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpor(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3086,101 +2979,25 @@ void X86_64Assembler::por(XmmRegister dst, XmmRegister src) {
+ 
+ /* VEX.128.66.0F.WIG EB /r VPOR xmm1, xmm2, xmm3/m128 */
+ void X86_64Assembler::vpor(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!src1.NeedsRex()) {
+-    return vpor(dst, src2, src1);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0xEB);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0xEB, SET_VEX_PP_66, /*is_commutative*/ true);
+ }
+ 
+ /* VEX.128.0F 56 /r VORPS xmm1,xmm2, xmm3/m128 */
+ void X86_64Assembler::vorps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!src1.NeedsRex()) {
+-    return vorps(dst, src2, src1);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_NONE);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0x56);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0x56, SET_VEX_PP_NONE, /*is_commutative*/ true);
+ }
+ 
+ /* VEX.128.66.0F 56 /r VORPD xmm1,xmm2, xmm3/m128 */
+ void X86_64Assembler::vorpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
+-  bool is_twobyte_form = false;
+-  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
+-  if (!src2.NeedsRex()) {
+-    is_twobyte_form = true;
+-  } else if (!src1.NeedsRex()) {
+-    return vorpd(dst, src2, src1);
+-  }
+-  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+-  X86_64ManagedRegister vvvv_reg =
+-      X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+-  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
+-  if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  } else {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+-                                   /*X=*/ false,
+-                                   src2.NeedsRex(),
+-                                   SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
+-  }
+-  EmitUint8(ByteZero);
+-  EmitUint8(ByteOne);
+-  if (!is_twobyte_form) {
+-    EmitUint8(ByteTwo);
+-  }
+-  EmitUint8(0x56);
+-  EmitXmmRegisterOperand(dst.LowBits(), src2);
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0x56, SET_VEX_PP_66, /*is_commutative*/ true);
+ }
+ 
+ void X86_64Assembler::pavgb(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpavgb(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3190,6 +3007,10 @@ void X86_64Assembler::pavgb(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pavgw(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpavgw(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3198,6 +3019,20 @@ void X86_64Assembler::pavgw(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++/*VEX.128.66.0F.WIG E0 /r VPAVGB xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F.WIG E0 /r VPAVGB ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpavgb(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0xE0, SET_VEX_PP_66, /*is_commutative*/ true);
++}
++
++/*VEX.128.66.0F.WIG E3 /r VPAVGW xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F.WIG E3 /r VPAVGW ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpavgw(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0xE3, SET_VEX_PP_66, /*is_commutative*/ true);
++}
++
+ void X86_64Assembler::psadbw(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+@@ -3217,9 +3052,10 @@ void X86_64Assembler::pmaddwd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::vpmaddwd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
+-  DCHECK(CpuHasAVXorAVX2FeatureFlag());
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
+   bool is_twobyte_form = false;
+   uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  uint8_t VEX_L = GetEncodedVexLen(dst);
+   if (!src2.NeedsRex()) {
+     is_twobyte_form = true;
+   } else if (!src1.NeedsRex()) {
+@@ -3230,13 +3066,13 @@ void X86_64Assembler::vpmaddwd(XmmRegister dst, XmmRegister src1, XmmRegister sr
+   X86_64ManagedRegister vvvv_reg =
+       X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
+   if (is_twobyte_form) {
+-    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, VEX_L, SET_VEX_PP_66);
+   } else {
+     ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
+                                    /*X=*/ false,
+                                    src2.NeedsRex(),
+                                    SET_VEX_M_0F);
+-    ByteTwo = EmitVexPrefixByteTwo(/*W=*/ false, vvvv_reg, SET_VEX_L_128, SET_VEX_PP_66);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, vvvv_reg, VEX_L, SET_VEX_PP_66);
+   }
+   EmitUint8(ByteZero);
+   EmitUint8(ByteOne);
+@@ -3267,6 +3103,31 @@ void X86_64Assembler::phaddd(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++/*VEX.128.66.0F38.WIG 02 /r VPHADDD xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F38.WIG 02 /r VPHADDD ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vphaddd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  uint8_t byte_zero, byte_one, byte_two;
++  uint8_t VEX_L = GetEncodedVexLen(dst);
++  X86_64ManagedRegister vvvv_reg = X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++
++  // Instruction VEX Prefix
++  byte_zero = EmitVexPrefixByteZero(/*is_twobyte_form*/ false);
++  byte_one = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                  /*X=*/false,
++                                  src2.NeedsRex(),
++                                  SET_VEX_M_0F_38);
++  byte_two = EmitVexPrefixByteTwo(/*W=*/false, vvvv_reg, VEX_L, SET_VEX_PP_66);
++
++  EmitUint8(byte_zero);
++  EmitUint8(byte_one);
++  EmitUint8(byte_two);
++  // Instruction Opcode
++  EmitUint8(0x02);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
+ void X86_64Assembler::haddps(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0xF2);
+@@ -3324,6 +3185,10 @@ void X86_64Assembler::hsubpd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pminsb(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpminsb(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3334,6 +3199,10 @@ void X86_64Assembler::pminsb(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pmaxsb(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpmaxsb(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3344,6 +3213,10 @@ void X86_64Assembler::pmaxsb(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pminsw(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpminsw(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3353,6 +3226,10 @@ void X86_64Assembler::pminsw(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pmaxsw(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpmaxsw(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3362,6 +3239,10 @@ void X86_64Assembler::pmaxsw(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pminsd(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpminsd(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3372,6 +3253,10 @@ void X86_64Assembler::pminsd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pmaxsd(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpmaxsd(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3382,6 +3267,10 @@ void X86_64Assembler::pmaxsd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pminub(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpminub(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3391,6 +3280,10 @@ void X86_64Assembler::pminub(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pmaxub(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpmaxub(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3400,6 +3293,10 @@ void X86_64Assembler::pmaxub(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pminuw(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpminuw(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3410,6 +3307,10 @@ void X86_64Assembler::pminuw(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pmaxuw(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpmaxuw(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3420,6 +3321,10 @@ void X86_64Assembler::pmaxuw(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pminud(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpminud(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3430,6 +3335,10 @@ void X86_64Assembler::pminud(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pmaxud(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpmaxud(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3440,6 +3349,10 @@ void X86_64Assembler::pmaxud(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::minps(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vminps(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitOptionalRex32(dst, src);
+   EmitUint8(0x0F);
+@@ -3448,6 +3361,10 @@ void X86_64Assembler::minps(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::maxps(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vmaxps(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitOptionalRex32(dst, src);
+   EmitUint8(0x0F);
+@@ -3456,6 +3373,10 @@ void X86_64Assembler::maxps(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::minpd(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vminpd(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3465,6 +3386,10 @@ void X86_64Assembler::minpd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::maxpd(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vmaxpd(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3474,6 +3399,10 @@ void X86_64Assembler::maxpd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pcmpeqb(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpcmpeqb(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3510,6 +3439,11 @@ void X86_64Assembler::pcmpeqq(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++void X86_64Assembler::vpcmpeqb(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecArithAndLogicalOperation(dst, src1, src2, 0x74, SET_VEX_PP_66, /*is_commutative*/ true);
++}
++
+ void X86_64Assembler::pcmpgtb(XmmRegister dst, XmmRegister src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+@@ -3538,6 +3472,10 @@ void X86_64Assembler::pcmpgtd(XmmRegister dst, XmmRegister src) {
+ }
+ 
+ void X86_64Assembler::pcmpgtq(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpcmpgtq(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3547,6 +3485,11 @@ void X86_64Assembler::pcmpgtq(XmmRegister dst, XmmRegister src) {
+   EmitXmmRegisterOperand(dst.LowBits(), src);
+ }
+ 
++void X86_64Assembler::vpcmpgtq(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecMinMaxOperation(dst, src1, src2, SET_VEX_PP_66, /*is_vex_3byte*/ true, /*opcode*/ 0x37);
++}
++
+ void X86_64Assembler::shufpd(XmmRegister dst, XmmRegister src, const Immediate& imm) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+@@ -3580,6 +3523,10 @@ void X86_64Assembler::pshufd(XmmRegister dst, XmmRegister src, const Immediate&
+ 
+ 
+ void X86_64Assembler::punpcklbw(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpunpcklbw(dst, dst, src);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex32(dst, src);
+@@ -3661,6 +3608,10 @@ void X86_64Assembler::punpckhqdq(XmmRegister dst, XmmRegister src) {
+ 
+ void X86_64Assembler::psllw(XmmRegister reg, const Immediate& shift_count) {
+   DCHECK(shift_count.is_uint8());
++  if (reg.IsYMM()) {
++    vpsllw(reg, reg, shift_count);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex(false, false, false, false, reg.NeedsRex());
+@@ -3673,6 +3624,10 @@ void X86_64Assembler::psllw(XmmRegister reg, const Immediate& shift_count) {
+ 
+ void X86_64Assembler::pslld(XmmRegister reg, const Immediate& shift_count) {
+   DCHECK(shift_count.is_uint8());
++  if (reg.IsYMM()) {
++    vpslld(reg, reg, shift_count);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex(false, false, false, false, reg.NeedsRex());
+@@ -3685,6 +3640,10 @@ void X86_64Assembler::pslld(XmmRegister reg, const Immediate& shift_count) {
+ 
+ void X86_64Assembler::psllq(XmmRegister reg, const Immediate& shift_count) {
+   DCHECK(shift_count.is_uint8());
++  if (reg.IsYMM()) {
++    vpsllq(reg, reg, shift_count);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex(false, false, false, false, reg.NeedsRex());
+@@ -3694,9 +3653,33 @@ void X86_64Assembler::psllq(XmmRegister reg, const Immediate& shift_count) {
+   EmitUint8(shift_count.value());
+ }
+ 
++/*VEX.128.66.0F.WIG 71 /6 ib VPSLLW xmm1, xmm2, imm8
++  VEX.256.66.0F.WIG 71 /6 ib VPSLLW ymm1, ymm2, imm8*/
++void X86_64Assembler::vpsllw(XmmRegister dst, XmmRegister src, const Immediate& shift_count) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecShiftOperation(dst, src, shift_count, 0x71, 6);
++}
++
++/*VEX.128.66.0F.WIG 72 /6 ib VPSLLD xmm1, xmm2, imm8
++  VEX.256.66.0F.WIG 72 /6 ib VPSLLD ymm1, ymm2, imm8*/
++void X86_64Assembler::vpslld(XmmRegister dst, XmmRegister src, const Immediate& shift_count) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecShiftOperation(dst, src, shift_count, 0x72, 6);
++}
++
++/*VEX.128.66.0F.WIG 73 /6 ib VPSLLQ xmm1, xmm2, imm8
++  VEX.256.66.0F.WIG 73 /6 ib VPSLLQ ymm1, ymm2, imm8*/
++void X86_64Assembler::vpsllq(XmmRegister dst, XmmRegister src, const Immediate& shift_count) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecShiftOperation(dst, src, shift_count, 0x73, 6);
++}
+ 
+ void X86_64Assembler::psraw(XmmRegister reg, const Immediate& shift_count) {
+   DCHECK(shift_count.is_uint8());
++  if (reg.IsYMM()) {
++    vpsraw(reg, reg, shift_count);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex(false, false, false, false, reg.NeedsRex());
+@@ -3709,6 +3692,10 @@ void X86_64Assembler::psraw(XmmRegister reg, const Immediate& shift_count) {
+ 
+ void X86_64Assembler::psrad(XmmRegister reg, const Immediate& shift_count) {
+   DCHECK(shift_count.is_uint8());
++  if (reg.IsYMM()) {
++    vpsrad(reg, reg, shift_count);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex(false, false, false, false, reg.NeedsRex());
+@@ -3718,9 +3705,26 @@ void X86_64Assembler::psrad(XmmRegister reg, const Immediate& shift_count) {
+   EmitUint8(shift_count.value());
+ }
+ 
++/*VEX.128.66.0F.WIG 71 /4 ib VPSRAW xmm1, xmm2, imm8
++  VEX.256.66.0F.WIG 71 /4 ib VPSRAW ymm1, ymm2, imm8*/
++void X86_64Assembler::vpsraw(XmmRegister dst, XmmRegister src, const Immediate& shift_count) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecShiftOperation(dst, src, shift_count, 0x71, 4);
++}
++
++/*VEX.128.66.0F.WIG 72 /4 ib VPSRAD xmm1, xmm2, imm8
++  VEX.256.66.0F.WIG 72 /4 ib VPSRAD ymm1, ymm2, imm8*/
++void X86_64Assembler::vpsrad(XmmRegister dst, XmmRegister src, const Immediate& shift_count) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecShiftOperation(dst, src, shift_count, 0x72, 4);
++}
+ 
+ void X86_64Assembler::psrlw(XmmRegister reg, const Immediate& shift_count) {
+   DCHECK(shift_count.is_uint8());
++  if (reg.IsYMM()) {
++    vpsrlw(reg, reg, shift_count);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex(false, false, false, false, reg.NeedsRex());
+@@ -3733,6 +3737,10 @@ void X86_64Assembler::psrlw(XmmRegister reg, const Immediate& shift_count) {
+ 
+ void X86_64Assembler::psrld(XmmRegister reg, const Immediate& shift_count) {
+   DCHECK(shift_count.is_uint8());
++  if (reg.IsYMM()) {
++    vpsrld(reg, reg, shift_count);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex(false, false, false, false, reg.NeedsRex());
+@@ -3745,6 +3753,10 @@ void X86_64Assembler::psrld(XmmRegister reg, const Immediate& shift_count) {
+ 
+ void X86_64Assembler::psrlq(XmmRegister reg, const Immediate& shift_count) {
+   DCHECK(shift_count.is_uint8());
++  if (reg.IsYMM()) {
++    vpsrlq(reg, reg, shift_count);
++    return;
++  }
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+   EmitUint8(0x66);
+   EmitOptionalRex(false, false, false, false, reg.NeedsRex());
+@@ -3766,6 +3778,302 @@ void X86_64Assembler::psrldq(XmmRegister reg, const Immediate& shift_count) {
+   EmitUint8(shift_count.value());
+ }
+ 
++/*VEX.128.66.0F.WIG 71 /2 ib VPSRLW xmm1, xmm2, imm8
++  VEX.256.66.0F.WIG 71 /2 ib VPSRLW ymm1, ymm2, imm8*/
++void X86_64Assembler::vpsrlw(XmmRegister dst, XmmRegister src, const Immediate& shift_count) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecShiftOperation(dst, src, shift_count, 0x71, 2);
++}
++
++/*VEX.128.66.0F.WIG 72 /2 ib VPSRLD xmm1, xmm2, imm8
++  VEX.256.66.0F.WIG 72 /2 ib VPSRLD ymm1, ymm2, imm8*/
++void X86_64Assembler::vpsrld(XmmRegister dst, XmmRegister src, const Immediate& shift_count) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecShiftOperation(dst, src, shift_count, 0x72, 2);
++}
++
++/*VEX.128.66.0F.WIG 73 /2 ib VPSRLQ xmm1, xmm2, imm8
++  VEX.256.66.0F.WIG 73 /2 ib VPSRLQ ymm1, ymm2, imm8*/
++void X86_64Assembler::vpsrlq(XmmRegister dst, XmmRegister src, const Immediate& shift_count) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecShiftOperation(dst, src, shift_count, 0x73, 2);
++}
++
++/*VEX.256.66.0F3A.W1 01 /r ib VPERMPD ymm1, ymm2/m256, imm8*/
++void X86_64Assembler::vpermpd(XmmRegister dst, XmmRegister src, const Immediate& indices) {
++  DCHECK(CpuHasAVX2FeatureFlag());
++  DCHECK(dst.IsYMM());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  uint8_t VEX_L = GetEncodedVexLen(dst);
++  ByteZero = EmitVexPrefixByteZero(/*is_twobyte_form*/ false);
++  ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                 /*X=*/false,
++                                 src.NeedsRex(),
++                                 SET_VEX_M_0F_3A);
++  ByteTwo = EmitVexPrefixByteTwo(/*W=*/true, VEX_L, SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(ByteTwo);
++  EmitUint8(0x01);
++  EmitXmmRegisterOperand(dst.LowBits(), src);
++  EmitUint8(indices.value());
++}
++
++/*VEX.128.66.0F38 38 /r VPMINSB xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F38 38 /r VPMINSB ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpminsb(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecMinMaxOperation(dst, src1, src2, SET_VEX_PP_66, /*is_vex_3byte*/ true, /*opcode*/ 0x38);
++}
++
++/*VEX.128.66.0F38.WIG 3C /r VPMAXSB xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F38.WIG 3C /r VPMAXSB ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpmaxsb(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecMinMaxOperation(dst, src1, src2, SET_VEX_PP_66, /*is_vex_3byte*/ true, /*opcode*/ 0x3C);
++}
++
++/*VEX.128.66.0F EA /r VPMINSW xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F EA /r VPMINSW ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpminsw(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecMinMaxOperation(dst,
++                         src1,
++                         src2,
++                         SET_VEX_PP_66,
++                         /*is_vex_3byte*/ false,
++                         /*opcode*/ 0xEA,
++                         /*is_commutative*/ true);
++}
++
++/*VEX.128.66.0F.WIG EE /r VPMAXSW xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F.WIG EE /r VPMAXSW ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpmaxsw(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecMinMaxOperation(dst,
++                         src1,
++                         src2,
++                         SET_VEX_PP_66,
++                         /*is_vex_3byte*/ false,
++                         /*opcode*/ 0xEE,
++                         /*is_commutative*/ true);
++}
++
++/*VEX.128.66.0F38.WIG 39 /r VPMINSD xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F38.WIG 39 /r VPMINSD ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpminsd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecMinMaxOperation(dst, src1, src2, SET_VEX_PP_66, /*is_vex_3byte*/ true, /*opcode*/ 0x39);
++}
++
++/*VEX.128.66.0F38.WIG 3D /r VPMAXSD xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F38.WIG 3D /r VPMAXSD ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpmaxsd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecMinMaxOperation(dst, src1, src2, SET_VEX_PP_66, /*is_vex_3byte*/ true, /*opcode*/ 0x3D);
++}
++
++/*VEX.128.66.0F DA /r VPMINUB xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F DA /r VPMINUB ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpminub(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecMinMaxOperation(dst,
++                         src1,
++                         src2,
++                         SET_VEX_PP_66,
++                         /*is_vex_3byte*/ false,
++                         /*opcode*/ 0xDA,
++                         /*is_commutative*/ true);
++}
++
++/*VEX.128.66.0F DE /r VPMAXUB xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F DE /r VPMAXUB ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpmaxub(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecMinMaxOperation(dst,
++                         src1,
++                         src2,
++                         SET_VEX_PP_66,
++                         /*is_vex_3byte*/ false,
++                         /*opcode*/ 0xDE,
++                         /*is_commutative*/ true);
++}
++
++/*VEX.128.66.0F38 3A/r VPMINUW xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F38 3A/r VPMINUW ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpminuw(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecMinMaxOperation(dst, src1, src2, SET_VEX_PP_66, /*is_vex_3byte*/ true, /*opcode*/ 0x3A);
++}
++
++/*VEX.128.66.0F38 3E/r VPMAXUW xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F38 3E/r VPMAXUW ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpmaxuw(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecMinMaxOperation(dst, src1, src2, SET_VEX_PP_66, /*is_vex_3byte*/ true, /*opcode*/ 0x3E);
++}
++
++/*VEX.128.66.0F38.WIG 3B /r VPMINUD xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F38.WIG 3B /r VPMINUD ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpminud(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecMinMaxOperation(dst, src1, src2, SET_VEX_PP_66, /*is_vex_3byte*/ true, /*opcode*/ 0x3B);
++}
++
++/*VEX.128.66.0F38.WIG 3F /r VPMAXUD xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F38.WIG 3F /r VPMAXUD ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpmaxud(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecMinMaxOperation(dst, src1, src2, SET_VEX_PP_66, /*is_vex_3byte*/ true, /*opcode*/ 0x3F);
++}
++
++/*VEX.128.0F.WIG 5D /r VMINPS xmm1, xmm2, xmm3/m128
++  VEX.256.0F.WIG 5D /r VMINPS ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vminps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  EmitVecMinMaxOperation(dst, src1, src2, SET_VEX_PP_NONE, /*is_vex_3byte*/ false, /*opcode*/ 0x5D);
++}
++
++/*VEX.128.0F.WIG 5F /r VMAXPS xmm1, xmm2, xmm3/m128
++  VEX.256.0F.WIG 5F /r VMAXPS ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vmaxps(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  EmitVecMinMaxOperation(dst, src1, src2, SET_VEX_PP_NONE, /*is_vex_3byte*/ false, /*opcode*/ 0x5F);
++}
++
++/*VEX.128.66.0F.WIG 5D /r VMINPD xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F.WIG 5D /r VMINPD ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vminpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  EmitVecMinMaxOperation(dst, src1, src2, SET_VEX_PP_66, /*is_vex_3byte*/ false, /*opcode*/ 0x5D);
++}
++
++/*VEX.128.66.0F.WIG 5F /r VMAXPD xmm1, xmm2, xmm3/m128
++  VEX.256.66.0F.WIG 5F /r VMAXPD ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vmaxpd(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  EmitVecMinMaxOperation(dst, src1, src2, SET_VEX_PP_66, /*is_vex_3byte*/ false, /*opcode*/ 0x5F);
++}
++
++void X86_64Assembler::vbroadcastss(XmmRegister dst, XmmRegister src) {
++  DCHECK(CpuHasAVX2FeatureFlag());
++  EmitVecBroadcastInstruction(dst, src, 0x18);
++}
++
++void X86_64Assembler::vbroadcastsd(XmmRegister dst, XmmRegister src) {
++  DCHECK(CpuHasAVX2FeatureFlag());
++  EmitVecBroadcastInstruction(dst, src, 0x19);
++}
++
++void X86_64Assembler::vpbroadcastb(XmmRegister dst, XmmRegister src) {
++  DCHECK(CpuHasAVX2FeatureFlag());
++  EmitVecBroadcastInstruction(dst, src, 0x78);
++}
++
++void X86_64Assembler::vpbroadcastw(XmmRegister dst, XmmRegister src) {
++  DCHECK(CpuHasAVX2FeatureFlag());
++  EmitVecBroadcastInstruction(dst, src, 0x79);
++}
++
++void X86_64Assembler::vpbroadcastd(XmmRegister dst, XmmRegister src) {
++  DCHECK(CpuHasAVX2FeatureFlag());
++  EmitVecBroadcastInstruction(dst, src, 0x58);
++}
++
++void X86_64Assembler::vpbroadcastq(XmmRegister dst, XmmRegister src) {
++  DCHECK(CpuHasAVX2FeatureFlag());
++  EmitVecBroadcastInstruction(dst, src, 0x59);
++}
++
++void X86_64Assembler::pabsb(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpabsb(dst, src);
++    return;
++  }
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  EmitUint8(0x66);
++  EmitOptionalRex(false, false, dst.NeedsRex(), false, src.NeedsRex());
++  EmitUint8(0x0F);
++  EmitUint8(0x38);
++  EmitUint8(0x1C);
++  EmitRegisterOperand(dst.LowBits(), src.LowBits());
++}
++
++void X86_64Assembler::pabsw(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpabsw(dst, src);
++    return;
++  }
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  EmitUint8(0x66);
++  EmitOptionalRex(false, false, dst.NeedsRex(), false, src.NeedsRex());
++  EmitUint8(0x0F);
++  EmitUint8(0x38);
++  EmitUint8(0x1D);
++  EmitRegisterOperand(dst.LowBits(), src.LowBits());
++}
++
++void X86_64Assembler::pabsd(XmmRegister dst, XmmRegister src) {
++  if (dst.IsYMM()) {
++    vpabsd(dst, src);
++    return;
++  }
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  EmitUint8(0x66);
++  EmitOptionalRex(false, false, dst.NeedsRex(), false, src.NeedsRex());
++  EmitUint8(0x0F);
++  EmitUint8(0x38);
++  EmitUint8(0x1E);
++  EmitRegisterOperand(dst.LowBits(), src.LowBits());
++}
++
++void X86_64Assembler::vpabsb(XmmRegister dst, XmmRegister src) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecBroadcastInstruction(dst, src, 0x1C);
++}
++
++void X86_64Assembler::vpabsw(XmmRegister dst, XmmRegister src) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecBroadcastInstruction(dst, src, 0x1D);
++}
++
++void X86_64Assembler::vpabsd(XmmRegister dst, XmmRegister src) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  EmitVecBroadcastInstruction(dst, src, 0x1E);
++}
++
++/*VEX.128.66.0F.WIG 60/r VPUNPCKLBW xmm1,xmm2, xmm3/m128
++  VEX.256.66.0F.WIG 60 /r VPUNPCKLBW ymm1, ymm2, ymm3/m256*/
++void X86_64Assembler::vpunpcklbw(XmmRegister dst, XmmRegister src1, XmmRegister src2) {
++  DCHECK(CpuHasAVX2FeatureFlag() || (!dst.IsYMM() && CpuHasAVXFeatureFlag()));
++  uint8_t byte_zero, byte_one, byte_two;
++  bool is_twobyte_form = true;
++  uint8_t VEX_L = GetEncodedVexLen(dst);
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++
++  if (src2.NeedsRex()) {
++    is_twobyte_form = false;
++  }
++  // Instruction VEX Prefix
++  byte_zero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg = X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++
++  if (is_twobyte_form) {
++    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, VEX_L, SET_VEX_PP_66);
++  } else {
++    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                    /*X=*/false,
++                                    src2.NeedsRex(),
++                                    SET_VEX_M_0F);
++    byte_two = EmitVexPrefixByteTwo(/*W=*/false, vvvv_reg, VEX_L, SET_VEX_PP_66);
++  }
++  EmitUint8(byte_zero);
++  EmitUint8(byte_one);
++  if (!is_twobyte_form) {
++    EmitUint8(byte_two);
++  }
++
++  // Instruction Opcode
++  EmitUint8(0x60);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
+ 
+ void X86_64Assembler::fldl(const Address& src) {
+   AssemblerBuffer::EnsureCapacity ensured(&buffer_);
+@@ -5347,6 +5655,14 @@ void X86_64Assembler::ud2() {
+   EmitUint8(0x0B);
+ }
+ 
++void X86_64Assembler::vzeroupper() {
++  DCHECK(CpuHasAVXFeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  EmitUint8(0xC5);
++  EmitUint8(0xF8);
++  EmitUint8(0x77);
++}
++
+ void X86_64Assembler::LoadDoubleConstant(XmmRegister dst, double value) {
+   // TODO: Need to have a code constants table.
+   int64_t constant = bit_cast<int64_t, double>(value);
+@@ -5616,6 +5932,10 @@ void X86_64Assembler::EmitRex64(CpuRegister dst, XmmRegister src) {
+   EmitOptionalRex(false, true, dst.NeedsRex(), false, src.NeedsRex());
+ }
+ 
++void X86_64Assembler::EmitRex64(XmmRegister dst, XmmRegister src) {
++  EmitOptionalRex(false, true, dst.NeedsRex(), false, src.NeedsRex());
++}
++
+ void X86_64Assembler::EmitRex64(CpuRegister dst, const Operand& operand) {
+   uint8_t rex = 0x48 | operand.rex();  // REX.W000
+   if (dst.NeedsRex()) {
+@@ -5756,6 +6076,145 @@ uint8_t X86_64Assembler::EmitVexPrefixByteOne(bool R, bool X, bool B, int SET_VE
+   return vex_prefix;
+ }
+ 
++void X86_64Assembler::EmitVecArithAndLogicalOperation(XmmRegister dst,
++                                                      XmmRegister src1,
++                                                      XmmRegister src2,
++                                                      uint8_t opcode,
++                                                      int vex_pp,
++                                                      bool is_commutative) {
++  DCHECK(CpuHasAVXFeatureFlag());
++  bool is_twobyte_form = false;
++  uint8_t ByteZero = 0x00, ByteOne = 0x00, ByteTwo = 0x00;
++  uint8_t VEX_L = GetEncodedVexLen(dst);
++  if (!src2.NeedsRex()) {
++    is_twobyte_form = true;
++  } else if (is_commutative && !src1.NeedsRex()) {
++    return EmitVecArithAndLogicalOperation(dst, src2, src1, opcode, vex_pp, is_commutative);
++  }
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++
++  X86_64ManagedRegister vvvv_reg = X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  ByteZero = EmitVexPrefixByteZero(is_twobyte_form);
++  if (is_twobyte_form) {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, VEX_L, vex_pp);
++  } else {
++    ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                   /*X=*/false,
++                                   src2.NeedsRex(),
++                                   SET_VEX_M_0F);
++    ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, vvvv_reg, VEX_L, vex_pp);
++  }
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  if (!is_twobyte_form) {
++    EmitUint8(ByteTwo);
++  }
++  EmitUint8(opcode);
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
++void X86_64Assembler::EmitVecMinMaxOperation(XmmRegister dst,
++                                             XmmRegister src1,
++                                             XmmRegister src2,
++                                             uint8_t vex_pp,
++                                             bool is_vex_3byte,
++                                             uint8_t opcode,
++                                             bool is_commutative) {
++  DCHECK(CpuHasAVXFeatureFlag());
++  uint8_t byte_zero, byte_one, byte_two;
++  bool is_twobyte_form = !is_vex_3byte;
++  uint8_t VEX_L = GetEncodedVexLen(dst);
++
++  if (is_twobyte_form) {
++    if (is_commutative && src2.NeedsRex() && !src1.NeedsRex()) {
++      return EmitVecMinMaxOperation(dst, src2, src1, vex_pp, is_vex_3byte, opcode, is_commutative);
++    }
++    is_twobyte_form = !src2.NeedsRex();
++  }
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  // Instruction VEX Prefix
++  byte_zero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg = X86_64ManagedRegister::FromXmmRegister(src1.AsFloatRegister());
++  if (is_twobyte_form) {
++    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, VEX_L, vex_pp);
++  } else {
++    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                    /*X=*/false,
++                                    src2.NeedsRex(),
++                                    is_vex_3byte ? SET_VEX_M_0F_38 : SET_VEX_M_0F);
++    byte_two = EmitVexPrefixByteTwo(/*W=*/false, vvvv_reg, VEX_L, vex_pp);
++  }
++  EmitUint8(byte_zero);
++  EmitUint8(byte_one);
++  if (!is_twobyte_form) {
++    EmitUint8(byte_two);
++  }
++  // Instruction Opcode
++  EmitUint8(opcode);
++
++  // Instruction Operands
++  EmitXmmRegisterOperand(dst.LowBits(), src2);
++}
++
++void X86_64Assembler::EmitVecBroadcastInstruction(XmmRegister dst,
++                                                  XmmRegister src,
++                                                  uint8_t opcode) {
++  DCHECK(CpuHasAVXFeatureFlag());
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++  uint8_t ByteOne = 0x00, ByteZero = 0x00, ByteTwo = 0x00;
++  uint8_t VEX_L = GetEncodedVexLen(dst);
++  ByteZero = EmitVexPrefixByteZero(false /*is_twobyte_form */);
++  ByteOne = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                 /*X=*/false,
++                                 src.NeedsRex(),
++                                 SET_VEX_M_0F_38);
++  ByteTwo = EmitVexPrefixByteTwo(/*W=*/false, VEX_L, SET_VEX_PP_66);
++  EmitUint8(ByteZero);
++  EmitUint8(ByteOne);
++  EmitUint8(ByteTwo);
++  EmitUint8(opcode);
++  EmitXmmRegisterOperand(dst.LowBits(), src);
++}
++
++void X86_64Assembler::EmitVecShiftOperation(XmmRegister dst,
++                                            XmmRegister src,
++                                            const Immediate& shift_count,
++                                            uint8_t opcode,
++                                            uint8_t operand_byte) {
++  DCHECK(CpuHasAVXFeatureFlag());
++  uint8_t byte_zero, byte_one, byte_two;
++  bool is_twobyte_form = true;
++  uint8_t VEX_L = GetEncodedVexLen(dst);
++  AssemblerBuffer::EnsureCapacity ensured(&buffer_);
++
++  if (src.NeedsRex()) {
++    is_twobyte_form = false;
++  }
++  // Instruction VEX Prefix
++  byte_zero = EmitVexPrefixByteZero(is_twobyte_form);
++  X86_64ManagedRegister vvvv_reg = X86_64ManagedRegister::FromXmmRegister(dst.AsFloatRegister());
++  if (is_twobyte_form) {
++    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(), vvvv_reg, VEX_L, SET_VEX_PP_66);
++  } else {
++    byte_one = EmitVexPrefixByteOne(dst.NeedsRex(),
++                                    /*X=*/false,
++                                    src.NeedsRex(),
++                                    SET_VEX_M_0F);
++    byte_two = EmitVexPrefixByteTwo(/*W=*/false, vvvv_reg, VEX_L, SET_VEX_PP_66);
++  }
++  EmitUint8(byte_zero);
++  EmitUint8(byte_one);
++  if (!is_twobyte_form) {
++    EmitUint8(byte_two);
++  }
++  // Instruction Opcode
++  EmitUint8(opcode);
++
++  // Instruction Operands
++  EmitXmmRegisterOperand(operand_byte, src);
++  EmitUint8(shift_count.value());
++}
++
+ uint8_t X86_64Assembler::EmitVexPrefixByteOne(bool R,
+                                               X86_64ManagedRegister operand,
+                                               int SET_VEX_L,
+@@ -5803,7 +6262,9 @@ uint8_t X86_64Assembler::EmitVexPrefixByteTwo(bool W,
+     vex_prefix |= SET_VEX_W;
+   }
+   // Bits[6:3] - 'vvvv' the source or dest register specifier
+-  if (operand.IsXmmRegister()) {
++  if (operand.IsNoRegister()) {
++    vex_prefix |= 0x78;
++  } else if (operand.IsXmmRegister()) {
+     XmmRegister vvvv = operand.AsXmmRegister();
+     int inverted_reg = 15 - static_cast<int>(vvvv.AsFloatRegister());
+     uint8_t reg = static_cast<uint8_t>(inverted_reg);
+@@ -5825,25 +6286,8 @@ uint8_t X86_64Assembler::EmitVexPrefixByteTwo(bool W,
+ uint8_t X86_64Assembler::EmitVexPrefixByteTwo(bool W,
+                                               int SET_VEX_L,
+                                               int SET_VEX_PP) {
+-  // Vex Byte 2,
+-  uint8_t vex_prefix = VEX_INIT;
+-
+-  /** Bit[7] This bits needs to be set to '1' with default value.
+-  When using C4H form of VEX prefix, REX.W value is ignored */
+-  if (W) {
+-    vex_prefix |= SET_VEX_W;
+-  }
+-  /** Bits[6:3] - 'vvvv' the source or dest register specifier */
+-  vex_prefix |= (0x0F << 3);
+-  /** Bit[2] - "L" If VEX.L = 1 indicates 256-bit vector operation,
+-  VEX.L = 0 indicates 128 bit vector operation */
+-  vex_prefix |= SET_VEX_L;
+-
+-  // Bits[1:0] -  "pp"
+-  if (SET_VEX_PP != SET_VEX_PP_NONE) {
+-    vex_prefix |= SET_VEX_PP;
+-  }
+-  return vex_prefix;
++  X86_64ManagedRegister vvvv_reg = ManagedRegister::NoRegister().AsX86_64();
++  return EmitVexPrefixByteTwo(W, vvvv_reg, SET_VEX_L, SET_VEX_PP);
+ }
+ 
+ }  // namespace x86_64
+diff --git a/compiler/utils/x86_64/assembler_x86_64.h b/compiler/utils/x86_64/assembler_x86_64.h
+index b7475cd367..909a3f305c 100644
+--- a/compiler/utils/x86_64/assembler_x86_64.h
++++ b/compiler/utils/x86_64/assembler_x86_64.h
+@@ -484,16 +484,21 @@ class X86_64Assembler final : public Assembler {
+   void movups(XmmRegister dst, const Address& src);  // load unaligned
+   void movaps(const Address& dst, XmmRegister src);  // store aligned
+   void movups(const Address& dst, XmmRegister src);  // store unaligned
++  void movups(XmmRegister dst, XmmRegister src);
+ 
+   void vmovaps(XmmRegister dst, XmmRegister src);     // move
+   void vmovaps(XmmRegister dst, const Address& src);  // load aligned
+   void vmovaps(const Address& dst, XmmRegister src);  // store aligned
+   void vmovups(XmmRegister dst, const Address& src);  // load unaligned
+   void vmovups(const Address& dst, XmmRegister src);  // store unaligned
++  void vmovups(XmmRegister dst, XmmRegister src);
+ 
+   void movss(XmmRegister dst, const Address& src);
+   void movss(const Address& dst, XmmRegister src);
+   void movss(XmmRegister dst, XmmRegister src);
++  void vmovss(XmmRegister dst, const Address& src);
++  void vmovss(const Address& dst, XmmRegister src);
++  void vmovss(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void movsxd(CpuRegister dst, CpuRegister src);
+   void movsxd(CpuRegister dst, const Address& src);
+@@ -502,6 +507,10 @@ class X86_64Assembler final : public Assembler {
+   void movd(CpuRegister dst, XmmRegister src);  // Note: this is the r64 version, formally movq.
+   void movd(XmmRegister dst, CpuRegister src, bool is64bit);
+   void movd(CpuRegister dst, XmmRegister src, bool is64bit);
++  void vmovq(XmmRegister dst, CpuRegister src);
++  void vmovq(CpuRegister dst, XmmRegister src);
++  void vmovd(XmmRegister dst, CpuRegister src, bool is64bit = false);
++  void vmovd(CpuRegister dst, XmmRegister src, bool is64bit = false);
+ 
+   void addss(XmmRegister dst, XmmRegister src);
+   void addss(XmmRegister dst, const Address& src);
+@@ -517,15 +526,10 @@ class X86_64Assembler final : public Assembler {
+   void mulps(XmmRegister dst, XmmRegister src);
+   void divps(XmmRegister dst, XmmRegister src);
+ 
+-  void vmulps(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+-  void vmulpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+-  void vdivps(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+-  void vdivpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+-
+   void vaddps(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
+   void vsubps(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
+-  void vsubpd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
+-  void vaddpd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++  void vmulps(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vdivps(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void vfmadd213ss(XmmRegister accumulator, XmmRegister left, XmmRegister right);
+   void vfmadd213sd(XmmRegister accumulator, XmmRegister left, XmmRegister right);
+@@ -545,6 +549,9 @@ class X86_64Assembler final : public Assembler {
+   void movsd(XmmRegister dst, const Address& src);
+   void movsd(const Address& dst, XmmRegister src);
+   void movsd(XmmRegister dst, XmmRegister src);
++  void vmovsd(XmmRegister dst, const Address& src);
++  void vmovsd(const Address& dst, XmmRegister src);
++  void vmovsd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void addsd(XmmRegister dst, XmmRegister src);
+   void addsd(XmmRegister dst, const Address& src);
+@@ -560,6 +567,11 @@ class X86_64Assembler final : public Assembler {
+   void mulpd(XmmRegister dst, XmmRegister src);
+   void divpd(XmmRegister dst, XmmRegister src);
+ 
++  void vaddpd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++  void vsubpd(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++  void vmulpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vdivpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++
+   void movdqa(XmmRegister dst, XmmRegister src);     // move
+   void movdqa(XmmRegister dst, const Address& src);  // load aligned
+   void movdqu(XmmRegister dst, const Address& src);  // load unaligned
+@@ -576,23 +588,23 @@ class X86_64Assembler final : public Assembler {
+   void psubb(XmmRegister dst, XmmRegister src);
+ 
+   void vpaddb(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
+-  void vpaddw(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
++  void vpsubb(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void paddw(XmmRegister dst, XmmRegister src);
+   void psubw(XmmRegister dst, XmmRegister src);
+   void pmullw(XmmRegister dst, XmmRegister src);
+-  void vpmullw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+-  void vpsubb(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpaddw(XmmRegister dst, XmmRegister add_left, XmmRegister add_right);
+   void vpsubw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+-  void vpsubd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpmullw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void paddd(XmmRegister dst, XmmRegister src);
+   void psubd(XmmRegister dst, XmmRegister src);
+   void pmulld(XmmRegister dst, XmmRegister src);
+-  void vpmulld(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void vpaddd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpsubd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpmulld(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void paddq(XmmRegister dst, XmmRegister src);
+   void psubq(XmmRegister dst, XmmRegister src);
+@@ -609,6 +621,15 @@ class X86_64Assembler final : public Assembler {
+   void psubusw(XmmRegister dst, XmmRegister src);
+   void psubsw(XmmRegister dst, XmmRegister src);
+ 
++  void vpaddusb(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpaddsb(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpaddusw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpaddsw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpsubusb(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpsubsb(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpsubusw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpsubsw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++
+   void cvtsi2ss(XmmRegister dst, CpuRegister src);  // Note: this is the r/m32 version.
+   void cvtsi2ss(XmmRegister dst, CpuRegister src, bool is64bit);
+   void cvtsi2ss(XmmRegister dst, const Address& src, bool is64bit);
+@@ -630,6 +651,7 @@ class X86_64Assembler final : public Assembler {
+   void cvttsd2si(CpuRegister dst, XmmRegister src, bool is64bit);
+ 
+   void cvtdq2ps(XmmRegister dst, XmmRegister src);
++  void vcvtdq2ps(XmmRegister dst, XmmRegister src);
+   void cvtdq2pd(XmmRegister dst, XmmRegister src);
+ 
+   void comiss(XmmRegister a, XmmRegister b);
+@@ -681,11 +703,15 @@ class X86_64Assembler final : public Assembler {
+ 
+   void pavgb(XmmRegister dst, XmmRegister src);  // no addr variant (for now)
+   void pavgw(XmmRegister dst, XmmRegister src);
++  void vpavgb(XmmRegister dst, XmmRegister src1, XmmRegister src2);  // no addr variant (for now)
++  void vpavgw(XmmRegister dst, XmmRegister src, XmmRegister src2);
++
+   void psadbw(XmmRegister dst, XmmRegister src);
+   void pmaddwd(XmmRegister dst, XmmRegister src);
+   void vpmaddwd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+   void phaddw(XmmRegister dst, XmmRegister src);
+   void phaddd(XmmRegister dst, XmmRegister src);
++  void vphaddd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+   void haddps(XmmRegister dst, XmmRegister src);
+   void haddpd(XmmRegister dst, XmmRegister src);
+   void phsubw(XmmRegister dst, XmmRegister src);
+@@ -712,24 +738,59 @@ class X86_64Assembler final : public Assembler {
+   void minpd(XmmRegister dst, XmmRegister src);
+   void maxpd(XmmRegister dst, XmmRegister src);
+ 
++  void vpminsb(XmmRegister dst, XmmRegister src1, XmmRegister src2);  // no addr variant (for now)
++  void vpmaxsb(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpminsw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpmaxsw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpminsd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpmaxsd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++
++  void vpminub(XmmRegister dst, XmmRegister src1, XmmRegister src2);  // no addr variant (for now)
++  void vpmaxub(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpminuw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpmaxuw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpminud(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vpmaxud(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++
++  void vminps(XmmRegister dst, XmmRegister src1, XmmRegister src2);  // no addr variant (for now)
++  void vmaxps(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vminpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++  void vmaxpd(XmmRegister dst, XmmRegister src1, XmmRegister src2);
++
+   void pcmpeqb(XmmRegister dst, XmmRegister src);
+   void pcmpeqw(XmmRegister dst, XmmRegister src);
+   void pcmpeqd(XmmRegister dst, XmmRegister src);
+   void pcmpeqq(XmmRegister dst, XmmRegister src);
++  void vpcmpeqb(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void pcmpgtb(XmmRegister dst, XmmRegister src);
+   void pcmpgtw(XmmRegister dst, XmmRegister src);
+   void pcmpgtd(XmmRegister dst, XmmRegister src);
+   void pcmpgtq(XmmRegister dst, XmmRegister src);  // SSE4.2
++  void vpcmpgtq(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void shufpd(XmmRegister dst, XmmRegister src, const Immediate& imm);
+   void shufps(XmmRegister dst, XmmRegister src, const Immediate& imm);
+   void pshufd(XmmRegister dst, XmmRegister src, const Immediate& imm);
++  void vbroadcastss(XmmRegister dst, XmmRegister src);
++  void vbroadcastsd(XmmRegister dst, XmmRegister src);
++  void vpbroadcastb(XmmRegister dst, XmmRegister src);
++  void vpbroadcastw(XmmRegister dst, XmmRegister src);
++  void vpbroadcastd(XmmRegister dst, XmmRegister src);
++  void vpbroadcastq(XmmRegister dst, XmmRegister src);
++
++  void pabsb(XmmRegister dst, XmmRegister src);
++  void pabsw(XmmRegister dst, XmmRegister src);
++  void pabsd(XmmRegister dst, XmmRegister src);
++  void vpabsb(XmmRegister dst, XmmRegister src);
++  void vpabsw(XmmRegister dst, XmmRegister src);
++  void vpabsd(XmmRegister dst, XmmRegister src);
+ 
+   void punpcklbw(XmmRegister dst, XmmRegister src);
+   void punpcklwd(XmmRegister dst, XmmRegister src);
+   void punpckldq(XmmRegister dst, XmmRegister src);
+   void punpcklqdq(XmmRegister dst, XmmRegister src);
++  void vpunpcklbw(XmmRegister dst, XmmRegister src1, XmmRegister src2);
+ 
+   void punpckhbw(XmmRegister dst, XmmRegister src);
+   void punpckhwd(XmmRegister dst, XmmRegister src);
+@@ -739,15 +800,26 @@ class X86_64Assembler final : public Assembler {
+   void psllw(XmmRegister reg, const Immediate& shift_count);
+   void pslld(XmmRegister reg, const Immediate& shift_count);
+   void psllq(XmmRegister reg, const Immediate& shift_count);
++  void vpsllw(XmmRegister dst, XmmRegister src, const Immediate& shift_count);
++  void vpslld(XmmRegister dst, XmmRegister src, const Immediate& shift_count);
++  void vpsllq(XmmRegister dst, XmmRegister src, const Immediate& shift_count);
+ 
+   void psraw(XmmRegister reg, const Immediate& shift_count);
+   void psrad(XmmRegister reg, const Immediate& shift_count);
+   // no psraq
++  void vpsraw(XmmRegister dst, XmmRegister src, const Immediate& shift_count);
++  void vpsrad(XmmRegister dst, XmmRegister src, const Immediate& shift_count);
++  // vpsraq defined only with EVEX
+ 
+   void psrlw(XmmRegister reg, const Immediate& shift_count);
+   void psrld(XmmRegister reg, const Immediate& shift_count);
+   void psrlq(XmmRegister reg, const Immediate& shift_count);
+   void psrldq(XmmRegister reg, const Immediate& shift_count);
++  void vpsrlw(XmmRegister dst, XmmRegister src, const Immediate& shift_count);
++  void vpsrld(XmmRegister dst, XmmRegister src, const Immediate& shift_count);
++  void vpsrlq(XmmRegister dst, XmmRegister src, const Immediate& shift_count);
++
++  void vpermpd(XmmRegister dst, XmmRegister src, const Immediate& indices);
+ 
+   void flds(const Address& src);
+   void fstps(const Address& dst);
+@@ -989,6 +1061,8 @@ class X86_64Assembler final : public Assembler {
+ 
+   void ud2();
+ 
++  void vzeroupper();
++
+   //
+   // Macros for High-level operations.
+   //
+@@ -1110,7 +1184,8 @@ class X86_64Assembler final : public Assembler {
+     }
+   }
+ 
+-  bool CpuHasAVXorAVX2FeatureFlag();
++  bool CpuHasAVXFeatureFlag();
++  bool CpuHasAVX2FeatureFlag();
+ 
+  private:
+   void EmitUint8(uint8_t value);
+@@ -1154,6 +1229,7 @@ class X86_64Assembler final : public Assembler {
+   void EmitRex64(XmmRegister dst, const Operand& operand);
+   void EmitRex64(XmmRegister dst, CpuRegister src);
+   void EmitRex64(CpuRegister dst, XmmRegister src);
++  void EmitRex64(XmmRegister dst, XmmRegister src);
+ 
+   // Emit a REX prefix to normalize byte registers plus necessary register bit encodings.
+   // `normalize_both` parameter controls if the REX prefix is checked only for the `src` register
+@@ -1179,6 +1255,26 @@ class X86_64Assembler final : public Assembler {
+                                int SET_VEX_L,
+                                int SET_VEX_PP);
+ 
++  void EmitVecMinMaxOperation(XmmRegister dst,
++                              XmmRegister src1,
++                              XmmRegister src2,
++                              uint8_t vex_pp,
++                              bool is_vex_3byte,
++                              uint8_t opcode,
++                              bool is_commutative = false);
++  void EmitVecArithAndLogicalOperation(XmmRegister dst,
++                                       XmmRegister src1,
++                                       XmmRegister src2,
++                                       uint8_t opcode,
++                                       int vex_pp,
++                                       bool is_commutative = false);
++  void EmitVecShiftOperation(XmmRegister dst,
++                             XmmRegister src,
++                             const Immediate& shift_count,
++                             uint8_t opcode,
++                             uint8_t operand_byte);
++  void EmitVecBroadcastInstruction(XmmRegister dst, XmmRegister src, uint8_t opcode);
++
+   // Helper function to emit a shorter variant of XCHG if at least one operand is RAX/EAX/AX.
+   bool try_xchg_rax(CpuRegister dst,
+                     CpuRegister src,
+diff --git a/compiler/utils/x86_64/assembler_x86_64_test.cc b/compiler/utils/x86_64/assembler_x86_64_test.cc
+index e351baafee..c5e68f1913 100644
+--- a/compiler/utils/x86_64/assembler_x86_64_test.cc
++++ b/compiler/utils/x86_64/assembler_x86_64_test.cc
+@@ -24,6 +24,7 @@
+ #include "base/macros.h"
+ #include "base/malloc_arena_pool.h"
+ #include "base/stl_util.h"
++#include "disassembler_x86.h"
+ #include "jni_macro_assembler_x86_64.h"
+ #include "utils/assembler_test.h"
+ #include "utils/jni_macro_assembler_test.h"
+@@ -136,13 +137,15 @@ class AssemblerX86_64Test : public AssemblerTest<x86_64::X86_64Assembler,
+                                                  x86_64::Address,
+                                                  x86_64::CpuRegister,
+                                                  x86_64::XmmRegister,
+-                                                 x86_64::Immediate> {
++                                                 x86_64::Immediate,
++						 x86_64::XmmRegister> {
+  public:
+   using Base = AssemblerTest<x86_64::X86_64Assembler,
+                              x86_64::Address,
+                              x86_64::CpuRegister,
+                              x86_64::XmmRegister,
+-                             x86_64::Immediate>;
++                             x86_64::Immediate,
++			     x86_64::XmmRegister>;
+ 
+  protected:
+   AssemblerX86_64Test() : Base() {
+@@ -153,6 +156,35 @@ class AssemblerX86_64Test : public AssemblerTest<x86_64::X86_64Assembler,
+     return InstructionSet::kX86_64;
+   }
+ 
++  static void VerifyDisassemblerDriver(const std::vector<uint8_t>& art_code,
++                                       const std::string& ref_assembly_text,
++                                       [[maybe_unused]] const std::string& test_name) {
++    ASSERT_NE(ref_assembly_text.length(), 0U) << "Empty assembly";
++    std::string art_disassembly;
++    MemoryRegion codeMem(const_cast<uint8_t*>(&art_code[0]), art_code.size());
++    x86::DisassemblerX86* disasm = static_cast<art::x86::DisassemblerX86*>(
++        Disassembler::Create(InstructionSet::kX86_64,
++                             new DisassemblerOptions(false,
++                                                     codeMem.begin(),
++                                                     codeMem.end(),
++                                                     /* can_read_literals_= */ true,
++                                                     &Thread::DumpThreadOffset<PointerSize::k64>)));
++    size_t length = 0;
++    std::stringstream sstream;
++    for (const uint8_t* cur = codeMem.begin(); cur < codeMem.end(); cur += length) {
++      length = (disasm)->Dump(sstream, cur);
++      // ART dumps disassembly in this format
++      // Address: Hexbytes \t%-7s<prefix> opcode ....
++      // Extract just the disassembly and compress spaces
++      std::string disassembly = sstream.str();
++      disassembly = disassembly.substr(disassembly.find('\t') + 1);
++      disassembly = disassembly.substr(disassembly.find_first_not_of(" "));
++      art_disassembly += disassembly;
++      sstream.str("");
++    }
++    ASSERT_EQ(art_disassembly, ref_assembly_text) << "Disassembler check failed.";
++  }
++
+   void SetUpHelpers() override {
+     if (addresses_singleton_.size() == 0) {
+       // One addressing mode to test the repeat drivers.
+@@ -309,6 +341,28 @@ class AssemblerX86_64Test : public AssemblerTest<x86_64::X86_64Assembler,
+     return ArrayRef<const x86_64::XmmRegister>(kFPRegisters);
+   }
+ 
++  ArrayRef<const x86_64::XmmRegister> GetVectorRegisters() override {
++    static constexpr x86_64::XmmRegister kVectorRegisters[] = {
++        x86_64::XmmRegister(x86_64::XMM0, 32),
++        x86_64::XmmRegister(x86_64::XMM1, 32),
++        x86_64::XmmRegister(x86_64::XMM2, 32),
++        x86_64::XmmRegister(x86_64::XMM3, 32),
++        x86_64::XmmRegister(x86_64::XMM4, 32),
++        x86_64::XmmRegister(x86_64::XMM5, 32),
++        x86_64::XmmRegister(x86_64::XMM6, 32),
++        x86_64::XmmRegister(x86_64::XMM7, 32),
++        x86_64::XmmRegister(x86_64::XMM8, 32),
++        x86_64::XmmRegister(x86_64::XMM9, 32),
++        x86_64::XmmRegister(x86_64::XMM10, 32),
++        x86_64::XmmRegister(x86_64::XMM11, 32),
++        x86_64::XmmRegister(x86_64::XMM12, 32),
++        x86_64::XmmRegister(x86_64::XMM13, 32),
++        x86_64::XmmRegister(x86_64::XMM14, 32),
++        x86_64::XmmRegister(x86_64::XMM15, 32),
++    };
++    return ArrayRef<const x86_64::XmmRegister>(kVectorRegisters);
++  }
++
+   x86_64::Immediate CreateImmediate(int64_t imm_value) override {
+     return x86_64::Immediate(imm_value);
+   }
+@@ -1266,11 +1320,11 @@ TEST_F(AssemblerX86_64Test, Movaps) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VMovaps) {
+-  DriverStr(RepeatFF(&x86_64::X86_64Assembler::vmovaps, "vmovaps %{reg2}, %{reg1}"), "vmovaps");
++  DriverStr(RepeatVV(&x86_64::X86_64Assembler::vmovaps, "vmovaps %{reg2}, %{reg1}"), "vmovaps");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, Movaps) {
+-  DriverStr(RepeatFF(&x86_64::X86_64Assembler::movaps, "vmovaps %{reg2}, %{reg1}"), "avx_movaps");
++  DriverStr(RepeatVV(&x86_64::X86_64Assembler::movaps, "vmovaps %{reg2}, %{reg1}"), "avx_movaps");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, MovapsStore) {
+@@ -1278,11 +1332,11 @@ TEST_F(AssemblerX86_64Test, MovapsStore) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VMovapsStore) {
+-  DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovaps, "vmovaps %{reg}, {mem}"), "vmovaps_s");
++  DriverStr(RepeatAV(&x86_64::X86_64Assembler::vmovaps, "vmovaps %{reg}, {mem}"), "vmovaps_s");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, MovapsStore) {
+-  DriverStr(RepeatAF(&x86_64::X86_64Assembler::movaps, "vmovaps %{reg}, {mem}"), "avx_movaps_s");
++  DriverStr(RepeatAV(&x86_64::X86_64Assembler::movaps, "vmovaps %{reg}, {mem}"), "avx_movaps_s");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, MovapsLoad) {
+@@ -1290,11 +1344,11 @@ TEST_F(AssemblerX86_64Test, MovapsLoad) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VMovapsLoad) {
+-  DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovaps, "vmovaps {mem}, %{reg}"), "vmovaps_l");
++  DriverStr(RepeatVA(&x86_64::X86_64Assembler::vmovaps, "vmovaps {mem}, %{reg}"), "vmovaps_l");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, MovapsLoad) {
+-  DriverStr(RepeatFA(&x86_64::X86_64Assembler::movaps, "vmovaps {mem}, %{reg}"), "avx_movaps_l");
++  DriverStr(RepeatVA(&x86_64::X86_64Assembler::movaps, "vmovaps {mem}, %{reg}"), "avx_movaps_l");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, MovupsStore) {
+@@ -1302,11 +1356,11 @@ TEST_F(AssemblerX86_64Test, MovupsStore) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VMovupsStore) {
+-  DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovups, "vmovups %{reg}, {mem}"), "vmovups_s");
++  DriverStr(RepeatAV(&x86_64::X86_64Assembler::vmovups, "vmovups %{reg}, {mem}"), "vmovups_s");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, MovupsStore) {
+-  DriverStr(RepeatAF(&x86_64::X86_64Assembler::movups, "vmovups %{reg}, {mem}"), "avx_movups_s");
++  DriverStr(RepeatAV(&x86_64::X86_64Assembler::movups, "vmovups %{reg}, {mem}"), "avx_movups_s");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, MovupsLoad) {
+@@ -1314,11 +1368,19 @@ TEST_F(AssemblerX86_64Test, MovupsLoad) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VMovupsLoad) {
+-  DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovups, "vmovups {mem}, %{reg}"), "vmovups_l");
++  DriverStr(RepeatVA(&x86_64::X86_64Assembler::vmovups, "vmovups {mem}, %{reg}"), "vmovups_l");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, MovupsLoad) {
+-  DriverStr(RepeatFA(&x86_64::X86_64Assembler::movups, "vmovups {mem}, %{reg}"), "avx_movups_l");
++  DriverStr(RepeatVA(&x86_64::X86_64Assembler::movups, "vmovups {mem}, %{reg}"), "avx_movups_l");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VMovupsR2R) {
++  DriverStr(RepeatVV(&x86_64::X86_64Assembler::vmovups, "vmovups %{reg2}, %{reg1}"), "vmovups_r2r");
++}
++
++TEST_F(AssemblerX86_64AVXTest, MovupsR2R) {
++  DriverStr(RepeatVV(&x86_64::X86_64Assembler::movups, "vmovups %{reg2}, %{reg1}"), "avx_movups_r2r");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Movss) {
+@@ -1330,11 +1392,11 @@ TEST_F(AssemblerX86_64Test, Movapd) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VMovapd) {
+-  DriverStr(RepeatFF(&x86_64::X86_64Assembler::vmovapd, "vmovapd %{reg2}, %{reg1}"), "vmovapd");
++  DriverStr(RepeatVV(&x86_64::X86_64Assembler::vmovapd, "vmovapd %{reg2}, %{reg1}"), "vmovapd");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, Movapd) {
+-  DriverStr(RepeatFF(&x86_64::X86_64Assembler::movapd, "vmovapd %{reg2}, %{reg1}"), "avx_movapd");
++  DriverStr(RepeatVV(&x86_64::X86_64Assembler::movapd, "vmovapd %{reg2}, %{reg1}"), "avx_movapd");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, MovapdStore) {
+@@ -1342,11 +1404,11 @@ TEST_F(AssemblerX86_64Test, MovapdStore) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VMovapdStore) {
+-  DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovapd, "vmovapd %{reg}, {mem}"), "vmovapd_s");
++  DriverStr(RepeatAV(&x86_64::X86_64Assembler::vmovapd, "vmovapd %{reg}, {mem}"), "vmovapd_s");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, MovapdStore) {
+-  DriverStr(RepeatAF(&x86_64::X86_64Assembler::movapd, "vmovapd %{reg}, {mem}"), "avx_movapd_s");
++  DriverStr(RepeatAV(&x86_64::X86_64Assembler::movapd, "vmovapd %{reg}, {mem}"), "avx_movapd_s");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, MovapdLoad) {
+@@ -1354,11 +1416,11 @@ TEST_F(AssemblerX86_64Test, MovapdLoad) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VMovapdLoad) {
+-  DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovapd, "vmovapd {mem}, %{reg}"), "vmovapd_l");
++  DriverStr(RepeatVA(&x86_64::X86_64Assembler::vmovapd, "vmovapd {mem}, %{reg}"), "vmovapd_l");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, MovapdLoad) {
+-  DriverStr(RepeatFA(&x86_64::X86_64Assembler::movapd, "vmovapd {mem}, %{reg}"), "avx_movapd_l");
++  DriverStr(RepeatVA(&x86_64::X86_64Assembler::movapd, "vmovapd {mem}, %{reg}"), "avx_movapd_l");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, MovupdStore) {
+@@ -1366,11 +1428,11 @@ TEST_F(AssemblerX86_64Test, MovupdStore) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VMovupdStore) {
+-  DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovupd, "vmovupd %{reg}, {mem}"), "vmovupd_s");
++  DriverStr(RepeatAV(&x86_64::X86_64Assembler::vmovupd, "vmovupd %{reg}, {mem}"), "vmovupd_s");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, MovupdStore) {
+-  DriverStr(RepeatAF(&x86_64::X86_64Assembler::movupd, "vmovupd %{reg}, {mem}"), "avx_movupd_s");
++  DriverStr(RepeatAV(&x86_64::X86_64Assembler::movupd, "vmovupd %{reg}, {mem}"), "avx_movupd_s");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, MovupdLoad) {
+@@ -1378,11 +1440,11 @@ TEST_F(AssemblerX86_64Test, MovupdLoad) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VMovupdLoad) {
+-  DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovupd, "vmovupd {mem}, %{reg}"), "vmovupd_l");
++  DriverStr(RepeatVA(&x86_64::X86_64Assembler::vmovupd, "vmovupd {mem}, %{reg}"), "vmovupd_l");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, MovupdLoad) {
+-  DriverStr(RepeatFA(&x86_64::X86_64Assembler::movupd, "vmovupd {mem}, %{reg}"), "avx_movupd_l");
++  DriverStr(RepeatVA(&x86_64::X86_64Assembler::movupd, "vmovupd {mem}, %{reg}"), "avx_movupd_l");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Movsd) {
+@@ -1394,11 +1456,11 @@ TEST_F(AssemblerX86_64Test, Movdqa) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VMovdqa) {
+-  DriverStr(RepeatFF(&x86_64::X86_64Assembler::vmovdqa, "vmovdqa %{reg2}, %{reg1}"), "vmovdqa");
++  DriverStr(RepeatVV(&x86_64::X86_64Assembler::vmovdqa, "vmovdqa %{reg2}, %{reg1}"), "vmovdqa");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, Movdqa) {
+-  DriverStr(RepeatFF(&x86_64::X86_64Assembler::movdqa, "vmovdqa %{reg2}, %{reg1}"), "avx_movdqa");
++  DriverStr(RepeatVV(&x86_64::X86_64Assembler::movdqa, "vmovdqa %{reg2}, %{reg1}"), "avx_movdqa");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, MovdqaStore) {
+@@ -1406,11 +1468,11 @@ TEST_F(AssemblerX86_64Test, MovdqaStore) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VMovdqaStore) {
+-  DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovdqa, "vmovdqa %{reg}, {mem}"), "vmovdqa_s");
++  DriverStr(RepeatAV(&x86_64::X86_64Assembler::vmovdqa, "vmovdqa %{reg}, {mem}"), "vmovdqa_s");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, MovdqaStore) {
+-  DriverStr(RepeatAF(&x86_64::X86_64Assembler::movdqa, "vmovdqa %{reg}, {mem}"), "avx_movdqa_s");
++  DriverStr(RepeatAV(&x86_64::X86_64Assembler::movdqa, "vmovdqa %{reg}, {mem}"), "avx_movdqa_s");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, MovdqaLoad) {
+@@ -1418,11 +1480,11 @@ TEST_F(AssemblerX86_64Test, MovdqaLoad) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VMovdqaLoad) {
+-  DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovdqa, "vmovdqa {mem}, %{reg}"), "vmovdqa_l");
++  DriverStr(RepeatVA(&x86_64::X86_64Assembler::vmovdqa, "vmovdqa {mem}, %{reg}"), "vmovdqa_l");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, MovdqaLoad) {
+-  DriverStr(RepeatFA(&x86_64::X86_64Assembler::movdqa, "vmovdqa {mem}, %{reg}"), "avx_movdqa_l");
++  DriverStr(RepeatVA(&x86_64::X86_64Assembler::movdqa, "vmovdqa {mem}, %{reg}"), "avx_movdqa_l");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, MovdquStore) {
+@@ -1430,11 +1492,11 @@ TEST_F(AssemblerX86_64Test, MovdquStore) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VMovdquStore) {
+-  DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovdqu, "vmovdqu %{reg}, {mem}"), "vmovdqu_s");
++  DriverStr(RepeatAV(&x86_64::X86_64Assembler::vmovdqu, "vmovdqu %{reg}, {mem}"), "vmovdqu_s");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, MovdquStore) {
+-  DriverStr(RepeatAF(&x86_64::X86_64Assembler::movdqu, "vmovdqu %{reg}, {mem}"), "avx_movdqu_s");
++  DriverStr(RepeatAV(&x86_64::X86_64Assembler::movdqu, "vmovdqu %{reg}, {mem}"), "avx_movdqu_s");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, MovdquLoad) {
+@@ -1442,11 +1504,11 @@ TEST_F(AssemblerX86_64Test, MovdquLoad) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VMovdquLoad) {
+-  DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovdqu, "vmovdqu {mem}, %{reg}"), "vmovdqu_l");
++  DriverStr(RepeatVA(&x86_64::X86_64Assembler::vmovdqu, "vmovdqu {mem}, %{reg}"), "vmovdqu_l");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, MovdquLoad) {
+-  DriverStr(RepeatFA(&x86_64::X86_64Assembler::movdqu, "vmovdqu {mem}, %{reg}"), "avx_movdqu_l");
++  DriverStr(RepeatVA(&x86_64::X86_64Assembler::movdqu, "vmovdqu {mem}, %{reg}"), "avx_movdqu_l");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Movd1) {
+@@ -1470,8 +1532,8 @@ TEST_F(AssemblerX86_64Test, Addps) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VAddps) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vaddps, "vaddps %{reg3}, %{reg2}, %{reg1}"), "vaddps");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vaddps, "vaddps %{reg3}, %{reg2}, %{reg1}"),
++            "vaddps");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Addpd) {
+@@ -1479,8 +1541,8 @@ TEST_F(AssemblerX86_64Test, Addpd) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VAddpd) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vaddpd, "vaddpd %{reg3}, %{reg2}, %{reg1}"), "vaddpd");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vaddpd, "vaddpd %{reg3}, %{reg2}, %{reg1}"),
++            "vaddpd");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Subss) {
+@@ -1496,8 +1558,8 @@ TEST_F(AssemblerX86_64Test, Subps) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VSubps) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vsubps, "vsubps %{reg3},%{reg2}, %{reg1}"), "vsubps");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vsubps, "vsubps %{reg3},%{reg2}, %{reg1}"),
++            "vsubps");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Subpd) {
+@@ -1505,8 +1567,8 @@ TEST_F(AssemblerX86_64Test, Subpd) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VSubpd) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vsubpd, "vsubpd %{reg3}, %{reg2}, %{reg1}"), "vsubpd");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vsubpd, "vsubpd %{reg3}, %{reg2}, %{reg1}"),
++            "vsubpd");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Mulss) {
+@@ -1522,8 +1584,8 @@ TEST_F(AssemblerX86_64Test, Mulps) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VMulps) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vmulps, "vmulps %{reg3}, %{reg2}, %{reg1}"), "vmulps");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vmulps, "vmulps %{reg3}, %{reg2}, %{reg1}"),
++            "vmulps");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Mulpd) {
+@@ -1531,8 +1593,8 @@ TEST_F(AssemblerX86_64Test, Mulpd) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VMulpd) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vmulpd, "vmulpd %{reg3}, %{reg2}, %{reg1}"), "vmulpd");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vmulpd, "vmulpd %{reg3}, %{reg2}, %{reg1}"),
++            "vmulpd");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Divss) {
+@@ -1548,8 +1610,8 @@ TEST_F(AssemblerX86_64Test, Divps) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VDivps) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vdivps, "vdivps %{reg3}, %{reg2}, %{reg1}"), "vdivps");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vdivps, "vdivps %{reg3}, %{reg2}, %{reg1}"),
++            "vdivps");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Divpd) {
+@@ -1557,8 +1619,8 @@ TEST_F(AssemblerX86_64Test, Divpd) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VDivpd) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vdivpd, "vdivpd %{reg3}, %{reg2}, %{reg1}"), "vdivpd");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vdivpd, "vdivpd %{reg3}, %{reg2}, %{reg1}"),
++            "vdivpd");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Paddb) {
+@@ -1566,8 +1628,8 @@ TEST_F(AssemblerX86_64Test, Paddb) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VPaddb) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vpaddb, "vpaddb %{reg3}, %{reg2}, %{reg1}"), "vpaddb");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpaddb, "vpaddb %{reg3}, %{reg2}, %{reg1}"),
++            "vpaddb");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Psubb) {
+@@ -1575,8 +1637,8 @@ TEST_F(AssemblerX86_64Test, Psubb) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VPsubb) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vpsubb, "vpsubb %{reg3},%{reg2}, %{reg1}"), "vpsubb");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpsubb, "vpsubb %{reg3},%{reg2}, %{reg1}"),
++            "vpsubb");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Paddw) {
+@@ -1584,13 +1646,13 @@ TEST_F(AssemblerX86_64Test, Paddw) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VPsubw) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vpsubw, "vpsubw %{reg3}, %{reg2}, %{reg1}"), "vpsubw");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpsubw, "vpsubw %{reg3}, %{reg2}, %{reg1}"),
++            "vpsubw");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VPaddw) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vpaddw, "vpaddw %{reg3}, %{reg2}, %{reg1}"), "vpaddw");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpaddw, "vpaddw %{reg3}, %{reg2}, %{reg1}"),
++            "vpaddw");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Psubw) {
+@@ -1602,8 +1664,8 @@ TEST_F(AssemblerX86_64Test, Pmullw) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VPmullw) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vpmullw, "vpmullw %{reg3}, %{reg2}, %{reg1}"), "vpmullw");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpmullw, "vpmullw %{reg3}, %{reg2}, %{reg1}"),
++            "vpmullw");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Paddd) {
+@@ -1611,8 +1673,8 @@ TEST_F(AssemblerX86_64Test, Paddd) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VPaddd) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vpaddd, "vpaddd %{reg3}, %{reg2}, %{reg1}"), "vpaddd");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpaddd, "vpaddd %{reg3}, %{reg2}, %{reg1}"),
++            "vpaddd");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Psubd) {
+@@ -1620,8 +1682,8 @@ TEST_F(AssemblerX86_64Test, Psubd) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VPsubd) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vpsubd, "vpsubd %{reg3}, %{reg2}, %{reg1}"), "vpsubd");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpsubd, "vpsubd %{reg3}, %{reg2}, %{reg1}"),
++            "vpsubd");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Pmulld) {
+@@ -1629,8 +1691,8 @@ TEST_F(AssemblerX86_64Test, Pmulld) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VPmulld) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vpmulld, "vpmulld %{reg3}, %{reg2}, %{reg1}"), "vpmulld");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpmulld, "vpmulld %{reg3}, %{reg2}, %{reg1}"),
++            "vpmulld");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Paddq) {
+@@ -1638,8 +1700,8 @@ TEST_F(AssemblerX86_64Test, Paddq) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VPaddq) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vpaddq, "vpaddq %{reg3}, %{reg2}, %{reg1}"), "vpaddq");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpaddq, "vpaddq %{reg3}, %{reg2}, %{reg1}"),
++            "vpaddq");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Psubq) {
+@@ -1647,8 +1709,8 @@ TEST_F(AssemblerX86_64Test, Psubq) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VPsubq) {
+-  DriverStr(
+-      RepeatFFF(&x86_64::X86_64Assembler::vpsubq, "vpsubq %{reg3}, %{reg2}, %{reg1}"), "vpsubq");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpsubq, "vpsubq %{reg3}, %{reg2}, %{reg1}"),
++            "vpsubq");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Paddusb) {
+@@ -1772,18 +1834,17 @@ TEST_F(AssemblerX86_64Test, Pxor) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VPXor) {
+-  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vpxor,
+-                      "vpxor %{reg3}, %{reg2}, %{reg1}"), "vpxor");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpxor, "vpxor %{reg3}, %{reg2}, %{reg1}"), "vpxor");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VXorps) {
+-  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vxorps,
+-                      "vxorps %{reg3}, %{reg2}, %{reg1}"), "vxorps");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vxorps, "vxorps %{reg3}, %{reg2}, %{reg1}"),
++            "vxorps");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VXorpd) {
+-  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vxorpd,
+-                      "vxorpd %{reg3}, %{reg2}, %{reg1}"), "vxorpd");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vxorpd, "vxorpd %{reg3}, %{reg2}, %{reg1}"),
++            "vxorpd");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Andps) {
+@@ -1799,18 +1860,17 @@ TEST_F(AssemblerX86_64Test, Pand) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VPAnd) {
+-  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vpand,
+-                      "vpand %{reg3}, %{reg2}, %{reg1}"), "vpand");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpand, "vpand %{reg3}, %{reg2}, %{reg1}"), "vpand");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VAndps) {
+-  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vandps,
+-                      "vandps %{reg3}, %{reg2}, %{reg1}"), "vandps");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vandps, "vandps %{reg3}, %{reg2}, %{reg1}"),
++            "vandps");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VAndpd) {
+-  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vandpd,
+-                      "vandpd %{reg3}, %{reg2}, %{reg1}"), "vandpd");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vandpd, "vandpd %{reg3}, %{reg2}, %{reg1}"),
++            "vandpd");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Andn) {
+@@ -1829,18 +1889,18 @@ TEST_F(AssemblerX86_64Test, Pandn) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VPAndn) {
+-  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vpandn,
+-                      "vpandn %{reg3}, %{reg2}, %{reg1}"), "vpandn");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpandn, "vpandn %{reg3}, %{reg2}, %{reg1}"),
++            "vpandn");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VAndnps) {
+-  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vandnps,
+-                      "vandnps %{reg3}, %{reg2}, %{reg1}"), "vandnps");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vandnps, "vandnps %{reg3}, %{reg2}, %{reg1}"),
++            "vandnps");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VAndnpd) {
+-  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vandnpd,
+-                      "vandnpd %{reg3}, %{reg2}, %{reg1}"), "vandnpd");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vandnpd, "vandnpd %{reg3}, %{reg2}, %{reg1}"),
++            "vandnpd");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Orps) {
+@@ -1856,18 +1916,15 @@ TEST_F(AssemblerX86_64Test, Por) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VPor) {
+-  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vpor,
+-                      "vpor %{reg3}, %{reg2}, %{reg1}"), "vpor");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpor, "vpor %{reg3}, %{reg2}, %{reg1}"), "vpor");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, Vorps) {
+-  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vorps,
+-                      "vorps %{reg3}, %{reg2}, %{reg1}"), "vorps");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vorps, "vorps %{reg3}, %{reg2}, %{reg1}"), "vorps");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, Vorpd) {
+-  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vorpd,
+-                      "vorpd %{reg3}, %{reg2}, %{reg1}"), "vorpd");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vorpd, "vorpd %{reg3}, %{reg2}, %{reg1}"), "vorpd");
+ }
+ 
+ TEST_F(AssemblerX86_64Test, Pavgb) {
+@@ -1887,8 +1944,8 @@ TEST_F(AssemblerX86_64Test, Pmaddwd) {
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VPmaddwd) {
+-  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vpmaddwd,
+-                      "vpmaddwd %{reg3}, %{reg2}, %{reg1}"), "vpmaddwd");
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpmaddwd, "vpmaddwd %{reg3}, %{reg2}, %{reg1}"),
++            "vpmaddwd");
+ }
+ 
+ TEST_F(AssemblerX86_64AVXTest, VFmadd213ss) {
+@@ -2147,6 +2204,744 @@ TEST_F(AssemblerX86_64Test, Psrldq) {
+             "psrldq $2, %xmm15\n", "psrldqi");
+ }
+ 
++// Assembler tests for AVX
++TEST_F(AssemblerX86_64AVXTest, VMovssLoad) {
++  DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovss, "vmovss {mem}, %{reg}"), "vmovss_l");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VMovssStore) {
++  DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovss, "vmovss %{reg}, {mem}"), "vmovss_s");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VMovss) {
++  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vmovss, "vmovss %{reg3}, %{reg2}, %{reg1}"),
++            "vmovss");
++}
++
++// TEST_F(AssemblerX86_64AVXTest, VMovsdLoad) {
++//   DriverStr(RepeatFA(&x86_64::X86_64Assembler::vmovsd, "vmovsd {mem}, %{reg}"), "vmovsd_l");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, VMovsdStore) {
++//   DriverStr(RepeatAF(&x86_64::X86_64Assembler::vmovsd, "vmovsd %{reg}, {mem}"), "vmovsd_s");
++// }
++
++TEST_F(AssemblerX86_64AVXTest, VMovsd) {
++  DriverStr(RepeatFFF(&x86_64::X86_64Assembler::vmovsd, "vmovsd %{reg3}, %{reg2}, %{reg1}"),
++            "vmovsd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VMovd1) {
++  DriverStr(RepeatFR(&x86_64::X86_64Assembler::vmovq, "vmovq %{reg2}, %{reg1}"), "vmovd.1");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VMovd2) {
++  DriverStr(RepeatRF(&x86_64::X86_64Assembler::vmovq, "vmovq %{reg2}, %{reg1}"), "vmovd.2");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPaddusb) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpaddusb, "vpaddusb %{reg3}, %{reg2}, %{reg1}"),
++            "vpaddusb");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPaddsb) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpaddsb, "vpaddsb %{reg3}, %{reg2}, %{reg1}"),
++            "vpaddsb");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPaddusw) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpaddusw, "vpaddusw %{reg3}, %{reg2}, %{reg1}"),
++            "vpaddusw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPaddsw) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpaddsw, "vpaddsw %{reg3}, %{reg2}, %{reg1}"),
++            "vpaddsw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPsubusb) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpsubusb, "vpsubusb %{reg3}, %{reg2}, %{reg1}"),
++            "vpsubusb");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPsubsb) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpsubsb, "vpsubsb %{reg3}, %{reg2}, %{reg1}"),
++            "vpsubsb");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPsubusw) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpsubusw, "vpsubusw %{reg3}, %{reg2}, %{reg1}"),
++            "vpsubusw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPsubsw) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpsubsw, "vpsubsw %{reg3}, %{reg2}, %{reg1}"),
++            "vpsubsw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VCvtdq2ps) {
++  DriverStr(RepeatVV(&x86_64::X86_64Assembler::vcvtdq2ps, "vcvtdq2ps %{reg2}, %{reg1}"),
++            "vcvtdq2ps");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPavgb) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpavgb, "vpavgb %{reg3}, %{reg2}, %{reg1}"),
++            "vpavgb");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPavgw) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpavgw, "vpavgw %{reg3}, %{reg2}, %{reg1}"),
++            "vpavgw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPhaddd) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vphaddd, "vphaddd %{reg3}, %{reg2}, %{reg1}"),
++            "vphaddd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPminsb) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpminsb, "vpminsb %{reg3}, %{reg2}, %{reg1}"),
++            "vpminsb");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPmaxsb) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpmaxsb, "vpmaxsb %{reg3}, %{reg2}, %{reg1}"),
++            "vpmaxsb");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPminsw) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpminsw, "vpminsw %{reg3}, %{reg2}, %{reg1}"),
++            "vpminsw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPmaxsw) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpmaxsw, "vpmaxsw %{reg3}, %{reg2}, %{reg1}"),
++            "vpmaxsw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPminsd) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpminsd, "vpminsd %{reg3}, %{reg2}, %{reg1}"),
++            "vpminsd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPmaxsd) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpmaxsd, "vpmaxsd %{reg3}, %{reg2}, %{reg1}"),
++            "vpmaxsd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPminub) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpminub, "vpminub %{reg3}, %{reg2}, %{reg1}"),
++            "vpminub");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPmaxub) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpmaxub, "vpmaxub %{reg3}, %{reg2}, %{reg1}"),
++            "vpmaxub");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPminuw) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpminuw, "vpminuw %{reg3}, %{reg2}, %{reg1}"),
++            "vpminuw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPmaxuw) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpmaxuw, "vpmaxuw %{reg3}, %{reg2}, %{reg1}"),
++            "vpmaxuw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPminud) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpminud, "vpminud %{reg3}, %{reg2}, %{reg1}"),
++            "vpminud");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPmaxud) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpmaxud, "vpmaxud %{reg3}, %{reg2}, %{reg1}"),
++            "vpmaxud");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VMinps) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vminps, "vminps %{reg3}, %{reg2}, %{reg1}"),
++            "vminps");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VMaxps) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vmaxps, "vmaxps %{reg3}, %{reg2}, %{reg1}"),
++            "vmaxps");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VMinpd) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vminpd, "vminpd %{reg3}, %{reg2}, %{reg1}"),
++            "vminpd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VMaxpd) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vmaxpd, "vmaxpd %{reg3}, %{reg2}, %{reg1}"),
++            "vmaxpd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPcmpeqb) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpcmpeqb, "vpcmpeqb %{reg3}, %{reg2}, %{reg1}"),
++            "vpcmpeqb");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPcmpgtq) {
++  DriverStr(RepeatVVV(&x86_64::X86_64Assembler::vpcmpgtq, "vpcmpgtq %{reg3}, %{reg2}, %{reg1}"),
++            "vpcmpgtq");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VBroadcastss) {
++  DriverStr(RepeatVF(&x86_64::X86_64Assembler::vbroadcastss, "vbroadcastss %{reg2}, %{reg1}"),
++            "vbroadcastss");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VBroadcastsd) {
++  DriverStr(RepeatVF(&x86_64::X86_64Assembler::vbroadcastsd, "vbroadcastsd %{reg2}, %{reg1}"),
++            "vbroadcastsd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPbroadcastb) {
++  DriverStr(RepeatVF(&x86_64::X86_64Assembler::vpbroadcastb, "vpbroadcastb %{reg2}, %{reg1}"),
++            "vpbroadcastb");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPbroadcastw) {
++  DriverStr(RepeatVF(&x86_64::X86_64Assembler::vpbroadcastw, "vpbroadcastw %{reg2}, %{reg1}"),
++            "vpbroadcastw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPbroadcastd) {
++  DriverStr(RepeatVF(&x86_64::X86_64Assembler::vpbroadcastd, "vpbroadcastd %{reg2}, %{reg1}"),
++            "vpbroadcastd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPbroadcastq) {
++  DriverStr(RepeatVF(&x86_64::X86_64Assembler::vpbroadcastq, "vpbroadcastq %{reg2}, %{reg1}"),
++            "vpbroadcastq");
++}
++
++TEST_F(AssemblerX86_64AVXTest, Pabsb) {
++  DriverStr(RepeatFF(&x86_64::X86_64Assembler::pabsb, "pabsb %{reg2}, %{reg1}"), "pabsb");
++}
++
++TEST_F(AssemblerX86_64AVXTest, Pabsw) {
++  DriverStr(RepeatFF(&x86_64::X86_64Assembler::pabsw, "pabsw %{reg2}, %{reg1}"), "pabsw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, Pabsd) {
++  DriverStr(RepeatFF(&x86_64::X86_64Assembler::pabsd, "pabsd %{reg2}, %{reg1}"), "pabsd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPabsb) {
++  DriverStr(RepeatVV(&x86_64::X86_64Assembler::vpabsb, "vpabsb %{reg2}, %{reg1}"), "vpabsb");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPabsw) {
++  DriverStr(RepeatVV(&x86_64::X86_64Assembler::vpabsw, "vpabsw %{reg2}, %{reg1}"), "vpabsw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPabsd) {
++  DriverStr(RepeatVV(&x86_64::X86_64Assembler::vpabsd, "vpabsd %{reg2}, %{reg1}"), "vpabsd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPsllw) {
++  DriverStr(RepeatVVI(&x86_64::X86_64Assembler::vpsllw, 1U, "vpsllw ${imm}, %{reg2}, %{reg1}"),
++            "vpsllw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPslld) {
++  DriverStr(RepeatVVI(&x86_64::X86_64Assembler::vpslld, 1U, "vpslld ${imm}, %{reg2}, %{reg1}"),
++            "vpslld");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPsllq) {
++  DriverStr(RepeatVVI(&x86_64::X86_64Assembler::vpsllq, 1U, "vpsllq ${imm}, %{reg2}, %{reg1}"),
++            "vpsllq");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPsraw) {
++  DriverStr(RepeatVVI(&x86_64::X86_64Assembler::vpsraw, 1U, "vpsraw ${imm}, %{reg2}, %{reg1}"),
++            "vpsraw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPsrad) {
++  DriverStr(RepeatVVI(&x86_64::X86_64Assembler::vpsrad, 1U, "vpsrad ${imm}, %{reg2}, %{reg1}"),
++            "vpsrad");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPsrlw) {
++  DriverStr(RepeatVVI(&x86_64::X86_64Assembler::vpsrlw, 1U, "vpsrlw ${imm}, %{reg2}, %{reg1}"),
++            "vpsrlw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPsrld) {
++  DriverStr(RepeatVVI(&x86_64::X86_64Assembler::vpsrld, 1U, "vpsrld ${imm}, %{reg2}, %{reg1}"),
++            "vpsrld");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPsrlq) {
++  DriverStr(RepeatVVI(&x86_64::X86_64Assembler::vpsrlq, 1U, "vpsrlq ${imm}, %{reg2}, %{reg1}"),
++            "vpsrlq");
++}
++
++TEST_F(AssemblerX86_64AVXTest, VPermpd) {
++  DriverStr(RepeatVVI(&x86_64::X86_64Assembler::vpermpd, 1U, "vpermpd ${imm}, %{reg2}, %{reg1}"),
++            "vpermpd");
++}
++
++// Disassembler tests
++TEST_F(AssemblerX86_64AVXTest, DisassVMovaps) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVV(&x86_64::X86_64Assembler::vmovaps, "vmovaps {reg1}, {reg2}"),
++                  "disass-vmovaps");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassMovaps) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVV(&x86_64::X86_64Assembler::movaps, "vmovaps {reg1}, {reg2}"),
++                  "disass-avx_movaps");
++}
++
++// TODO: Disassembler tests cannot handle memory right now because of difference in
++//       the format between ART disassembly and the combination generator
++// TEST_F(AssemblerX86_64AVXTest, DisassVMovapsStore) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatAV(&x86_64::X86_64Assembler::vmovaps,
++//                        "vmovaps {mem}, {reg}"), "disass-vmovaps_s");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassMovapsStore) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatAV(&x86_64::X86_64Assembler::movaps,
++//                        "vmovaps {mem}, {reg}"), "disass-avx_movaps_s");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassVMovapsLoad) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatVA(&x86_64::X86_64Assembler::vmovaps,
++//                        "vmovaps {reg}, {mem}"), "disass-vmovaps_l");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassMovapsLoad) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatVA(&x86_64::X86_64Assembler::movaps,
++//                        "vmovaps {reg}, {mem}"), "disass-avx_movaps_l");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassVMovupsStore) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatAV(&x86_64::X86_64Assembler::vmovups,
++//                        "vmovups {mem}, {reg}"), "disass-vmovups_s");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassMovupsStore) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatAV(&x86_64::X86_64Assembler::movups,
++//                        "vmovups {mem}, {reg}"), "disass-avx_movups_s");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassVMovupsLoad) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatVA(&x86_64::X86_64Assembler::vmovups,
++//                        "vmovups {reg}, {mem}"), "disass-vmovups_l");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassMovupsLoad) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatVA(&x86_64::X86_64Assembler::movups,
++//                        "vmovups {reg}, {mem}"), "disass-avx_movups_l");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassVMovssLoad){
++//    CustomDriverStr(VerifyDisassemblerDriver, RepeatFA(&x86_64::X86_64Assembler::vmovss,
++//                         "vmovss {reg}, {mem}"), "disass-vmovss_l");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassVMovssStore){
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatAF(&x86_64::X86_64Assembler::vmovss,
++//                        "vmovss {mem}, {reg}"), "disass-vmovss_s");
++// }
++
++TEST_F(AssemblerX86_64AVXTest, DisassVMovss) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatFFF(&x86_64::X86_64Assembler::vmovss, "vmovss {reg1}, {reg2}, {reg3}"),
++                  "disass-vmovss");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVMovapd) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVV(&x86_64::X86_64Assembler::vmovapd, "vmovapd {reg1}, {reg2}"),
++                  "disass-vmovapd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassMovapd) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVV(&x86_64::X86_64Assembler::movapd, "vmovapd {reg1}, {reg2}"),
++                  "disass-avx_movapd");
++}
++
++// TEST_F(AssemblerX86_64AVXTest, DisassVMovapdStore) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatAV(&x86_64::X86_64Assembler::vmovapd,
++//                        "vmovapd {mem}, {reg}"), "disass-vmovapd_s");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassMovapdStore) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatAV(&x86_64::X86_64Assembler::movapd,
++//                        "vmovapd {mem}, {reg}"), "disass-avx_movapd_s");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassVMovapdLoad) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatVA(&x86_64::X86_64Assembler::vmovapd,
++//                        "vmovapd {reg}, {mem}"), "disass-vmovapd_l");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassMovapdLoad) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatVA(&x86_64::X86_64Assembler::movapd,
++//                        "vmovapd {reg}, {mem}"), "disass-avx_movapd_l");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassVMovupdStore) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatAV(&x86_64::X86_64Assembler::vmovupd,
++//                        "vmovupd {mem}, {reg}"), "disass-vmovupd_s");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassMovupdStore) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatAV(&x86_64::X86_64Assembler::movupd,
++//                        "vmovupd {mem}, {reg}"), "disass-avx_movupd_s");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassVMovupdLoad) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatVA(&x86_64::X86_64Assembler::vmovupd,
++//                        "vmovupd {reg}, {mem}"), "disass-vmovupd_l");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassMovupdLoad) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatVA(&x86_64::X86_64Assembler::movupd,
++//                        "vmovupd {reg}, {mem}"), "disass-avx_movupd_l");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassVMovsdLoad) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatFA(&x86_64::X86_64Assembler::vmovsd,
++//                        "vmovsd {reg}, {mem}"), "disass-vmovsd_l");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassVMovsdStore) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatAF(&x86_64::X86_64Assembler::vmovsd,
++//                        "vmovsd {mem}, {reg}"), "disass-vmovsd_s");
++// }
++
++TEST_F(AssemblerX86_64AVXTest, DisassVMovsd) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatFFF(&x86_64::X86_64Assembler::vmovsd, "vmovsd {reg1}, {reg2}, {reg3}"),
++                  "disass-vmovsd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVMovdqa) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVV(&x86_64::X86_64Assembler::vmovdqa, "vmovdqa {reg1}, {reg2}"),
++                  "disass-vmovdqa");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassMovdqa) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVV(&x86_64::X86_64Assembler::movdqa, "vmovdqa {reg1}, {reg2}"),
++                  "disass-avx_movdqa");
++}
++
++// TEST_F(AssemblerX86_64AVXTest, DisassVMovdqaStore) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatAV(&x86_64::X86_64Assembler::vmovdqa,
++//                        "vmovdqa {mem}, {reg}"), "disass-vmovdqa_s");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassMovdqaStore) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatAV(&x86_64::X86_64Assembler::movdqa,
++//                        "vmovdqa {mem}, {reg}"), "disass-avx_movdqa_s");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassVMovdqaLoad) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatVA(&x86_64::X86_64Assembler::vmovdqa,
++//                        "vmovdqa {reg}, {mem}"), "disass-vmovdqa_l");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassMovdqaLoad) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatVA(&x86_64::X86_64Assembler::movdqa,
++//                        "vmovdqa {reg}, {mem}"), "disass-avx_movdqa_l");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassVMovdquStore) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatAV(&x86_64::X86_64Assembler::vmovdqu,
++//                        "vmovdqu {mem}, {reg}"), "disass-vmovdqu_s");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassMovdquStore) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatAV(&x86_64::X86_64Assembler::movdqu,
++//                        "vmovdqu {mem}, {reg}"), "disass-avx_movdqu_s");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassVMovdquLoad) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatVA(&x86_64::X86_64Assembler::vmovdqu,
++//                        "vmovdqu {reg}, {mem}"), "disass-vmovdqu_l");
++// }
++
++// TEST_F(AssemblerX86_64AVXTest, DisassMovdquLoad) {
++//   CustomDriverStr(VerifyDisassemblerDriver, RepeatVA(&x86_64::X86_64Assembler::movdqu,
++//                        "vmovdqu {reg}, {mem}"), "disass-avx_movdqu_l");
++// }
++
++TEST_F(AssemblerX86_64AVXTest, DisassVMovd1) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatFR(&x86_64::X86_64Assembler::vmovq, "vmovq {reg1}, {reg2}"),
++                  "disass-vmovd.1");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVMovd2) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatRF(&x86_64::X86_64Assembler::vmovq, "vmovq {reg1}, {reg2}"),
++                  "disass-vmovd.2");
++}
++
++// TODO: Disassembler tests cannot handle commutative instructions like vaddps
++//       Hence no disassembler tests for add, mul, avg, xor, or, and etc.
++
++TEST_F(AssemblerX86_64AVXTest, DisassVSubps) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVV(&x86_64::X86_64Assembler::vsubps, "vsubps {reg1}, {reg2}, {reg3}"),
++                  "disass-vsubps");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVSubpd) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVV(&x86_64::X86_64Assembler::vsubpd, "vsubpd {reg1}, {reg2}, {reg3}"),
++                  "disass-vsubpd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVDivps) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVV(&x86_64::X86_64Assembler::vdivps, "vdivps {reg1}, {reg2}, {reg3}"),
++                  "disassvdivps");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVDivpd) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVV(&x86_64::X86_64Assembler::vdivpd, "vdivpd {reg1}, {reg2}, {reg3}"),
++                  "disass-vdivpd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPsubb) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVV(&x86_64::X86_64Assembler::vpsubb, "vpsubb {reg1}, {reg2}, {reg3}"),
++                  "disass-vpsubb");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPsubw) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVV(&x86_64::X86_64Assembler::vpsubw, "vpsubw {reg1}, {reg2}, {reg3}"),
++                  "disass-vpsubw");
++}
++
++TEST_F(AssemblerX86_64Test, DisassCvtdq2ps) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatFF(&x86_64::X86_64Assembler::cvtdq2ps, "cvtdq2ps {reg1}, {reg2}"),
++                  "disass-cvtdq2ps");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPsubd) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVV(&x86_64::X86_64Assembler::vpsubd, "vpsubd {reg1}, {reg2}, {reg3}"),
++                  "disass-vpsubd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPmulld) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVV(&x86_64::X86_64Assembler::vpmulld, "vpmulld {reg1}, {reg2}, {reg3}"),
++                  "disass-vpmulld");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPsubq) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVV(&x86_64::X86_64Assembler::vpsubq, "vpsubq {reg1}, {reg2}, {reg3}"),
++                  "disass-vpsubq");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPsubusb) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVV(&x86_64::X86_64Assembler::vpsubusb, "vpsubusb {reg1}, {reg2}, {reg3}"),
++                  "disass-vpsubusb");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPsubsb) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVV(&x86_64::X86_64Assembler::vpsubsb, "vpsubsb {reg1}, {reg2}, {reg3}"),
++                  "disass-vpsubsb");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPsubusw) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVV(&x86_64::X86_64Assembler::vpsubusw, "vpsubusw {reg1}, {reg2}, {reg3}"),
++                  "disass-vpsubusw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPsubsw) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVV(&x86_64::X86_64Assembler::vpsubsw, "vpsubsw {reg1}, {reg2}, {reg3}"),
++                  "disass-vpsubsw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVCvtdq2ps) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVV(&x86_64::X86_64Assembler::vcvtdq2ps, "vcvtdq2ps {reg1}, {reg2}"),
++                  "disass-vcvtdq2ps");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPAndn) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVV(&x86_64::X86_64Assembler::vpandn, "vpandn {reg1}, {reg2}, {reg3}"),
++                  "disass-vpandn");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVAndnps) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVV(&x86_64::X86_64Assembler::vandnps, "vandnps {reg1}, {reg2}, {reg3}"),
++                  "disass-vandnps");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVAndnpd) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVV(&x86_64::X86_64Assembler::vandnpd, "vandnpd {reg1}, {reg2}, {reg3}"),
++                  "disass-vandnpd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPhaddd) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVV(&x86_64::X86_64Assembler::vphaddd, "vphaddd {reg1}, {reg2}, {reg3}"),
++                  "disass-vphaddd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVFmadd213ss) {
++  CustomDriverStr(
++      VerifyDisassemblerDriver,
++      RepeatFFF(&x86_64::X86_64Assembler::vfmadd213ss, "vfmadd213ss {reg1}, {reg2}, {reg3}"),
++      "disass-vfmadd213ss");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVFmadd213sd) {
++  CustomDriverStr(
++      VerifyDisassemblerDriver,
++      RepeatFFF(&x86_64::X86_64Assembler::vfmadd213sd, "vfmadd213sd {reg1}, {reg2}, {reg3}"),
++      "disass-vfmadd213sd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVBroadcastss) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVF(&x86_64::X86_64Assembler::vbroadcastss, "vbroadcastss {reg1}, {reg2}"),
++                  "disass-vbroadcastss");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVBroadcastsd) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVF(&x86_64::X86_64Assembler::vbroadcastsd, "vbroadcastsd {reg1}, {reg2}"),
++                  "disass-vbroadcastsd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPbroadcastb) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVF(&x86_64::X86_64Assembler::vpbroadcastb, "vpbroadcastb {reg1}, {reg2}"),
++                  "disass-vpbroadcastb");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPbroadcastw) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVF(&x86_64::X86_64Assembler::vpbroadcastw, "vpbroadcastw {reg1}, {reg2}"),
++                  "disass-vpbroadcastw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPbroadcastd) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVF(&x86_64::X86_64Assembler::vpbroadcastd, "vpbroadcastd {reg1}, {reg2}"),
++                  "disass-vpbroadcastd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPbroadcastq) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVF(&x86_64::X86_64Assembler::vpbroadcastq, "vpbroadcastq {reg1}, {reg2}"),
++                  "disass-vpbroadcastq");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassPabsb) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatFF(&x86_64::X86_64Assembler::pabsb, "pabsb {reg1}, {reg2}"),
++                  "disass-pabsb");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassPabsw) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatFF(&x86_64::X86_64Assembler::pabsw, "pabsw {reg1}, {reg2}"),
++                  "disass-pabsw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassPabsd) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatFF(&x86_64::X86_64Assembler::pabsd, "pabsd {reg1}, {reg2}"),
++                  "disass-pabsd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPabsb) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVV(&x86_64::X86_64Assembler::vpabsb, "vpabsb {reg1}, {reg2}"),
++                  "disass-vpabsb");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPabsw) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVV(&x86_64::X86_64Assembler::vpabsw, "vpabsw {reg1}, {reg2}"),
++                  "disass-vpabsw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPabsd) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVV(&x86_64::X86_64Assembler::vpabsd, "vpabsd {reg1}, {reg2}"),
++                  "disass-vpabsd");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPsllw) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVI(&x86_64::X86_64Assembler::vpsllw, 1U, "vpsllw {reg2}, {reg1}, {imm}"),
++                  "disass-vpsllw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPslld) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVI(&x86_64::X86_64Assembler::vpslld, 1U, "vpslld {reg2}, {reg1}, {imm}"),
++                  "disass-vpslld");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPsllq) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVI(&x86_64::X86_64Assembler::vpsllq, 1U, "vpsllq {reg2}, {reg1}, {imm}"),
++                  "disass-vpsllq");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPsraw) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVI(&x86_64::X86_64Assembler::vpsraw, 1U, "vpsraw {reg2}, {reg1}, {imm}"),
++                  "disass-vpsraw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPsrad) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVI(&x86_64::X86_64Assembler::vpsrad, 1U, "vpsrad {reg2}, {reg1}, {imm}"),
++                  "disass-vpsrad");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPsrlw) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVI(&x86_64::X86_64Assembler::vpsrlw, 1U, "vpsrlw {reg2}, {reg1}, {imm}"),
++                  "disass-vpsrlw");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPsrld) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVI(&x86_64::X86_64Assembler::vpsrld, 1U, "vpsrld {reg2}, {reg1}, {imm}"),
++                  "disass-vpsrld");
++}
++
++TEST_F(AssemblerX86_64AVXTest, DisassVPsrlq) {
++  CustomDriverStr(VerifyDisassemblerDriver,
++                  RepeatVVI(&x86_64::X86_64Assembler::vpsrlq, 1U, "vpsrlq {reg2}, {reg1}, {imm}"),
++                  "disass-vpsrlq");
++}
++
+ std::string x87_fn([[maybe_unused]] AssemblerX86_64Test::Base* assembler_test,
+                    x86_64::X86_64Assembler* assembler) {
+   std::ostringstream str;
+diff --git a/compiler/utils/x86_64/constants_x86_64.h b/compiler/utils/x86_64/constants_x86_64.h
+index 52ac987766..22f72169cd 100644
+--- a/compiler/utils/x86_64/constants_x86_64.h
++++ b/compiler/utils/x86_64/constants_x86_64.h
+@@ -51,8 +51,10 @@ std::ostream& operator<<(std::ostream& os, const CpuRegister& reg);
+ 
+ class XmmRegister {
+  public:
+-  explicit constexpr XmmRegister(FloatRegister r) : reg_(r) {}
+-  explicit constexpr XmmRegister(int r) : reg_(FloatRegister(r)) {}
++  explicit constexpr XmmRegister(FloatRegister r) : reg_(r), vector_length_(0) {}
++  explicit constexpr XmmRegister(int r) : reg_(FloatRegister(r)), vector_length_(0) {}
++  constexpr XmmRegister(FloatRegister r, size_t vector_length) : reg_(r), vector_length_(vector_length) {}
++  constexpr XmmRegister(int r, size_t vector_length) : reg_(FloatRegister(r)), vector_length_(vector_length) {}
+   constexpr FloatRegister AsFloatRegister() const {
+     return reg_;
+   }
+@@ -65,8 +67,14 @@ class XmmRegister {
+   bool operator==(const XmmRegister& other) const {
+     return reg_ == other.reg_;
+   }
++  size_t GetVecLen() const { return vector_length_; }
++  bool IsYMM() const {
++    return vector_length_ == 32;  // 256-bit
++  }
++
+  private:
+   const FloatRegister reg_;
++  size_t vector_length_;
+ };
+ std::ostream& operator<<(std::ostream& os, const XmmRegister& reg);
+ 
+diff --git a/disassembler/disassembler_x86.cc b/disassembler/disassembler_x86.cc
+index bf8af72c3e..b4765bc091 100644
+--- a/disassembler/disassembler_x86.cc
++++ b/disassembler/disassembler_x86.cc
+@@ -96,6 +96,8 @@ static void DumpAnyReg(std::ostream& os, uint8_t rex, size_t reg,
+     DumpReg0(os, rex, reg, byte_operand, size_override);
+   } else if (reg_file == SSE) {
+     os << "xmm" << reg;
++  } else if (reg_file == AVX) {
++    os << "ymm" << reg;
+   } else {
+     os << "mm" << reg;
+   }
+@@ -288,6 +290,8 @@ void DisassemblerX86::GetInstructionDetails(const uint8_t* instr, x86_instr *ins
+ }
+ 
+ size_t DisassemblerX86::DumpInstruction(std::ostream& os, const uint8_t* instr,x86_instr *insn_x86) {
++  InstructionContext ctxt(this, instr);
++  instr = ctxt.shadowInstr;
+   if (os) {
+      size_t nop_size = DumpNops(os, instr);
+      if (nop_size != 0u) {
+@@ -360,7 +364,9 @@ size_t DisassemblerX86::DumpInstruction(std::ostream& os, const uint8_t* instr,x
+   bool no_ops = false;
+   RegFile src_reg_file = GPR;
+   RegFile dst_reg_file = GPR;
+-
++  bool needs_vex = false;  // To detect VEX only instructions
++  bool has_3_operands = false;
++  bool width_qualified = false;
+ 
+   switch (*instr) {
+ #define DISASSEMBLER_ENTRY(opname, \
+@@ -463,9 +469,11 @@ DISASSEMBLER_ENTRY(cmp,
+       case 0x10: case 0x11:
+         if (prefix[0] == 0xF2) {
+           opcode1 = "movsd";
++          has_3_operands = ctxt.hasVex && ((*(instr + 1) & 0xC0) == 0xC0);
+           prefix[0] = 0;  // clear prefix now it's served its purpose as part of the opcode
+         } else if (prefix[0] == 0xF3) {
+           opcode1 = "movss";
++          has_3_operands = ctxt.hasVex && ((*(instr + 1) & 0xC0) == 0xC0);
+           prefix[0] = 0;  // clear prefix now it's served its purpose as part of the opcode
+         } else if (prefix[2] == 0x66) {
+           opcode1 = "movupd";
+@@ -593,10 +601,38 @@ DISASSEMBLER_ENTRY(cmp,
+             case 0x02:
+               opcode1 = "phaddd";
+               prefix[2] = 0;
++              has_3_operands = ctxt.hasVex;
+               has_modrm = true;
+               load = true;
+               src_reg_file = dst_reg_file = SSE;
+               break;
++            case 0x18:
++              opcode1 = "broadcastss";
++              needs_vex = has_modrm = load = true;
++              dst_reg_file = AVX;
++              src_reg_file = SSE;
++              break;
++            case 0x19:
++              opcode1 = "broadcastsd";
++              needs_vex = has_modrm = load = true;
++              dst_reg_file = AVX;
++              src_reg_file = SSE;
++              break;
++            case 0x1C:
++              opcode1 = "pabsb";
++              width_qualified = has_modrm = load = true;
++              src_reg_file = dst_reg_file = SSE;
++              break;
++            case 0x1D:
++              opcode1 = "pabsw";
++              width_qualified = has_modrm = load = true;
++              src_reg_file = dst_reg_file = SSE;
++              break;
++            case 0x1E:
++              opcode1 = "pabsd";
++              width_qualified = has_modrm = load = true;
++              src_reg_file = dst_reg_file = SSE;
++              break;
+             case 0x29:
+               opcode1 = "pcmpeqq";
+               prefix[2] = 0;
+@@ -614,6 +650,7 @@ DISASSEMBLER_ENTRY(cmp,
+             case 0x38:
+               opcode1 = "pminsb";
+               prefix[2] = 0;
++              has_3_operands = ctxt.hasVex;
+               has_modrm = true;
+               load = true;
+               src_reg_file = dst_reg_file = SSE;
+@@ -621,6 +658,7 @@ DISASSEMBLER_ENTRY(cmp,
+             case 0x39:
+               opcode1 = "pminsd";
+               prefix[2] = 0;
++              has_3_operands = ctxt.hasVex;
+               has_modrm = true;
+               load = true;
+               src_reg_file = dst_reg_file = SSE;
+@@ -628,6 +666,7 @@ DISASSEMBLER_ENTRY(cmp,
+             case 0x3A:
+               opcode1 = "pminuw";
+               prefix[2] = 0;
++              has_3_operands = ctxt.hasVex;
+               has_modrm = true;
+               load = true;
+               src_reg_file = dst_reg_file = SSE;
+@@ -635,6 +674,7 @@ DISASSEMBLER_ENTRY(cmp,
+             case 0x3B:
+               opcode1 = "pminud";
+               prefix[2] = 0;
++              has_3_operands = ctxt.hasVex;
+               has_modrm = true;
+               load = true;
+               src_reg_file = dst_reg_file = SSE;
+@@ -642,6 +682,7 @@ DISASSEMBLER_ENTRY(cmp,
+             case 0x3C:
+               opcode1 = "pmaxsb";
+               prefix[2] = 0;
++              has_3_operands = ctxt.hasVex;
+               has_modrm = true;
+               load = true;
+               src_reg_file = dst_reg_file = SSE;
+@@ -649,6 +690,7 @@ DISASSEMBLER_ENTRY(cmp,
+             case 0x3D:
+               opcode1 = "pmaxsd";
+               prefix[2] = 0;
++              has_3_operands = ctxt.hasVex;
+               has_modrm = true;
+               load = true;
+               src_reg_file = dst_reg_file = SSE;
+@@ -656,6 +698,7 @@ DISASSEMBLER_ENTRY(cmp,
+             case 0x3E:
+               opcode1 = "pmaxuw";
+               prefix[2] = 0;
++              has_3_operands = ctxt.hasVex;
+               has_modrm = true;
+               load = true;
+               src_reg_file = dst_reg_file = SSE;
+@@ -663,6 +706,7 @@ DISASSEMBLER_ENTRY(cmp,
+             case 0x3F:
+               opcode1 = "pmaxud";
+               prefix[2] = 0;
++              has_3_operands = ctxt.hasVex;
+               has_modrm = true;
+               load = true;
+               src_reg_file = dst_reg_file = SSE;
+@@ -670,10 +714,43 @@ DISASSEMBLER_ENTRY(cmp,
+             case 0x40:
+               opcode1 = "pmulld";
+               prefix[2] = 0;
++              has_3_operands = ctxt.hasVex;
+               has_modrm = true;
+               load = true;
+               src_reg_file = dst_reg_file = SSE;
+               break;
++            case 0x58:
++              opcode1 = "pbroadcastd";
++              needs_vex = has_modrm = load = true;
++              dst_reg_file = AVX;
++              src_reg_file = SSE;
++              break;
++            case 0x59:
++              opcode1 = "pbroadcastq";
++              needs_vex = has_modrm = load = true;
++              dst_reg_file = AVX;
++              src_reg_file = SSE;
++              break;
++            case 0x78:
++              opcode1 = "pbroadcastb";
++              needs_vex = has_modrm = load = true;
++              dst_reg_file = AVX;
++              src_reg_file = SSE;
++              break;
++            case 0x79:
++              opcode1 = "pbroadcastw";
++              needs_vex = has_modrm = load = true;
++              dst_reg_file = AVX;
++              src_reg_file = SSE;
++              break;
++            case 0xA9:
++              opcode1 = "fmadd213ss";
++              if ((rex & REX_W) != 0) {
++                opcode1 = "fmadd213sd";
++              }
++              width_qualified = has_3_operands = needs_vex = has_modrm = load = true;
++              dst_reg_file = src_reg_file = SSE;
++              break;
+             default:
+               opcode_tmp = StringPrintf("unknown opcode '0F 38 %02X'", *instr);
+               opcode1 = opcode_tmp.c_str();
+@@ -687,6 +764,12 @@ DISASSEMBLER_ENTRY(cmp,
+         instr++;
+         if (prefix[2] == 0x66) {
+           switch (*instr) {
++            case 0x01:
++              opcode1 = "permpd";
++              width_qualified = needs_vex = has_modrm = load = true;
++              dst_reg_file = src_reg_file = AVX;
++              immediate_bytes = 1;
++              break;
+             case 0x0A:
+               opcode1 = "roundss";
+               prefix[2] = 0;
+@@ -764,6 +847,7 @@ DISASSEMBLER_ENTRY(cmp,
+           case 0x5F: opcode1 = "max"; break;
+           default: LOG(FATAL) << "Unreachable"; UNREACHABLE();
+         }
++        has_3_operands = ctxt.hasVex;
+         if (prefix[2] == 0x66) {
+           opcode2 = "pd";
+           prefix[2] = 0;  // clear prefix now it's served its purpose as part of the opcode
+@@ -861,6 +945,10 @@ DISASSEMBLER_ENTRY(cmp,
+           dst_reg_file = MMX;
+         }
+         opcode1 = "movd";
++        if ((rex & REX_W) != 0) {
++          opcode1 = "movq";
++        }
++        width_qualified = true;
+         load = true;
+         has_modrm = true;
+         break;
+@@ -911,6 +999,7 @@ DISASSEMBLER_ENTRY(cmp,
+             "unknown-71", "unknown-71", "psrlw", "unknown-71",
+             "psraw",      "unknown-71", "psllw", "unknown-71"};
+         modrm_opcodes = x71_opcodes;
++        has_3_operands = ctxt.hasVex;
+         reg_is_opcode = true;
+         has_modrm = true;
+         store = true;
+@@ -927,6 +1016,7 @@ DISASSEMBLER_ENTRY(cmp,
+             "unknown-72", "unknown-72", "psrld", "unknown-72",
+             "psrad",      "unknown-72", "pslld", "unknown-72"};
+         modrm_opcodes = x72_opcodes;
++        has_3_operands = ctxt.hasVex;
+         reg_is_opcode = true;
+         has_modrm = true;
+         store = true;
+@@ -943,6 +1033,7 @@ DISASSEMBLER_ENTRY(cmp,
+             "unknown-73", "unknown-73", "psrlq", "psrldq",
+             "unknown-73", "unknown-73", "psllq", "unknown-73"};
+         modrm_opcodes = x73_opcodes;
++        has_3_operands = ctxt.hasVex;
+         reg_is_opcode = true;
+         has_modrm = true;
+         store = true;
+@@ -962,10 +1053,15 @@ DISASSEMBLER_ENTRY(cmp,
+           case 0x75: opcode1 = "pcmpeqw"; break;
+           case 0x76: opcode1 = "pcmpeqd"; break;
+         }
++        has_3_operands = ctxt.hasVex;
+         prefix[2] = 0;
+         has_modrm = true;
+         load = true;
+         break;
++      case 0x77:
++        needs_vex = true;
++        opcode1 = "zeroupper";
++        break;
+       case 0x7C:
+         if (prefix[0] == 0xF2) {
+           opcode1 = "haddps";
+@@ -990,6 +1086,10 @@ DISASSEMBLER_ENTRY(cmp,
+           src_reg_file = MMX;
+         }
+         opcode1 = "movd";
++        if ((rex & REX_W) != 0) {
++          opcode1 = "movq";
++        }
++        width_qualified = true;
+         has_modrm = true;
+         store = true;
+         break;
+@@ -1189,6 +1289,7 @@ DISASSEMBLER_ENTRY(cmp,
+           src_reg_file = dst_reg_file = MMX;
+         }
+         opcode1 = "paddq";
++        has_3_operands = ctxt.hasVex;
+         prefix[2] = 0;
+         has_modrm = true;
+         load = true;
+@@ -1201,6 +1302,7 @@ DISASSEMBLER_ENTRY(cmp,
+           src_reg_file = dst_reg_file = MMX;
+         }
+         opcode1 = "pand";
++        has_3_operands = ctxt.hasVex;
+         prefix[2] = 0;
+         has_modrm = true;
+         load = true;
+@@ -1209,6 +1311,7 @@ DISASSEMBLER_ENTRY(cmp,
+         if (prefix[2] == 0x66) {
+           opcode1 = "pmullw";
+           prefix[2] = 0;
++          has_3_operands = ctxt.hasVex;
+           has_modrm = true;
+           load = true;
+           src_reg_file = dst_reg_file = SSE;
+@@ -1223,6 +1326,7 @@ DISASSEMBLER_ENTRY(cmp,
+       case 0xDC:
+       case 0xDD:
+       case 0xDE:
++      case 0xDF:
+       case 0xE0:
+       case 0xE3:
+       case 0xE8:
+@@ -1237,6 +1341,7 @@ DISASSEMBLER_ENTRY(cmp,
+         } else {
+           src_reg_file = dst_reg_file = MMX;
+         }
++        has_3_operands = ctxt.hasVex;
+         switch (*instr) {
+           case 0xD8: opcode1 = "psubusb"; break;
+           case 0xD9: opcode1 = "psubusw"; break;
+@@ -1244,6 +1349,9 @@ DISASSEMBLER_ENTRY(cmp,
+           case 0xDC: opcode1 = "paddusb"; break;
+           case 0xDD: opcode1 = "paddusw"; break;
+           case 0xDE: opcode1 = "pmaxub"; break;
++          case 0xDF:
++            opcode1 = "pandn";
++            break;
+           case 0xE0: opcode1 = "pavgb"; break;
+           case 0xE3: opcode1 = "pavgw"; break;
+           case 0xE8: opcode1 = "psubsb"; break;
+@@ -1266,6 +1374,7 @@ DISASSEMBLER_ENTRY(cmp,
+         }
+         opcode1 = "por";
+         prefix[2] = 0;
++        has_3_operands = ctxt.hasVex;
+         has_modrm = true;
+         load = true;
+         break;
+@@ -1277,11 +1386,13 @@ DISASSEMBLER_ENTRY(cmp,
+           src_reg_file = dst_reg_file = MMX;
+         }
+         opcode1 = "pxor";
++        has_3_operands = ctxt.hasVex;
+         prefix[2] = 0;
+         has_modrm = true;
+         load = true;
+         break;
+       case 0xF4:
++      case 0xF5:
+       case 0xF6:
+       case 0xF8:
+       case 0xF9:
+@@ -1298,6 +1409,9 @@ DISASSEMBLER_ENTRY(cmp,
+         }
+         switch (*instr) {
+           case 0xF4: opcode1 = "pmuludq"; break;
++          case 0xF5:
++            opcode1 = "pmaddwd";
++            break;
+           case 0xF6: opcode1 = "psadbw"; break;
+           case 0xF8: opcode1 = "psubb"; break;
+           case 0xF9: opcode1 = "psubw"; break;
+@@ -1307,6 +1421,7 @@ DISASSEMBLER_ENTRY(cmp,
+           case 0xFD: opcode1 = "paddw"; break;
+           case 0xFE: opcode1 = "paddd"; break;
+         }
++        has_3_operands = ctxt.hasVex;
+         prefix[2] = 0;
+         has_modrm = true;
+         load = true;
+@@ -1504,6 +1619,25 @@ DISASSEMBLER_ENTRY(cmp,
+     opcode1 = opcode_tmp.c_str();
+     break;
+   }
++
++  if (needs_vex && !ctxt.hasVex) {
++    opcode_tmp = StringPrintf("unknown opcode '%02X', may be missing VEX prefix", *instr);
++    opcode1 = opcode_tmp.c_str();
++  }
++
++  // If it needs vex, then we know the exact register types before hand
++  if (!needs_vex && ctxt.hasVex && ctxt.Vex.vector_length == 1) {
++    if (src_reg_file == MMX) {
++      src_reg_file = SSE;
++    } else if (src_reg_file == SSE) {
++      src_reg_file = AVX;
++    }
++    if (dst_reg_file == MMX) {
++      dst_reg_file = SSE;
++    } else if (dst_reg_file == SSE) {
++      dst_reg_file = AVX;
++    }
++  }
+   std::ostringstream args;
+   // We force the REX prefix to be available for 64-bit target
+   // in order to dump addr (base/index) registers correctly.
+@@ -1530,13 +1664,17 @@ DISASSEMBLER_ENTRY(cmp,
+       opcode3 = modrm_opcodes[reg_or_opcode];
+     }
+ 
+-    // Add opcode suffixes to indicate size.
+-    if (byte_operand) {
+-      opcode4 = "b";
+-    } else if ((rex & REX_W) != 0) {
+-      opcode4 = "q";
+-    } else if (prefix[2] == 0x66) {
+-      opcode4 = "w";
++    // Not applicable for vex only opcodes and opcodes with
++    // fully qualified widths, ex: vpbroadcastb, vpabsb
++    if (!needs_vex && !width_qualified) {
++      // Add opcode suffixes to indicate size.
++      if (byte_operand) {
++        opcode4 = "b";
++      } else if ((rex & REX_W) != 0) {
++        opcode4 = "q";
++      } else if (prefix[2] == 0x66) {
++        opcode4 = "w";
++      }
+     }
+ 
+     if (load) {
+@@ -1544,6 +1682,10 @@ DISASSEMBLER_ENTRY(cmp,
+         DumpReg(args, rex, reg_or_opcode, byte_operand, prefix[2], dst_reg_file);
+         args << ", ";
+       }
++      if (has_3_operands) {
++        DumpAnyReg(args, 0, ctxt.Vex.operand, false, 0, dst_reg_file);
++        args << ", ";
++      }
+       DumpSegmentOverride(args, prefix[1]);
+ 
+       args << address;
+@@ -1551,6 +1693,10 @@ DISASSEMBLER_ENTRY(cmp,
+       DCHECK(store);
+       DumpSegmentOverride(args, prefix[1]);
+       args << address;
++      if (has_3_operands) {
++        args << ", ";
++        DumpAnyReg(args, 0, ctxt.Vex.operand, false, 0, dst_reg_file);
++      }
+       if (!reg_is_opcode) {
+         args << ", ";
+         DumpReg(args, rex, reg_or_opcode, byte_operand, prefix[2], src_reg_file);
+@@ -1616,10 +1762,21 @@ DISASSEMBLER_ENTRY(cmp,
+     case 0: prefix_str = ""; break;
+     default: LOG(FATAL) << "Unreachable"; UNREACHABLE();
+   }
++  size_t actual_bytes_read =
++      (instr - begin_instr - (ctxt.Vex.shadow_prefix_length - ctxt.Vex.prefix_length));
+   if (os) {
+-     os << FormatInstructionPointer(begin_instr)
+-        << StringPrintf(": %22s    \t%-7s%s%s%s%s%s ", DumpCodeHex(begin_instr, instr).c_str(),
+-                     prefix_str, opcode0, opcode1, opcode2, opcode3, opcode4)
++  opcode0 = (ctxt.hasVex) ? "v" : opcode0;
++  // We may be decoding from a shadow buffer, make adjustments to read from orig buffer
++  const uint8_t* adjustedInstr = ctxt.origInstr + actual_bytes_read;
++  os << FormatInstructionPointer(ctxt.origInstr)
++     << StringPrintf(": %22s    \t%-7s%s%s%s%s%s ",
++                     DumpCodeHex(ctxt.origInstr, adjustedInstr).c_str(),
++                     prefix_str,
++                     opcode0,
++                     opcode1,
++                     opcode2,
++                     opcode3,
++                     opcode4)
+         << args.str() << '\n';
+   }
+   if (insn_x86 != nullptr) {
+@@ -1635,9 +1792,136 @@ DISASSEMBLER_ENTRY(cmp,
+      insn_x86->prefix[3] = prefix[3];
+      insn_x86->opcode = instr;
+   }
+-  return instr - begin_instr;
++  return actual_bytes_read;
+ }  // NOLINT(readability/fn_size)
+ 
++DisassemblerX86::InstructionContext::InstructionContext(DisassemblerX86* disass,
++                                                        const uint8_t* instr) {
++  disassembler = disass;
++  origInstr = instr;
++  shadowInstr = instr;
++  // The existing disassembler understands REX prefix
++  // Inorder to reuse all existing code, interpret the VEX Prefix here,
++  // and generate byte sequence as if it were emitted with a REX prefix.
++  // Later when we enable EVEX ISA we should use similar strategy.
++  if (Vex.ConvertToRex(
++          instr, shadowInstrBuffer, disassembler->GetDisassemblerOptions()->end_address_)) {
++    shadowInstr = shadowInstrBuffer;
++    hasVex = true;
++  }
++}
++
++bool DisassemblerX86::InstructionContext::VexPrefix::ConvertToRex(const uint8_t* instr,
++                                                                  uint8_t* const decodeBuffer,
++                                                                  const uint8_t* instr_end) {
++  if (*instr != TWO_BYTE_VEX && *instr != THREE_BYTE_VEX) {
++    prefix_length = 0;
++    shadow_prefix_length = 0;
++    vector_length = 0;
++    operand = 0;
++    return false;
++  }
++
++  memset(decodeBuffer, 0, kMaxInstructionLength + 1);
++  uint8_t byteZero = 0, byteOne = 0, byteTwo = 0;
++  uint8_t pp = 0, rex = 0, mm1 = 0, mm2 = 0;
++  byteZero = *instr;
++  byteOne = *(instr + 1);
++  instr += 2;
++
++  if (byteZero == TWO_BYTE_VEX) {
++    prefix_length = 2;
++    // Emit REX prefix if required
++    // Extract REX.R [7] bit
++    // Note that in VEX prefix R is stored as 1's complement
++    if (((byteOne >> 7) & 1) == 0) {
++      rex = 0x44;  // REX.0R00
++    }
++    // VEX_M is assumed as SET_VEX_M_0F for 2-byte VEX
++    mm1 = 0x0F;
++    // Extract the VEX_PP [1:0] bits as prefix
++    pp = (byteOne & 0x03);
++    // Extract VEX_L [2] bit
++    vector_length = (byteOne >> 2) & 0x01;
++    // Extract operand [6:3] bits is operand stored as 1's complement
++    operand = (~(byteOne >> 3) & 0x0F);
++  } else {
++    prefix_length = 3;
++    byteTwo = *instr;
++    instr++;
++    // Emit REX prefix if required
++    // Extract REX.RXB [7:5] bits
++    // Note that in VEX prefix R is stored as 1's complement
++    if ((byteOne & 0xE0) != 0xE0) {
++      rex = 0x40;
++      rex |= (~(byteOne >> 5) & 0x07);
++    }
++    // Extract the VEX_M [4:0] bits
++    switch ((byteOne & 0x0F)) {
++      case 0x01:  // SET_VEX_M_0F
++        mm1 = 0x0F;
++        break;
++      case 0x02:  // SET_VEX_M_0F_38
++        mm1 = 0x0F;
++        mm2 = 0x38;
++        break;
++      case 0x03:  // SET_VEX_M_0F_3A
++        mm1 = 0x0F;
++        mm2 = 0x3A;
++        break;
++      default:
++        break;
++    }
++    // Extract the REX.W [7] bit
++    if ((byteTwo & 0x80) != 0) {
++      rex |= 0x48;
++    }
++    // Extract the VEX_PP [1:0] bits as prefix
++    pp = (byteTwo & 0x03);
++    // Extract VEX_L [2] bit
++    vector_length = (byteTwo >> 2) & 0x01;
++    // Extract operand [6:3] bits is operand stored as 1's complement
++    operand = (~(byteTwo >> 3) & 0x0F);
++  }
++
++  // Decode the pp prefix
++  switch (pp) {
++    case 0x01:  // SET_VEX_PP_66
++      pp = 0x66;
++      break;
++    case 0x02:  // SET_VEX_PP_F3
++      pp = 0xF3;
++      break;
++    case 0x03:  // SET_VEX_PP_F2
++      pp = 0xF2;
++      break;
++    default:  // SET_VEX_PP_NONE
++      pp = 0;
++      break;
++  }
++
++  // Resultant byte sequence to pass on
++  // pp rex mm1 mm2 instr
++  int idx = 0;
++  if (pp != 0) {
++    decodeBuffer[idx++] = pp;
++  }
++  if (rex != 0) {
++    decodeBuffer[idx++] = rex;
++  }
++  if (mm1 != 0) {
++    decodeBuffer[idx++] = mm1;
++  }
++  if (mm2 != 0) {
++    decodeBuffer[idx++] = mm2;
++  }
++  shadow_prefix_length = idx;
++  // Fill the remaining buffer
++  for (; idx < kMaxInstructionLength && instr < instr_end; ++instr) {
++    decodeBuffer[idx++] = *instr;
++  }
++  return true;
++}
+ 
+ }  // namespace x86
+ }  // namespace art
+diff --git a/disassembler/disassembler_x86.h b/disassembler/disassembler_x86.h
+index 009643e052..47d62b0345 100644
+--- a/disassembler/disassembler_x86.h
++++ b/disassembler/disassembler_x86.h
+@@ -31,7 +31,9 @@ struct x86_instr {
+         const uint8_t* opcode;            /* Opcode byte */
+ };
+ 
+-enum RegFile { GPR, MMX, SSE };
++static constexpr uint8_t kMaxInstructionLength = 15;
++
++enum RegFile { GPR, MMX, SSE, AVX };
+ 
+ class DisassemblerX86 final : public Disassembler {
+  public:
+@@ -43,6 +45,28 @@ class DisassemblerX86 final : public Disassembler {
+   void Dump(std::ostream& os, const uint8_t* begin, const uint8_t* end) override;
+ 
+  private:
++  struct InstructionContext {
++    DisassemblerX86* disassembler;
++    bool hasVex;
++    const uint8_t* origInstr;
++    const uint8_t* shadowInstr;
++    uint8_t shadowInstrBuffer[kMaxInstructionLength + 1];
++
++    struct VexPrefix {
++      uint8_t prefix_length;
++      uint8_t shadow_prefix_length;
++      uint8_t vector_length;
++      uint8_t operand;
++
++      bool ConvertToRex(const uint8_t* instr,
++                        uint8_t* const decodeBuffer,
++                        const uint8_t* instr_end);
++    };
++    struct VexPrefix Vex;
++
++    InstructionContext(DisassemblerX86* disass, const uint8_t* instr);
++  };
++
+   size_t DumpNops(std::ostream& os, const uint8_t* instr);
+   size_t DumpInstruction(std::ostream& os, const uint8_t* instr, x86_instr *ins = nullptr);
+ 
+diff --git a/runtime/arch/x86/instruction_set_features_x86.h b/runtime/arch/x86/instruction_set_features_x86.h
+index e6fbc33fdb..668c4ed741 100644
+--- a/runtime/arch/x86/instruction_set_features_x86.h
++++ b/runtime/arch/x86/instruction_set_features_x86.h
+@@ -31,7 +31,7 @@
+ #define SET_VEX_M_0F_3A 0x03
+ #define SET_VEX_W       0x80
+ #define SET_VEX_L_128   0x00
+-#define SET_VEL_L_256   0x04
++#define SET_VEX_L_256   0x04
+ #define SET_VEX_PP_NONE 0x00
+ #define SET_VEX_PP_66   0x01
+ #define SET_VEX_PP_F3   0x02
+-- 
+2.25.1
+

--- a/aosp_diff/preliminary/art/0005-Introduce-the-notion-of-vector-registers.patch
+++ b/aosp_diff/preliminary/art/0005-Introduce-the-notion-of-vector-registers.patch
@@ -1,0 +1,1024 @@
+From 066363860fc04baad3715cb5d9b6bfc6936f3628 Mon Sep 17 00:00:00 2001
+From: Vinay Prasad Kompella <vinay.kompella@intel.com>
+Date: Wed, 30 Oct 2024 20:16:45 +0530
+Subject: [PATCH 5/6] Introduce the notion of vector registers
+
+For arm, x86 vector registers are extensions of FP registers.
+Risc-v has exclusive set of vector registers. This patch focuses
+mainly on overlapping FP/vector registers.
+
+For arm, x86 FP/vector registers are one and the same.
+They cannot be used simultaneously without clobbering the other.
+We model vector registers as FP registers with a vector length > 0
+
+Vector codegen need not request for vector registers via LocationsBuilder,
+the use of vector registers will be driven by vector length from loop vectorization.
+The vector length is saved on the locations during register allocation.
+Implicitly the allocated FP registers contain this info, making them vector registers.
+
+Test: art/test.py -b --host
+      Run the above test with and without "avx,avx2" features
+
+Tracked-On: OAM-126116
+Change-Id: I9bea8fb13ffb3cb77a13753aae2356c49fba5837
+Signed-off-by: Vinay Prasad Kompella <vinay.kompella@intel.com>
+---
+ compiler/optimizing/code_generator.cc         |  14 +-
+ compiler/optimizing/code_generator.h          |  14 ++
+ .../code_generator_vector_x86_64.cc           |  32 +++-
+ compiler/optimizing/code_generator_x86_64.cc  | 109 ++++++++---
+ compiler/optimizing/code_generator_x86_64.h   |   7 +-
+ compiler/optimizing/locations.h               | 180 ++++++++++++++++--
+ compiler/optimizing/optimizing_unit_test.h    |   3 +-
+ .../register_allocation_resolver.cc           |   3 +-
+ .../register_allocator_linear_scan.cc         |  19 +-
+ .../optimizing/register_allocator_test.cc     |   9 +-
+ compiler/optimizing/ssa_liveness_analysis.cc  |  19 +-
+ compiler/optimizing/ssa_liveness_analysis.h   |  69 +++++--
+ 12 files changed, 398 insertions(+), 80 deletions(-)
+
+diff --git a/compiler/optimizing/code_generator.cc b/compiler/optimizing/code_generator.cc
+index 88bd818b0c..9cb6a9fe0e 100644
+--- a/compiler/optimizing/code_generator.cc
++++ b/compiler/optimizing/code_generator.cc
+@@ -1741,7 +1741,12 @@ void SlowPathCode::SaveLiveRegisters(CodeGenerator* codegen, LocationSummary* lo
+     DCHECK_LT(stack_offset, codegen->GetFrameSize() - codegen->FrameEntrySpillSize());
+     DCHECK_LT(i, kMaximumNumberOfExpectedRegisters);
+     saved_fpu_stack_offsets_[i] = stack_offset;
+-    stack_offset += codegen->SaveFloatingPointRegister(stack_offset, i);
++    if (codegen->HasOverlappingFPVecRegisters() && locations->GetNumLiveVectorRegisters() > 0) {
++      stack_offset +=
++          codegen->SaveVectorRegister(stack_offset, locations->LiveFPVecRegAsLocation(i));
++    } else {
++      stack_offset += codegen->SaveFloatingPointRegister(stack_offset, i);
++    }
+   }
+ }
+ 
+@@ -1759,7 +1764,12 @@ void SlowPathCode::RestoreLiveRegisters(CodeGenerator* codegen, LocationSummary*
+   for (uint32_t i : LowToHighBits(fp_spills)) {
+     DCHECK_LT(stack_offset, codegen->GetFrameSize() - codegen->FrameEntrySpillSize());
+     DCHECK_LT(i, kMaximumNumberOfExpectedRegisters);
+-    stack_offset += codegen->RestoreFloatingPointRegister(stack_offset, i);
++    if (codegen->HasOverlappingFPVecRegisters() && locations->GetNumLiveVectorRegisters() > 0) {
++      stack_offset +=
++          codegen->RestoreVectorRegister(stack_offset, locations->LiveFPVecRegAsLocation(i));
++    } else {
++      stack_offset += codegen->RestoreFloatingPointRegister(stack_offset, i);
++    }
+   }
+ }
+ 
+diff --git a/compiler/optimizing/code_generator.h b/compiler/optimizing/code_generator.h
+index aec7b45a1a..b132d8c8a1 100644
+--- a/compiler/optimizing/code_generator.h
++++ b/compiler/optimizing/code_generator.h
+@@ -241,6 +241,8 @@ class CodeGenerator : public DeletableArenaObject<kArenaAllocCodeGenerator> {
+ 
+   // Get the size of the target SIMD register in bytes.
+   virtual size_t GetSIMDRegisterWidth() const = 0;
++  virtual bool HasOverlappingFPVecRegisters() const { return false; }
++
+   virtual uintptr_t GetAddressOf(HBasicBlock* block) = 0;
+   void InitializeCodeGeneration(size_t number_of_spill_slots,
+                                 size_t maximum_safepoint_spill_size,
+@@ -280,6 +282,18 @@ class CodeGenerator : public DeletableArenaObject<kArenaAllocCodeGenerator> {
+   virtual size_t SaveFloatingPointRegister(size_t stack_index, uint32_t reg_id) = 0;
+   virtual size_t RestoreFloatingPointRegister(size_t stack_index, uint32_t reg_id) = 0;
+ 
++  virtual size_t SaveVectorRegister([[maybe_unused]] size_t stack_index,
++                                    [[maybe_unused]] Location loc) {
++    LOG(FATAL) << "Unexpected or Unimplemented";
++    return 0;
++  }
++
++  virtual size_t RestoreVectorRegister([[maybe_unused]] size_t stack_index,
++                                       [[maybe_unused]] Location loc) {
++    LOG(FATAL) << "Unexpected or Unimplemented";
++    return 0;
++  }
++
+   virtual bool NeedsTwoRegisters(DataType::Type type) const = 0;
+   // Returns whether we should split long moves in parallel moves.
+   virtual bool ShouldSplitLongMoves() const { return false; }
+diff --git a/compiler/optimizing/code_generator_vector_x86_64.cc b/compiler/optimizing/code_generator_vector_x86_64.cc
+index 47afa3b4a1..31626f9e44 100644
+--- a/compiler/optimizing/code_generator_vector_x86_64.cc
++++ b/compiler/optimizing/code_generator_vector_x86_64.cc
+@@ -45,8 +45,12 @@ void LocationsBuilderX86_64::VisitVecReplicateScalar(HVecReplicateScalar* instru
+     case DataType::Type::kFloat64:
+       locations->SetInAt(0, is_zero ? Location::ConstantLocation(input)
+                                     : Location::RequiresFpuRegister());
+-      locations->SetOut(is_zero ? Location::RequiresFpuRegister()
+-                                : Location::SameAsFirstInput());
++      // This is a special instruction with scalar-in and vector-out
++      // If we use same register for In and Out, we would wrongly consider it as vector-in
++      //   during register allocation.
++      // Any parallel moves generated, would have trouble as we wrongly marked
++      // the in-reg as vector. Use a different register for in and out to avoid this.
++      locations->SetOut(Location::RequiresFpuRegister());
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -94,12 +98,18 @@ void InstructionCodeGeneratorX86_64::VisitVecReplicateScalar(HVecReplicateScalar
+       break;
+     case DataType::Type::kFloat32:
+       DCHECK_EQ(4u, instruction->GetVectorLength());
+-      DCHECK(locations->InAt(0).Equals(locations->Out()));
++      {
++        XmmRegister src = locations->InAt(0).AsFpuRegister<XmmRegister>();
++        __ movups(dst, src);
++      }
+       __ shufps(dst, dst, Immediate(0));
+       break;
+     case DataType::Type::kFloat64:
+       DCHECK_EQ(2u, instruction->GetVectorLength());
+-      DCHECK(locations->InAt(0).Equals(locations->Out()));
++      {
++        XmmRegister src = locations->InAt(0).AsFpuRegister<XmmRegister>();
++        __ movups(dst, src);
++      }
+       __ shufpd(dst, dst, Immediate(0));
+       break;
+     default:
+@@ -124,7 +134,13 @@ void LocationsBuilderX86_64::VisitVecExtractScalar(HVecExtractScalar* instructio
+     case DataType::Type::kFloat32:
+     case DataType::Type::kFloat64:
+       locations->SetInAt(0, Location::RequiresFpuRegister());
+-      locations->SetOut(Location::SameAsFirstInput());
++      // This is a special instruction with scalar-out and vector-in
++      // If we use same register for In and Out, we would consider it as vector-out
++      //   during register allocation.
++      // Eventually any users will see it as a vector register.
++      // Using a different register for out, ensures its not marked as vector
++      locations->SetOut(Location::RequiresFpuRegister());
++
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -155,7 +171,11 @@ void InstructionCodeGeneratorX86_64::VisitVecExtractScalar(HVecExtractScalar* in
+     case DataType::Type::kFloat64:
+       DCHECK_LE(2u, instruction->GetVectorLength());
+       DCHECK_LE(instruction->GetVectorLength(), 4u);
+-      DCHECK(locations->InAt(0).Equals(locations->Out()));  // no code required
++      {
++        XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++        __ movups(dst, src);
++      }
++
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+diff --git a/compiler/optimizing/code_generator_x86_64.cc b/compiler/optimizing/code_generator_x86_64.cc
+index e2b4344be9..893a485616 100644
+--- a/compiler/optimizing/code_generator_x86_64.cc
++++ b/compiler/optimizing/code_generator_x86_64.cc
+@@ -1543,6 +1543,32 @@ size_t CodeGeneratorX86_64::RestoreFloatingPointRegister(size_t stack_index, uin
+   return GetSlowPathFPWidth();
+ }
+ 
++size_t CodeGeneratorX86_64::SaveVectorRegister(size_t stack_index, Location loc) {
++  DCHECK(loc.IsFpuRegister());
++  size_t slowpath_fp_width = GetSlowPathFPWidth();
++  DCHECK(GetGraph()->HasSIMD());
++  // Although we have fully qualified location with vector length, we choose not to use it.
++  // If there is atleast 1 live 256-bit register, we must emit AVX2 for all registers,
++  // to avoid performance issues
++  XmmRegister vReg(loc.reg(), GetSIMDRegisterWidth());
++  DCHECK_EQ(vReg.GetVecLen(), slowpath_fp_width);
++  __ movups(Address(CpuRegister(RSP), stack_index), vReg);
++  return slowpath_fp_width;
++}
++
++size_t CodeGeneratorX86_64::RestoreVectorRegister(size_t stack_index, Location loc) {
++  DCHECK(loc.IsFpuRegister());
++  size_t slowpath_fp_width = GetSlowPathFPWidth();
++  DCHECK(GetGraph()->HasSIMD());
++  // Although we have fully qualified location with vector length, we choose not to use it.
++  // If there is atleast 1 live 256-bit register, we must emit AVX2 for all registers,
++  // to avoid performance issues
++  XmmRegister vReg(loc.reg(), GetSIMDRegisterWidth());
++  DCHECK_EQ(vReg.GetVecLen(), slowpath_fp_width);
++  __ movups(vReg, Address(CpuRegister(RSP), stack_index));
++  return slowpath_fp_width;
++}
++
+ void CodeGeneratorX86_64::InvokeRuntime(QuickEntrypointEnum entrypoint,
+                                         HInstruction* instruction,
+                                         uint32_t dex_pc,
+@@ -1980,11 +2006,13 @@ void CodeGeneratorX86_64::Move(Location destination, Location source) {
+       __ movq(dest, Address(CpuRegister(RSP), source.GetStackIndex()));
+     }
+   } else if (destination.IsFpuRegister()) {
+-    XmmRegister dest = destination.AsFpuRegister<XmmRegister>();
++    XmmRegister dest = destination.AsFPVectorRegister<XmmRegister>();
+     if (source.IsRegister()) {
+       __ movd(dest, source.AsRegister<CpuRegister>());
+     } else if (source.IsFpuRegister()) {
+-      __ movaps(dest, source.AsFpuRegister<XmmRegister>());
++      XmmRegister src = source.AsFPVectorRegister<XmmRegister>();
++      DCHECK_EQ(dest.GetVecLen(), src.GetVecLen());
++      __ movaps(dest, src);
+     } else if (source.IsConstant()) {
+       HConstant* constant = source.GetConstant();
+       int64_t value = CodeGenerator::GetInt64ValueOf(constant);
+@@ -6363,6 +6391,9 @@ void ParallelMoveResolverX86_64::EmitMove(size_t index) {
+   Location source = move->GetSource();
+   Location destination = move->GetDestination();
+ 
++  // Parallel moves may involve vector registers.
++  // Hence the special handling to always retrieve
++  // FpuRegister locations as VectorRegister
+   if (source.IsRegister()) {
+     if (destination.IsRegister()) {
+       __ movq(destination.AsRegister<CpuRegister>(), source.AsRegister<CpuRegister>());
+@@ -6379,8 +6410,9 @@ void ParallelMoveResolverX86_64::EmitMove(size_t index) {
+       __ movl(destination.AsRegister<CpuRegister>(),
+               Address(CpuRegister(RSP), source.GetStackIndex()));
+     } else if (destination.IsFpuRegister()) {
+-      __ movss(destination.AsFpuRegister<XmmRegister>(),
+-              Address(CpuRegister(RSP), source.GetStackIndex()));
++      DCHECK_EQ(destination.GetVecLen(), 0u);
++      __ movss(destination.AsFPVectorRegister<XmmRegister>(),
++               Address(CpuRegister(RSP), source.GetStackIndex()));
+     } else {
+       DCHECK(destination.IsStackSlot());
+       __ movl(CpuRegister(TMP), Address(CpuRegister(RSP), source.GetStackIndex()));
+@@ -6391,7 +6423,8 @@ void ParallelMoveResolverX86_64::EmitMove(size_t index) {
+       __ movq(destination.AsRegister<CpuRegister>(),
+               Address(CpuRegister(RSP), source.GetStackIndex()));
+     } else if (destination.IsFpuRegister()) {
+-      __ movsd(destination.AsFpuRegister<XmmRegister>(),
++      DCHECK_EQ(destination.GetVecLen(), 0u);
++      __ movsd(destination.AsFPVectorRegister<XmmRegister>(),
+                Address(CpuRegister(RSP), source.GetStackIndex()));
+     } else {
+       DCHECK(destination.IsDoubleStackSlot()) << destination;
+@@ -6400,7 +6433,8 @@ void ParallelMoveResolverX86_64::EmitMove(size_t index) {
+     }
+   } else if (source.IsSIMDStackSlot()) {
+     if (destination.IsFpuRegister()) {
+-      __ movups(destination.AsFpuRegister<XmmRegister>(),
++      DCHECK_EQ(source.GetVecLen(), destination.GetVecLen());
++      __ movups(destination.AsFPVectorRegister<XmmRegister>(),
+                 Address(CpuRegister(RSP), source.GetStackIndex()));
+     } else {
+       DCHECK(destination.IsSIMDStackSlot());
+@@ -6456,17 +6490,22 @@ void ParallelMoveResolverX86_64::EmitMove(size_t index) {
+     }
+   } else if (source.IsFpuRegister()) {
+     if (destination.IsFpuRegister()) {
+-      __ movaps(destination.AsFpuRegister<XmmRegister>(), source.AsFpuRegister<XmmRegister>());
++      DCHECK_EQ(source.GetVecLen(), destination.GetVecLen());
++      __ movaps(destination.AsFPVectorRegister<XmmRegister>(),
++                source.AsFPVectorRegister<XmmRegister>());
+     } else if (destination.IsStackSlot()) {
++      DCHECK_EQ(source.GetVecLen(), 0u);
+       __ movss(Address(CpuRegister(RSP), destination.GetStackIndex()),
+-               source.AsFpuRegister<XmmRegister>());
++               source.AsFPVectorRegister<XmmRegister>());
+     } else if (destination.IsDoubleStackSlot()) {
++      DCHECK_EQ(source.GetVecLen(), 0u);
+       __ movsd(Address(CpuRegister(RSP), destination.GetStackIndex()),
+-               source.AsFpuRegister<XmmRegister>());
++               source.AsFPVectorRegister<XmmRegister>());
+     } else {
+        DCHECK(destination.IsSIMDStackSlot());
+-      __ movups(Address(CpuRegister(RSP), destination.GetStackIndex()),
+-                source.AsFpuRegister<XmmRegister>());
++       DCHECK_EQ(source.GetVecLen(), destination.GetVecLen());
++       __ movups(Address(CpuRegister(RSP), destination.GetStackIndex()),
++                 source.AsFPVectorRegister<XmmRegister>());
+     }
+   }
+ }
+@@ -6501,15 +6540,24 @@ void ParallelMoveResolverX86_64::Exchange64(XmmRegister reg, int mem) {
+   __ movd(reg, CpuRegister(TMP));
+ }
+ 
+-void ParallelMoveResolverX86_64::Exchange128(XmmRegister reg, int mem) {
+-  size_t extra_slot = 2 * kX86_64WordSize;
++void ParallelMoveResolverX86_64::ExchangeSIMD(XmmRegister reg, int mem) {
++  // We are operating on Vector register for sure
++  size_t extra_slot = reg.GetVecLen();
+   __ subq(CpuRegister(RSP), Immediate(extra_slot));
+-  __ movups(Address(CpuRegister(RSP), 0), XmmRegister(reg));
+-  ExchangeMemory64(0, mem + extra_slot, 2);
+-  __ movups(XmmRegister(reg), Address(CpuRegister(RSP), 0));
++  __ movups(Address(CpuRegister(RSP), 0), reg);
++  ExchangeMemory64(0, mem + extra_slot, extra_slot >> 3);
++  __ movups(reg, Address(CpuRegister(RSP), 0));
+   __ addq(CpuRegister(RSP), Immediate(extra_slot));
+ }
+ 
++void ParallelMoveResolverX86_64::ExchangeFPReg(XmmRegister reg1, XmmRegister reg2) {
++  // We may be either operating on plain FP registers or Vector registers
++  DCHECK_EQ(reg1.GetVecLen(), reg2.GetVecLen());
++  __ pxor(reg1, reg2);
++  __ pxor(reg2, reg1);
++  __ pxor(reg1, reg2);
++}
++
+ void ParallelMoveResolverX86_64::ExchangeMemory32(int mem1, int mem2) {
+   ScratchRegisterScope ensure_scratch(
+       this, TMP, RAX, codegen_->GetNumberOfCoreRegisters());
+@@ -6548,6 +6596,9 @@ void ParallelMoveResolverX86_64::EmitSwap(size_t index) {
+   Location source = move->GetSource();
+   Location destination = move->GetDestination();
+ 
++  // Parallel moves may involve vector registers.
++  // Hence the special handling to always retrieve
++  // FpuRegister locations as VectorRegister
+   if (source.IsRegister() && destination.IsRegister()) {
+     Exchange64(source.AsRegister<CpuRegister>(), destination.AsRegister<CpuRegister>());
+   } else if (source.IsRegister() && destination.IsStackSlot()) {
+@@ -6563,23 +6614,29 @@ void ParallelMoveResolverX86_64::EmitSwap(size_t index) {
+   } else if (source.IsDoubleStackSlot() && destination.IsDoubleStackSlot()) {
+     ExchangeMemory64(destination.GetStackIndex(), source.GetStackIndex(), 1);
+   } else if (source.IsFpuRegister() && destination.IsFpuRegister()) {
+-    __ movd(CpuRegister(TMP), source.AsFpuRegister<XmmRegister>());
+-    __ movaps(source.AsFpuRegister<XmmRegister>(), destination.AsFpuRegister<XmmRegister>());
+-    __ movd(destination.AsFpuRegister<XmmRegister>(), CpuRegister(TMP));
++    ExchangeFPReg(source.AsFPVectorRegister<XmmRegister>(),
++                  destination.AsFPVectorRegister<XmmRegister>());
+   } else if (source.IsFpuRegister() && destination.IsStackSlot()) {
+-    Exchange32(source.AsFpuRegister<XmmRegister>(), destination.GetStackIndex());
++    DCHECK_EQ(source.GetVecLen(), 0u);
++    Exchange32(source.AsFPVectorRegister<XmmRegister>(), destination.GetStackIndex());
+   } else if (source.IsStackSlot() && destination.IsFpuRegister()) {
+-    Exchange32(destination.AsFpuRegister<XmmRegister>(), source.GetStackIndex());
++    DCHECK_EQ(destination.GetVecLen(), 0u);
++    Exchange32(destination.AsFPVectorRegister<XmmRegister>(), source.GetStackIndex());
+   } else if (source.IsFpuRegister() && destination.IsDoubleStackSlot()) {
+-    Exchange64(source.AsFpuRegister<XmmRegister>(), destination.GetStackIndex());
++    DCHECK_EQ(source.GetVecLen(), 0u);
++    Exchange64(source.AsFPVectorRegister<XmmRegister>(), destination.GetStackIndex());
+   } else if (source.IsDoubleStackSlot() && destination.IsFpuRegister()) {
+-    Exchange64(destination.AsFpuRegister<XmmRegister>(), source.GetStackIndex());
++    DCHECK_EQ(destination.GetVecLen(), 0u);
++    Exchange64(destination.AsFPVectorRegister<XmmRegister>(), source.GetStackIndex());
+   } else if (source.IsSIMDStackSlot() && destination.IsSIMDStackSlot()) {
+-    ExchangeMemory64(destination.GetStackIndex(), source.GetStackIndex(), 2);
++    DCHECK_EQ(source.GetVecLen(), destination.GetVecLen());
++    ExchangeMemory64(destination.GetStackIndex(), source.GetStackIndex(), source.GetVecLen() >> 3);
+   } else if (source.IsFpuRegister() && destination.IsSIMDStackSlot()) {
+-    Exchange128(source.AsFpuRegister<XmmRegister>(), destination.GetStackIndex());
++    DCHECK_EQ(source.GetVecLen(), destination.GetVecLen());
++    ExchangeSIMD(source.AsFPVectorRegister<XmmRegister>(), destination.GetStackIndex());
+   } else if (destination.IsFpuRegister() && source.IsSIMDStackSlot()) {
+-    Exchange128(destination.AsFpuRegister<XmmRegister>(), source.GetStackIndex());
++    DCHECK_EQ(source.GetVecLen(), destination.GetVecLen());
++    ExchangeSIMD(destination.AsFPVectorRegister<XmmRegister>(), source.GetStackIndex());
+   } else {
+     LOG(FATAL) << "Unimplemented swap between " << source << " and " << destination;
+   }
+diff --git a/compiler/optimizing/code_generator_x86_64.h b/compiler/optimizing/code_generator_x86_64.h
+index 81c8ead32e..3f366d01ad 100644
+--- a/compiler/optimizing/code_generator_x86_64.h
++++ b/compiler/optimizing/code_generator_x86_64.h
+@@ -206,7 +206,8 @@ class ParallelMoveResolverX86_64 : public ParallelMoveResolverWithSwap {
+   void Exchange64(CpuRegister reg1, CpuRegister reg2);
+   void Exchange64(CpuRegister reg, int mem);
+   void Exchange64(XmmRegister reg, int mem);
+-  void Exchange128(XmmRegister reg, int mem);
++  void ExchangeSIMD(XmmRegister reg, int mem);
++  void ExchangeFPReg(XmmRegister reg1, XmmRegister reg2);
+   void ExchangeMemory32(int mem1, int mem2);
+   void ExchangeMemory64(int mem1, int mem2, int num_of_qwords);
+ 
+@@ -401,6 +402,8 @@ class CodeGeneratorX86_64 : public CodeGenerator {
+   size_t RestoreCoreRegister(size_t stack_index, uint32_t reg_id) override;
+   size_t SaveFloatingPointRegister(size_t stack_index, uint32_t reg_id) override;
+   size_t RestoreFloatingPointRegister(size_t stack_index, uint32_t reg_id) override;
++  size_t SaveVectorRegister(size_t stack_index, Location loc) override;
++  size_t RestoreVectorRegister(size_t stack_index, Location loc) override;
+ 
+   // Generate code to invoke a runtime entry point.
+   void InvokeRuntime(QuickEntrypointEnum entrypoint,
+@@ -434,6 +437,8 @@ class CodeGeneratorX86_64 : public CodeGenerator {
+     return 2 * kX86_64WordSize;
+   }
+ 
++  bool HasOverlappingFPVecRegisters() const override { return true; }
++
+   HGraphVisitor* GetLocationBuilder() override {
+     return &location_builder_;
+   }
+diff --git a/compiler/optimizing/locations.h b/compiler/optimizing/locations.h
+index 2209f05c0b..2791a9352f 100644
+--- a/compiler/optimizing/locations.h
++++ b/compiler/optimizing/locations.h
+@@ -22,8 +22,10 @@
+ #include "base/bit_field.h"
+ #include "base/bit_utils.h"
+ #include "base/bit_vector.h"
++#include "base/logging.h"
+ #include "base/macros.h"
+ #include "base/value_object.h"
++#include "runtime_globals.h"
+ 
+ namespace art HIDDEN {
+ 
+@@ -53,7 +55,7 @@ class Location : public ValueObject {
+   enum Kind {
+     kInvalid = 0,
+     kConstant = 1,
+-    kStackSlot = 2,  // 32bit stack slot.
++    kStackSlot = 2,        // 32bit stack slot.
+     kDoubleStackSlot = 3,  // 64bit stack slot.
+ 
+     kRegister = 4,  // Core register.
+@@ -70,13 +72,15 @@ class Location : public ValueObject {
+     // We do not use the value 9 because it conflicts with kLocationConstantMask.
+     kDoNotUse9 = 9,
+ 
+-    kSIMDStackSlot = 10,  // 128bit stack slot. TODO: generalize with encoded #bytes?
++    kVecRegister = 10,  // Vector register.
++
++    kSIMDStackSlot = 11,  // 128bit stack slot. TODO: generalize with encoded #bytes?
+ 
+     // Unallocated location represents a location that is not fixed and can be
+     // allocated by a register allocator.  Each unallocated location has
+     // a policy that specifies what kind of location is suitable. Payload
+     // contains register allocation policy.
+-    kUnallocated = 11,
++    kUnallocated = 12,
+   };
+ 
+   constexpr Location() : ValueObject(), value_(kInvalid) {
+@@ -91,6 +95,7 @@ class Location : public ValueObject {
+     static_assert((kRegisterPair & kLocationConstantMask) != kConstant, "TagError");
+     static_assert((kFpuRegisterPair & kLocationConstantMask) != kConstant, "TagError");
+     static_assert((kConstant & kLocationConstantMask) == kConstant, "TagError");
++    static_assert((kVecRegister & kLocationConstantMask) != kConstant, "TagError");
+ 
+     DCHECK(!IsValid());
+   }
+@@ -139,6 +144,15 @@ class Location : public ValueObject {
+     return Location(kFpuRegister, reg);
+   }
+ 
++  static Location FpuRegisterLocation(int reg, int vecLen) {
++    return Location(kFpuRegister, reg, vecLen);
++  }
++
++  // TODO: Implement this when we enable to architecures with exclusive Vec register
++  static Location VecRegisterLocation([[maybe_unused]] int reg, [[maybe_unused]] int vecLen) {
++    UNREACHABLE();
++  }
++
+   static constexpr Location RegisterPairLocation(int low, int high) {
+     return Location(kRegisterPair, low << 16 | high);
+   }
+@@ -155,6 +169,10 @@ class Location : public ValueObject {
+     return GetKind() == kFpuRegister;
+   }
+ 
++  bool IsVecRegister() const {
++    return (GetKind() == kVecRegister) || (IsFpuRegister() && GetVecLen() > 0);
++  }
++
+   bool IsRegisterPair() const {
+     return GetKind() == kRegisterPair;
+   }
+@@ -194,6 +212,23 @@ class Location : public ValueObject {
+     return static_cast<T>(reg());
+   }
+ 
++  template <typename T, bool kHasOverlappingFPVecRegisters = false>
++  T AsVectorRegister() const {
++    if (kHasOverlappingFPVecRegisters) {
++      DCHECK(IsFpuRegister());
++      return T(reg(), GetVecLen());
++    } else {
++      DCHECK(!IsFpuRegister());
++      DCHECK(IsVecRegister());
++      return static_cast<T>(reg());
++    }
++  }
++
++  template <typename T>
++  T AsFPVectorRegister() const {
++    return AsVectorRegister<T, true>();
++  }
++
+   template <typename T>
+   T AsRegisterPairLow() const {
+     DCHECK(IsRegisterPair());
+@@ -274,9 +309,9 @@ class Location : public ValueObject {
+     return GetKind() == kDoubleStackSlot;
+   }
+ 
+-  static Location SIMDStackSlot(intptr_t stack_index) {
++  static Location SIMDStackSlot(intptr_t stack_index, size_t num_of_slots = 0) {
+     uintptr_t payload = EncodeStackIndex(stack_index);
+-    Location loc(kSIMDStackSlot, payload);
++    Location loc(kSIMDStackSlot, payload, num_of_slots * kVRegSize);
+     // Ensure that sign is preserved.
+     DCHECK_EQ(loc.GetStackIndex(), stack_index);
+     return loc;
+@@ -295,7 +330,7 @@ class Location : public ValueObject {
+         return Location::DoubleStackSlot(spill_slot);
+       default:
+         // Assume all other stack slot sizes correspond to SIMD slot size.
+-        return Location::SIMDStackSlot(spill_slot);
++        return Location::SIMDStackSlot(spill_slot, num_of_slots);
+     }
+   }
+ 
+@@ -316,7 +351,12 @@ class Location : public ValueObject {
+   }
+ 
+   bool Equals(Location other) const {
+-    return value_ == other.value_;
++    // Handle the case of overlapping FP vector registers
++    if (IsFpuRegister() && other.IsFpuRegister()) {
++      return reg() == other.reg();
++    } else {
++      return value_ == other.value_;
++    }
+   }
+ 
+   bool Contains(Location other) const {
+@@ -354,6 +394,8 @@ class Location : public ValueObject {
+       case kFpuRegister: return "F";
+       case kRegisterPair: return "RP";
+       case kFpuRegisterPair: return "FP";
++      case kVecRegister:
++        return "V";
+       case kDoNotUse5:  // fall-through
+       case kDoNotUse9:
+         LOG(FATAL) << "Should not use this location kind";
+@@ -415,16 +457,35 @@ class Location : public ValueObject {
+     return GetPayload();
+   }
+ 
++  size_t GetVecLen() const {
++    uint8_t decodedVecLen = GetVecLenAsPowerOf2();
++    return (decodedVecLen > 0) ? (1 << decodedVecLen) : 0;
++  }
++
++  uint8_t GetVecLenAsPowerOf2() const {
++    DCHECK(IsFpuRegister() || IsVecRegister() || IsSIMDStackSlot());
++    return VecLenField::Decode(value_);
++  }
++
+  private:
+   // Number of bits required to encode Kind value.
+   static constexpr uint32_t kBitsForKind = 4;
+-  static constexpr uint32_t kBitsForPayload = kBitsPerIntPtrT - kBitsForKind;
++  static constexpr uint32_t kBitsForVecLen = 4;
++  static constexpr uint32_t kBitsForPayload = kBitsPerIntPtrT - (kBitsForKind + kBitsForVecLen);
+   static constexpr uintptr_t kLocationConstantMask = 0x3;
+ 
+   explicit Location(uintptr_t value) : value_(value) {}
+ 
+-  constexpr Location(Kind kind, uintptr_t payload)
+-      : value_(KindField::Encode(kind) | PayloadField::Encode(payload)) {}
++  constexpr Location(Kind kind, uintptr_t payload, size_t vecLen = 0)
++      : value_(KindField::Encode(kind) | VecLenField::Encode(0) | PayloadField::Encode(payload)) {
++    if (vecLen > 0 && (kind == kFpuRegister || kind == kVecRegister || kind == kSIMDStackSlot)) {
++      size_t vecLenAsPowOf2 = CTZ(vecLen);
++      DCHECK_LE(vecLenAsPowOf2, 15U) << "Insufficient bits to represent vector length";
++      value_ |= VecLenField::Encode(vecLenAsPowOf2);
++    } else {
++      DCHECK_EQ(vecLen, 0U) << "Invalid vecLen on Location of kind - " << DebugString();
++    }
++  }
+ 
+   uintptr_t GetPayload() const {
+     return PayloadField::Decode(value_);
+@@ -433,7 +494,8 @@ class Location : public ValueObject {
+   static void DCheckInstructionIsConstant(HInstruction* instruction);
+ 
+   using KindField = BitField<Kind, 0, kBitsForKind>;
+-  using PayloadField = BitField<uintptr_t, kBitsForKind, kBitsForPayload>;
++  using VecLenField = BitField<size_t, kBitsForKind, kBitsForVecLen>;
++  using PayloadField = BitField<uintptr_t, kBitsForKind + kBitsForVecLen, kBitsForPayload>;
+ 
+   // Layout for kUnallocated locations payload.
+   using PolicyField = BitField<Policy, 0, 3>;
+@@ -458,18 +520,41 @@ class RegisterSet : public ValueObject {
+   void Add(Location loc) {
+     if (loc.IsRegister()) {
+       core_registers_ |= (1 << loc.reg());
+-    } else {
+-      DCHECK(loc.IsFpuRegister());
++    } else if (loc.IsFpuRegister()) {
+       floating_point_registers_ |= (1 << loc.reg());
++      DCHECK_IMPLIES(!has_overlapping_fp_vec_registers_, vector_registers_ == 0U)
++          << "All FP Vec registers must either be overlapping/non-overlapping";
++      if (loc.IsVecRegister()) {
++        vector_registers_ |= (1 << loc.reg());
++        DCHECK(vector_length_as_pow_of_2_ == 0 ||
++               vector_length_as_pow_of_2_ == loc.GetVecLenAsPowerOf2())
++            << "Unexpected vector length " << (1 << loc.GetVecLenAsPowerOf2());
++        vector_length_as_pow_of_2_ = loc.GetVecLenAsPowerOf2();
++        has_overlapping_fp_vec_registers_ = true;
++      }
++    } else {
++      DCHECK(loc.IsVecRegister());
++      DCHECK(!has_overlapping_fp_vec_registers_);
++      DCHECK(vector_length_as_pow_of_2_ == 0 ||
++               vector_length_as_pow_of_2_ == loc.GetVecLenAsPowerOf2())
++            << "Unexpected vector length " << (1 << loc.GetVecLenAsPowerOf2());
++      vector_length_as_pow_of_2_ = loc.GetVecLenAsPowerOf2();
++      vector_registers_ |= (1 << loc.reg());
+     }
+   }
+ 
+   void Remove(Location loc) {
+     if (loc.IsRegister()) {
+       core_registers_ &= ~(1 << loc.reg());
+-    } else {
+-      DCHECK(loc.IsFpuRegister()) << loc;
++    } else if (loc.IsFpuRegister()) {
+       floating_point_registers_ &= ~(1 << loc.reg());
++      if (has_overlapping_fp_vec_registers_) {
++        vector_registers_ &= ~(1 << loc.reg());
++      }
++    } else {
++      DCHECK(loc.IsVecRegister()) << loc;
++      DCHECK(!has_overlapping_fp_vec_registers_);
++      vector_registers_ &= ~(1 << loc.reg());
+     }
+   }
+ 
+@@ -481,6 +566,8 @@ class RegisterSet : public ValueObject {
+     return Contains(floating_point_registers_, id);
+   }
+ 
++  bool ContainsVectorRegister(uint32_t id) const { return Contains(vector_registers_, id); }
++
+   static bool Contains(uint32_t register_set, uint32_t reg) {
+     return (register_set & (1 << reg)) != 0;
+   }
+@@ -503,9 +590,12 @@ class RegisterSet : public ValueObject {
+   }
+ 
+   size_t GetNumberOfRegisters() const {
+-    return POPCOUNT(core_registers_) + POPCOUNT(floating_point_registers_);
++    size_t total = POPCOUNT(core_registers_) + POPCOUNT(floating_point_registers_);
++    return has_overlapping_fp_vec_registers_ ? total : (total + GetNumberOfVectorRegisters());
+   }
+ 
++  size_t GetNumberOfVectorRegisters() const { return POPCOUNT(vector_registers_); }
++
+   uint32_t GetCoreRegisters() const {
+     return core_registers_;
+   }
+@@ -514,12 +604,50 @@ class RegisterSet : public ValueObject {
+     return floating_point_registers_;
+   }
+ 
++  uint32_t GetVectorRegisters() const { return vector_registers_; }
++
++  Location VecRegAsLocation(uint32_t reg_id) const {
++    if (ContainsVectorRegister(reg_id)) {
++      size_t vecLen =
++          (vector_length_as_pow_of_2_ > 0) ? (1 << vector_length_as_pow_of_2_) : 0;
++      return (has_overlapping_fp_vec_registers_) ? Location::FpuRegisterLocation(reg_id, vecLen) :
++                                                   Location::VecRegisterLocation(reg_id, vecLen);
++    }
++    return Location::NoLocation();
++  }
++
+  private:
+-  RegisterSet() : core_registers_(0), floating_point_registers_(0) {}
+-  RegisterSet(uint32_t core, uint32_t fp) : core_registers_(core), floating_point_registers_(fp) {}
++  RegisterSet()
++      : core_registers_(0),
++        floating_point_registers_(0),
++        vector_registers_(0),
++        vector_length_as_pow_of_2_(0),
++        has_overlapping_fp_vec_registers_(false) {}
++  RegisterSet(uint32_t core, uint32_t fp)
++      : core_registers_(core),
++        floating_point_registers_(fp),
++        vector_registers_(0),
++        vector_length_as_pow_of_2_(0),
++        has_overlapping_fp_vec_registers_(false) {}
++  RegisterSet(uint32_t core,
++              uint32_t fp,
++              uint32_t vecreg,
++              uint8_t vec_length_as_pow_of_2,
++              bool FPVecRegOverlap)
++      : core_registers_(core),
++        floating_point_registers_(fp),
++        vector_registers_(vecreg),
++        vector_length_as_pow_of_2_(vec_length_as_pow_of_2),
++        has_overlapping_fp_vec_registers_(FPVecRegOverlap) {}
+ 
+   uint32_t core_registers_;
+   uint32_t floating_point_registers_;
++  // TODO: Vector registers require vector length info as well, although not for all archs
++  //  Storing vector length needs atleast 4 bits/reg => 16 bytes per RegisterSet/location summary
++  //  For now we simplify by just assuming vector length to be fixed
++  uint32_t vector_registers_;
++  uint8_t  vector_length_as_pow_of_2_;
++  bool has_overlapping_fp_vec_registers_;
+ };
+ 
+ static constexpr bool kIntrinsified = true;
+@@ -684,6 +812,8 @@ class LocationSummary : public ArenaObject<kArenaAllocLocationSummary> {
+     return live_registers_.GetNumberOfRegisters();
+   }
+ 
++  size_t GetNumLiveVectorRegisters() const { return live_registers_.GetNumberOfVectorRegisters(); }
++
+   bool OutputUsesSameAs(uint32_t input_index) const {
+     return (input_index == 0)
+         && output_.IsUnallocated()
+@@ -707,6 +837,20 @@ class LocationSummary : public ArenaObject<kArenaAllocLocationSummary> {
+     return intrinsified_;
+   }
+ 
++  Location LiveFPVecRegAsLocation(int reg_id) const {
++    if (live_registers_.ContainsVectorRegister(reg_id)) {
++      return LiveVecRegAsLocation(reg_id);
++    } else if (live_registers_.ContainsFloatingPointRegister(reg_id)) {
++      return Location::FpuRegisterLocation(reg_id);
++    } else {
++      return Location::NoLocation();
++    }
++  }
++
++  Location LiveVecRegAsLocation(int reg_id) const {
++    return live_registers_.VecRegAsLocation(reg_id);
++  }
++
+  private:
+   LocationSummary(HInstruction* instruction,
+                   CallKind call_kind,
+diff --git a/compiler/optimizing/optimizing_unit_test.h b/compiler/optimizing/optimizing_unit_test.h
+index e1d8969b2b..f6817b6754 100644
+--- a/compiler/optimizing/optimizing_unit_test.h
++++ b/compiler/optimizing/optimizing_unit_test.h
+@@ -96,7 +96,8 @@ inline LiveInterval* BuildInterval(const size_t ranges[][2],
+                                    int reg = -1,
+                                    HInstruction* defined_by = nullptr) {
+   LiveInterval* interval =
+-      LiveInterval::MakeInterval(allocator, DataType::Type::kInt32, defined_by);
++      LiveInterval::MakeInterval(allocator, DataType::Type::kInt32, defined_by,
++                                  /*has_overlapping_fp_vec_regs*/false);
+   if (defined_by != nullptr) {
+     defined_by->SetLiveInterval(interval);
+   }
+diff --git a/compiler/optimizing/register_allocation_resolver.cc b/compiler/optimizing/register_allocation_resolver.cc
+index a4b1698b8d..c690783687 100644
+--- a/compiler/optimizing/register_allocation_resolver.cc
++++ b/compiler/optimizing/register_allocation_resolver.cc
+@@ -218,7 +218,8 @@ void RegisterAllocationResolver::Resolve(ArrayRef<HInstruction* const> safepoint
+               temp->GetRegister(), temp->GetHighInterval()->GetRegister());
+           locations->SetTempAt(temp_index, location);
+         } else {
+-          locations->SetTempAt(temp_index, Location::FpuRegisterLocation(temp->GetRegister()));
++          DCHECK(temp->HasRegister());
++          locations->SetTempAt(temp_index, temp->ToLocation());
+         }
+         break;
+ 
+diff --git a/compiler/optimizing/register_allocator_linear_scan.cc b/compiler/optimizing/register_allocator_linear_scan.cc
+index 458d1a740e..85bb748fbc 100644
+--- a/compiler/optimizing/register_allocator_linear_scan.cc
++++ b/compiler/optimizing/register_allocator_linear_scan.cc
+@@ -54,9 +54,11 @@ RegisterAllocatorLinearScan::RegisterAllocatorLinearScan(ScopedArenaAllocator* a
+         physical_core_register_intervals_(allocator->Adapter(kArenaAllocRegisterAllocator)),
+         physical_fp_register_intervals_(allocator->Adapter(kArenaAllocRegisterAllocator)),
+         block_registers_for_call_interval_(
+-            LiveInterval::MakeFixedInterval(allocator, kNoRegister, DataType::Type::kVoid)),
++            LiveInterval::MakeFixedInterval(allocator, kNoRegister, DataType::Type::kVoid,
++                                            codegen->HasOverlappingFPVecRegisters())),
+         block_registers_special_interval_(
+-            LiveInterval::MakeFixedInterval(allocator, kNoRegister, DataType::Type::kVoid)),
++            LiveInterval::MakeFixedInterval(allocator, kNoRegister, DataType::Type::kVoid,
++                                            codegen->HasOverlappingFPVecRegisters())),
+         temp_intervals_(allocator->Adapter(kArenaAllocRegisterAllocator)),
+         int_spill_slots_(allocator->Adapter(kArenaAllocRegisterAllocator)),
+         long_spill_slots_(allocator->Adapter(kArenaAllocRegisterAllocator)),
+@@ -147,7 +149,8 @@ void RegisterAllocatorLinearScan::BlockRegister(Location location,
+       ? DataType::Type::kInt32
+       : DataType::Type::kFloat32;
+   if (interval == nullptr) {
+-    interval = LiveInterval::MakeFixedInterval(allocator_, reg, type);
++    interval = LiveInterval::MakeFixedInterval(
++        allocator_, reg, type, codegen_->HasOverlappingFPVecRegisters());
+     if (location.IsRegister()) {
+       physical_core_register_intervals_[reg] = interval;
+     } else {
+@@ -331,7 +334,10 @@ void RegisterAllocatorLinearScan::CheckForTempLiveIntervals(HInstruction* instru
+       switch (temp.GetPolicy()) {
+         case Location::kRequiresRegister: {
+           LiveInterval* interval =
+-              LiveInterval::MakeTempInterval(allocator_, DataType::Type::kInt32);
++              LiveInterval::MakeTempInterval(allocator_,
++                                             DataType::Type::kInt32,
++                                             instruction,
++                                             codegen_->HasOverlappingFPVecRegisters());
+           temp_intervals_.push_back(interval);
+           interval->AddTempUse(instruction, i);
+           unhandled_core_intervals_.push_back(interval);
+@@ -340,7 +346,10 @@ void RegisterAllocatorLinearScan::CheckForTempLiveIntervals(HInstruction* instru
+ 
+         case Location::kRequiresFpuRegister: {
+           LiveInterval* interval =
+-              LiveInterval::MakeTempInterval(allocator_, DataType::Type::kFloat64);
++              LiveInterval::MakeTempInterval(allocator_,
++                                             DataType::Type::kFloat64,
++                                             instruction,
++                                             codegen_->HasOverlappingFPVecRegisters());
+           temp_intervals_.push_back(interval);
+           interval->AddTempUse(instruction, i);
+           if (codegen_->NeedsTwoRegisters(DataType::Type::kFloat64)) {
+diff --git a/compiler/optimizing/register_allocator_test.cc b/compiler/optimizing/register_allocator_test.cc
+index 8f1e724569..4d95d61434 100644
+--- a/compiler/optimizing/register_allocator_test.cc
++++ b/compiler/optimizing/register_allocator_test.cc
+@@ -428,15 +428,18 @@ TEST_F(RegisterAllocatorTest, FreeUntil) {
+   // Put the one that should be picked in the middle of the inactive list to ensure
+   // we do not depend on an order.
+   LiveInterval* interval =
+-      LiveInterval::MakeFixedInterval(GetScopedAllocator(), 0, DataType::Type::kInt32);
++      LiveInterval::MakeFixedInterval(GetScopedAllocator(), 0, DataType::Type::kInt32,
++                                      codegen.HasOverlappingFPVecRegisters());
+   interval->AddRange(40, 50);
+   register_allocator.inactive_.push_back(interval);
+ 
+-  interval = LiveInterval::MakeFixedInterval(GetScopedAllocator(), 0, DataType::Type::kInt32);
++  interval = LiveInterval::MakeFixedInterval(GetScopedAllocator(), 0, DataType::Type::kInt32,
++                                              codegen.HasOverlappingFPVecRegisters());
+   interval->AddRange(20, 30);
+   register_allocator.inactive_.push_back(interval);
+ 
+-  interval = LiveInterval::MakeFixedInterval(GetScopedAllocator(), 0, DataType::Type::kInt32);
++  interval = LiveInterval::MakeFixedInterval(GetScopedAllocator(), 0, DataType::Type::kInt32,
++                                              codegen.HasOverlappingFPVecRegisters());
+   interval->AddRange(60, 70);
+   register_allocator.inactive_.push_back(interval);
+ 
+diff --git a/compiler/optimizing/ssa_liveness_analysis.cc b/compiler/optimizing/ssa_liveness_analysis.cc
+index 317e0999d7..bce7937acb 100644
+--- a/compiler/optimizing/ssa_liveness_analysis.cc
++++ b/compiler/optimizing/ssa_liveness_analysis.cc
+@@ -55,8 +55,8 @@ void SsaLivenessAnalysis::NumberInstructions() {
+       if (locations != nullptr && locations->Out().IsValid()) {
+         instructions_from_ssa_index_.push_back(current);
+         current->SetSsaIndex(ssa_index++);
+-        current->SetLiveInterval(
+-            LiveInterval::MakeInterval(allocator_, current->GetType(), current));
++        current->SetLiveInterval(LiveInterval::MakeInterval(
++            allocator_, current->GetType(), current, codegen_->HasOverlappingFPVecRegisters()));
+       }
+       current->SetLifetimePosition(lifetime_position);
+     }
+@@ -73,8 +73,8 @@ void SsaLivenessAnalysis::NumberInstructions() {
+       if (locations != nullptr && locations->Out().IsValid()) {
+         instructions_from_ssa_index_.push_back(current);
+         current->SetSsaIndex(ssa_index++);
+-        current->SetLiveInterval(
+-            LiveInterval::MakeInterval(allocator_, current->GetType(), current));
++        current->SetLiveInterval(LiveInterval::MakeInterval(
++            allocator_, current->GetType(), current, codegen_->HasOverlappingFPVecRegisters()));
+       }
+       instructions_from_lifetime_position_.push_back(current);
+       current->SetLifetimePosition(lifetime_position);
+@@ -509,6 +509,17 @@ Location LiveInterval::ToLocation() const {
+       if (HasHighInterval()) {
+         return Location::FpuRegisterPairLocation(GetRegister(), GetHighInterval()->GetRegister());
+       } else {
++        if (has_overlapping_fp_vec_registers_) {
++          HInstruction* definition = GetParent()->GetDefinedBy();
++          // For vector operation we want to embedd the vector length in the Location info
++          DCHECK(definition != nullptr);
++          // Determine if location is a vector by getting needed spill slots
++          size_t needed_spill_slots = NumberOfSpillSlotsNeeded();
++          needed_spill_slots = (needed_spill_slots > 2) ? needed_spill_slots : 0;
++          DCHECK_IMPLIES(needed_spill_slots > 0, definition->IsVecOperation() ||
++                          (definition->IsPhi() && definition->InputAt(1)->IsVecOperation()));
++          return Location::FpuRegisterLocation(GetRegister(), needed_spill_slots * kVRegSize);
++        }
+         return Location::FpuRegisterLocation(GetRegister());
+       }
+     } else {
+diff --git a/compiler/optimizing/ssa_liveness_analysis.h b/compiler/optimizing/ssa_liveness_analysis.h
+index e9422edb15..b9d55a37b6 100644
+--- a/compiler/optimizing/ssa_liveness_analysis.h
++++ b/compiler/optimizing/ssa_liveness_analysis.h
+@@ -276,18 +276,44 @@ class LiveInterval : public ArenaObject<kArenaAllocSsaLiveness> {
+  public:
+   static LiveInterval* MakeInterval(ScopedArenaAllocator* allocator,
+                                     DataType::Type type,
+-                                    HInstruction* instruction = nullptr) {
+-    return new (allocator) LiveInterval(allocator, type, instruction);
++                                    HInstruction* instruction,
++                                    bool has_overlapping_fp_vec_regs) {
++    return new (allocator) LiveInterval(allocator,
++                                        type,
++                                        instruction,
++                                        /*is_fixed*/ false,
++                                        /*reg*/ kNoRegister,
++                                        /*is_temp*/ false,
++                                        /*is_high_interval*/ false,
++                                        has_overlapping_fp_vec_regs);
+   }
+ 
+   static LiveInterval* MakeFixedInterval(ScopedArenaAllocator* allocator,
+                                          int reg,
+-                                         DataType::Type type) {
+-    return new (allocator) LiveInterval(allocator, type, nullptr, true, reg, false);
+-  }
+-
+-  static LiveInterval* MakeTempInterval(ScopedArenaAllocator* allocator, DataType::Type type) {
+-    return new (allocator) LiveInterval(allocator, type, nullptr, false, kNoRegister, true);
++                                         DataType::Type type,
++                                         bool has_overlapping_fp_vec_regs) {
++    return new (allocator) LiveInterval(allocator,
++                                        type,
++                                        nullptr,
++                                        true,
++                                        reg,
++                                        /*is_temp*/ false,
++                                        /*is_high_interval*/ false,
++                                        has_overlapping_fp_vec_regs);
++  }
++
++  static LiveInterval* MakeTempInterval(ScopedArenaAllocator* allocator,
++                                        DataType::Type type,
++                                        HInstruction* instruction,
++                                        bool has_overlapping_fp_vec_regs) {
++    return new (allocator) LiveInterval(allocator,
++                                        type,
++                                        instruction,
++                                        false,
++                                        kNoRegister,
++                                        true,
++                                        /*is_high_interval*/ false,
++                                        has_overlapping_fp_vec_regs);
+   }
+ 
+   bool IsFixed() const { return is_fixed_; }
+@@ -658,8 +684,14 @@ class LiveInterval : public ArenaObject<kArenaAllocSsaLiveness> {
+       // This range dies before `position`, no need to split.
+       return nullptr;
+     }
+-
+-    LiveInterval* new_interval = new (allocator_) LiveInterval(allocator_, type_);
++    LiveInterval* new_interval = new (allocator_) LiveInterval(allocator_,
++                                                               type_,
++                                                               defined_by_,
++                                                               /*is_fixed*/ false,
++                                                               /*reg*/ kNoRegister,
++                                                               /*is_temp*/ false,
++                                                               /*is_high_interval*/ false,
++                                                               has_overlapping_fp_vec_registers_);
+     SafepointPosition* new_last_safepoint = FindSafepointJustBefore(position);
+     if (new_last_safepoint == nullptr) {
+       new_interval->first_safepoint_ = first_safepoint_;
+@@ -849,8 +881,14 @@ class LiveInterval : public ArenaObject<kArenaAllocSsaLiveness> {
+     DCHECK(IsParent());
+     DCHECK(!HasHighInterval());
+     DCHECK(!HasLowInterval());
+-    high_or_low_interval_ = new (allocator_) LiveInterval(
+-        allocator_, type_, defined_by_, false, kNoRegister, is_temp, true);
++    high_or_low_interval_ = new (allocator_) LiveInterval(allocator_,
++                                                          type_,
++                                                          defined_by_,
++                                                          false,
++                                                          kNoRegister,
++                                                          is_temp,
++                                                          true,
++                                                          has_overlapping_fp_vec_registers_);
+     high_or_low_interval_->high_or_low_interval_ = this;
+     if (first_range_ != nullptr) {
+       high_or_low_interval_->first_range_ = first_range_->Dup(allocator_);
+@@ -983,7 +1021,8 @@ class LiveInterval : public ArenaObject<kArenaAllocSsaLiveness> {
+                bool is_fixed = false,
+                int reg = kNoRegister,
+                bool is_temp = false,
+-               bool is_high_interval = false)
++               bool is_high_interval = false,
++               bool has_overlapping_fp_vec_regs = false)
+       : allocator_(allocator),
+         first_range_(nullptr),
+         last_range_(nullptr),
+@@ -1000,6 +1039,7 @@ class LiveInterval : public ArenaObject<kArenaAllocSsaLiveness> {
+         is_fixed_(is_fixed),
+         is_temp_(is_temp),
+         is_high_interval_(is_high_interval),
++        has_overlapping_fp_vec_registers_(has_overlapping_fp_vec_regs),
+         high_or_low_interval_(nullptr),
+         defined_by_(defined_by) {}
+ 
+@@ -1133,6 +1173,9 @@ class LiveInterval : public ArenaObject<kArenaAllocSsaLiveness> {
+   // Whether this interval is a synthesized interval for register pair.
+   const bool is_high_interval_;
+ 
++  // Whether vector registers overlap with fp registers.
++  const bool has_overlapping_fp_vec_registers_;
++
+   // If this interval needs a register pair, the high or low equivalent.
+   // `is_high_interval_` tells whether this holds the low or the high.
+   LiveInterval* high_or_low_interval_;
+-- 
+2.25.1
+

--- a/aosp_diff/preliminary/art/0006-Implement-AVX2-based-Vectorization-for-x86_64.patch
+++ b/aosp_diff/preliminary/art/0006-Implement-AVX2-based-Vectorization-for-x86_64.patch
@@ -1,0 +1,1758 @@
+From c107c563a8f3100a5ace2e7aa3f1b99ee4cd0873 Mon Sep 17 00:00:00 2001
+From: Vinay Prasad Kompella <vinay.kompella@intel.com>
+Date: Fri, 1 Nov 2024 21:20:10 +0530
+Subject: [PATCH 6/6] Implement AVX2 based Vectorization for x86_64
+
+This patch enables 256-bit vectorization when AVX2 is enabled.
+Vector codegen does not check AVX, relies only on AVX2 for simplicity.
+We use a fixed vector length for now, for simplicity
+
+Observed significant gains in tests:
+JBench - 19%
+SpecJVM (scimark.lu.small) - 35%
+        (scimark.lu.large) - 19%
+
+Test: art/test.py -b --host
+      Run the above test with and without "avx,avx2" features
+
+Tracked-On: OAM-126116
+Change-Id: I7f457c230273fb63b917165270bc5496071f0a54
+Signed-off-by: Vinay Prasad Kompella <vinay.kompella@intel.com>
+---
+ .../code_generator_vector_x86_64.cc           | 632 +++++++++---------
+ compiler/optimizing/code_generator_x86_64.cc  |  62 +-
+ compiler/optimizing/code_generator_x86_64.h   |   3 +-
+ compiler/optimizing/loop_analysis.cc          |   4 +
+ compiler/optimizing/loop_analysis.h           |   2 +
+ compiler/optimizing/loop_optimization.cc      |  38 +-
+ compiler/optimizing/nodes.h                   |  26 +-
+ compiler/optimizing/nodes_x86.h               |  11 +
+ test/530-checker-lse-simd/src/Main.java       |  12 +
+ test/656-checker-simd-opt/src/Main.java       |  44 +-
+ .../file_format/c1visualizer/parser.py        |   8 +-
+ .../file_format/c1visualizer/struct.py        |   4 +
+ tools/checker/match/file.py                   |   3 +
+ tools/checker/match/line.py                   |   1 +
+ 14 files changed, 487 insertions(+), 363 deletions(-)
+
+diff --git a/compiler/optimizing/code_generator_vector_x86_64.cc b/compiler/optimizing/code_generator_vector_x86_64.cc
+index 31626f9e44..f83ed0451b 100644
+--- a/compiler/optimizing/code_generator_vector_x86_64.cc
++++ b/compiler/optimizing/code_generator_vector_x86_64.cc
+@@ -25,6 +25,17 @@ namespace x86_64 {
+ // NOLINT on __ macro to suppress wrong warning/fix (misc-macro-parentheses) from clang-tidy.
+ #define __ down_cast<X86_64Assembler*>(GetAssembler())->  // NOLINT
+ 
++static void CheckVectorization(CodeGeneratorX86_64* codegen,
++                               HVecOperation* instruction,
++                               XmmRegister& reg,
++                               bool* uses_avx2 = nullptr) {
++  DCHECK_EQ(instruction->GetVectorLength() * DataType::Size(instruction->GetPackedType()), codegen->GetSIMDRegisterWidth());
++  DCHECK_EQ(codegen->GetInstructionSetFeatures().HasAVX2(), reg.IsYMM());
++  if (uses_avx2 != nullptr) {
++    *uses_avx2 = codegen->GetInstructionSetFeatures().HasAVX2();
++  }
++}
++
+ void LocationsBuilderX86_64::VisitVecReplicateScalar(HVecReplicateScalar* instruction) {
+   LocationSummary* locations = new (GetGraph()->GetAllocator()) LocationSummary(instruction);
+   HInstruction* input = instruction->InputAt(0);
+@@ -60,12 +71,13 @@ void LocationsBuilderX86_64::VisitVecReplicateScalar(HVecReplicateScalar* instru
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecReplicateScalar(HVecReplicateScalar* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
+-
+-  bool cpu_has_avx = CpuHasAvxFeatureFlag();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++  // Generic vectorization size check
++  bool uses_avx2 = false;
++  CheckVectorization(codegen_, instruction, dst, &uses_avx2);
+   // Shorthand for any type of zero.
+   if (IsZeroBitPattern(instruction->InputAt(0))) {
+-    cpu_has_avx ? __ vxorps(dst, dst, dst) : __ xorps(dst, dst);
++    uses_avx2 ? __ vxorps(dst, dst, dst) : __ xorps(dst, dst);
+     return;
+   }
+ 
+@@ -73,44 +85,60 @@ void InstructionCodeGeneratorX86_64::VisitVecReplicateScalar(HVecReplicateScalar
+     case DataType::Type::kBool:
+     case DataType::Type::kUint8:
+     case DataType::Type::kInt8:
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+       __ movd(dst, locations->InAt(0).AsRegister<CpuRegister>(), /*64-bit*/ false);
+-      __ punpcklbw(dst, dst);
+-      __ punpcklwd(dst, dst);
+-      __ pshufd(dst, dst, Immediate(0));
++      if (!uses_avx2) {
++        __ punpcklbw(dst, dst);
++        __ punpcklwd(dst, dst);
++        __ pshufd(dst, dst, Immediate(0));
++      } else {
++        __ vpbroadcastb(dst, dst);
++      }
+       break;
+     case DataType::Type::kUint16:
+     case DataType::Type::kInt16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+       __ movd(dst, locations->InAt(0).AsRegister<CpuRegister>(), /*64-bit*/ false);
+-      __ punpcklwd(dst, dst);
+-      __ pshufd(dst, dst, Immediate(0));
++      if (!uses_avx2) {  
++        __ punpcklwd(dst, dst);
++        __ pshufd(dst, dst, Immediate(0));
++      } else {
++        __ vpbroadcastw(dst, dst);
++      }
+       break;
+     case DataType::Type::kInt32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+       __ movd(dst, locations->InAt(0).AsRegister<CpuRegister>(), /*64-bit*/ false);
+-      __ pshufd(dst, dst, Immediate(0));
++      if (!uses_avx2) {
++        __ pshufd(dst, dst, Immediate(0));
++      } else {
++        __ vpbroadcastd(dst, dst);
++      }
+       break;
+     case DataType::Type::kInt64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+       __ movd(dst, locations->InAt(0).AsRegister<CpuRegister>(), /*64-bit*/ true);
+-      __ punpcklqdq(dst, dst);
++      if (!uses_avx2) {
++        __ punpcklqdq(dst, dst);
++      } else {
++        __ vpbroadcastq(dst, dst);
++      }
+       break;
+     case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      {
++      if (!uses_avx2) {
+         XmmRegister src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+         __ movups(dst, src);
++        __ shufps(dst, dst, Immediate(0));
++      } else {
++        XmmRegister src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++        __ vbroadcastss(dst, src);
+       }
+-      __ shufps(dst, dst, Immediate(0));
+       break;
+     case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      {
++      if (!uses_avx2) {
+         XmmRegister src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+         __ movups(dst, src);
++        __ shufpd(dst, dst, Immediate(0));
++      } else {
++        XmmRegister src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++        __ vbroadcastsd(dst, src);
+       }
+-      __ shufpd(dst, dst, Immediate(0));
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -150,7 +178,10 @@ void LocationsBuilderX86_64::VisitVecExtractScalar(HVecExtractScalar* instructio
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecExtractScalar(HVecExtractScalar* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister src = locations->InAt(0).AsFpuRegister<XmmRegister>();
++  XmmRegister src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, src);
++
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kBool:
+     case DataType::Type::kUint8:
+@@ -160,17 +191,13 @@ void InstructionCodeGeneratorX86_64::VisitVecExtractScalar(HVecExtractScalar* in
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+       UNREACHABLE();
+     case DataType::Type::kInt32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+       __ movd(locations->Out().AsRegister<CpuRegister>(), src, /*64-bit*/ false);
+       break;
+     case DataType::Type::kInt64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+       __ movd(locations->Out().AsRegister<CpuRegister>(), src, /*64-bit*/ true);
+       break;
+     case DataType::Type::kFloat32:
+     case DataType::Type::kFloat64:
+-      DCHECK_LE(2u, instruction->GetVectorLength());
+-      DCHECK_LE(instruction->GetVectorLength(), 4u);
+       {
+         XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
+         __ movups(dst, src);
+@@ -217,16 +244,27 @@ void LocationsBuilderX86_64::VisitVecReduce(HVecReduce* instruction) {
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecReduce(HVecReduce* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  XmmRegister src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  bool uses_avx2 = false;
++  CheckVectorization(codegen_, instruction, dst, &uses_avx2);
++
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kInt32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+       switch (instruction->GetReductionKind()) {
+         case HVecReduce::kSum:
+-          __ movaps(dst, src);
+-          __ phaddd(dst, dst);
+-          __ phaddd(dst, dst);
++          if (!uses_avx2) {
++            __ movaps(dst, src);
++            __ phaddd(dst, dst);
++            __ phaddd(dst, dst);
++          } else {
++            __ vmovaps(dst, src);
++            __ vphaddd(dst, dst, dst);
++            __ vpermpd(dst, dst, Immediate(0xd8));
++            __ vphaddd(dst, dst, dst);
++            __ vphaddd(dst, dst, dst);
++          }
+           break;
+         case HVecReduce::kMin:
+         case HVecReduce::kMax:
+@@ -236,14 +274,23 @@ void InstructionCodeGeneratorX86_64::VisitVecReduce(HVecReduce* instruction) {
+       }
+       break;
+     case DataType::Type::kInt64: {
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      XmmRegister tmp = locations->GetTemp(0).AsFpuRegister<XmmRegister>();
++      XmmRegister tmp = locations->GetTemp(0).AsFPVectorRegister<XmmRegister>();
+       switch (instruction->GetReductionKind()) {
+         case HVecReduce::kSum:
+-          __ movaps(tmp, src);
+-          __ movaps(dst, src);
+-          __ punpckhqdq(tmp, tmp);
+-          __ paddq(dst, tmp);
++          if (!uses_avx2) {
++            __ movaps(tmp, src);
++            __ movaps(dst, src);
++            __ punpckhqdq(tmp, tmp);
++            __ paddq(dst, tmp);
++          } else {
++            __ vmovaps(tmp, src);
++            __ vmovaps(dst, src);
++            __ vpermpd(tmp, tmp, Immediate(0x4E));
++            __ vpaddq(dst, dst, tmp);
++            __ vmovaps(tmp, dst);
++            __ vpermpd(tmp, tmp, Immediate(0xB1));
++            __ vpaddq(dst, dst, tmp);
++          }
+           break;
+         case HVecReduce::kMin:
+         case HVecReduce::kMax:
+@@ -263,12 +310,14 @@ void LocationsBuilderX86_64::VisitVecCnv(HVecCnv* instruction) {
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecCnv(HVecCnv* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  XmmRegister src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
+   DataType::Type from = instruction->GetInputType();
+   DataType::Type to = instruction->GetResultType();
++
++  CheckVectorization(codegen_, instruction, dst);
++
+   if (from == DataType::Type::kInt32 && to == DataType::Type::kFloat32) {
+-    DCHECK_EQ(4u, instruction->GetVectorLength());
+     __ cvtdq2ps(dst, src);
+   } else {
+     LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -281,38 +330,35 @@ void LocationsBuilderX86_64::VisitVecNeg(HVecNeg* instruction) {
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecNeg(HVecNeg* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  XmmRegister src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint8:
+     case DataType::Type::kInt8:
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+       __ pxor(dst, dst);
+       __ psubb(dst, src);
+       break;
+     case DataType::Type::kUint16:
+     case DataType::Type::kInt16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+       __ pxor(dst, dst);
+       __ psubw(dst, src);
+       break;
+     case DataType::Type::kInt32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+       __ pxor(dst, dst);
+       __ psubd(dst, src);
+       break;
+     case DataType::Type::kInt64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+       __ pxor(dst, dst);
+       __ psubq(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+       __ xorps(dst, dst);
+       __ subps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+       __ xorpd(dst, dst);
+       __ subpd(dst, src);
+       break;
+@@ -325,34 +371,45 @@ void InstructionCodeGeneratorX86_64::VisitVecNeg(HVecNeg* instruction) {
+ void LocationsBuilderX86_64::VisitVecAbs(HVecAbs* instruction) {
+   CreateVecUnOpLocations(GetGraph()->GetAllocator(), instruction);
+   // Integral-abs requires a temporary for the comparison.
+-  if (instruction->GetPackedType() == DataType::Type::kInt32) {
++  if (instruction->GetPackedType() == DataType::Type::kInt64) {
+     instruction->GetLocations()->AddTemp(Location::RequiresFpuRegister());
+   }
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecAbs(HVecAbs* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  XmmRegister src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++
+   switch (instruction->GetPackedType()) {
++    case DataType::Type::kBool:
++    case DataType::Type::kInt8:
++      __ pabsb(dst, src);
++      break;
++    case DataType::Type::kInt16:
++      __ pabsw(dst, src);
++      break;
+     case DataType::Type::kInt32: {
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      XmmRegister tmp = locations->GetTemp(0).AsFpuRegister<XmmRegister>();
+-      __ movaps(dst, src);
+-      __ pxor(tmp, tmp);
+-      __ pcmpgtd(tmp, dst);
+-      __ pxor(dst, tmp);
+-      __ psubd(dst, tmp);
++      __ pabsd(dst, src);
+       break;
+     }
++    case DataType::Type::kInt64: {
++        XmmRegister tmp = locations->GetTemp(0).AsFPVectorRegister<XmmRegister>();
++        __ movaps(dst, src);
++        __ pxor(tmp, tmp);
++        __ pcmpgtq(tmp, dst);
++        __ pxor(dst, tmp);
++        __ psubq(dst, tmp);
++      }
++      break;
+     case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+       __ pcmpeqb(dst, dst);  // all ones
+       __ psrld(dst, Immediate(1));
+       __ andps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+       __ pcmpeqb(dst, dst);  // all ones
+       __ psrlq(dst, Immediate(1));
+       __ andpd(dst, src);
+@@ -373,16 +430,18 @@ void LocationsBuilderX86_64::VisitVecNot(HVecNot* instruction) {
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecNot(HVecNot* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  XmmRegister src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kBool: {  // special case boolean-not
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+-      XmmRegister tmp = locations->GetTemp(0).AsFpuRegister<XmmRegister>();
+-      __ pxor(dst, dst);
+-      __ pcmpeqb(tmp, tmp);  // all ones
+-      __ psubb(dst, tmp);  // 16 x one
+-      __ pxor(dst, src);
++      XmmRegister tmp = locations->GetTemp(0).AsFPVectorRegister<XmmRegister>();
++        __ pxor(dst, dst);
++        __ pcmpeqb(tmp, tmp);  // all ones
++        __ psubb(dst, tmp);  // 16 x one
++        __ pxor(dst, src);
+       break;
+     }
+     case DataType::Type::kUint8:
+@@ -391,18 +450,14 @@ void InstructionCodeGeneratorX86_64::VisitVecNot(HVecNot* instruction) {
+     case DataType::Type::kInt16:
+     case DataType::Type::kInt32:
+     case DataType::Type::kInt64:
+-      DCHECK_LE(2u, instruction->GetVectorLength());
+-      DCHECK_LE(instruction->GetVectorLength(), 16u);
+       __ pcmpeqb(dst, dst);  // all ones
+       __ pxor(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+       __ pcmpeqb(dst, dst);  // all ones
+       __ xorps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+       __ pcmpeqb(dst, dst);  // all ones
+       __ xorpd(dst, src);
+       break;
+@@ -435,69 +490,38 @@ static void CreateVecBinOpLocations(ArenaAllocator* allocator, HVecBinaryOperati
+   }
+ }
+ 
+-static void CreateVecTerOpLocations(ArenaAllocator* allocator, HVecOperation* instruction) {
+-  LocationSummary* locations = new (allocator) LocationSummary(instruction);
+-  switch (instruction->GetPackedType()) {
+-    case DataType::Type::kBool:
+-    case DataType::Type::kUint8:
+-    case DataType::Type::kInt8:
+-    case DataType::Type::kUint16:
+-    case DataType::Type::kInt16:
+-    case DataType::Type::kInt32:
+-    case DataType::Type::kInt64:
+-    case DataType::Type::kFloat32:
+-    case DataType::Type::kFloat64:
+-      locations->SetInAt(0, Location::RequiresFpuRegister());
+-      locations->SetInAt(1, Location::RequiresFpuRegister());
+-      locations->SetOut(Location::RequiresFpuRegister());
+-      break;
+-    default:
+-      LOG(FATAL) << "Unsupported SIMD type";
+-      UNREACHABLE();
+-  }
+-}
+-
+ void LocationsBuilderX86_64::VisitVecAdd(HVecAdd* instruction) {
+-  if (CpuHasAvxFeatureFlag()) {
+-    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
+-  } else {
+-    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+-  }
++  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecAdd(HVecAdd* instruction) {
+-  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
+-  DCHECK(cpu_has_avx || other_src == dst);
++  XmmRegister src = locations->InAt(1).AsFPVectorRegister<XmmRegister>();
++  XmmRegister other_src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++  DCHECK(other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint8:
+     case DataType::Type::kInt8:
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vpaddb(dst, other_src, src) : __ paddb(dst, src);
++      __ paddb(dst, src);
+       break;
+     case DataType::Type::kUint16:
+     case DataType::Type::kInt16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vpaddw(dst, other_src, src) : __ paddw(dst, src);
++      __ paddw(dst, src);
+       break;
+     case DataType::Type::kInt32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vpaddd(dst, other_src, src) : __ paddd(dst, src);
++      __ paddd(dst, src);
+       break;
+     case DataType::Type::kInt64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vpaddq(dst, other_src, src) : __ paddq(dst, src);
++      __ paddq(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vaddps(dst, other_src, src) : __ addps(dst, src);
++      __ addps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vaddpd(dst, other_src, src) : __ addpd(dst, src);
++      __ addpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -511,24 +535,23 @@ void LocationsBuilderX86_64::VisitVecSaturationAdd(HVecSaturationAdd* instructio
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecSaturationAdd(HVecSaturationAdd* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
+-  XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  XmmRegister other_src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister src = locations->InAt(1).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++  DCHECK(other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint8:
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+       __ paddusb(dst, src);
+       break;
+     case DataType::Type::kInt8:
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+       __ paddsb(dst, src);
+       break;
+     case DataType::Type::kUint16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+       __ paddusw(dst, src);
+       break;
+     case DataType::Type::kInt16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+       __ paddsw(dst, src);
+       break;
+     default:
+@@ -543,19 +566,19 @@ void LocationsBuilderX86_64::VisitVecHalvingAdd(HVecHalvingAdd* instruction) {
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecHalvingAdd(HVecHalvingAdd* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
+-  XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  XmmRegister other_src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister src = locations->InAt(1).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
+ 
++  CheckVectorization(codegen_, instruction, dst);
++  DCHECK(other_src == dst);
+   DCHECK(instruction->IsRounded());
+ 
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint8:
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+       __ pavgb(dst, src);
+       break;
+     case DataType::Type::kUint16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+       __ pavgw(dst, src);
+       break;
+     default:
+@@ -565,46 +588,37 @@ void InstructionCodeGeneratorX86_64::VisitVecHalvingAdd(HVecHalvingAdd* instruct
+ }
+ 
+ void LocationsBuilderX86_64::VisitVecSub(HVecSub* instruction) {
+-  if (CpuHasAvxFeatureFlag()) {
+-    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
+-  } else {
+-    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+-  }
++  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecSub(HVecSub* instruction) {
+-  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
+-  DCHECK(cpu_has_avx || other_src == dst);
++  XmmRegister src = locations->InAt(1).AsFPVectorRegister<XmmRegister>();
++  XmmRegister other_src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++  DCHECK(other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint8:
+     case DataType::Type::kInt8:
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vpsubb(dst, other_src, src) : __ psubb(dst, src);
++      __ psubb(dst, src);
+       break;
+     case DataType::Type::kUint16:
+     case DataType::Type::kInt16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vpsubw(dst, other_src, src) : __ psubw(dst, src);
++      __ psubw(dst, src);
+       break;
+     case DataType::Type::kInt32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vpsubd(dst, other_src, src) : __ psubd(dst, src);
++      __ psubd(dst, src);
+       break;
+     case DataType::Type::kInt64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vpsubq(dst, other_src, src) : __ psubq(dst, src);
++      __ psubq(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vsubps(dst, other_src, src) : __ subps(dst, src);
++      __ subps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vsubpd(dst, other_src, src) : __ subpd(dst, src);
++      __ subpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -618,24 +632,23 @@ void LocationsBuilderX86_64::VisitVecSaturationSub(HVecSaturationSub* instructio
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecSaturationSub(HVecSaturationSub* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
+-  XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  XmmRegister other_src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister src = locations->InAt(1).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++  DCHECK(other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint8:
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+       __ psubusb(dst, src);
+       break;
+     case DataType::Type::kInt8:
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+       __ psubsb(dst, src);
+       break;
+     case DataType::Type::kUint16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+       __ psubusw(dst, src);
+       break;
+     case DataType::Type::kInt16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+       __ psubsw(dst, src);
+       break;
+     default:
+@@ -645,37 +658,30 @@ void InstructionCodeGeneratorX86_64::VisitVecSaturationSub(HVecSaturationSub* in
+ }
+ 
+ void LocationsBuilderX86_64::VisitVecMul(HVecMul* instruction) {
+-  if (CpuHasAvxFeatureFlag()) {
+-    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
+-  } else {
+-    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+-  }
++  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecMul(HVecMul* instruction) {
+-  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
+-  DCHECK(cpu_has_avx || other_src == dst);
++  XmmRegister src = locations->InAt(1).AsFPVectorRegister<XmmRegister>();
++  XmmRegister other_src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++  DCHECK(other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint16:
+     case DataType::Type::kInt16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vpmullw(dst, other_src, src) : __ pmullw(dst, src);
++      __ pmullw(dst, src);
+       break;
+     case DataType::Type::kInt32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vpmulld(dst, other_src, src): __ pmulld(dst, src);
++      __ pmulld(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vmulps(dst, other_src, src) : __ mulps(dst, src);
++      __ mulps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vmulpd(dst, other_src, src) : __ mulpd(dst, src);
++      __ mulpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -684,28 +690,23 @@ void InstructionCodeGeneratorX86_64::VisitVecMul(HVecMul* instruction) {
+ }
+ 
+ void LocationsBuilderX86_64::VisitVecDiv(HVecDiv* instruction) {
+-  if (CpuHasAvxFeatureFlag()) {
+-    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
+-  } else {
+-    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+-  }
++  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecDiv(HVecDiv* instruction) {
+-  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
+-  DCHECK(cpu_has_avx || other_src == dst);
++  XmmRegister src = locations->InAt(1).AsFPVectorRegister<XmmRegister>();
++  XmmRegister other_src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++  DCHECK(other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vdivps(dst, other_src, src) : __ divps(dst, src);
++      __ divps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vdivpd(dst, other_src, src) : __ divpd(dst, src);
++      __ divpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -719,41 +720,37 @@ void LocationsBuilderX86_64::VisitVecMin(HVecMin* instruction) {
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecMin(HVecMin* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
+-  XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  //   DCHECK(locations->InAt(0).Equals(locations->Out()));
++  XmmRegister other_src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister src = locations->InAt(1).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++  DCHECK(other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint8:
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+       __ pminub(dst, src);
+       break;
+     case DataType::Type::kInt8:
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+       __ pminsb(dst, src);
+       break;
+     case DataType::Type::kUint16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+       __ pminuw(dst, src);
+       break;
+     case DataType::Type::kInt16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+       __ pminsw(dst, src);
+       break;
+     case DataType::Type::kUint32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+       __ pminud(dst, src);
+       break;
+     case DataType::Type::kInt32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+       __ pminsd(dst, src);
+       break;
+     // Next cases are sloppy wrt 0.0 vs -0.0.
+     case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+       __ minps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+       __ minpd(dst, src);
+       break;
+     default:
+@@ -768,41 +765,37 @@ void LocationsBuilderX86_64::VisitVecMax(HVecMax* instruction) {
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecMax(HVecMax* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+-  DCHECK(locations->InAt(0).Equals(locations->Out()));
+-  XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  //   DCHECK(locations->InAt(0).Equals(locations->Out()));
++  XmmRegister other_src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister src = locations->InAt(1).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++  DCHECK(other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint8:
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+       __ pmaxub(dst, src);
+       break;
+     case DataType::Type::kInt8:
+-      DCHECK_EQ(16u, instruction->GetVectorLength());
+       __ pmaxsb(dst, src);
+       break;
+     case DataType::Type::kUint16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+       __ pmaxuw(dst, src);
+       break;
+     case DataType::Type::kInt16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+       __ pmaxsw(dst, src);
+       break;
+     case DataType::Type::kUint32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+       __ pmaxud(dst, src);
+       break;
+     case DataType::Type::kInt32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+       __ pmaxsd(dst, src);
+       break;
+     // Next cases are sloppy wrt 0.0 vs -0.0.
+     case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+       __ maxps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+       __ maxpd(dst, src);
+       break;
+     default:
+@@ -812,20 +805,17 @@ void InstructionCodeGeneratorX86_64::VisitVecMax(HVecMax* instruction) {
+ }
+ 
+ void LocationsBuilderX86_64::VisitVecAnd(HVecAnd* instruction) {
+-  if (CpuHasAvxFeatureFlag()) {
+-    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
+-  } else {
+-    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+-  }
++  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecAnd(HVecAnd* instruction) {
+-  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
+-  DCHECK(cpu_has_avx || other_src == dst);
++  XmmRegister other_src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister src = locations->InAt(1).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++  DCHECK(other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kBool:
+     case DataType::Type::kUint8:
+@@ -834,17 +824,13 @@ void InstructionCodeGeneratorX86_64::VisitVecAnd(HVecAnd* instruction) {
+     case DataType::Type::kInt16:
+     case DataType::Type::kInt32:
+     case DataType::Type::kInt64:
+-      DCHECK_LE(2u, instruction->GetVectorLength());
+-      DCHECK_LE(instruction->GetVectorLength(), 16u);
+-      cpu_has_avx ? __ vpand(dst, other_src, src) : __ pand(dst, src);
++      __ pand(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vandps(dst, other_src, src) : __ andps(dst, src);
++      __ andps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vandpd(dst, other_src, src) : __ andpd(dst, src);
++      __ andpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -853,20 +839,17 @@ void InstructionCodeGeneratorX86_64::VisitVecAnd(HVecAnd* instruction) {
+ }
+ 
+ void LocationsBuilderX86_64::VisitVecAndNot(HVecAndNot* instruction) {
+-  if (CpuHasAvxFeatureFlag()) {
+-    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
+-  } else {
+-    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+-  }
++  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecAndNot(HVecAndNot* instruction) {
+-  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
+-  DCHECK(cpu_has_avx || other_src == dst);
++  XmmRegister other_src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister src = locations->InAt(1).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++  DCHECK(other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kBool:
+     case DataType::Type::kUint8:
+@@ -875,17 +858,13 @@ void InstructionCodeGeneratorX86_64::VisitVecAndNot(HVecAndNot* instruction) {
+     case DataType::Type::kInt16:
+     case DataType::Type::kInt32:
+     case DataType::Type::kInt64:
+-      DCHECK_LE(2u, instruction->GetVectorLength());
+-      DCHECK_LE(instruction->GetVectorLength(), 16u);
+-      cpu_has_avx ? __ vpandn(dst, other_src, src) : __ pandn(dst, src);
++      __ pandn(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vandnps(dst, other_src, src) : __ andnps(dst, src);
++      __ andnps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vandnpd(dst, other_src, src) : __ andnpd(dst, src);
++      __ andnpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -894,20 +873,17 @@ void InstructionCodeGeneratorX86_64::VisitVecAndNot(HVecAndNot* instruction) {
+ }
+ 
+ void LocationsBuilderX86_64::VisitVecOr(HVecOr* instruction) {
+-  if (CpuHasAvxFeatureFlag()) {
+-    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
+-  } else {
+-    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+-  }
++  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecOr(HVecOr* instruction) {
+-  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
+-  DCHECK(cpu_has_avx || other_src == dst);
++  XmmRegister other_src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister src = locations->InAt(1).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++  DCHECK(other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kBool:
+     case DataType::Type::kUint8:
+@@ -916,17 +892,13 @@ void InstructionCodeGeneratorX86_64::VisitVecOr(HVecOr* instruction) {
+     case DataType::Type::kInt16:
+     case DataType::Type::kInt32:
+     case DataType::Type::kInt64:
+-      DCHECK_LE(2u, instruction->GetVectorLength());
+-      DCHECK_LE(instruction->GetVectorLength(), 16u);
+-      cpu_has_avx ? __ vpor(dst, other_src, src) : __ por(dst, src);
++      __ por(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vorps(dst, other_src, src) : __ orps(dst, src);
++      __ orps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vorpd(dst, other_src, src) : __ orpd(dst, src);
++      __ orpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -935,20 +907,17 @@ void InstructionCodeGeneratorX86_64::VisitVecOr(HVecOr* instruction) {
+ }
+ 
+ void LocationsBuilderX86_64::VisitVecXor(HVecXor* instruction) {
+-  if (CpuHasAvxFeatureFlag()) {
+-    CreateVecTerOpLocations(GetGraph()->GetAllocator(), instruction);
+-  } else {
+-    CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+-  }
++  CreateVecBinOpLocations(GetGraph()->GetAllocator(), instruction);
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecXor(HVecXor* instruction) {
+-  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister other_src = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister src = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
+-  DCHECK(cpu_has_avx || other_src == dst);
++  XmmRegister other_src = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister src = locations->InAt(1).AsFPVectorRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++  DCHECK(other_src == dst);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kBool:
+     case DataType::Type::kUint8:
+@@ -957,17 +926,13 @@ void InstructionCodeGeneratorX86_64::VisitVecXor(HVecXor* instruction) {
+     case DataType::Type::kInt16:
+     case DataType::Type::kInt32:
+     case DataType::Type::kInt64:
+-      DCHECK_LE(2u, instruction->GetVectorLength());
+-      DCHECK_LE(instruction->GetVectorLength(), 16u);
+-      cpu_has_avx ? __ vpxor(dst, other_src, src) : __ pxor(dst, src);
++      __ pxor(dst, src);
+       break;
+     case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vxorps(dst, other_src, src) : __ xorps(dst, src);
++      __ xorps(dst, src);
+       break;
+     case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      cpu_has_avx ? __ vxorpd(dst, other_src, src) : __ xorpd(dst, src);
++      __ xorpd(dst, src);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -1001,19 +966,19 @@ void InstructionCodeGeneratorX86_64::VisitVecShl(HVecShl* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+   DCHECK(locations->InAt(0).Equals(locations->Out()));
+   int32_t value = locations->InAt(1).GetConstant()->AsIntConstant()->GetValue();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint16:
+     case DataType::Type::kInt16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+       __ psllw(dst, Immediate(static_cast<int8_t>(value)));
+       break;
+     case DataType::Type::kInt32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+       __ pslld(dst, Immediate(static_cast<int8_t>(value)));
+       break;
+     case DataType::Type::kInt64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+       __ psllq(dst, Immediate(static_cast<int8_t>(value)));
+       break;
+     default:
+@@ -1030,15 +995,16 @@ void InstructionCodeGeneratorX86_64::VisitVecShr(HVecShr* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+   DCHECK(locations->InAt(0).Equals(locations->Out()));
+   int32_t value = locations->InAt(1).GetConstant()->AsIntConstant()->GetValue();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint16:
+     case DataType::Type::kInt16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+       __ psraw(dst, Immediate(static_cast<int8_t>(value)));
+       break;
+     case DataType::Type::kInt32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+       __ psrad(dst, Immediate(static_cast<int8_t>(value)));
+       break;
+     default:
+@@ -1055,19 +1021,19 @@ void InstructionCodeGeneratorX86_64::VisitVecUShr(HVecUShr* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+   DCHECK(locations->InAt(0).Equals(locations->Out()));
+   int32_t value = locations->InAt(1).GetConstant()->AsIntConstant()->GetValue();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, dst);
++
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kUint16:
+     case DataType::Type::kInt16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+       __ psrlw(dst, Immediate(static_cast<int8_t>(value)));
+       break;
+     case DataType::Type::kInt32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+       __ psrld(dst, Immediate(static_cast<int8_t>(value)));
+       break;
+     case DataType::Type::kInt64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+       __ psrlq(dst, Immediate(static_cast<int8_t>(value)));
+       break;
+     default:
+@@ -1110,13 +1076,13 @@ void LocationsBuilderX86_64::VisitVecSetScalars(HVecSetScalars* instruction) {
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecSetScalars(HVecSetScalars* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister dst = locations->Out().AsFpuRegister<XmmRegister>();
++  XmmRegister dst = locations->Out().AsFPVectorRegister<XmmRegister>();
+ 
+   DCHECK_EQ(1u, instruction->InputCount());  // only one input currently implemented
+ 
++  CheckVectorization(codegen_, instruction, dst);
+   // Zero out all other elements first.
+-  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+-  cpu_has_avx ? __ vxorps(dst, dst, dst) : __ xorps(dst, dst);
++  __ xorps(dst, dst);
+ 
+   // Shorthand for any type of zero.
+   if (IsZeroBitPattern(instruction->InputAt(0))) {
+@@ -1133,20 +1099,16 @@ void InstructionCodeGeneratorX86_64::VisitVecSetScalars(HVecSetScalars* instruct
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+       UNREACHABLE();
+     case DataType::Type::kInt32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+       __ movd(dst, locations->InAt(0).AsRegister<CpuRegister>());
+       break;
+     case DataType::Type::kInt64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+       __ movd(dst, locations->InAt(0).AsRegister<CpuRegister>());  // is 64-bit
+       break;
+     case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      __ movss(dst, locations->InAt(0).AsFpuRegister<XmmRegister>());
++      __ movss(dst, locations->InAt(0).AsFPVectorRegister<XmmRegister>());
+       break;
+     case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      __ movsd(dst, locations->InAt(0).AsFpuRegister<XmmRegister>());
++      __ movsd(dst, locations->InAt(0).AsFPVectorRegister<XmmRegister>());
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -1203,16 +1165,18 @@ void LocationsBuilderX86_64::VisitVecDotProd(HVecDotProd* instruction) {
+ }
+ 
+ void InstructionCodeGeneratorX86_64::VisitVecDotProd(HVecDotProd* instruction) {
+-  bool cpu_has_avx = CpuHasAvxFeatureFlag();
+   LocationSummary* locations = instruction->GetLocations();
+-  XmmRegister acc = locations->InAt(0).AsFpuRegister<XmmRegister>();
+-  XmmRegister left = locations->InAt(1).AsFpuRegister<XmmRegister>();
+-  XmmRegister right = locations->InAt(2).AsFpuRegister<XmmRegister>();
++  XmmRegister acc = locations->InAt(0).AsFPVectorRegister<XmmRegister>();
++  XmmRegister left = locations->InAt(1).AsFPVectorRegister<XmmRegister>();
++  XmmRegister right = locations->InAt(2).AsFPVectorRegister<XmmRegister>();
++
++  bool uses_avx2 = false;
++  CheckVectorization(codegen_, instruction, acc, &uses_avx2);
++
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kInt32: {
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      XmmRegister tmp = locations->GetTemp(0).AsFpuRegister<XmmRegister>();
+-      if (!cpu_has_avx) {
++      XmmRegister tmp = locations->GetTemp(0).AsFPVectorRegister<XmmRegister>();
++      if (!uses_avx2) {
+         __ movaps(tmp, right);
+         __ pmaddwd(tmp, left);
+         __ paddd(acc, tmp);
+@@ -1287,16 +1251,19 @@ void InstructionCodeGeneratorX86_64::VisitVecLoad(HVecLoad* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+   size_t size = DataType::Size(instruction->GetPackedType());
+   Address address = VecAddress(locations, size, instruction->IsStringCharAt());
+-  XmmRegister reg = locations->Out().AsFpuRegister<XmmRegister>();
+-  bool is_aligned16 = instruction->GetAlignment().IsAlignedAt(16);
++  XmmRegister reg = locations->Out().AsFPVectorRegister<XmmRegister>();
++  bool uses_avx2 = false;
++
++  CheckVectorization(codegen_, instruction, reg, &uses_avx2);
++
++  bool is_aligned = instruction->GetAlignment().IsAlignedAt(reg.IsYMM() ? 32 : 16);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kInt16:  // (short) s.charAt(.) can yield HVecLoad/Int16/StringCharAt.
+     case DataType::Type::kUint16:
+-      DCHECK_EQ(8u, instruction->GetVectorLength());
+       // Special handling of compressed/uncompressed string load.
+       if (mirror::kUseStringCompression && instruction->IsStringCharAt()) {
+         NearLabel done, not_compressed;
+-        XmmRegister tmp = locations->GetTemp(0).AsFpuRegister<XmmRegister>();
++        XmmRegister tmp = locations->GetTemp(0).AsFPVectorRegister<XmmRegister>();
+         // Test compression bit.
+         static_assert(static_cast<uint32_t>(mirror::StringCompressionFlag::kCompressed) == 0u,
+                       "Expecting 0=compressed, 1=uncompressed");
+@@ -1304,13 +1271,19 @@ void InstructionCodeGeneratorX86_64::VisitVecLoad(HVecLoad* instruction) {
+         __ testb(Address(locations->InAt(0).AsRegister<CpuRegister>(), count_offset), Immediate(1));
+         __ j(kNotZero, &not_compressed);
+         // Zero extend 8 compressed bytes into 8 chars.
+-        __ movsd(reg, VecAddress(locations, 1, instruction->IsStringCharAt()));
++        if (!uses_avx2) {
++          __ movsd(reg, VecAddress(locations, 1, instruction->IsStringCharAt()));
++        } else {
++          __ movdqu(reg, VecAddress(locations, 1, instruction->IsStringCharAt()));
++          // Permute to 0213, so that we can operate on the low quad words
++          __ vpermpd(reg, reg, Immediate(0xd8));
++        }
+         __ pxor(tmp, tmp);
+         __ punpcklbw(reg, tmp);
+         __ jmp(&done);
+         // Load 8 direct uncompressed chars.
+         __ Bind(&not_compressed);
+-        is_aligned16 ?  __ movdqa(reg, address) :  __ movdqu(reg, address);
++        is_aligned ? __ movdqa(reg, address) : __ movdqu(reg, address);
+         __ Bind(&done);
+         return;
+       }
+@@ -1320,17 +1293,13 @@ void InstructionCodeGeneratorX86_64::VisitVecLoad(HVecLoad* instruction) {
+     case DataType::Type::kInt8:
+     case DataType::Type::kInt32:
+     case DataType::Type::kInt64:
+-      DCHECK_LE(2u, instruction->GetVectorLength());
+-      DCHECK_LE(instruction->GetVectorLength(), 16u);
+-      is_aligned16 ? __ movdqa(reg, address) : __ movdqu(reg, address);
++      is_aligned ? __ movdqa(reg, address) : __ movdqu(reg, address);
+       break;
+     case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      is_aligned16 ? __ movaps(reg, address) : __ movups(reg, address);
++      is_aligned ? __ movaps(reg, address) : __ movups(reg, address);
+       break;
+     case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      is_aligned16 ? __ movapd(reg, address) : __ movupd(reg, address);
++      is_aligned ? __ movapd(reg, address) : __ movupd(reg, address);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -1346,8 +1315,11 @@ void InstructionCodeGeneratorX86_64::VisitVecStore(HVecStore* instruction) {
+   LocationSummary* locations = instruction->GetLocations();
+   size_t size = DataType::Size(instruction->GetPackedType());
+   Address address = VecAddress(locations, size, /*is_string_char_at*/ false);
+-  XmmRegister reg = locations->InAt(2).AsFpuRegister<XmmRegister>();
+-  bool is_aligned16 = instruction->GetAlignment().IsAlignedAt(16);
++  XmmRegister reg = locations->InAt(2).AsFPVectorRegister<XmmRegister>();
++
++  CheckVectorization(codegen_, instruction, reg);
++
++  bool is_aligned = instruction->GetAlignment().IsAlignedAt(reg.IsYMM() ? 32 : 16);
+   switch (instruction->GetPackedType()) {
+     case DataType::Type::kBool:
+     case DataType::Type::kUint8:
+@@ -1356,17 +1328,13 @@ void InstructionCodeGeneratorX86_64::VisitVecStore(HVecStore* instruction) {
+     case DataType::Type::kInt16:
+     case DataType::Type::kInt32:
+     case DataType::Type::kInt64:
+-      DCHECK_LE(2u, instruction->GetVectorLength());
+-      DCHECK_LE(instruction->GetVectorLength(), 16u);
+-      is_aligned16 ? __ movdqa(address, reg) : __ movdqu(address, reg);
++      is_aligned ? __ movdqa(address, reg) : __ movdqu(address, reg);
+       break;
+     case DataType::Type::kFloat32:
+-      DCHECK_EQ(4u, instruction->GetVectorLength());
+-      is_aligned16 ? __ movaps(address, reg) : __ movups(address, reg);
++      is_aligned ? __ movaps(address, reg) : __ movups(address, reg);
+       break;
+     case DataType::Type::kFloat64:
+-      DCHECK_EQ(2u, instruction->GetVectorLength());
+-      is_aligned16 ? __ movapd(address, reg) : __ movupd(address, reg);
++      is_aligned ? __ movapd(address, reg) : __ movupd(address, reg);
+       break;
+     default:
+       LOG(FATAL) << "Unsupported SIMD type: " << instruction->GetPackedType();
+@@ -1424,6 +1392,12 @@ void InstructionCodeGeneratorX86_64::VisitVecPredNot(HVecPredNot* instruction) {
+   UNREACHABLE();
+ }
+ 
++void LocationsBuilderX86_64::VisitX86Clear(HX86Clear* clear) { clear->SetLocations(nullptr); }
++
++void InstructionCodeGeneratorX86_64::VisitX86Clear(HX86Clear* clear ATTRIBUTE_UNUSED) {
++  __ vzeroupper();
++}
++
+ #undef __
+ 
+ }  // namespace x86_64
+diff --git a/compiler/optimizing/code_generator_x86_64.cc b/compiler/optimizing/code_generator_x86_64.cc
+index 893a485616..acf2d590f6 100644
+--- a/compiler/optimizing/code_generator_x86_64.cc
++++ b/compiler/optimizing/code_generator_x86_64.cc
+@@ -167,6 +167,27 @@ class SuspendCheckSlowPathX86_64 : public SlowPathCode {
+     CodeGeneratorX86_64* x86_64_codegen = down_cast<CodeGeneratorX86_64*>(codegen);
+     __ Bind(GetEntryLabel());
+     SaveLiveRegisters(codegen, locations);  // Only saves full width XMM for SIMD.
++    // If this is related to an AVX2 loop,
++    //  we must emit vzeroupper here before invoking runtime methods
++    if (codegen->GetGraph()->HasSIMD() && x86_64_codegen->GetInstructionSetFeatures().HasAVX2()) {
++      // Live SIMD registers => is a SIMD loop
++      if (locations->GetNumLiveVectorRegisters() > 0) {
++        __ vzeroupper();
++      } else if (instruction_->GetBlock()->IsInLoop()) {
++        // Slow path: Look at the loop_body to determine its a SIMD loop
++        HBasicBlock* loop_header = instruction_->GetBlock()->GetLoopInformation()->GetHeader();
++        // SIMD loop headers are guarenteed to have loop_body as second successor
++        if (loop_header->GetSuccessors().size() == 2u) {
++          HBasicBlock* loop_body = loop_header->GetSuccessors()[1];
++          for (HInstructionIterator it(loop_body->GetInstructions()); !it.Done(); it.Advance()) {
++            if (it.Current()->IsVecOperation()) {
++              __ vzeroupper();
++              break;
++            }
++          }
++        }
++      }
++    }
+     x86_64_codegen->InvokeRuntime(kQuickTestSuspend, instruction_, instruction_->GetDexPc(), this);
+     CheckEntrypointTypes<kQuickTestSuspend, void, void>();
+     RestoreLiveRegisters(codegen, locations);  // Only restores full width XMM for SIMD.
+@@ -6439,10 +6460,21 @@ void ParallelMoveResolverX86_64::EmitMove(size_t index) {
+     } else {
+       DCHECK(destination.IsSIMDStackSlot());
+       size_t high = kX86_64WordSize;
+-      __ movq(CpuRegister(TMP), Address(CpuRegister(RSP), source.GetStackIndex()));
+-      __ movq(Address(CpuRegister(RSP), destination.GetStackIndex()), CpuRegister(TMP));
+-      __ movq(CpuRegister(TMP), Address(CpuRegister(RSP), source.GetStackIndex() + high));
+-      __ movq(Address(CpuRegister(RSP), destination.GetStackIndex() + high), CpuRegister(TMP));
++      if (codegen_->GetSIMDRegisterWidth() == (2 * kX86_64WordSize)) {
++        __ movq(CpuRegister(TMP), Address(CpuRegister(RSP), source.GetStackIndex()));
++        __ movq(Address(CpuRegister(RSP), destination.GetStackIndex()), CpuRegister(TMP));
++        __ movq(CpuRegister(TMP), Address(CpuRegister(RSP), source.GetStackIndex() + high));
++        __ movq(Address(CpuRegister(RSP), destination.GetStackIndex() + high), CpuRegister(TMP));
++      } else {
++        //Easier to spill a vector register
++        size_t extra_slot = codegen_->GetSIMDRegisterWidth();
++        __ subq(CpuRegister(RSP), Immediate(extra_slot));
++        __ movups(Address(CpuRegister(RSP), 0), XmmRegister(XMM0, extra_slot));
++        __ movups(XmmRegister(XMM0, extra_slot), Address(CpuRegister(RSP), source.GetStackIndex() + extra_slot));
++        __ movups(Address(CpuRegister(RSP), destination.GetStackIndex() + extra_slot), XmmRegister(XMM0, extra_slot));
++        __ movups(XmmRegister(XMM0, extra_slot), Address(CpuRegister(RSP), 0));
++        __ addq(CpuRegister(RSP), Immediate(extra_slot));
++      }
+     }
+   } else if (source.IsConstant()) {
+     HConstant* constant = source.GetConstant();
+@@ -6591,6 +6623,26 @@ void ParallelMoveResolverX86_64::ExchangeMemory64(int mem1, int mem2, int num_of
+   }
+ }
+ 
++void ParallelMoveResolverX86_64::ExchangeMemorySIMD(int mem1, int mem2) {
++  // It is better to spill a ymm onto stack than looping with 64-bit regs
++  size_t extra_slot = codegen_->GetSIMDRegisterWidth();
++  if (extra_slot > 2 * kX86_64WordSize) {
++    __ subq(CpuRegister(RSP), Immediate(2 * extra_slot));
++    __ movups(Address(CpuRegister(RSP), 0), XmmRegister(XMM0, extra_slot));
++    __ movups(Address(CpuRegister(RSP), extra_slot), XmmRegister(XMM1, extra_slot));
++    __ movups(XmmRegister(XMM0, extra_slot), Address(CpuRegister(RSP), mem2 + 2 * extra_slot));
++    __ movups(XmmRegister(XMM1, extra_slot), Address(CpuRegister(RSP), mem1 + 2 * extra_slot));
++    __ movups(Address(CpuRegister(RSP), mem2 + 2 * extra_slot), XmmRegister(XMM1, extra_slot));
++    __ movups(Address(CpuRegister(RSP), mem1 + 2 * extra_slot), XmmRegister(XMM0, extra_slot));
++    __ movups(XmmRegister(XMM1, extra_slot), Address(CpuRegister(RSP), extra_slot));
++    __ movups(XmmRegister(XMM0, extra_slot), Address(CpuRegister(RSP), 0));
++    __ addq(CpuRegister(RSP), Immediate(2 * extra_slot));
++  } else {
++    ExchangeMemory64(mem1, mem2, extra_slot >> 3);
++  }
++}
++
++
+ void ParallelMoveResolverX86_64::EmitSwap(size_t index) {
+   MoveOperands* move = moves_[index];
+   Location source = move->GetSource();
+@@ -6630,7 +6682,7 @@ void ParallelMoveResolverX86_64::EmitSwap(size_t index) {
+     Exchange64(destination.AsFPVectorRegister<XmmRegister>(), source.GetStackIndex());
+   } else if (source.IsSIMDStackSlot() && destination.IsSIMDStackSlot()) {
+     DCHECK_EQ(source.GetVecLen(), destination.GetVecLen());
+-    ExchangeMemory64(destination.GetStackIndex(), source.GetStackIndex(), source.GetVecLen() >> 3);
++    ExchangeMemorySIMD(destination.GetStackIndex(), source.GetStackIndex());
+   } else if (source.IsFpuRegister() && destination.IsSIMDStackSlot()) {
+     DCHECK_EQ(source.GetVecLen(), destination.GetVecLen());
+     ExchangeSIMD(source.AsFPVectorRegister<XmmRegister>(), destination.GetStackIndex());
+diff --git a/compiler/optimizing/code_generator_x86_64.h b/compiler/optimizing/code_generator_x86_64.h
+index 3f366d01ad..70801910bd 100644
+--- a/compiler/optimizing/code_generator_x86_64.h
++++ b/compiler/optimizing/code_generator_x86_64.h
+@@ -210,6 +210,7 @@ class ParallelMoveResolverX86_64 : public ParallelMoveResolverWithSwap {
+   void ExchangeFPReg(XmmRegister reg1, XmmRegister reg2);
+   void ExchangeMemory32(int mem1, int mem2);
+   void ExchangeMemory64(int mem1, int mem2, int num_of_qwords);
++  void ExchangeMemorySIMD(int mem1, int mem2);
+ 
+   CodeGeneratorX86_64* const codegen_;
+ 
+@@ -434,7 +435,7 @@ class CodeGeneratorX86_64 : public CodeGenerator {
+   }
+ 
+   size_t GetSIMDRegisterWidth() const override {
+-    return 2 * kX86_64WordSize;
++    return GetInstructionSetFeatures().HasAVX2() ? 4 * kX86_64WordSize : 2 * kX86_64WordSize;
+   }
+ 
+   bool HasOverlappingFPVecRegisters() const override { return true; }
+diff --git a/compiler/optimizing/loop_analysis.cc b/compiler/optimizing/loop_analysis.cc
+index b3f9e835de..d6bea11047 100644
+--- a/compiler/optimizing/loop_analysis.cc
++++ b/compiler/optimizing/loop_analysis.cc
+@@ -354,6 +354,10 @@ class X86_64LoopHelper : public ArchDefaultLoopHelper {
+ 
+     return unroll_factor;
+   }
++
++  bool NeedsVectorRegisterClear() const override {
++    return codegen_.GetSIMDRegisterWidth() > (2 * codegen_.GetWordSize());
++  }
+ };
+ 
+ uint32_t X86_64LoopHelper::GetUnrollingFactor(HLoopInformation* loop_info,
+diff --git a/compiler/optimizing/loop_analysis.h b/compiler/optimizing/loop_analysis.h
+index cd8f00588d..957b1ee2a1 100644
+--- a/compiler/optimizing/loop_analysis.h
++++ b/compiler/optimizing/loop_analysis.h
+@@ -182,6 +182,8 @@ class ArchNoOptsLoopHelper : public ArenaObject<kArenaAllocOptimization> {
+     return LoopAnalysisInfo::kNoUnrollingFactor;
+   }
+ 
++  virtual bool NeedsVectorRegisterClear() const { return false; }
++
+  protected:
+   const CodeGenerator& codegen_;
+ };
+diff --git a/compiler/optimizing/loop_optimization.cc b/compiler/optimizing/loop_optimization.cc
+index 8d698d6c82..b0b6536ef8 100644
+--- a/compiler/optimizing/loop_optimization.cc
++++ b/compiler/optimizing/loop_optimization.cc
+@@ -1515,6 +1515,19 @@ void HLoopOptimization::VectorizeTraditional(LoopNode* node,
+                                        LoopAnalysisInfo::kNoUnrollingFactor);
+   }
+ 
++#if defined(ART_ENABLE_CODEGEN_x86_64)
++  if (arch_loop_helper_->NeedsVectorRegisterClear()) {
++    // No more BB are inserted at the exit of vloop
++    // Add the HX86Clear at the exit of the vloop
++    // This is required for X86 when switching out of AVX2 context
++    HBasicBlock* vloop_header = preheader_for_vector_loop->GetSingleSuccessor();
++    DCHECK(vloop_header);
++    HBasicBlock* vloop_exit = vloop_header->GetSuccessors()[0];
++    vloop_exit->InsertInstructionBefore(new (global_allocator_) HX86Clear(),
++                                        vloop_exit->GetLastInstruction());
++  }
++#endif
++
+   FinalizeVectorization(node);
+ }
+ 
+@@ -2124,6 +2137,9 @@ bool HLoopOptimization::TrySetVectorType(DataType::Type type, uint64_t* restrict
+       // Allow vectorization for SSE4.1-enabled X86 devices only (128-bit SIMD).
+       *restrictions |= kNoIfCond;
+       if (features->AsX86InstructionSetFeatures()->HasSSE4_1()) {
++        bool bSupportedType = true;
++        size_t vector_length = simd_register_size_ / DataType::Size(type);
++        DCHECK_EQ(simd_register_size_ % DataType::Size(type), 0u);
+         switch (type) {
+           case DataType::Type::kBool:
+           case DataType::Type::kUint8:
+@@ -2136,7 +2152,7 @@ bool HLoopOptimization::TrySetVectorType(DataType::Type type, uint64_t* restrict
+                              kNoUnroundedHAdd |
+                              kNoSAD |
+                              kNoDotProd;
+-            return TrySetVectorLength(type, 16);
++            break;
+           case DataType::Type::kUint16:
+             *restrictions |= kNoDiv |
+                              kNoAbs |
+@@ -2144,29 +2160,37 @@ bool HLoopOptimization::TrySetVectorType(DataType::Type type, uint64_t* restrict
+                              kNoUnroundedHAdd |
+                              kNoSAD |
+                              kNoDotProd;
+-            return TrySetVectorLength(type, 8);
++            break;
+           case DataType::Type::kInt16:
+             *restrictions |= kNoDiv |
+                              kNoAbs |
+                              kNoSignedHAdd |
+                              kNoUnroundedHAdd |
+                              kNoSAD;
+-            return TrySetVectorLength(type, 8);
++            break;
+           case DataType::Type::kInt32:
+             *restrictions |= kNoDiv | kNoSAD;
+-            return TrySetVectorLength(type, 4);
++            break;
+           case DataType::Type::kInt64:
+             *restrictions |= kNoMul | kNoDiv | kNoShr | kNoAbs | kNoSAD;
+-            return TrySetVectorLength(type, 2);
++            break;
+           case DataType::Type::kFloat32:
+             *restrictions |= kNoReduction;
+-            return TrySetVectorLength(type, 4);
++            break;
+           case DataType::Type::kFloat64:
+             *restrictions |= kNoReduction;
+-            return TrySetVectorLength(type, 2);
++            break;
+           default:
++            bSupportedType = false;
+             break;
+         }  // switch type
++        if (bSupportedType) {
++          // Remove ABS restriction for 64-bit
++          if (compiler_options_->GetInstructionSet() == InstructionSet::kX86_64) {
++            *restrictions &= ~kNoAbs;
++          }
++          return TrySetVectorLength(type, vector_length);
++        }
+       }
+       return false;
+     default:
+diff --git a/compiler/optimizing/nodes.h b/compiler/optimizing/nodes.h
+index 1e3aca64db..3a0032d977 100644
+--- a/compiler/optimizing/nodes.h
++++ b/compiler/optimizing/nodes.h
+@@ -1691,7 +1691,11 @@ class HLoopInformationOutwardIterator : public ValueObject {
+ #define FOR_EACH_CONCRETE_INSTRUCTION_X86_COMMON(M)
+ #endif
+ 
++#if defined(ART_ENABLE_CODEGEN_x86_64)
++#define FOR_EACH_CONCRETE_INSTRUCTION_X86_64(M) M(X86Clear, Instruction)
++#else
+ #define FOR_EACH_CONCRETE_INSTRUCTION_X86_64(M)
++#endif
+ 
+ #define FOR_EACH_CONCRETE_INSTRUCTION(M)                                \
+   FOR_EACH_CONCRETE_INSTRUCTION_COMMON(M)                               \
+@@ -2453,18 +2457,16 @@ class HInstruction : public ArenaObject<kArenaAllocInstruction> {
+   }
+ 
+   bool IsRemovable() const {
+-    return
+-        !DoesAnyWrite() &&
+-        // TODO(solanes): Merge calls from IsSuspendCheck to IsControlFlow into one that doesn't
+-        // do virtual dispatching.
+-        !IsSuspendCheck() &&
+-        !IsNop() &&
+-        !IsParameterValue() &&
+-        // If we added an explicit barrier then we should keep it.
+-        !IsMemoryBarrier() &&
+-        !IsConstructorFence() &&
+-        !IsControlFlow() &&
+-        !CanThrow();
++    return !DoesAnyWrite() &&
++           // TODO(solanes): Merge calls from IsSuspendCheck to IsControlFlow into one that doesn't
++           // do virtual dispatching.
++           !IsSuspendCheck() && !IsNop() && !IsParameterValue() &&
++           // If we added an explicit barrier then we should keep it.
++           !IsMemoryBarrier() && !IsConstructorFence() && !IsControlFlow() &&
++#if defined(ART_ENABLE_CODEGEN_x86_64)
++           !IsX86Clear() &&
++#endif
++           !CanThrow();
+   }
+ 
+   bool IsDeadAndRemovable() const {
+diff --git a/compiler/optimizing/nodes_x86.h b/compiler/optimizing/nodes_x86.h
+index 14d9823355..898b6ea6dc 100644
+--- a/compiler/optimizing/nodes_x86.h
++++ b/compiler/optimizing/nodes_x86.h
+@@ -214,6 +214,17 @@ class HX86MaskOrResetLeastSetBit final : public HUnaryOperation {
+   DEFAULT_COPY_CONSTRUCTOR(X86MaskOrResetLeastSetBit);
+ };
+ 
++class HX86Clear final : public HExpression<0> {
++ public:
++  explicit HX86Clear(uint32_t dex_pc = kNoDexPc)
++      : HExpression(kX86Clear, SideEffects::None(), dex_pc) {}
++
++  DECLARE_INSTRUCTION(X86Clear);
++
++ protected:
++  DEFAULT_COPY_CONSTRUCTOR(X86Clear);
++};
++
+ }  // namespace art
+ 
+ #endif  // ART_COMPILER_OPTIMIZING_NODES_X86_H_
+diff --git a/test/530-checker-lse-simd/src/Main.java b/test/530-checker-lse-simd/src/Main.java
+index c9be5a6440..99efbbee79 100644
+--- a/test/530-checker-lse-simd/src/Main.java
++++ b/test/530-checker-lse-simd/src/Main.java
+@@ -87,6 +87,12 @@ public class Main {
+   /// CHECK-NEXT: BelowOrEqual
+   //
+   /// CHECK:      ArrayGet loop:none
++  /// CHECK-IF:   hasIsaFeature("avx2")
++    /// CHECK-IF: isIsa("x86_64")
++      // Incase of avx2 we must generate a HX86Clear just before return
++      /// CHECK: X86Clear
++    /// CHECK-FI:
++  /// CHECK-FI:
+   /// CHECK-NEXT: Return
+ 
+   /// CHECK-START: double Main.$noinline$test02(double[], int) load_store_elimination (after)
+@@ -131,6 +137,12 @@ public class Main {
+   //
+   /// CHECK-START: double Main.$noinline$test03(int) load_store_elimination (before)
+   /// CHECK:      ArrayGet loop:none
++  /// CHECK-IF:   hasIsaFeature("avx2")
++    /// CHECK-IF: isIsa("x86_64")
++      // Incase of avx2 we must generate a HX86Clear just before return
++      /// CHECK: X86Clear
++    /// CHECK-FI:
++  /// CHECK-FI:
+   /// CHECK-NEXT: Return
+ 
+   /// CHECK-START: double Main.$noinline$test03(int) load_store_elimination (after)
+diff --git a/test/656-checker-simd-opt/src/Main.java b/test/656-checker-simd-opt/src/Main.java
+index 6b08d6352e..478d4522a8 100644
+--- a/test/656-checker-simd-opt/src/Main.java
++++ b/test/656-checker-simd-opt/src/Main.java
+@@ -45,8 +45,15 @@ public class Main {
+   //
+   /// CHECK-ELSE:
+   //
+-  ///     CHECK-DAG: <<Incr:i\d+>>  IntConstant 4                        loop:none
+-  ///     CHECK-DAG: <<Repl:d\d+>>  VecReplicateScalar [<<Cons>>]        loop:none
++  //      Check 256-bit & 128-bit vectorization
++  ///   CHECK-IF: hasIsaFeature("avx2")
++  ///       CHECK-DAG: <<Incr:i\d+>>  IntConstant 8                        loop:none
++  ///       CHECK-DAG: <<Repl:d\d+>>  VecReplicateScalar [<<Cons>>]        loop:none
++  ///   CHECK-ELSE:
++  ///       CHECK-DAG: <<Incr:i\d+>>  IntConstant 4                        loop:none
++  ///       CHECK-DAG: <<Repl:d\d+>>  VecReplicateScalar [<<Cons>>]        loop:none
++  ///   CHECK-FI:
++  //
+   ///     CHECK-NOT:                VecReplicateScalar
+   ///     CHECK-DAG: <<Phi:i\d+>>   Phi                                  loop:<<Loop:B\d+>> outer_loop:none
+   ///     CHECK-DAG: <<Get1:d\d+>>  VecLoad [{{l\d+}},<<Phi>>]           loop:<<Loop>>      outer_loop:none
+@@ -290,8 +297,15 @@ public class Main {
+   //
+   /// CHECK-ELSE:
+   //
+-  ///     CHECK-DAG: <<L2:j\d+>>    LongConstant 2               loop:none
+-  ///     CHECK-DAG: <<Rep:d\d+>>   VecReplicateScalar [<<Get>>] loop:none
++  //    Check 256-bit & 128-bit vectorization
++  ///   CHECK-IF: hasIsaFeature("avx2")
++  ///       CHECK-DAG: <<L2:j\d+>>    LongConstant 4               loop:none
++  ///       CHECK-DAG: <<Rep:d\d+>>   VecReplicateScalar [<<Get>>] loop:none
++  ///   CHECK-ELSE:
++  ///       CHECK-DAG: <<L2:j\d+>>    LongConstant 2               loop:none
++  ///       CHECK-DAG: <<Rep:d\d+>>   VecReplicateScalar [<<Get>>] loop:none
++  ///   CHECK-FI:
++  //
+   ///     CHECK-DAG: <<Set:d\d+>>   VecSetScalars [<<L1>>]       loop:none
+   ///     CHECK-DAG: <<Phi1:j\d+>>  Phi [<<L0>>,{{j\d+}}]        loop:<<Loop:B\d+>> outer_loop:none
+   ///     CHECK-DAG: <<Phi2:d\d+>>  Phi [<<Set>>,{{d\d+}}]       loop:<<Loop>>      outer_loop:none
+@@ -331,8 +345,15 @@ public class Main {
+   //
+   /// CHECK-ELSE:
+   //
+-  ///     CHECK-DAG: <<I4:i\d+>>    IntConstant 4                       loop:none
+-  ///     CHECK-DAG: <<Rep:d\d+>>   VecReplicateScalar [<<Cnv>>]        loop:none
++  //    Check 256-bit & 128-bit vectorization
++  ///   CHECK-IF: hasIsaFeature("avx2")
++  ///       CHECK-DAG: <<I4:i\d+>>    IntConstant 8                       loop:none
++  ///       CHECK-DAG: <<Rep:d\d+>>   VecReplicateScalar [<<Cnv>>]        loop:none
++  ///   CHECK-ELSE:
++  ///       CHECK-DAG: <<I4:i\d+>>    IntConstant 4                       loop:none
++  ///       CHECK-DAG: <<Rep:d\d+>>   VecReplicateScalar [<<Cnv>>]        loop:none
++  ///   CHECK-FI:
++  //
+   ///     CHECK-DAG: <<Phi:i\d+>>   Phi [<<I0>>,{{i\d+}}]               loop:<<Loop:B\d+>> outer_loop:none
+   ///     CHECK-DAG:                VecStore [{{l\d+}},<<Phi>>,<<Rep>>] loop:<<Loop>>      outer_loop:none
+   ///     CHECK-DAG:                Add [<<Phi>>,<<I4>>]                loop:<<Loop>>      outer_loop:none
+@@ -372,8 +393,15 @@ public class Main {
+   //
+   /// CHECK-ELSE:
+   //
+-  ///     CHECK-DAG: <<I4:i\d+>>    IntConstant 4                       loop:none
+-  ///     CHECK-DAG: <<Rep:d\d+>>   VecReplicateScalar [<<Cnv>>]        loop:none
++  //    Check 256-bit & 128-bit vectorization
++  ///   CHECK-IF: hasIsaFeature("avx2")
++  ///       CHECK-DAG: <<I4:i\d+>>    IntConstant 8                       loop:none
++  ///       CHECK-DAG: <<Rep:d\d+>>   VecReplicateScalar [<<Cnv>>]        loop:none
++  ///   CHECK-ELSE:
++  ///       CHECK-DAG: <<I4:i\d+>>    IntConstant 4                       loop:none
++  ///       CHECK-DAG: <<Rep:d\d+>>   VecReplicateScalar [<<Cnv>>]        loop:none
++  ///   CHECK-FI:
++  //
+   ///     CHECK-DAG: <<Phi:i\d+>>   Phi [<<I0>>,{{i\d+}}]               loop:<<Loop:B\d+>> outer_loop:none
+   ///     CHECK-DAG: <<Load:d\d+>>  VecLoad [{{l\d+}},<<Phi>>]          loop:<<Loop>>      outer_loop:none
+   ///     CHECK-DAG: <<Add:d\d+>>   VecAdd [<<Load>>,<<Rep>>]           loop:<<Loop>>      outer_loop:none
+diff --git a/tools/checker/file_format/c1visualizer/parser.py b/tools/checker/file_format/c1visualizer/parser.py
+index 26087cfdf0..408e6c221c 100644
+--- a/tools/checker/file_format/c1visualizer/parser.py
++++ b/tools/checker/file_format/c1visualizer/parser.py
+@@ -61,7 +61,13 @@ def _parse_c1_line(c1_file, line, line_no, state, filename):
+       if not method_name:
+         Logger.fail("Empty method name in output", filename, line_no)
+ 
+-      match = re.search(r"isa_features:([\w,-]+)", method_name)
++      # Gather isa info as well
++      match = re.search(r"isa:(\w+)", method_name)
++      if match:
++        c1_file.set_isa(match.group(1))
++
++      # Some features may contain a '.' like sse4.1
++      match = re.search(r"isa_features:([\w\.?\w,-]+)", method_name)
+       if match:
+         raw_features = match.group(1).split(",")
+         # Create a map of features in the form {feature_name: is_enabled}.
+diff --git a/tools/checker/file_format/c1visualizer/struct.py b/tools/checker/file_format/c1visualizer/struct.py
+index 7f3032016c..1d7c270f36 100644
+--- a/tools/checker/file_format/c1visualizer/struct.py
++++ b/tools/checker/file_format/c1visualizer/struct.py
+@@ -24,9 +24,13 @@ class C1visualizerFile(PrintableMixin):
+     self.base_file_name = os.path.basename(filename)
+     self.full_file_name = filename
+     self.passes = []
++    self.isa = ""
+     self.instruction_set_features = ImmutableDict()
+     self.read_barrier_type = "none"
+ 
++  def set_isa(self, isa):
++    self.isa = isa
++
+   def set_isa_features(self, features):
+     self.instruction_set_features = ImmutableDict(features)
+ 
+diff --git a/tools/checker/match/file.py b/tools/checker/match/file.py
+index 33bb9d1abe..df2984dbe8 100644
+--- a/tools/checker/match/file.py
++++ b/tools/checker/match/file.py
+@@ -321,6 +321,7 @@ class ExecutionState(object):
+ def match_test_case(
+     test_case,
+     c1_pass,
++    isa,
+     instruction_set_features,
+     read_barrier_type):
+   """ Runs a test case against a C1visualizer graph dump.
+@@ -330,6 +331,7 @@ def match_test_case(
+   assert test_case.name == c1_pass.name
+ 
+   initial_variables = {
++      "ISA": isa,
+       "ISA_FEATURES": instruction_set_features,
+       "READ_BARRIER_TYPE": read_barrier_type
+   }
+@@ -361,6 +363,7 @@ def match_files(checker_file, c1_file, target_arch, debuggable_mode, print_cfg):
+       match_test_case(
+           test_case,
+           c1_pass,
++          c1_file.isa,
+           c1_file.instruction_set_features,
+           c1_file.read_barrier_type)
+       Logger.test_passed()
+diff --git a/tools/checker/match/line.py b/tools/checker/match/line.py
+index 987ae61186..14b2eafa1d 100644
+--- a/tools/checker/match/line.py
++++ b/tools/checker/match/line.py
+@@ -128,6 +128,7 @@ def get_eval_text(expression, variables, pos):
+ def evaluate_line(checker_line, variables):
+   assert checker_line.is_eval_content_statement()
+   # Required for eval.
++  isIsa = lambda isa: variables["ISA"] == isa
+   hasIsaFeature = lambda feature: variables["ISA_FEATURES"].get(feature, False)
+   readBarrierType = lambda barrier_type: variables["READ_BARRIER_TYPE"] == barrier_type
+   eval_string = "".join(get_eval_text(expr,
+-- 
+2.25.1
+


### PR DESCRIPTION
This patch includes-
  -Implement-AVX2-instructions-in-x64-assembler
  -Introduce-the-notion-of-vector-registers
  -Implement-AVX2-based-Vectorization-for-x86_64

Observed significant gains in tests:
JBench - 19%
SpecJVM (scimark.lu.small) - 35%
                (scimark.lu.large) - 19%

Test done: Build and boot is fine, Run the benchmarks suite.

Tracked-On: OAM-126116