### PR TITLE
Remove duplicated icons on second home launcher

### DIFF
--- a/aosp_diff/aaos_iasw/packages/services/Car/0005-Remove-duplicated-icons-on-second-home-launcher.patch
+++ b/aosp_diff/aaos_iasw/packages/services/Car/0005-Remove-duplicated-icons-on-second-home-launcher.patch
@@ -1,0 +1,41 @@
+From 4f7479e844a933a6a3b1a5f1bce48edb5b08c4a2 Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Fri, 13 Dec 2024 08:15:15 +0800
+Subject: [PATCH] Remove duplicated icons on second home launcher
+
+AppEntrys from PackageManagerService may be duplicated, then launcher
+will display duplicated icons, so remove it before it displays.
+
+Tracked-On: OAM-128330
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ .../car/multidisplay/launcher/AppListAdapter.java   | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppListAdapter.java b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppListAdapter.java
+index 980d312174..ac53f505cc 100644
+--- a/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppListAdapter.java
++++ b/tests/MultiDisplaySecondaryHomeTestLauncher/src/com/android/car/multidisplay/launcher/AppListAdapter.java
+@@ -49,6 +49,19 @@ public final class AppListAdapter extends ArrayAdapter<AppEntry> {
+             } else {
+                 Log.d(TAG, "Adding " + data.size() + " apps");
+             }
++            //remove duplicated icons
++            for(int i = 0; i< data.size(); i++) {
++                for (int j = data.size() - 1; j > i; j--) {
++                    String packagename =
++                            data.get(i).getComponentName().getPackageName();
++                    String dup_packagename =
++                            data.get(j).getComponentName().getPackageName();
++
++                    if (packagename.equals(dup_packagename)) {
++                        data.remove(j);
++                    }
++                }
++            }
+             addAll(data);
+         }
+     }
+-- 
+2.34.1
+


### PR DESCRIPTION
AppEntrys from PackageManagerService may be duplicated, then launcher will display duplicated icons, so remove it before it displays.

Tracked-On: OAM-128330