### PR TITLE
Fix testPartialWakelock

### DIFF
--- a/aosp_diff/preliminary/packages/modules/StatsD/0001-Fix-testPartialWakelock.patch
+++ b/aosp_diff/preliminary/packages/modules/StatsD/0001-Fix-testPartialWakelock.patch
@@ -1,0 +1,57 @@
+From ac55652d538795b75f6870c5c3f8a7eea3190379 Mon Sep 17 00:00:00 2001
+From: Jeffrey Huang <jeffreyhuang@google.com>
+Date: Wed, 4 Dec 2024 13:01:26 -0800
+Subject: [PATCH] Fix testPartialWakelock
+
+1. The original intention is to avoid running this test on auto, but it
+   is currently only running on auto
+
+2. It looks like WAKELOCK_STATE_CHANGED is no longer logging the other
+   two enums for a while now
+
+Bug: 375518548
+Test: atest ValidationTests#testPartialWakelock
+Change-Id: Ia93a34a4b218c0676922e54731d9632760017037
+---
+ .../android/cts/statsd/validation/ValidationTests.java | 10 ++++------
+ 1 file changed, 4 insertions(+), 6 deletions(-)
+
+diff --git a/tests/src/android/cts/statsd/validation/ValidationTests.java b/tests/src/android/cts/statsd/validation/ValidationTests.java
+index a3f010917..0f80b6294 100644
+--- a/tests/src/android/cts/statsd/validation/ValidationTests.java
++++ b/tests/src/android/cts/statsd/validation/ValidationTests.java
+@@ -107,7 +107,7 @@ public class ValidationTests extends DeviceTestCase implements IBuildReceiver {
+     private static final boolean ENABLE_LOAD_TEST = false;
+ 
+     public void testPartialWakelock() throws Exception {
+-        if (!DeviceUtils.hasFeature(getDevice(), FEATURE_AUTOMOTIVE)) return;
++        if (DeviceUtils.hasFeature(getDevice(), FEATURE_AUTOMOTIVE)) return;
+         resetBatteryStats();
+         DeviceUtils.unplugDevice(getDevice());
+         DeviceUtils.flushBatteryStatsHandlers(getDevice());
+@@ -119,11 +119,9 @@ public class ValidationTests extends DeviceTestCase implements IBuildReceiver {
+ 
+         final int atomTag = Atom.WAKELOCK_STATE_CHANGED_FIELD_NUMBER;
+         Set<Integer> wakelockOn = new HashSet<>(Arrays.asList(
+-                WakelockStateChanged.State.ACQUIRE_VALUE,
+-                WakelockStateChanged.State.CHANGE_ACQUIRE_VALUE));
++                WakelockStateChanged.State.ACQUIRE_VALUE));
+         Set<Integer> wakelockOff = new HashSet<>(Arrays.asList(
+-                WakelockStateChanged.State.RELEASE_VALUE,
+-                WakelockStateChanged.State.CHANGE_RELEASE_VALUE));
++                WakelockStateChanged.State.RELEASE_VALUE));
+ 
+         final String EXPECTED_TAG = "StatsdPartialWakelock";
+         final WakeLockLevelEnum EXPECTED_LEVEL = WakeLockLevelEnum.PARTIAL_WAKE_LOCK;
+@@ -154,7 +152,7 @@ public class ValidationTests extends DeviceTestCase implements IBuildReceiver {
+ 
+     @RestrictedBuildTest
+     public void testPartialWakelockDuration() throws Exception {
+-        if (!DeviceUtils.hasFeature(getDevice(), FEATURE_AUTOMOTIVE)) return;
++        if (DeviceUtils.hasFeature(getDevice(), FEATURE_AUTOMOTIVE)) return;
+ 
+         // getUid() needs shell command via ADB. turnScreenOff() sometimes let system go to suspend.
+         // ADB disconnection causes failure of getUid(). Move up here before turnScreenOff().
+-- 
+2.34.1
+


### PR DESCRIPTION
Porting an AOSP patch from open source to fix CTS failure in base_aaos

TestDone: android.cts.statsd.validation.ValidationTests#testPartialWakelock

Tracked-On: OAM-