### PR TITLE
Fix javacrash of com.android.gallery3d on a null object reference

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Gallery2/0003-Fix-javacrash-of-com.android.gallery3d-on-a-null-obj.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Gallery2/0003-Fix-javacrash-of-com.android.gallery3d-on-a-null-obj.patch
@@ -1,0 +1,34 @@
+From d2c31617bca0970e44ff6c2fcf910f4a4df669bf Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Mon, 2 Dec 2024 13:32:30 +0800
+Subject: [PATCH] Fix javacrash of com.android.gallery3d on a null object
+ reference
+
+Galley will copy old image set when it shows presentation again,
+and it initializes new image set according old set, it will crash
+when the old set is null, so check it before copy.
+
+Tracked-On: OAM-127639
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ src/com/android/gallery3d/filtershow/FilterShowActivity.java | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/com/android/gallery3d/filtershow/FilterShowActivity.java b/src/com/android/gallery3d/filtershow/FilterShowActivity.java
+index 63e7ba7b2..bbb674524 100644
+--- a/src/com/android/gallery3d/filtershow/FilterShowActivity.java
++++ b/src/com/android/gallery3d/filtershow/FilterShowActivity.java
+@@ -638,6 +638,10 @@ public class FilterShowActivity extends FragmentActivity implements OnItemClickL
+             PrimaryImage.getImage().onNewLook(filterRepresentation);
+         }
+         ImagePreset oldPreset = PrimaryImage.getImage().getPreset();
++        //Current image does not exist
++        if (oldPreset == null) {
++            return;
++        }
+         ImagePreset copy = new ImagePreset(oldPreset);
+         FilterRepresentation representation = copy.getRepresentation(filterRepresentation);
+         if (representation == null) {
+-- 
+2.34.1
+


### PR DESCRIPTION
Galley will copy old image set when it shows presentation again, and it initializes new image set according old set, it will crash when the old set is null, so check it before copy.

Tracked-On: OAM-127639