### PR TITLE
Fix NullPointerException of com.android.camera2

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Camera2/0003-Fix-NullPointerException-of-com.android.camera2.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Camera2/0003-Fix-NullPointerException-of-com.android.camera2.patch
@@ -1,0 +1,33 @@
+From c349451cbe4be6361f9904264009d8a36511b0ae Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Mon, 13 Jan 2025 15:08:16 +0800
+Subject: [PATCH 3/3] Fix NullPointerException of com.android.camera2
+
+App update view item but this item is not the instance of video
+view holder, so add protection to avoid crash.
+
+Tracked-On: OAM-129042
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ src/com/android/camera/data/VideoItem.java | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/camera/data/VideoItem.java b/src/com/android/camera/data/VideoItem.java
+index ec134f753..fe61cd1cd 100644
+--- a/src/com/android/camera/data/VideoItem.java
++++ b/src/com/android/camera/data/VideoItem.java
+@@ -187,7 +187,10 @@ public class VideoItem extends FilmstripItemBase<VideoItemData> {
+ 
+     @Override
+     public void renderTiny(@Nonnull View view) {
+-        renderTiny(getViewHolder(view));
++        VideoViewHolder holder = getViewHolder(view);
++        if (holder != null) {
++            renderTiny(holder);
++        }
+     }
+ 
+     @Override
+-- 
+2.34.1
+


### PR DESCRIPTION
App update view item but this item is not the instance of video view holder, so add protection to avoid crash.

Tracked-On: OAM-129042