### PR TITLE
Add run time permissions for CarDialer application

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Car/DialerPrebuilt/0001-Add-run-time-permissions-for-CarDialer-application.patch
+++ b/aosp_diff/base_aaos/packages/apps/Car/DialerPrebuilt/0001-Add-run-time-permissions-for-CarDialer-application.patch
@@ -1,0 +1,43 @@
+From cf64229c7195ff0794267df6541c8b72f492ce2f Mon Sep 17 00:00:00 2001
+From: "Cui, Yuxin" <yuxin.cui@intel.com>
+Date: Fri, 25 Oct 2024 04:26:01 +0000
+Subject: [PATCH] Add run time permissions for CarDialer application
+
+Grant the runtime permissions of CarDialerApp by default to display
+dialer context in dialer app with Bluetooth connected:
+android.permission.READ_CALL_LOG
+android.permission.WRITE_CALL_LOG
+android.permission.READ_PHONE_STATE
+android.permission.CALL_PHONE
+android.permission.SEND_SMS
+
+Tests done: PBAP contact sync
+1.Enable Bluetooth and connect to mobile.
+2.open dialer application
+3.Check for the contacts are able to sync.
+
+Tracked-On: OAM-127645
+Signed-off-by: Cui, Yuxin <yuxin.cui@intel.com>
+Signed-off-by: Bhadouria, Aman <aman.bhadouria@intel.com>
+---
+ default-permissions-com.android.car.dialer.xml | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/default-permissions-com.android.car.dialer.xml b/default-permissions-com.android.car.dialer.xml
+index 0e691fb..fb9e38d 100644
+--- a/default-permissions-com.android.car.dialer.xml
++++ b/default-permissions-com.android.car.dialer.xml
+@@ -19,5 +19,10 @@
+ <exceptions>
+     <exception package="com.android.car.dialer">
+       <permission name="android.permission.BLUETOOTH_CONNECT" fixed="false"/>
++      <permission name="android.permission.READ_CALL_LOG" fixed="false"/>
++      <permission name="android.permission.WRITE_CALL_LOG" fixed="false"/>
++      <permission name="android.permission.READ_PHONE_STATE" fixed="false"/>
++      <permission name="android.permission.CALL_PHONE" fixed="false"/>
++      <permission name="android.permission.SEND_SMS" fixed="false"/>
+     </exception>
+ </exceptions>
+-- 
+2.34.1
+


### PR DESCRIPTION
Grant the runtime permissions of CarDialerApp by default to display dialer context in dialer app with Bluetooth connected: android.permission.READ_CALL_LOG
android.permission.WRITE_CALL_LOG
android.permission.READ_PHONE_STATE
android.permission.CALL_PHONE
android.permission.SEND_SMS

Tests done: PBAP contact sync
1.Enable Bluetooth and connect to mobile.
2.Open dialer application
3.Check for the contacts are able to sync.

Tracked-On: OAM-127645