### PR TITLE
Fix NullPointerException of com.android.gallery3d

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Gallery2/0007-Fix-NullPointerException-of-com.android.gallery3d.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Gallery2/0007-Fix-NullPointerException-of-com.android.gallery3d.patch
@@ -1,0 +1,43 @@
+From 17fd8611dcf8895d986fe478863201e79f581ef0 Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Thu, 16 Jan 2025 16:08:10 +0800
+Subject: [PATCH] Fix NullPointerException of com.android.gallery3d
+
+Activity has been resumed but the FrameLayout is not saved, so app
+will crash when it opens again, so save the framelayout and add
+portection before it is used.
+
+Tracked-On: OAM-128558
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ .../android/gallery3d/filtershow/EditorPlaceHolder.java    | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/com/android/gallery3d/filtershow/EditorPlaceHolder.java b/src/com/android/gallery3d/filtershow/EditorPlaceHolder.java
+index 8c447b40b..9f0b82d75 100644
+--- a/src/com/android/gallery3d/filtershow/EditorPlaceHolder.java
++++ b/src/com/android/gallery3d/filtershow/EditorPlaceHolder.java
+@@ -31,7 +31,7 @@ public class EditorPlaceHolder {
+     private static final String LOGTAG = "EditorPlaceHolder";
+ 
+     private FilterShowActivity mActivity = null;
+-    private FrameLayout mContainer = null;
++    private static FrameLayout mContainer = null;
+     private HashMap<Integer, Editor> mEditors = new HashMap<Integer, Editor>();
+     private Vector<ImageShow> mOldViews = new Vector<ImageShow>();
+ 
+@@ -82,7 +82,10 @@ public class EditorPlaceHolder {
+     }
+ 
+     public void hide() {
+-        mContainer.setVisibility(View.GONE);
++        if (mContainer != null) {
++            mContainer.setVisibility(View.GONE);
++        }
++
+     }
+ 
+     public void hideOldViews() {
+-- 
+2.34.1
+


### PR DESCRIPTION
Activity has been resumed but the FrameLayout is not saved, so app will crash when it opens again, so save the framelayout and add portection before it is used.

Tracked-On: OAM-128558