### PR TITLE
Fix failures in DevicePolicyManagerTest

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/0021-Revert-Cleanup-always_persist_do.patch
+++ b/aosp_diff/preliminary/frameworks/base/0021-Revert-Cleanup-always_persist_do.patch
@@ -1,0 +1,50 @@
+From b0ac38294a0849473bf43da9bd80f2998b389c6f Mon Sep 17 00:00:00 2001
+From: SaliniVenate <salini.venate@intel.com>
+Date: Sun, 2 Feb 2025 13:48:46 +0000
+Subject: [PATCH] Revert "Cleanup always_persist_do"
+
+This reverts commit 9f50f62e77bb14a78a1395db9aabe201e3fe85da.
+---
+ core/java/android/app/admin/flags/flags.aconfig        | 10 ++++++++++
+ .../com/android/server/devicepolicy/OwnersData.java    |  4 +++-
+ 2 files changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/core/java/android/app/admin/flags/flags.aconfig b/core/java/android/app/admin/flags/flags.aconfig
+index d9f886d41aa8..a094e8ff6288 100644
+--- a/core/java/android/app/admin/flags/flags.aconfig
++++ b/core/java/android/app/admin/flags/flags.aconfig
+@@ -248,6 +248,16 @@ flag {
+   bug: "295301164"
+ }
+ 
++flag {
++  name: "always_persist_do"
++  namespace: "enterprise"
++  description: "Always write device_owners2.xml so that migration flags aren't lost"
++  bug: "335232744"
++  metadata {
++    purpose: PURPOSE_BUGFIX
++  }
++}
++
+ flag {
+   name: "is_recursive_required_app_merging_enabled"
+   namespace: "enterprise"
+diff --git a/services/devicepolicy/java/com/android/server/devicepolicy/OwnersData.java b/services/devicepolicy/java/com/android/server/devicepolicy/OwnersData.java
+index 87fd0024a0fa..52a784559510 100644
+--- a/services/devicepolicy/java/com/android/server/devicepolicy/OwnersData.java
++++ b/services/devicepolicy/java/com/android/server/devicepolicy/OwnersData.java
+@@ -361,7 +361,9 @@ class OwnersData {
+ 
+         @Override
+         boolean shouldWrite() {
+-            return true;
++            return Flags.alwaysPersistDo()
++                    || (mDeviceOwner != null) || (mSystemUpdatePolicy != null)
++                    || (mSystemUpdateInfo != null);
+         }
+ 
+         @Override
+-- 
+2.34.1
+


### PR DESCRIPTION
DevicePolicyManagerTest tests were failing with below error:
  E TestRunner: java.lang.NoSuchMethodError: No static method
  alwaysPersistDo()Z in class Landroid/app/admin/flags/Flags;
  or its super classes (declaration of 'android.app.admin.flags.Flags'
  appears in /system/framework/framework.jar)

Tests Done: atest FrameworksServicesTests:DevicePolicyManagerTest

Tracked-On: OAM-129869