### PR TITLE
Fix CursorIndexOutOfBoundsException on com.android.gallery3d

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Gallery2/0003-Fix-CursorIndexOutOfBoundsException-on-com.android.g.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Gallery2/0003-Fix-CursorIndexOutOfBoundsException-on-com.android.g.patch
@@ -1,0 +1,30 @@
+From d00569f27465e85812716b202883d97a73b083d1 Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Wed, 20 Nov 2024 08:44:44 +0800
+Subject: [PATCH] Fix CursorIndexOutOfBoundsException on com.android.gallery3d
+
+Media file is not exist on some pathes, so the cursor of the path is not
+null but the size is zero, so need check both.
+
+Tracked-On: OAM-126618
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ src/com/android/gallery3d/filtershow/cache/ImageLoader.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/com/android/gallery3d/filtershow/cache/ImageLoader.java b/src/com/android/gallery3d/filtershow/cache/ImageLoader.java
+index 003ff482f..24a99ba4b 100644
+--- a/src/com/android/gallery3d/filtershow/cache/ImageLoader.java
++++ b/src/com/android/gallery3d/filtershow/cache/ImageLoader.java
+@@ -84,7 +84,7 @@ public final class ImageLoader {
+     public static String getLocalPathFromUri(Context context, Uri uri) {
+         Cursor cursor = context.getContentResolver().query(uri,
+                 new String[]{MediaStore.Images.Media.DATA}, null, null, null);
+-        if (cursor == null) {
++        if (cursor == null  || cursor.getCount() == 0) {
+             return null;
+         }
+         int index = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA);
+-- 
+2.34.1
+


### PR DESCRIPTION
Media file is not exist on some pathes, so the cursor of the path is not null but the size is zero, so need check both.

Tracked-On: OAM-126618