### PR TITLE
Close unused Image before acquire new one

### DIFF
--- a/aosp_diff/aaos_iasw/frameworks/base/0001-Close-unused-Image-before-acquire-new-one.patch
+++ b/aosp_diff/aaos_iasw/frameworks/base/0001-Close-unused-Image-before-acquire-new-one.patch
@@ -1,0 +1,35 @@
+From 120575a4a1b122431d2ec081863009fd6ab4a077 Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Wed, 22 Jan 2025 10:32:07 +0800
+Subject: [PATCH] Close unused Image before acquire new one
+
+Fix IllegalStateException: maxImages (30) has already been acquired,
+call #close before acquiring more. Before onImageRequestCompleted,
+onImageAvailable may be called multiple times, with only the last one
+being used. And acquireLatestImage has limitations, so it is necessary
+to close unused images.
+
+Tracked-On: OAM-129481
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ .../com/android/systemui/screenshot/ScrollCaptureClient.java  | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/packages/SystemUI/src/com/android/systemui/screenshot/ScrollCaptureClient.java b/packages/SystemUI/src/com/android/systemui/screenshot/ScrollCaptureClient.java
+index 93e5021fd6e0..54f618811a06 100644
+--- a/packages/SystemUI/src/com/android/systemui/screenshot/ScrollCaptureClient.java
++++ b/packages/SystemUI/src/com/android/systemui/screenshot/ScrollCaptureClient.java
+@@ -365,6 +365,10 @@ public class ScrollCaptureClient {
+         @Override
+         public void onImageAvailable(ImageReader reader) {
+             synchronized (mLock) {
++                if (mCapturedImage != null) {
++                    mCapturedImage.close();
++                }
++
+                 mCapturedImage = mReader.acquireLatestImage();
+                 if (mCapturedArea != null) {
+                     completeCaptureRequest();
+-- 
+2.34.1
+


### PR DESCRIPTION
Fix IllegalStateException: maxImages (30) has already been acquired, call #close before acquiring more. Before onImageRequestCompleted, onImageAvailable may be called multiple times, with only the last one being used. And acquireLatestImage has limitations, so it is necessary to close unused images.

Tracked-On: OAM-129481