### PR TITLE
Prevent Activity Restart on Keyboard Connection

### DIFF
--- a/aosp_diff/preliminary/packages/apps/Camera2/06_0006-Prevent-Activity-Restart-on-Keyboard-Connection.patch
+++ b/aosp_diff/preliminary/packages/apps/Camera2/06_0006-Prevent-Activity-Restart-on-Keyboard-Connection.patch
@@ -1,0 +1,34 @@
+From 7000c8b76b78b7f055746ea6cdb5df8ec2c63568 Mon Sep 17 00:00:00 2001
+From: NaveenVenturi1203 <venturi.naveen@intel.com>
+Date: Mon, 10 Feb 2025 09:28:56 +0000
+Subject: [PATCH] Prevent Activity Restart on Keyboard Connection
+
+Issue Detailed:Camera Activity restarting on keyboard connection leading
+to camera preview on/off, Android treats keyboard
+connection/disconnection as configuration change.
+
+Issue Fixed:Added Keyboard Config Changes in AndroidManifest to ignore
+keyboard connection/disconnection events
+
+Tracked-On: OAM-127079
+Signed-off-by: NaveenVenturi1203 <venturi.naveen@intel.com>
+---
+ AndroidManifest.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/AndroidManifest.xml b/AndroidManifest.xml
+index d2c35f2b9..a772df918 100644
+--- a/AndroidManifest.xml
++++ b/AndroidManifest.xml
+@@ -52,7 +52,7 @@
+         <activity
+             android:name="com.android.camera.CameraActivity"
+             android:clearTaskOnLaunch="true"
+-            android:configChanges="orientation|screenSize|keyboardHidden"
++            android:configChanges="orientation|screenSize|keyboardHidden|keyboard"
+             android:label="@string/app_name"
+             android:launchMode="singleTask"
+             android:taskAffinity="com.android.camera.CameraActivity"
+-- 
+2.34.1
+


### PR DESCRIPTION
Camera Activity restarting on keyboard connection leading to camera preview on/off, Android treats keyboard
connection/disconnection as configuration change.

Added Keyboard Config Changes in AndroidManifest to ignore keyboard connection/disconnection events

Tracked-On: OAM-127079