### PR TITLE
Fix IllegalStateException issue on gallery app

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Gallery2/0006-Fix-IllegalStateException-issue-on-gallery-app.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Gallery2/0006-Fix-IllegalStateException-issue-on-gallery-app.patch
@@ -1,0 +1,30 @@
+From 6a0a2281d592103d1ea81550dc1bcb7aabf27286 Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Fri, 3 Jan 2025 16:03:15 +0800
+Subject: [PATCH] Fix IllegalStateException issue on gallery app
+
+After activity onSaveInstanceState, can't commit Fragment task as
+we should not change the fragment status, use commitAllowingStateLoss
+to avoid the limitation.
+
+Tracked-On: OAM-128556
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ src/com/android/gallery3d/filtershow/editors/EditorPanel.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/com/android/gallery3d/filtershow/editors/EditorPanel.java b/src/com/android/gallery3d/filtershow/editors/EditorPanel.java
+index 199ddce8a..8742ebfff 100644
+--- a/src/com/android/gallery3d/filtershow/editors/EditorPanel.java
++++ b/src/com/android/gallery3d/filtershow/editors/EditorPanel.java
+@@ -154,6 +154,6 @@ public class EditorPanel extends Fragment {
+                 transaction.remove(statePanel);
+             }
+         }
+-        transaction.commit();
++        transaction.commitAllowingStateLoss();
+     }
+ }
+-- 
+2.34.1
+


### PR DESCRIPTION
After activity onSaveInstanceState, can't commit Fragment task as we should not change the fragment status, use commitAllowingStateLoss to avoid the limitation.

Tracked-On: OAM-128556