### PR TITLE
Apply WindowInsets for MainCameraActivity

### DIFF
--- a/aosp_diff/preliminary/packages/apps/Camera2/05_0005-Apply-Window-Insets-for-MainCameraActivity.patch
+++ b/aosp_diff/preliminary/packages/apps/Camera2/05_0005-Apply-Window-Insets-for-MainCameraActivity.patch
@@ -1,0 +1,52 @@
+From f891c7a4c09b582c51a57ab39ddca98c1b100bfd Mon Sep 17 00:00:00 2001
+From: NaveenVenturi1203 <venturi.naveen@intel.com>
+Date: Wed, 27 Nov 2024 11:22:41 +0000
+Subject: [PATCH] Apply Window Insets for MainCameraActivity
+
+Issue Detailed:Window Insets were not applied to MainCameraActivity
+Leading to Delete Button in FilmStripBottomControls being not displayed
+on the screen
+
+Issue Fixed: Applied Padding to MainActivityLayout acccording to the
+windowinsets
+
+Tracked-On: OAM-127727
+Signed-off-by : NaveenVenturi1203 <venturi.naveen@intel.com>
+---
+ src/com/android/camera/CameraActivity.java | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/src/com/android/camera/CameraActivity.java b/src/com/android/camera/CameraActivity.java
+index 547e24700..d5fa8c0d5 100644
+--- a/src/com/android/camera/CameraActivity.java
++++ b/src/com/android/camera/CameraActivity.java
+@@ -65,6 +65,9 @@ import android.view.WindowManager;
+ import android.widget.FrameLayout;
+ import android.widget.ImageView;
+ import android.widget.ShareActionProvider;
++import androidx.core.view.ViewCompat;
++import androidx.core.view.WindowInsetsCompat;
++import androidx.core.graphics.Insets;
+ 
+ import com.android.camera.app.AppController;
+ import com.android.camera.app.CameraAppUI;
+@@ -1571,6 +1574,16 @@ public class CameraActivity extends QuickActivity
+         // Add the session listener so we can track the session progress
+         // updates.
+         getServices().getCaptureSessionManager().addSessionListener(mSessionListener);
++
++        View mainActivityLayout = findViewById(R.id.activity_root_view);
++
++        ViewCompat.setOnApplyWindowInsetsListener(mainActivityLayout,(view,insets) -> {
++            Insets systemInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars());
++
++            mainActivityLayout.setPadding(mainActivityLayout.getPaddingLeft(),mainActivityLayout.getPaddingTop(),mainActivityLayout.getPaddingRight(),systemInsets.bottom);
++            return insets;
++        });
++
+         mFilmstripController = ((FilmstripView) findViewById(R.id.filmstrip_view)).getController();
+         mFilmstripController.setImageGap(
+                 getResources().getDimensionPixelSize(R.dimen.camera_film_strip_gap));
+-- 
+2.34.1
+


### PR DESCRIPTION
Window Insets were not applied to MainCameraActivity Leading to Delete Button in FilmStripBottomControls being not displayed on the screen

Applied Padding to MainActivityLayout acccording to the windowinsets

Tracked-On: OAM-127727
Signed-off-by : NaveenVenturi1203 <venturi.naveen@intel.com>