### PR TITLE
Enable NBS as sco driver supports it

### DIFF
--- a/aosp_diff/base_aaos/packages/modules/Bluetooth/0002-Enable-NBS-as-sco-driver-supports-it.patch
+++ b/aosp_diff/base_aaos/packages/modules/Bluetooth/0002-Enable-NBS-as-sco-driver-supports-it.patch
@@ -1,0 +1,48 @@
+From 856d075e1396953a423ef197f80e1a093806c6ec Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Thu, 2 Jan 2025 06:17:29 +0000
+Subject: [PATCH] Enable NBS as sco driver supports it
+
+BT USB SCO driver does not support WBS, resulting in HFP sco
+call not heard on remote side.
+
+Disable WBS and enable NBS. Now call audio heard on both side.
+
+Tests done:
+1. Connect BT headset
+2. Install MS teams
+3. #>cat proc/asound/cards
+4. Check btaudio_source sound card listed
+5. #>tinycap /data/caputre.dump -D 1 -d 0 -c 1 -r 8000
+6. #>tinyplay /data/playback.dump -D 1 -d 0 -c 1 -r 8000
+7. Validate the audio heard on both side
+
+Tracked-On: OAM-129007
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ system/bta/hf_client/bta_hf_client_at.cc | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/system/bta/hf_client/bta_hf_client_at.cc b/system/bta/hf_client/bta_hf_client_at.cc
+index 99dbdab0b5..b830c5a9ae 100644
+--- a/system/bta/hf_client/bta_hf_client_at.cc
++++ b/system/bta/hf_client/bta_hf_client_at.cc
+@@ -1808,11 +1808,13 @@ void bta_hf_client_send_at_bac(tBTA_HF_CLIENT_CB* client_cb) {
+ 
+   log::verbose("");
+ 
+-  if (bta_hf_client_cb_arr.is_support_lc3) {
++  /*if (bta_hf_client_cb_arr.is_support_lc3) {
+     buf = "AT+BAC=1,2,3\r";
+   } else {
+     buf = "AT+BAC=1,2\r";
+-  }
++  }*/
++  //Disable WBS and support only NB, as sco driver supports only NB.
++  buf = "AT+BAC=1\r";
+ 
+   bta_hf_client_send_at(client_cb, BTA_HF_CLIENT_AT_BAC, buf, strlen(buf));
+ }
+-- 
+2.34.1
+


### PR DESCRIPTION
BT USB SCO driver does not support WBS, resulting in HFP sco call not heard on remote side.

Disable WBS and enable NBS. Now call audio heard on both side.

Tests done:
1. Connect BT headset
2. Install MS teams
3. #>cat proc/asound/cards
4. Check btaudio_source sound card listed
5. #>tinycap /data/caputre.dump -D 1 -d 0 -c 1 -r 8000
6. #>tinyplay /data/playback.dump -D 1 -d 0 -c 1 -r 8000
7. Validate the audio heard on both side

Tracked-On: OAM-129007