### PR TITLE
Fix JavaCrash of android.car.usb.handler

### DIFF
--- a/aosp_diff/aaos_iasw/packages/services/Car/0003-Fix-JavaCrash-of-android.car.usb.handler.patch
+++ b/aosp_diff/aaos_iasw/packages/services/Car/0003-Fix-JavaCrash-of-android.car.usb.handler.patch
@@ -1,0 +1,70 @@
+From dc2c3680e56798a0c0f1fc244a60d6e7b7b0ca47 Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Mon, 18 Nov 2024 12:07:39 +0800
+Subject: [PATCH] Fix JavaCrash of android.car.usb.handler
+
+Monkey test open two tasks of android.car.usb.handler at the same
+time, they use one sqlite database, one task has been destoried,
+database is closed meanwhile other task is using the database, so
+crash happen, add instance count to check if database is used.
+
+TEST: run monkey test, no crash happen.
+
+Tracked-On: OAM-116601
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ .../android/car/usb/handler/UsbSettingsStorage.java  | 12 ++++++++++++
+ .../cartelemetryapp/CarMetricsCollectorService.java  |  1 +
+ 2 files changed, 13 insertions(+)
+
+diff --git a/car-usb-handler/src/android/car/usb/handler/UsbSettingsStorage.java b/car-usb-handler/src/android/car/usb/handler/UsbSettingsStorage.java
+index f9ef3ebb56..b1d110144d 100644
+--- a/car-usb-handler/src/android/car/usb/handler/UsbSettingsStorage.java
++++ b/car-usb-handler/src/android/car/usb/handler/UsbSettingsStorage.java
+@@ -186,6 +186,7 @@ public final class UsbSettingsStorage {
+     private static class UsbSettingsDbHelper extends SQLiteOpenHelper {
+         private static final int DATABASE_VERSION = 2;
+         private static final String DATABASE_NAME = "usb_devices.db";
++        private static int databaseInstance = 0;
+ 
+         // we are using device protected storage because we may need to access the db before the
+         // user has authenticated
+@@ -201,6 +202,8 @@ public final class UsbSettingsStorage {
+         public void onCreate(SQLiteDatabase db) {
+             createTable(db, TABLE_USB_SETTINGS);
+             createSerialIndex(db);
++            databaseInstance++;
++            Log.w(TAG, "Create new usb handler databaseInstance: " + databaseInstance);
+         }
+ 
+         private void createTable(SQLiteDatabase db, String tableName) {
+@@ -242,5 +245,14 @@ public final class UsbSettingsStorage {
+                 }
+             }
+         }
++
++        @Override
++        public void close() {
++            databaseInstance--;
++            Log.w(TAG, "Close usb handler databaseInstance: " + databaseInstance);
++            if( databaseInstance == 0){
++                super.close();
++            }
++         }
+     }
+ }
+diff --git a/tests/CarTelemetryApp/src/com/android/car/cartelemetryapp/CarMetricsCollectorService.java b/tests/CarTelemetryApp/src/com/android/car/cartelemetryapp/CarMetricsCollectorService.java
+index 22041e726e..46df9ef0e4 100644
+--- a/tests/CarTelemetryApp/src/com/android/car/cartelemetryapp/CarMetricsCollectorService.java
++++ b/tests/CarTelemetryApp/src/com/android/car/cartelemetryapp/CarMetricsCollectorService.java
+@@ -91,6 +91,7 @@ public class CarMetricsCollectorService extends Service {
+                 @Override
+                 public void setResultListener(IResultListener listener) {
+                     mResultListener = listener;
++                    mCarTelemetryManager.clearReportReadyListener();
+                     mCarTelemetryManager.setReportReadyListener(getMainExecutor(), mReportListener);
+                 }
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
Monkey test open two tasks of android.car.usb.handler at the same time, they use one sqlite database, one task has been destoried, database is closed meanwhile other task is using the database, so crash happen, add instance count to check if database is used.

TEST: run monkey test, no crash happen.

Tracked-On: OAM-116601