### PR TITLE
Fix metadata issue when reconnect pixel

### DIFF
--- a/aosp_diff/base_aaos/packages/modules/Bluetooth/0001-Fix-metadata-issue-when-reconnect-pixel.patch
+++ b/aosp_diff/base_aaos/packages/modules/Bluetooth/0001-Fix-metadata-issue-when-reconnect-pixel.patch
@@ -1,0 +1,52 @@
+From ccf7a575a903f1418256350f08f18504f001953b Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Mon, 25 Nov 2024 04:27:53 +0000
+Subject: [PATCH] Fix metadata issue when reconnect pixel
+
+When reconnecting pixel some times metadata is not synced.
+
+Issue: bt-stack issuing two AVRC browse channel, one as acceptor,
+other as initator, which is causing collision in lcid and resulting
+in l2cap disconnection of avrc browse channel, resulting in metadata
+sync issue.
+
+Solution: Don't initiate avrc browse channel as initiator, open only
+as acceptor. Now browse channel is always success and metadata is
+seen everytime.
+
+Tests Done:
+1. Boot the device with changes
+2. Connect to reference Pixel device
+3. Play Media From the Pixel Device
+4. Metadata information is displayed for the playing media
+
+Tracked-On: OAM-127243
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Signed-off-by: Bhadouria, Aman <aman.bhadouria@intel.com>
+---
+ system/bta/av/bta_av_act.cc | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/system/bta/av/bta_av_act.cc b/system/bta/av/bta_av_act.cc
+index e94c26d51f..36aab0f070 100644
+--- a/system/bta/av/bta_av_act.cc
++++ b/system/bta/av/bta_av_act.cc
+@@ -664,8 +664,13 @@ void bta_av_rc_opened(tBTA_AV_CB* p_cb, tBTA_AV_DATA* p_data) {
+   if ((p_cb->features & BTA_AV_FEAT_BROWSE) &&
+       (rc_open.peer_features & BTA_AV_FEAT_BROWSE) &&
+       ((p_cb->rcb[i].status & BTA_AV_RC_ROLE_MASK) == BTA_AV_RC_ROLE_INT)) {
+-    log::verbose("opening AVRC Browse channel");
+-    AVRC_OpenBrowse(p_data->rc_conn_chg.handle, AVCT_INT);
++    log::verbose("Not opening AVRC Browse channel as INT");
++    /* Commenting the below line as for IVI use case, for A2DP SNK, we dont
++     * support browsing channel. So no need to open browsing channel as
++     * INITIATOR. Revert this when have logic to resolve this conflict in
++     * stack/avct.
++     */
++    // AVRC_OpenBrowse(p_data->rc_conn_chg.handle, AVCT_INT);
+   }
+ }
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
When reconnecting pixel some times metadata is not synced.

Issue: bt-stack issuing two AVRC browse channel, one as acceptor, other as initator, which is causing collision in lcid and resulting in l2cap disconnection of avrc browse channel, resulting in metadata sync issue.

Solution: Don't initiate avrc browse channel as initiator, open only as acceptor. Now browse channel is always success and metadata is seen everytime.

Tracked-On: OAM-127243