### PR TITLE
Fix NullPointerException of com.android.camera2

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Camera2/0001-Fix-NullPointerException-of-com.android.camera2.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Camera2/0001-Fix-NullPointerException-of-com.android.camera2.patch
@@ -1,0 +1,46 @@
+From 88a8ed5535a5849bea42937a317805f4cfb848dd Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Mon, 6 Jan 2025 16:24:23 +0800
+Subject: [PATCH] Fix NullPointerException of com.android.camera2
+
+App will fill the removed item by left shift, but some items maybe
+invalid, so check the itme before filling, and protect the item when
+it is set Visibility.
+
+Tracked-On: OAM-129043
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ src/com/android/camera/widget/FilmstripView.java | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/com/android/camera/widget/FilmstripView.java b/src/com/android/camera/widget/FilmstripView.java
+index f6d56c52f..117584e0a 100644
+--- a/src/com/android/camera/widget/FilmstripView.java
++++ b/src/com/android/camera/widget/FilmstripView.java
+@@ -1364,7 +1364,10 @@ public class FilmstripView extends ViewGroup {
+             // anyone on the right is removed, and there's more data on the
+             // right available.
+             for (int i = removeAtBufferIndex; i < BUFFER_SIZE - 1; i++) {
+-                mViewItems[i] = mViewItems[i + 1];
++                //don't fill with invalid items
++                if( mViewItems[i + 1] != null) {
++                    mViewItems[i] = mViewItems[i + 1];
++                }
+             }
+ 
+             // pull data out from the DataAdapter for the last one.
+@@ -1376,7 +1379,10 @@ public class FilmstripView extends ViewGroup {
+ 
+             // The animation part.
+             if (inFullScreen()) {
+-                mViewItems[BUFFER_CENTER].setVisibility(VISIBLE);
++                if( mViewItems[BUFFER_CENTER] != null) {
++                    mViewItems[BUFFER_CENTER].setVisibility(VISIBLE);
++                }
++
+                 ViewItem nextItem = mViewItems[BUFFER_CENTER + 1];
+                 if (nextItem != null) {
+                     nextItem.setVisibility(INVISIBLE);
+-- 
+2.34.1
+


### PR DESCRIPTION
App will fill the removed item by left shift, but some items maybe invalid, so check the itme before filling, and protect the item when it is set Visibility.

Tracked-On: OAM-129043