### PR TITLE
Fix duplicated app icons on Car Launcher

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Car/Launcher/0001-Fix-duplicated-app-icons-on-Car-Launcher.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Car/Launcher/0001-Fix-duplicated-app-icons-on-Car-Launcher.patch
@@ -1,0 +1,63 @@
+From ab1b01d17826cb509779316b2a0ff6f0d9ee927f Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Sun, 8 Dec 2024 09:14:19 +0800
+Subject: [PATCH] Fix duplicated app icons on Car Launcher
+
+Some apps include media service, Car Launcher will draw
+app icon twice if it isn't defined on
+packages/apps/Car/libs/car-media-common/res/values/config.xml,
+and remove duplicated icons on availableActivities.
+
+Tracked-On: OAM-128342
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ .../car/carlauncher/AppLauncherUtils.java     | 26 +++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+
+diff --git a/src/com/android/car/carlauncher/AppLauncherUtils.java b/src/com/android/car/carlauncher/AppLauncherUtils.java
+index ce0cf40e..2af643b2 100644
+--- a/src/com/android/car/carlauncher/AppLauncherUtils.java
++++ b/src/com/android/car/carlauncher/AppLauncherUtils.java
+@@ -230,6 +230,20 @@ public class AppLauncherUtils {
+         List<LauncherActivityInfo> availableActivities =
+                 launcherApps.getActivityList(null, Process.myUserHandle());
+ 
++        //remove duplicated icons
++        for(int i = 0; i< availableActivities.size(); i++) {
++            for (int j = availableActivities.size() - 1; j > i; j--) {
++                String packagename =
++                        availableActivities.get(i).getComponentName().getPackageName();
++                String dup_packagename =
++                        availableActivities.get(j).getComponentName().getPackageName();
++
++                if (packagename.equals(dup_packagename)) {
++                    availableActivities.remove(j);
++                }
++            }
++        }
++
+         int launchablesSize = mediaServices.size() + availableActivities.size();
+         Map<ComponentName, AppMetaData> launchablesMap = new HashMap<>(launchablesSize);
+         Map<ComponentName, ResolveInfo> mediaServicesMap = new HashMap<>(mediaServices.size());
+@@ -251,6 +265,18 @@ public class AppLauncherUtils {
+                         customMediaComponents, appTypes, APP_TYPE_MEDIA_SERVICES)) {
+                     final boolean isDistractionOptimized = true;
+ 
++                    boolean isAvailableActivities = false;
++                    //Don't show the icon  as it will show on activities
++                    for (LauncherActivityInfo activityInfo : availableActivities) {
++                        ComponentName activitycomponentName = activityInfo.getComponentName();
++                        String activitypackageName = activitycomponentName.getPackageName();
++                        if (packageName.equals(activitypackageName)) {
++                            isAvailableActivities = true;
++                            break;
++                        }
++                    }
++                    if (isAvailableActivities) continue;
++
+                     Intent intent = new Intent(Car.CAR_INTENT_ACTION_MEDIA_TEMPLATE);
+                     intent.putExtra(Car.CAR_EXTRA_MEDIA_COMPONENT, componentName.flattenToString());
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
Some apps include media service, Car Launcher will draw app icon twice if it isn't defined on
packages/apps/Car/libs/car-media-common/res/values/config.xml, and remove duplicated icons on availableActivities.

Tracked-On: OAM-128342