### PR TITLE
Remove hovering pointers checking as multi-windows inputs

### DIFF
--- a/aosp_diff/aaos_iasw/frameworks/native/0003-Remove-hovering-pointers-checking-as-multi-windows-i.patch
+++ b/aosp_diff/aaos_iasw/frameworks/native/0003-Remove-hovering-pointers-checking-as-multi-windows-i.patch
@@ -1,0 +1,34 @@
+From 4971c820b8cdbbc142a4cd8a048ead4a6fa063b0 Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Fri, 24 Jan 2025 09:12:23 +0800
+Subject: [PATCH] Remove hovering pointers checking as multi-windows inputs
+
+AMOTION_EVENT_ACTION_DOWN event will be ignored as hovering pointers,
+so the soft IME can't be hide, remove the code in multi-windows inputs.
+
+Tracked-On: OAM-129624
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ services/inputflinger/dispatcher/InputDispatcher.cpp | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/services/inputflinger/dispatcher/InputDispatcher.cpp b/services/inputflinger/dispatcher/InputDispatcher.cpp
+index feea5e8df7..4decec00c5 100644
+--- a/services/inputflinger/dispatcher/InputDispatcher.cpp
++++ b/services/inputflinger/dispatcher/InputDispatcher.cpp
+@@ -2753,12 +2753,6 @@ std::vector<InputTarget> InputDispatcher::findTouchedWindowTargetsLocked(
+     } else if (maskedAction == AMOTION_EVENT_ACTION_CANCEL) {
+         // All pointers up or canceled.
+         tempTouchState.reset();
+-    } else if (maskedAction == AMOTION_EVENT_ACTION_DOWN) {
+-        // First pointer went down.
+-        if (oldState && (oldState->isDown() || oldState->hasHoveringPointers())) {
+-            ALOGD("Conflicting pointer actions: Down received while already down or hovering.");
+-            *outConflictingPointerActions = true;
+-        }
+     } else if (maskedAction == AMOTION_EVENT_ACTION_POINTER_UP) {
+         // One pointer went up.
+         int32_t pointerIndex = getMotionEventActionPointerIndex(action);
+-- 
+2.34.1
+


### PR DESCRIPTION
AMOTION_EVENT_ACTION_DOWN event will be ignored as hovering pointers, so the soft IME can't be hide, remove the code in multi-windows inputs.

Tracked-On: OAM-129624