### PR TITLE
WA for Resolution Screen Not Displayed

### DIFF
--- a/aosp_diff/caas/hardware/interfaces/0002-Change-Lens-Facing-to-External-for-External-Camera-H.patch
+++ b/aosp_diff/caas/hardware/interfaces/0002-Change-Lens-Facing-to-External-for-External-Camera-H.patch
@@ -1,0 +1,37 @@
+From 3be551cf007c3740d017a7a301f6bbcfb0c72d74 Mon Sep 17 00:00:00 2001
+From: NaveenVenturi1203 <venturi.naveen@intel.com>
+Date: Mon, 18 Nov 2024 06:41:10 +0000
+Subject: [PATCH] Change Lens Facing to External for External Camera HAL
+
+Issue Detailed: Lens Facing was set to back with support for external
+camera  leading to CTS Failure as CTS was expecting camera with lens
+facing external
+
+Issue Fixed: Changed the Lens Facing Metadata to EXTERNAL for External
+Camera HAL
+
+Tested-On: CTS Test Cases Passed
+
+Tracked-On: OAM-127055
+
+Signed-off-by: NaveenVenturi1203 <venturi.naveen@intel.com>
+---
+ camera/device/default/ExternalCameraDevice.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/camera/device/default/ExternalCameraDevice.cpp b/camera/device/default/ExternalCameraDevice.cpp
+index 50fbdd4efe..8e8474800f 100644
+--- a/camera/device/default/ExternalCameraDevice.cpp
++++ b/camera/device/default/ExternalCameraDevice.cpp
+@@ -420,7 +420,7 @@ status_t ExternalCameraDevice::initDefaultCharsKeys(
+     const uint8_t opticalStabilizationMode = ANDROID_LENS_OPTICAL_STABILIZATION_MODE_OFF;
+     UPDATE(ANDROID_LENS_INFO_AVAILABLE_OPTICAL_STABILIZATION, &opticalStabilizationMode, 1);
+ 
+-    const uint8_t facing = ANDROID_LENS_FACING_BACK;
++    const uint8_t facing = ANDROID_LENS_FACING_EXTERNAL;
+     UPDATE(ANDROID_LENS_FACING, &facing, 1);
+ 
+     // android.noiseReduction
+-- 
+2.34.1
+

--- a/aosp_diff/caas/packages/apps/Camera2/0001-WA-Reorder-Preference-Screen-in-Settings-Activity.patch
+++ b/aosp_diff/caas/packages/apps/Camera2/0001-WA-Reorder-Preference-Screen-in-Settings-Activity.patch
@@ -1,0 +1,83 @@
+From 512988758ddc8cdfb15a87ff034e5ce2b3755e57 Mon Sep 17 00:00:00 2001
+From: NaveenVenturi1203 <venturi.naveen@intel.com>
+Date: Fri, 8 Nov 2024 08:15:22 +0000
+Subject: [PATCH] Reorder Preference Screen in Settings Activity
+
+Issue Detailed: First Preference Screen in Camera Settings Activity is
+not getting displayed leading to resolution& quality screen not getting
+displayed.
+
+Issue Fixed: Reordered the Preference Screen to display Advanced
+Preference Screen first by forcefully enabling Advanced
+Preference Screen.
+
+Tested-On: Checked Resolution Screen is displayed in AOSP Camera
+Settings
+
+Tracked-On: OAM-127026
+
+Signed-off-by: NaveenVenturi1203 <venturi.naveen@intel.com>
+---
+ res/xml/camera_preferences.xml                | 23 +++++++++----------
+ .../settings/CameraSettingsActivity.java      |  6 +++++
+ 2 files changed, 17 insertions(+), 12 deletions(-)
+
+diff --git a/res/xml/camera_preferences.xml b/res/xml/camera_preferences.xml
+index 9c2a1a274..38845b938 100644
+--- a/res/xml/camera_preferences.xml
++++ b/res/xml/camera_preferences.xml
+@@ -18,6 +18,17 @@
+ <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+         android:key="prefscreen_top">
+ 
++  <!-- Advanced -->
++  <PreferenceScreen
++      android:key="pref_category_advanced"
++      android:title="@string/pref_category_advanced" >
++    <!-- Exposure Compensation -->
++    <com.android.camera.settings.ManagedSwitchPreference
++        android:defaultValue="false"
++        android:key="pref_camera_exposure_compensation_key"
++        android:title="@string/pref_camera_exposure_compensation" />
++  </PreferenceScreen>
++
+   <!-- Resolutions and Quality -->
+   <PreferenceScreen
+       android:key="pref_category_resolution"
+@@ -59,16 +70,4 @@
+       android:defaultValue="false"
+       android:key="pref_camera_recordlocation_key"
+       android:title="@string/pref_camera_save_location_title" />
+-
+-  <!-- Advanced -->
+-  <PreferenceScreen
+-      android:key="pref_category_advanced"
+-      android:title="@string/pref_category_advanced" >
+-    <!-- Exposure Compensation -->
+-    <com.android.camera.settings.ManagedSwitchPreference
+-        android:defaultValue="false"
+-        android:key="pref_camera_exposure_compensation_key"
+-        android:title="@string/pref_camera_exposure_compensation" />
+-  </PreferenceScreen>
+-
+ </PreferenceScreen>
+diff --git a/src/com/android/camera/settings/CameraSettingsActivity.java b/src/com/android/camera/settings/CameraSettingsActivity.java
+index 6c76e961c..c6166bf96 100644
+--- a/src/com/android/camera/settings/CameraSettingsActivity.java
++++ b/src/com/android/camera/settings/CameraSettingsActivity.java
+@@ -114,6 +114,12 @@ public class CameraSettingsActivity extends FragmentActivity {
+             fatalErrorHandler.onGenericCameraAccessFailure();
+         }
+ 
++        /*First Preference Screen is not getting displayed
++	 *so to avoid not displaying the Resolution Preference Screen,Adavanced Preference screen is forcefully enabled
++	 */
++
++        hideAdvancedScreen = false;
++
+         ActionBar actionBar = getActionBar();
+         actionBar.setDisplayHomeAsUpEnabled(true);
+         actionBar.setTitle(R.string.mode_settings);
+-- 
+2.34.1
+


### PR DESCRIPTION
1)First Preference Screen in CameraSettingsActivity is not getting displayed.
Reordered the Preference Screen to display the Resolution Screen.
Tracked-On: OAM-127026

2)Change Lens Position to External for External Camera HAL
Changed the Lens Position metadata from Back to External for External Camera HAL
Tracked-On: OAM-127055