### PR TITLE
Update BT HFP call state to audio manager

### DIFF
--- a/aosp_diff/base_aaos/packages/modules/Bluetooth/0002-Update-BT-HFP-call-state-to-audio-manager.patch
+++ b/aosp_diff/base_aaos/packages/modules/Bluetooth/0002-Update-BT-HFP-call-state-to-audio-manager.patch
@@ -1,0 +1,87 @@
+From ee78a86d781d957e116c5a1aeff1160d0715145e Mon Sep 17 00:00:00 2001
+From: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+Date: Thu, 16 Jan 2025 11:58:53 +0000
+Subject: [PATCH] Update BT HFP call state to audio manager
+
+As we are using btusb loopback device, there is no audio output
+if we open btusb card during DIALING/RINGING call state.
+
+Audio is routed properly when btusb loopback device is opened
+after call is picked up (i.e., call state to ACTIVE).
+
+We are updating this call state to audio manager, so that
+audio manager can open/close the btusb loopback device.
+
+Voice call verified.
+
+Tracked-On:
+Signed-off-by: Gowtham Anandha Babu <gowtham.anandha.babu@intel.com>
+---
+ .../hfpclient/HeadsetClientStateMachine.java  | 37 +++++++++++++++++++
+ 1 file changed, 37 insertions(+)
+
+diff --git a/android/app/src/com/android/bluetooth/hfpclient/HeadsetClientStateMachine.java b/android/app/src/com/android/bluetooth/hfpclient/HeadsetClientStateMachine.java
+index ee53a4dafe..1bc42b058d 100644
+--- a/android/app/src/com/android/bluetooth/hfpclient/HeadsetClientStateMachine.java
++++ b/android/app/src/com/android/bluetooth/hfpclient/HeadsetClientStateMachine.java
+@@ -124,6 +124,9 @@ public class HeadsetClientStateMachine extends StateMachine {
+     // Keep track of audio routing across all devices.
+     private static boolean sAudioIsRouted = false;
+ 
++    // Keep track of call state.
++    private static boolean sIsCallStateUpdatedToAudio = false;
++
+     private final Disconnected mDisconnected;
+     private final Connecting mConnecting;
+     private final Connected mConnected;
+@@ -373,6 +376,7 @@ public class HeadsetClientStateMachine extends StateMachine {
+         mService.sendBroadcast(
+                 intent, BLUETOOTH_CONNECT, Utils.getTempBroadcastOptions().toBundle());
+         HfpClientConnectionService.onCallChanged(c.getDevice(), c);
++	updateCallStateToAudioManager(c);
+     }
+ 
+     private void sendNetworkStateChangedIntent(BluetoothDevice device) {
+@@ -965,6 +969,39 @@ public class HeadsetClientStateMachine extends StateMachine {
+         sAudioIsRouted = enable;
+     }
+ 
++    synchronized void updateCallStateToAudioManager(HfpClientCall c) {
++        if (mAudioManager == null) {
++            Log.e(TAG, "AudioManager is null!");
++            return;
++        }
++
++        debug("bthfp_call_state=" + c.getState());
++        switch (c.getState()) {
++            case HfpClientCall.CALL_STATE_INCOMING:
++            case HfpClientCall.CALL_STATE_WAITING:
++            case HfpClientCall.CALL_STATE_HELD:
++            case HfpClientCall.CALL_STATE_HELD_BY_RESPONSE_AND_HOLD:
++            case HfpClientCall.CALL_STATE_ALERTING:
++            case HfpClientCall.CALL_STATE_DIALING:
++                /* Not handled as of now */
++                break;
++            case HfpClientCall.CALL_STATE_ACTIVE:
++                if (!sIsCallStateUpdatedToAudio) {
++                    mAudioManager.setParameters("bthfp_call_state=true");
++                    sIsCallStateUpdatedToAudio = true;
++                }
++                break;
++            case HfpClientCall.CALL_STATE_TERMINATED:
++                if (sIsCallStateUpdatedToAudio) {
++                    mAudioManager.setParameters("bthfp_call_state=false");
++                    sIsCallStateUpdatedToAudio = false;
++                }
++                break;
++            default:
++                break;
++        }
++    }
++
+     private AudioFocusRequest requestAudioFocus() {
+         AudioAttributes streamAttributes =
+                 new AudioAttributes.Builder()
+-- 
+2.34.1
+


### PR DESCRIPTION
As we are using btusb loopback device, there is no audio output if we open btusb card during DIALING/RINGING call state.

Audio is routed properly when btusb loopback device is opened after call is picked up (i.e., call state to ACTIVE).

We are updating this call state to audio manager, so that audio manager can open/close the btusb loopback device.

Voice call verified.

Tracked-On: