### PR TITLE
Fix for Android 15 Ip Provisioning Failure

### DIFF
--- a/aosp_diff/preliminary/packages/modules/NetworkStack/0001-Fix-for-Android-15-Ip-Provisioning-Failure.patch
+++ b/aosp_diff/preliminary/packages/modules/NetworkStack/0001-Fix-for-Android-15-Ip-Provisioning-Failure.patch
@@ -1,4 +1,4 @@
-From 3f76d97a8d138da4b96fa16c20508cea78a8f45a Mon Sep 17 00:00:00 2001
+From cbb518d008e291597519e3aefd1671011e1ba46a Mon Sep 17 00:00:00 2001
 From: "Bhadouria, Aman" <aman.bhadouria@intel.com>
 Date: Fri, 4 Oct 2024 08:06:13 +0000
 Subject: [PATCH] Fix for Android 15 Ip Provisioning Failure
@@ -7,10 +7,10 @@ In Android 15, Wifi is not working due to ip provisioning
 failure. This is because of DHCP Accept packet being filtered
 out by DhcpFilter from jni level.
 
-The DHCP handling logic from Android 14, which does not include
-the problematic macros, has been reinstated to resolve the issue.
-This ensures DHCP accept packets are not filtered and can reach
-the router.
+By checking the DHCP handling logic from Android 14, which does
+not include the problematic macros, we found that one of the
+macro had wrong jump statment. Now, DHCP accept packets are not
+filtered and can reach the router.
 
 Tests Done:
 1. Boot android image for both caas and base_aaos
@@ -19,61 +19,27 @@ Tests Done:
    and from Mobile Hotspot
 3. Wifi Connects Succesfully
 
+Tracked-On: OAM-129211
 Signed-off-by: Bhadouria, Aman <aman.bhadouria@intel.com>
-Signed-off-by: Babu, Gowtham Anandha <gowtham.anandha.babu@intel.com>
+Co-authored-by: Panda, Bharat B <bharat.b.panda@intel.com>
+Co-authored-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
 ---
- jni/network_stack_utils_jni.cpp | 24 ++++++++++++++++--------
- 1 file changed, 16 insertions(+), 8 deletions(-)
+ jni/network_stack_utils_jni.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/jni/network_stack_utils_jni.cpp b/jni/network_stack_utils_jni.cpp
-index 6f47d7ef..674e1ba3 100644
+index 6f47d7ef..7215e8ff 100644
 --- a/jni/network_stack_utils_jni.cpp
 +++ b/jni/network_stack_utils_jni.cpp
-@@ -42,6 +42,10 @@ namespace android {
- constexpr const char NETWORKSTACKUTILS_PKG_NAME[] =
-     "com/android/networkstack/util/NetworkStackUtils";
- 
-+static const uint32_t kEtherHeaderLen = sizeof(ether_header);
-+static const uint32_t kIPv4Protocol = kEtherHeaderLen + offsetof(iphdr, protocol);
-+static const uint32_t kIPv4FlagsOffset = kEtherHeaderLen + offsetof(iphdr, frag_off);
-+static const uint32_t kUDPDstPortIndirectOffset = kEtherHeaderLen + offsetof(udphdr, dest);
- static const uint16_t kDhcpClientPort = 68;
- 
- static bool checkLenAndCopy(JNIEnv* env, const jbyteArray& addr, int len, void* dst) {
-@@ -96,21 +100,25 @@ static void network_stack_utils_addArpEntry(JNIEnv *env, jclass clazz, jbyteArra
- static void network_stack_utils_attachDhcpFilter(JNIEnv *env, jclass clazz, jobject javaFd) {
+@@ -97,7 +97,7 @@ static void network_stack_utils_attachDhcpFilter(JNIEnv *env, jclass clazz, jobj
      static sock_filter filter_code[] = {
          // Check the protocol is UDP.
--        BPF_LOAD_IPV4_U8(protocol),
+         BPF_LOAD_IPV4_U8(protocol),
 -        BPF2_REJECT_IF_NOT_EQUAL(IPPROTO_UDP),
-+        BPF_STMT(BPF_LD  | BPF_B    | BPF_ABS, kIPv4Protocol),
-+        BPF_JUMP(BPF_JMP | BPF_JEQ  | BPF_K,   IPPROTO_UDP, 0, 6),
++        BPF2_ACCEPT_IF_EQUAL(IPPROTO_UDP),
  
          // Check this is not a fragment.
--        BPF_LOAD_IPV4_BE16(frag_off),
--        BPF2_REJECT_IF_ANY_MASKED_BITS_SET(IP_MF | IP_OFFMASK),
-+        BPF_STMT(BPF_LD  | BPF_H    | BPF_ABS, kIPv4FlagsOffset),
-+        BPF_JUMP(BPF_JMP | BPF_JSET | BPF_K,   IP_MF | IP_OFFMASK, 4, 0),
- 
-         // Get the IP header length.
--        BPF_LOADX_NET_RELATIVE_IPV4_HLEN,
-+        BPF_STMT(BPF_LDX | BPF_B    | BPF_MSH, kEtherHeaderLen),
- 
-         // Check the destination port.
--        BPF_LOAD_NETX_RELATIVE_DST_PORT,
--        BPF2_REJECT_IF_NOT_EQUAL(kDhcpClientPort),
-+        BPF_STMT(BPF_LD  | BPF_H    | BPF_IND, kUDPDstPortIndirectOffset),
-+        BPF_JUMP(BPF_JMP | BPF_JEQ  | BPF_K,   kDhcpClientPort, 0, 1),
- 
--        BPF_ACCEPT,
-+        // Accept.
-+        BPF_STMT(BPF_RET | BPF_K,              0xffff),
-+
-+        // Reject.
-+        BPF_STMT(BPF_RET | BPF_K,              0)
-     };
-     const sock_fprog filter = {
-         sizeof(filter_code) / sizeof(filter_code[0]),
+         BPF_LOAD_IPV4_BE16(frag_off),
 -- 
 2.34.1
 


### PR DESCRIPTION
In Android 15, Wifi is not working due to ip provisioning failure. This is because of DHCP Accept packet being filtered out by DhcpFilter from jni level.

By checking the DHCP handling logic from Android 14, which does not include the problematic macros, we found that one of the macro had wrong jump statement. Now, DHCP accept packets are not filtered and can reach the router.

Tests Done:
1. Boot android image for both caas and base_aaos with this change
2. Go to settings and Connect to Wifi from router and from Mobile Hotspot
3. Wifi Connects Succesfully

Tracked-On: OAM-129211