### PR TITLE
Fixed crash in DeskClock during monkey test.

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/DeskClock/0001-Fixed-crash-in-DeskClock-during-monkey-test.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/DeskClock/0001-Fixed-crash-in-DeskClock-during-monkey-test.patch
@@ -1,0 +1,57 @@
+From d4c1e3c7747c7e8c70e795a14aa61f82dcd8f534 Mon Sep 17 00:00:00 2001
+From: Ankit Agrawal <ankit.agarwal@intel.com>
+Date: Tue, 8 Aug 2023 11:18:16 +0530
+Subject: [PATCH] Fixed crash in DeskClock during monkey test.
+
+Getting below crash when running monkey test-:
+java.lang.NullPointerException: Parameter specified as non-null is null:
+method kotlin.jvm.internal.Intrinsics.checkNotNullParameter, parameter event
+at com.android.deskclock.LabelDialogFragment$ImeDoneListener.onEditorAction(Unknown Source:7)
+
+event parameter is currently declared as non null. it can be null also,
+So declaring it as null parameter.
+
+Tracked-On: OAM-128844
+Signed-off-by: Ankit Agrawal <ankit.agarwal@intel.com>
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ src/com/android/deskclock/LabelDialogFragment.kt | 4 ++--
+ src/com/android/deskclock/data/StopwatchModel.kt | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/com/android/deskclock/LabelDialogFragment.kt b/src/com/android/deskclock/LabelDialogFragment.kt
+index 77f0b7b35..811e47ade 100644
+--- a/src/com/android/deskclock/LabelDialogFragment.kt
++++ b/src/com/android/deskclock/LabelDialogFragment.kt
+@@ -150,7 +150,7 @@ class LabelDialogFragment : DialogFragment() {
+      * Handles completing the label edit from the IME keyboard.
+      */
+     private inner class ImeDoneListener : OnEditorActionListener {
+-        override fun onEditorAction(v: TextView, actionId: Int, event: KeyEvent): Boolean {
++        override fun onEditorAction(v: TextView, actionId: Int, event: KeyEvent?): Boolean {
+             if (actionId == EditorInfo.IME_ACTION_DONE) {
+                 setLabel()
+                 dismissAllowingStateLoss()
+@@ -227,4 +227,4 @@ class LabelDialogFragment : DialogFragment() {
+             fragment.show(tx, TAG)
+         }
+     }
+-}
+\ No newline at end of file
++}
+diff --git a/src/com/android/deskclock/data/StopwatchModel.kt b/src/com/android/deskclock/data/StopwatchModel.kt
+index c3e022f35..df55fdf64 100644
+--- a/src/com/android/deskclock/data/StopwatchModel.kt
++++ b/src/com/android/deskclock/data/StopwatchModel.kt
+@@ -125,7 +125,7 @@ internal class StopwatchModel(
+      * @return a newly recorded lap completed now; `null` if no more laps can be added
+      */
+     fun addLap(): Lap? {
+-        if (!mStopwatch!!.isRunning || !canAddMoreLaps()) {
++        if ((mStopwatch == null) || !mStopwatch!!.isRunning || !canAddMoreLaps()) {
+             return null
+         }
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
Getting below crash when running monkey test-:
java.lang.NullPointerException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkNotNullParameter, parameter event at com.android.deskclock.LabelDialogFragment$ImeDoneListener.onEditorAction(Unknown Source:7)

event parameter is currently declared as non null. it can be null also, So declaring it as null parameter.

Tracked-On: OAM-128844