### PR TITLE
Fix arithmeticException crash of com.android.camera2

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Camera2/0002-Fix-arithmeticException-crash-of-com.android.camera2.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Camera2/0002-Fix-arithmeticException-crash-of-com.android.camera2.patch
@@ -1,0 +1,33 @@
+From 1a74d37d02a17acdf0ee1820f829a03174dd31a4 Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Thu, 9 Jan 2025 13:33:58 +0800
+Subject: [PATCH] Fix arithmeticException crash of com.android.camera2
+
+Preview video with camera, app will animate bar to a single stop
+button, but the canvas of button does not exist or not intialized,
+ignore animation action.
+
+Tracked-On: OAM-129041
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ src/com/android/camera/ui/AnimatedCircleDrawable.java | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/com/android/camera/ui/AnimatedCircleDrawable.java b/src/com/android/camera/ui/AnimatedCircleDrawable.java
+index ebf89c935..cd88b42f5 100644
+--- a/src/com/android/camera/ui/AnimatedCircleDrawable.java
++++ b/src/com/android/camera/ui/AnimatedCircleDrawable.java
+@@ -83,6 +83,10 @@ public class AnimatedCircleDrawable extends Drawable {
+     }
+ 
+     public void animateToSmallRadius() {
++        //no canvas, don't need to animate
++        if (mCanvasWidth == 0 && mCanvasHeight == 0) {
++            return;
++        }
+         int smallLevel = map(mSmallRadiusTarget,
+                 0, diagonalLength(mCanvasWidth, mCanvasHeight)/2,
+                 0, DRAWABLE_MAX_LEVEL);
+-- 
+2.34.1
+


### PR DESCRIPTION
Preview video with camera, app will animate bar to a single stop button, but the canvas of button does not exist or not intialized, ignore animation action.

Tracked-On: OAM-129041