### PR TITLE
Enable Vulkan backend for HWUI

### DIFF
--- a/aosp_diff/caas/frameworks/base/0001-HWUI-Fallback-to-Medium-priority-when-high-is-not-pe.patch
+++ b/aosp_diff/caas/frameworks/base/0001-HWUI-Fallback-to-Medium-priority-when-high-is-not-pe.patch
@@ -1,0 +1,42 @@
+From 4625abf869ae42dcfecb41c66c73c76881198af4 Mon Sep 17 00:00:00 2001
+From: Aakash Sarkar <aakash.deep.sarkar@intel.com>
+Date: Tue, 26 Nov 2024 13:35:09 +0530
+Subject: [PATCH] [HWUI]: Fallback to Medium priority when high is not
+ permitted
+
+Vulkan backend for HWUI requires queue priority high when SurfaceFlinger
+is running as RT. However our vulkan driver doesn't allow any process
+without CAP_SYS_NICE to create high priority queues as it may starve
+other processes of GPU resources and downgrade their performance.
+
+As a workaround we have added this patch in HWUI to fallback to medium
+priority queues during vulkan logical device creation.
+
+TODO: We need to check if we can get HWUI to work without patching
+core Android code.
+
+Jira: OAM-126014
+Signed-off-by: Aakash Sarkar <Aakash.Deep.Sarkar@intel.com>
+---
+ libs/hwui/renderthread/VulkanManager.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/libs/hwui/renderthread/VulkanManager.cpp b/libs/hwui/renderthread/VulkanManager.cpp
+index 0d0af1110ca4..b9f4930d9de7 100644
+--- a/libs/hwui/renderthread/VulkanManager.cpp
++++ b/libs/hwui/renderthread/VulkanManager.cpp
+@@ -373,6 +373,11 @@ void VulkanManager::setupDevice(GrVkExtensions& grExtensions, VkPhysicalDeviceFe
+             nullptr,                               // ppEnabledFeatures
+     };
+ 
++    if ( VK_ERROR_NOT_PERMITTED_KHR == mCreateDevice(mPhysicalDevice, &deviceInfo, nullptr, &mDevice)) {
++	    ALOGW("Queue priority high is not permitted by driver. Retrying with medium priority");
++	    queuePriorityCreateInfo.globalPriority = VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT;
++    }
++
+     LOG_ALWAYS_FATAL_IF(mCreateDevice(mPhysicalDevice, &deviceInfo, nullptr, &mDevice));
+ 
+     GET_DEV_PROC(AllocateCommandBuffers);
+-- 
+2.47.0
+


### PR DESCRIPTION
This patch is required to enable vulkan backend for HWUI. This is required to get System UI to work correctly when angle is used as the primary Open GLES driver.

Test: Manually verified System UI to working correctly