### PR TITLE
adding flags property in Bluetooth aconfig

### DIFF
--- a/aosp_diff/base_aaos/packages/modules/Bluetooth/0005-adding-flags-property-in-Bluetooth-aconfig.patch
+++ b/aosp_diff/base_aaos/packages/modules/Bluetooth/0005-adding-flags-property-in-Bluetooth-aconfig.patch
@@ -1,0 +1,58 @@
+From 7cac472153e3c98024a388218de93efa7415b70f Mon Sep 17 00:00:00 2001
+From: rohith2xs <rohith2x.s@intel.com>
+Date: Tue, 4 Feb 2025 09:25:11 +0000
+Subject: [PATCH] adding flags property in Bluetooth aconfig
+
+- com.android.bluetooth.flags.auto_on_feature
+- com.android.bluetooth.flags.get_address_type_api
+
+To reflect the above added flags in
+"aconfig/ap4a/com.android.bluetooth.flags/"  their properties need
+to be updated in Bluetooth aconfig
+
+Updated in this path packages/modules/Bluetooth/flags/a2dp.aconfig
+
+Tests:
+ Android bootUp success
+ Bluetooth ON/OFF success
+ Bluetooth CONNECT/DISCONNECT to AP success
+ All Bluetooth testcase are passing
+
+Tracked-On: OAM-129864
+Signed-off-by: rohith2xs <rohith2x.s@intel.com>
+Signed-off-by: Bhadouria, Aman <aman.bhadouria@intel.com>
+---
+ flags/a2dp.aconfig | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/flags/a2dp.aconfig b/flags/a2dp.aconfig
+index 195573beea..b33e399d16 100644
+--- a/flags/a2dp.aconfig
++++ b/flags/a2dp.aconfig
+@@ -157,3 +157,23 @@ flag {
+         purpose: PURPOSE_BUGFIX
+     }
+ }
++
++flag {
++    name: "auto_on_feature"
++    namespace: "bluetooth"
++    description: "auto on feature"
++    bug: "000129864"
++    metadata {
++        purpose: PURPOSE_BUGFIX
++    }
++}
++
++flag {
++    name: "get_address_type_api"
++    namespace: "bluetooth"
++    description: "get address type api"
++    bug: "000129864"
++    metadata {
++        purpose: PURPOSE_BUGFIX
++    }
++} 
+-- 
+2.34.1
+


### PR DESCRIPTION
- com.android.bluetooth.flags.auto_on_feature
- com.android.bluetooth.flags.get_address_type_api

To reflect the above added flags in
"aconfig/ap4a/com.android.bluetooth.flags/"  their properties need to be updated in Bluetooth aconfig

Updated in this path packages/modules/Bluetooth/flags/a2dp.aconfig

Tests:
 Android bootUp success
 Bluetooth ON/OFF success
 Bluetooth CONNECT/DISCONNECT to AP success
 All Bluetooth testcase are passing

Tracked-On: OAM-129864