### PR TITLE
Add support for angle as the OpenGL ES driver

### DIFF
--- a/aosp_diff/preliminary/external/angle/0001-Vulkan-Don-t-require-renderability-in-AHBs.patch
+++ b/aosp_diff/preliminary/external/angle/0001-Vulkan-Don-t-require-renderability-in-AHBs.patch
@@ -1,0 +1,69 @@
+From 12b891360e655ca41f823baedb46dcff28b6c3d3 Mon Sep 17 00:00:00 2001
+From: Shahbaz Youssefi <syoussefi@chromium.org>
+Date: Mon, 23 Sep 2024 23:30:10 -0400
+Subject: [PATCH] Vulkan: Don't require renderability in AHBs
+
+If the AHB usage includes GPU_FRAMEBUFFER, in practice it should be
+impossible for the corresponding Vulkan format to not be renderable.
+However, to guard against potential driver bugs, renderability is still
+checked if the AHB usage includes that bit.
+
+Bug: b/368429977
+Change-Id: Iae23432c369cd933f14c143f67c08720d76009fc
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5881904
+Reviewed-by: mohan maiya <m.maiya@samsung.com>
+Reviewed-by: Charlie Lao <cclao@google.com>
+Commit-Queue: Shahbaz Youssefi <syoussefi@chromium.org>
+---
+ .../HardwareBufferImageSiblingVkAndroid.cpp   | 21 ++++++++++++-------
+ 1 file changed, 13 insertions(+), 8 deletions(-)
+
+diff --git a/src/libANGLE/renderer/vulkan/android/HardwareBufferImageSiblingVkAndroid.cpp b/src/libANGLE/renderer/vulkan/android/HardwareBufferImageSiblingVkAndroid.cpp
+index c652d00b3b..3c28935a39 100644
+--- a/src/libANGLE/renderer/vulkan/android/HardwareBufferImageSiblingVkAndroid.cpp
++++ b/src/libANGLE/renderer/vulkan/android/HardwareBufferImageSiblingVkAndroid.cpp
+@@ -177,6 +177,14 @@ egl::Error HardwareBufferImageSiblingVkAndroid::ValidateHardwareBuffer(
+         return egl::EglBadParameter() << "Failed to query AHardwareBuffer properties";
+     }
+ 
++    int width       = 0;
++    int height      = 0;
++    int depth       = 0;
++    int pixelFormat = 0;
++    uint64_t usage  = 0;
++    angle::android::GetANativeWindowBufferProperties(windowBuffer, &width, &height, &depth,
++                                                     &pixelFormat, &usage);
++
+     if (bufferFormatProperties.format == VK_FORMAT_UNDEFINED)
+     {
+         ASSERT(bufferFormatProperties.externalFormat != 0);
+@@ -191,7 +199,11 @@ egl::Error HardwareBufferImageSiblingVkAndroid::ValidateHardwareBuffer(
+     else
+     {
+         angle::FormatID formatID = vk::GetFormatIDFromVkFormat(bufferFormatProperties.format);
+-        if (!HasFullTextureFormatSupport(renderer, formatID))
++        const bool hasNecessaryFormatSupport =
++            (usage & AHARDWAREBUFFER_USAGE_GPU_FRAMEBUFFER) != 0
++                ? HasFullTextureFormatSupport(renderer, formatID)
++                : HasNonRenderableTextureFormatSupport(renderer, formatID);
++        if (!hasNecessaryFormatSupport)
+         {
+             return egl::EglBadParameter()
+                    << "AHardwareBuffer format " << bufferFormatProperties.format
+@@ -201,13 +213,6 @@ egl::Error HardwareBufferImageSiblingVkAndroid::ValidateHardwareBuffer(
+ 
+     if (attribs.getAsInt(EGL_PROTECTED_CONTENT_EXT, EGL_FALSE) == EGL_TRUE)
+     {
+-        int width       = 0;
+-        int height      = 0;
+-        int depth       = 0;
+-        int pixelFormat = 0;
+-        uint64_t usage  = 0;
+-        angle::android::GetANativeWindowBufferProperties(windowBuffer, &width, &height, &depth,
+-                                                         &pixelFormat, &usage);
+         if ((usage & AHARDWAREBUFFER_USAGE_PROTECTED_CONTENT) == 0)
+         {
+             return egl::EglBadAccess()
+-- 
+2.34.1
+

--- a/aosp_diff/preliminary/external/angle/0002-Vulkan-populate-ycbcr-conversionDesc-for-yuv-VkForma.patch
+++ b/aosp_diff/preliminary/external/angle/0002-Vulkan-populate-ycbcr-conversionDesc-for-yuv-VkForma.patch
@@ -1,0 +1,56 @@
+From 5737ddb32f4f9bff5de64ec4c5a523cd39d8993a Mon Sep 17 00:00:00 2001
+From: Juston Li <justonli@google.com>
+Date: Fri, 27 Sep 2024 18:17:16 +0000
+Subject: [PATCH] Vulkan: populate ycbcr conversionDesc for yuv VkFormats
+
+For this case, the external format has a vulkan equivalent VkFormat and
+is YUV, so conversionDesc needs to be populated.
+
+YcbcrConversionDesc::update() expects externalFormat to be 0 in this
+case since it has an equivalent.
+
+Bug: b/368429977
+Bug: b/352595520
+Change-Id: Ifdae7a539555d78bbbf9d11cdbb946cb815c7709
+Reviewed-on: https://chromium-review.googlesource.com/c/angle/angle/+/5896250
+Reviewed-by: Charlie Lao <cclao@google.com>
+Reviewed-by: Shahbaz Youssefi <syoussefi@chromium.org>
+Commit-Queue: Charlie Lao <cclao@google.com>
+---
+ .../android/HardwareBufferImageSiblingVkAndroid.cpp      | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/src/libANGLE/renderer/vulkan/android/HardwareBufferImageSiblingVkAndroid.cpp b/src/libANGLE/renderer/vulkan/android/HardwareBufferImageSiblingVkAndroid.cpp
+index 3c28935a39..0e35cbf959 100644
+--- a/src/libANGLE/renderer/vulkan/android/HardwareBufferImageSiblingVkAndroid.cpp
++++ b/src/libANGLE/renderer/vulkan/android/HardwareBufferImageSiblingVkAndroid.cpp
+@@ -392,7 +392,10 @@ angle::Result HardwareBufferImageSiblingVkAndroid::initImpl(DisplayVk *displayVk
+             // If not renderable, don't burn a slot on it.
+             vkFormat = &renderer->getFormat(angle::FormatID::NONE);
+         }
++    }
+ 
++    if (isExternal || imageFormat.isYUV)
++    {
+         // Note from Vulkan spec: Since GL_OES_EGL_image_external does not require the same sampling
+         // and conversion calculations as Vulkan does, achieving identical results between APIs may
+         // not be possible on some implementations.
+@@ -411,12 +414,12 @@ angle::Result HardwareBufferImageSiblingVkAndroid::initImpl(DisplayVk *displayVk
+                 : vk::YcbcrLinearFilterSupport::Unsupported;
+ 
+         conversionDesc.update(
+-            renderer, bufferFormatProperties.externalFormat,
++            renderer, isExternal ? bufferFormatProperties.externalFormat : 0,
+             bufferFormatProperties.suggestedYcbcrModel, bufferFormatProperties.suggestedYcbcrRange,
+             bufferFormatProperties.suggestedXChromaOffset,
+             bufferFormatProperties.suggestedYChromaOffset, vk::kDefaultYCbCrChromaFilter,
+-            bufferFormatProperties.samplerYcbcrConversionComponents, angle::FormatID::NONE,
+-            linearFilterSupported);
++            bufferFormatProperties.samplerYcbcrConversionComponents,
++            isExternal ? angle::FormatID::NONE : imageFormat.id, linearFilterSupported);
+     }
+ 
+     const gl::TextureType textureType = AhbDescUsageToTextureType(ahbDescription, layerCount);
+-- 
+2.34.1
+

--- a/aosp_diff/preliminary/frameworks/base/0001-HWUI-Fallback-to-Medium-priority-when-high-is-not-pe.patch
+++ b/aosp_diff/preliminary/frameworks/base/0001-HWUI-Fallback-to-Medium-priority-when-high-is-not-pe.patch
@@ -1,0 +1,48 @@
+From 90a9e2a7eb81de6e651e257bbce17dc7081aa1cc Mon Sep 17 00:00:00 2001
+From: Aakash Sarkar <aakash.deep.sarkar@intel.com>
+Date: Tue, 26 Nov 2024 13:35:09 +0530
+Subject: [PATCH] [HWUI]: Fallback to Medium priority when high is not
+ permitted
+
+Vulkan backend for HWUI requires queue priority high when SurfaceFlinger
+is running as RT. However our vulkan driver doesn't allow any process
+without CAP_SYS_NICE to create high priority queues as it may starve
+other processes of GPU resources and downgrade their performance.
+
+As a workaround we have added this patch in HWUI to fallback to medium
+priority queues during vulkan logical device creation.
+
+TODO: We need to check if we can get HWUI to work without patching
+core Android code.
+
+Tests done:
+- Android boot with angle and vulkan as backend
+- System UI is working correctly
+
+Tracked-On: OAM-126014
+Signed-off-by: Aakash Sarkar <Aakash.Deep.Sarkar@intel.com>
+---
+ libs/hwui/renderthread/VulkanManager.cpp | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/libs/hwui/renderthread/VulkanManager.cpp b/libs/hwui/renderthread/VulkanManager.cpp
+index 0d0af1110ca4..9e74cfc2a5b6 100644
+--- a/libs/hwui/renderthread/VulkanManager.cpp
++++ b/libs/hwui/renderthread/VulkanManager.cpp
+@@ -373,6 +373,13 @@ void VulkanManager::setupDevice(GrVkExtensions& grExtensions, VkPhysicalDeviceFe
+             nullptr,                               // ppEnabledFeatures
+     };
+ 
++    if (VK_ERROR_NOT_PERMITTED_KHR == mCreateDevice(mPhysicalDevice, &deviceInfo,
++                                                   nullptr, &mDevice)) {
++        ALOGW("Queue priority high is not permitted by the driver, \
++               Retrying with medium priority");
++        queuePriorityCreateInfo.globalPriority = VK_QUEUE_GLOBAL_PRIORITY_MEDIUM_EXT;
++    }
++
+     LOG_ALWAYS_FATAL_IF(mCreateDevice(mPhysicalDevice, &deviceInfo, nullptr, &mDevice));
+ 
+     GET_DEV_PROC(AllocateCommandBuffers);
+-- 
+2.47.0
+


### PR DESCRIPTION
This set of patches fix the visual artifacts seen in the System UI when Angle is used as the primary OpenGL ES driver with vulkan as the backend renderer. This also fix the crash seen while running video playback with Angle enabled.

Tests done:

 - Android boot with Angle and vulkan as backend
 - System UI is working correctly without any artifacts
 - Video playback working correctly
 - No visual artifacts seen in the Gallery App

Tracked-On: OAM-126014