### PR TITLE
Fixed for issue in Gallery during monkey test run.

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Gallery2/0005-Fixed-for-issue-in-Gallery-during-monkey-test-run.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Gallery2/0005-Fixed-for-issue-in-Gallery-during-monkey-test-run.patch
@@ -1,0 +1,37 @@
+From e00569e8d1eeccfec8f22111f0e401e3b5786c61 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Thu, 4 Apr 2024 10:05:11 +0530
+Subject: [PATCH] Fixed for issue in Gallery during monkey test run.
+
+Observing following crash during monkey test run
+java.lang.NullPointerException: Attempt to invoke virtual method
+'java.util.Collection.com.android.gallery3d.filtershow.pipeline
+.ImagePreset.getGeometryFilters()' on a null object reference
+
+Check for null condition.
+
+Tests: Launch Gallery app, open some image to edit.
+
+Tracked-On: OAM-128848
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ .../android/gallery3d/filtershow/imageshow/PrimaryImage.java    | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/com/android/gallery3d/filtershow/imageshow/PrimaryImage.java b/src/com/android/gallery3d/filtershow/imageshow/PrimaryImage.java
+index 63e683a1d..983327e7a 100644
+--- a/src/com/android/gallery3d/filtershow/imageshow/PrimaryImage.java
++++ b/src/com/android/gallery3d/filtershow/imageshow/PrimaryImage.java
+@@ -571,7 +571,7 @@ public class PrimaryImage implements RenderingRequestCaller {
+     public Matrix computeImageToScreen(Bitmap bitmapToDraw,
+                                        float rotate,
+                                        boolean applyGeometry) {
+-        if (getOriginalBounds() == null
++        if (mPreset == null || getOriginalBounds() == null
+                 || mImageShowSize.x == 0
+                 || mImageShowSize.y == 0) {
+             return null;
+-- 
+2.34.1
+


### PR DESCRIPTION
Observing following crash during monkey test run
java.lang.NullPointerException: Attempt to invoke virtual method 'java.util.Collection.com.android.gallery3d.filtershow.pipeline .ImagePreset.getGeometryFilters()' on a null object reference

Check for null condition.

Tests: Launch Gallery app, open some image to edit.

Tracked-On: OAM-128848