### PR TITLE
Enable HDMI audio

### DIFF
--- a/bsp_diff/caas/hardware/interfaces/0006-Enable-HDMI-audio.patch
+++ b/bsp_diff/caas/hardware/interfaces/0006-Enable-HDMI-audio.patch
@@ -1,0 +1,160 @@
+From 81535b7be0491e3643e7e26e4738b32a164f01aa Mon Sep 17 00:00:00 2001
+From: padmashree mandri <padmashree.mandri@intel.com>
+Date: Mon, 25 Nov 2024 06:13:21 +0000
+Subject: [PATCH] Enable HDMI audio
+
+This patch adds changes to enable HDMI audio in A15
+and also fallabck to Dummy when no HDMI device
+connected.
+
+Tracked-On: OAM-127579
+Signed-off-by: padmashree mandri <padmashree.mandri@intel.com>
+Signed-off-by: sgnanase <sundar.gnanasekaran@intel.com>
+Signed-off-by:Deepa, G K <g.k.deepa@intel.com>
+---
+ audio/aidl/default/primary/PrimaryMixer.cpp  |  1 -
+ audio/aidl/default/primary/PrimaryMixer.h    | 34 ++++++++++++++++++--
+ audio/aidl/default/primary/StreamPrimary.cpp | 27 +++++++++++-----
+ 3 files changed, 51 insertions(+), 11 deletions(-)
+
+diff --git a/audio/aidl/default/primary/PrimaryMixer.cpp b/audio/aidl/default/primary/PrimaryMixer.cpp
+index 577d010f20..34bddb42ab 100644
+--- a/audio/aidl/default/primary/PrimaryMixer.cpp
++++ b/audio/aidl/default/primary/PrimaryMixer.cpp
+@@ -17,7 +17,6 @@
+ #define LOG_TAG "AHAL_PrimaryMixer"
+ 
+ #include "PrimaryMixer.h"
+-
+ namespace aidl::android::hardware::audio::core::primary {
+ 
+ // static
+diff --git a/audio/aidl/default/primary/PrimaryMixer.h b/audio/aidl/default/primary/PrimaryMixer.h
+index 79f3fa844a..a1b226cef7 100644
+--- a/audio/aidl/default/primary/PrimaryMixer.h
++++ b/audio/aidl/default/primary/PrimaryMixer.h
+@@ -25,14 +25,13 @@
+ #include <android/binder_auto_utils.h>
+ 
+ #include "alsa/Mixer.h"
+-
++#define MAX_HDMI_DEVICES 20
+ namespace aidl::android::hardware::audio::core::primary {
+ 
+ class PrimaryMixer : public alsa::Mixer {
+   public:
+     static constexpr int kAlsaCard = 0;
+     static constexpr int kAlsaDevice = 0;
+-
+     static PrimaryMixer& getInstance();
+     static int get_pcm_card(const char* name)
+     {
+@@ -49,6 +48,37 @@ class PrimaryMixer : public alsa::Mixer {
+         return atoi(number_filepath + 4);
+     }
+ 
++    static int get_pcm_device(int card) {
++        struct mixer *mixer = NULL;
++        struct mixer_ctl *ctl;
++        mixer = mixer_open(card);
++        for (int i = 0; i < MAX_HDMI_DEVICES; i++) {
++            char ctl_name[100] ;
++            enum mixer_ctl_type type;
++            int num_values;
++            snprintf(ctl_name, sizeof(ctl_name), "HDMI/DP,pcm=%d Jack", i);
++            ctl = mixer_get_ctl_by_name(mixer, ctl_name);
++            if (ctl) {
++                type = mixer_ctl_get_type(ctl);
++                num_values = mixer_ctl_get_num_values(ctl);
++                for (int j = 0; j < num_values; j++) {
++                    switch (type) {
++                        case MIXER_CTL_TYPE_BOOL:
++                            if (mixer_ctl_get_value(ctl,j)) {
++                                mixer_close(mixer);
++                                return i;
++                            }
++                        break;
++                    default:
++                        break;
++                    }
++                }
++            }
++        }
++        mixer_close(mixer);
++        return -1;
++    }
++
+   private:
+     PrimaryMixer() : alsa::Mixer(kAlsaCard) {}
+ };
+diff --git a/audio/aidl/default/primary/StreamPrimary.cpp b/audio/aidl/default/primary/StreamPrimary.cpp
+index 2b673604f2..1d722a1a07 100644
+--- a/audio/aidl/default/primary/StreamPrimary.cpp
++++ b/audio/aidl/default/primary/StreamPrimary.cpp
+@@ -25,7 +25,6 @@
+ #include "PrimaryMixer.h"
+ #include "core-impl/StreamPrimary.h"
+ #include "core-impl/StreamStub.h"
+-
+ using aidl::android::hardware::audio::common::SinkMetadata;
+ using aidl::android::hardware::audio::common::SourceMetadata;
+ using aidl::android::media::audio::common::AudioDevice;
+@@ -34,7 +33,6 @@ using aidl::android::media::audio::common::AudioDeviceType;
+ using aidl::android::media::audio::common::AudioOffloadInfo;
+ using aidl::android::media::audio::common::MicrophoneInfo;
+ using android::base::GetBoolProperty;
+-
+ namespace aidl::android::hardware::audio::core {
+ 
+ StreamPrimary::StreamPrimary(StreamContext* context, const Metadata& metadata)
+@@ -91,21 +89,33 @@ StreamPrimary::StreamPrimary(StreamContext* context, const Metadata& metadata)
+     // which accounts for all frames passed from / to the client.
+     return ::android::OK;
+ }
+-
+ std::vector<alsa::DeviceProfile> StreamPrimary::getDeviceProfiles() {
++
+     int primary_card_num  = primary::PrimaryMixer::get_pcm_card("PCH");
+-    LOG(INFO) << __func__ << "Primary Card number is:" << primary_card_num;
++    int primary_device_num = primary::PrimaryMixer::get_pcm_device(primary_card_num);
++    // fallback to Dummy when no HDMI is connected
++    if (primary_device_num == -1 || primary_card_num == -1) {
++        primary_card_num = primary::PrimaryMixer::get_pcm_card("Dummy");
++        primary_device_num = primary::PrimaryMixer::kAlsaDevice;
++    }
++    LOG(DEBUG) << __func__ << "updated Selected Card: " << primary_card_num << "Device: "
++	    << primary_device_num;
++
+ 
+-    static const std::vector<alsa::DeviceProfile> kBuiltInSource{
++    std::vector<alsa::DeviceProfile> kBuiltInSource{
+             alsa::DeviceProfile{.card = primary_card_num,
+-                                .device = primary::PrimaryMixer::kAlsaDevice,
++                                .device = primary_device_num,
+                                 .direction = PCM_IN,
+                                 .isExternal = false}};
+-    static const std::vector<alsa::DeviceProfile> kBuiltInSink{
++    std::vector<alsa::DeviceProfile> kBuiltInSink{
+             alsa::DeviceProfile{.card = primary_card_num,
+-                                .device = primary::PrimaryMixer::kAlsaDevice,
++                                .device = primary_device_num,
+                                 .direction = PCM_OUT,
+                                 .isExternal = false}};
++    kBuiltInSink[0].card = primary_card_num;
++    kBuiltInSource[0].card = primary_card_num;
++    kBuiltInSink[0].device = primary_device_num;
++    kBuiltInSource[0].device = primary_device_num;
+     return mIsInput ? kBuiltInSource : kBuiltInSink;
+ }
+ 
+@@ -124,6 +134,7 @@ bool StreamInPrimary::useStubStream(const AudioDevice& device) {
+            (device.type.type == AudioDeviceType::IN_BUS && device.type.connection.empty());
+ }
+ 
++
+ StreamSwitcher::DeviceSwitchBehavior StreamInPrimary::switchCurrentStream(
+         const std::vector<::aidl::android::media::audio::common::AudioDevice>& devices) {
+     LOG(DEBUG) << __func__;
+-- 
+2.34.1
+


### PR DESCRIPTION
This patch adds changes to enable HDMI audio in A15 and also fallabck to Dummy when no HDMI device
connected.

Tracked-On: OAM-127579