### PR TITLE
ExternalCameraHAL: Fix incorrect nullptr check on bufPtr

### DIFF
--- a/aosp_diff/caas/hardware/interfaces/0001-ExternalCameraHAL-Fix-incorrect-nullptr-check-on-buf.patch
+++ b/aosp_diff/caas/hardware/interfaces/0001-ExternalCameraHAL-Fix-incorrect-nullptr-check-on-buf.patch
@@ -1,0 +1,31 @@
+From 160e74f125c41702794b7820d66dbda846bd04f6 Mon Sep 17 00:00:00 2001
+From: "Subhransu S. Prusty" <subhransu.prusty@intel.com>
+Date: Wed, 23 Oct 2024 09:05:57 +0530
+Subject: [PATCH] ExternalCameraHAL: Fix incorrect nullptr check on bufPtr
+
+Incorrect bufPtr nullptr check caused "null pointer dereference"
+error during video record stop. Fix to check nullptr on bufPtr without
+dererencing it.
+
+Tracked-On: OAM-123571
+Signed-off-by: Subhransu S. Prusty <subhransu.prusty@intel.com>
+---
+ camera/device/default/ExternalCameraDeviceSession.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/camera/device/default/ExternalCameraDeviceSession.cpp b/camera/device/default/ExternalCameraDeviceSession.cpp
+index 91196d4228..22a3c6e664 100644
+--- a/camera/device/default/ExternalCameraDeviceSession.cpp
++++ b/camera/device/default/ExternalCameraDeviceSession.cpp
+@@ -2846,7 +2846,7 @@ bool ExternalCameraDeviceSession::OutputThread::threadLoop() {
+     ALOGV("%s processing new request", __FUNCTION__);
+     const int kSyncWaitTimeoutMs = 500;
+     for (auto& halBuf : req->buffers) {
+-        if (*(halBuf.bufPtr) == nullptr) {
++        if (halBuf.bufPtr == nullptr) {
+             ALOGW("%s: buffer for stream %d missing", __FUNCTION__, halBuf.streamId);
+             halBuf.fenceTimeout = true;
+         } else if (halBuf.acquireFence >= 0) {
+-- 
+2.47.0
+


### PR DESCRIPTION
Incorrect bufPtr nullptr check caused "null pointer dereference" error during video record stop. Fix to check nullptr on bufPtr without dererencing it.

Tracked-On: OAM-123571