### PR TITLE
Enable NBS as sco driver supports it

### DIFF
--- a/aosp_diff/preliminary/packages/modules/Bluetooth/0005-Enable-NBS-as-sco-driver-supports-it.patch
+++ b/aosp_diff/preliminary/packages/modules/Bluetooth/0005-Enable-NBS-as-sco-driver-supports-it.patch
@@ -1,4 +1,4 @@
-From 856d075e1396953a423ef197f80e1a093806c6ec Mon Sep 17 00:00:00 2001
+From 40ceb68a93faa3072d70d1f42f787ed5c1cf9b79 Mon Sep 17 00:00:00 2001
 From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
 Date: Thu, 2 Jan 2025 06:17:29 +0000
 Subject: [PATCH] Enable NBS as sco driver supports it
@@ -19,6 +19,8 @@ Tests done:
 
 Tracked-On: OAM-129007
 Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Co-authored-by: Panda, Bharat B <bharat.b.panda@intel.com>
+Co-authored-by: Bhadouria, Aman <aman.bhadouria@intel.com>
 ---
  system/bta/hf_client/bta_hf_client_at.cc | 6 ++++--
  1 file changed, 4 insertions(+), 2 deletions(-)


### PR DESCRIPTION
BT USB SCO driver does not support WBS, resulting in HFP sco call not heard on remote side.

Disable WBS and enable NBS. Now call audio heard on both side.

Tests done:
1. Connect BT headset
2. Install MS teams
3. #>cat proc/asound/cards
4. Check btaudio_source sound card listed
5. #>tinycap /data/caputre.dump -D 1 -d 0 -c 1 -r 8000
6. #>tinyplay /data/playback.dump -D 1 -d 0 -c 1 -r 8000
7. Validate the audio heard on both side
