### PR TITLE
Enable HDMI audio

### DIFF
--- a/bsp_diff/caas/hardware/interfaces/0006-Enable-HDMI-audio.patch
+++ b/bsp_diff/caas/hardware/interfaces/0006-Enable-HDMI-audio.patch
@@ -1,0 +1,110 @@
+From 6e24ee35ee9d9ede86b55dd2cad0571b32377e63 Mon Sep 17 00:00:00 2001
+From: padmashree mandri <padmashree.mandri@intel.com>
+Date: Mon, 18 Nov 2024 09:06:40 +0000
+Subject: [PATCH] Enable HDMI audio
+
+This patch adds changes to fallback audio to HDMI
+when no inbuilt/3.5 pcm device present.
+
+Tracked-On: OAM-127579
+Signed-off-by: padmashree mandri <padmashree.mandri@intel.com>
+---
+ audio/aidl/default/primary/PrimaryMixer.h    | 34 +++++++++++++-------
+ audio/aidl/default/primary/StreamPrimary.cpp |  9 +++---
+ 2 files changed, 28 insertions(+), 15 deletions(-)
+
+diff --git a/audio/aidl/default/primary/PrimaryMixer.h b/audio/aidl/default/primary/PrimaryMixer.h
+index 79f3fa844a..c9e4c08159 100644
+--- a/audio/aidl/default/primary/PrimaryMixer.h
++++ b/audio/aidl/default/primary/PrimaryMixer.h
+@@ -21,8 +21,10 @@
+ #include <mutex>
+ #include <vector>
+ 
++#include <filesystem>
+ #include <android-base/thread_annotations.h>
+ #include <android/binder_auto_utils.h>
++#include <android-base/logging.h>
+ 
+ #include "alsa/Mixer.h"
+ 
+@@ -34,20 +36,30 @@ class PrimaryMixer : public alsa::Mixer {
+     static constexpr int kAlsaDevice = 0;
+ 
+     static PrimaryMixer& getInstance();
+-    static int get_pcm_card(const char* name)
+-    {
+-        char id_filepath[20] = {0};
+-        char number_filepath[20] = {0};
+-        ssize_t written;
+ 
+-        snprintf(id_filepath, sizeof(id_filepath), "/proc/asound/%s", name);
++static void get_pcm_card(const char* name, int *card, int *device)
++{
++    char id_filepath[20] = {0};
++    char number_filepath[20] = {0};
++    ssize_t written;
+ 
+-        written = readlink(id_filepath, number_filepath, sizeof(number_filepath));
+-        if (written < 0)
+-                return -1;
+-
+-        return atoi(number_filepath + 4);
++    snprintf(id_filepath, sizeof(id_filepath), "/proc/asound/%s", name);
++    written = readlink(id_filepath, number_filepath, sizeof(number_filepath));
++    if (written < 0) {
++        LOG(DEBUG) << "Sound card %s does not exist - setting default" << name;
++        return;
++    }
++    *card =  atoi(number_filepath + 4);
++    snprintf(id_filepath, sizeof(id_filepath), "/proc/asound/%s/pcm0p", name);
++    if (std::filesystem::exists(id_filepath) && std::filesystem::is_directory(id_filepath)) {
++        LOG(DEBUG) << "choosing primary card(0,0)";
++        *device = 0;
++    } else {
++        LOG(DEBUG) << "No builtin speaker or 3.5mm found, so switching to HDMI card(0,3)";
++        *device = 3;
+     }
++}
++
+ 
+   private:
+     PrimaryMixer() : alsa::Mixer(kAlsaCard) {}
+diff --git a/audio/aidl/default/primary/StreamPrimary.cpp b/audio/aidl/default/primary/StreamPrimary.cpp
+index 2b673604f2..0757c20afc 100644
+--- a/audio/aidl/default/primary/StreamPrimary.cpp
++++ b/audio/aidl/default/primary/StreamPrimary.cpp
+@@ -20,7 +20,6 @@
+ #include <audio_utils/clock.h>
+ #include <error/Result.h>
+ #include <error/expected_utils.h>
+-#include <unistd.h>
+ 
+ #include "PrimaryMixer.h"
+ #include "core-impl/StreamPrimary.h"
+@@ -93,17 +92,19 @@ StreamPrimary::StreamPrimary(StreamContext* context, const Metadata& metadata)
+ }
+ 
+ std::vector<alsa::DeviceProfile> StreamPrimary::getDeviceProfiles() {
+-    int primary_card_num  = primary::PrimaryMixer::get_pcm_card("PCH");
++    int primary_card_num, primary_device_num=0;
++    primary::PrimaryMixer::get_pcm_card("PCH", &primary_card_num, &primary_device_num);
+     LOG(INFO) << __func__ << "Primary Card number is:" << primary_card_num;
++    LOG(INFO) << __func__ << "Primary Device number is:" << primary_device_num;
+ 
+     static const std::vector<alsa::DeviceProfile> kBuiltInSource{
+             alsa::DeviceProfile{.card = primary_card_num,
+-                                .device = primary::PrimaryMixer::kAlsaDevice,
++                                .device = primary_device_num,
+                                 .direction = PCM_IN,
+                                 .isExternal = false}};
+     static const std::vector<alsa::DeviceProfile> kBuiltInSink{
+             alsa::DeviceProfile{.card = primary_card_num,
+-                                .device = primary::PrimaryMixer::kAlsaDevice,
++                                .device = primary_device_num,
+                                 .direction = PCM_OUT,
+                                 .isExternal = false}};
+     return mIsInput ? kBuiltInSource : kBuiltInSink;
+-- 
+2.34.1
+


### PR DESCRIPTION
This patch adds changes to fallback audio to HDMI
when no inbuilt/3.5 pcm device present.

Tracked-On: OAM-127579