### PR TITLE
Disable thermal-daemon for unsupported devices

### DIFF
--- a/aosp_diff/base_aaos/external/thermal_daemon/0002-Disable-thermal-daemon-for-not-supported-devices.patch
+++ b/aosp_diff/base_aaos/external/thermal_daemon/0002-Disable-thermal-daemon-for-not-supported-devices.patch
@@ -1,0 +1,33 @@
+From fe167c7d55002d01abdb425446f3be7842150ded Mon Sep 17 00:00:00 2001
+From: Manvi Bajaj <manvi.bajaj@intel.com>
+Date: Tue, 4 Feb 2025 06:30:33 +0000
+Subject: [PATCH] Disable thermal-daemon for not-supported devices
+
+This change will disable thermal-daemon service for all
+unsupported devices.
+
+Signed-off-by: Manvi Bajaj <manvi.bajaj@intel.com>
+---
+ src/thd_engine_default.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/thd_engine_default.cpp b/src/thd_engine_default.cpp
+index 5040462..458e094 100644
+--- a/src/thd_engine_default.cpp
++++ b/src/thd_engine_default.cpp
+@@ -747,9 +747,11 @@ int thd_engine_create_default_engine(bool ignore_cpuid_check,
+ 		thd_engine->set_config_file(conf_file);
+ 
+ 	if (thd_engine->thd_engine_start(ignore_cpuid_check) != THD_SUCCESS) {
+-		thd_log_error("THD engine start failed\n");
++		property_set("persist.vendor.thermal.daemon.supported", "0");
++		thd_log_error("Thermal Daemon not supported\n");
+ 		return THD_ERROR;
+ 	}
+ 
++	property_set("persist.vendor.thermal.daemon.supported", "1");
+ 	return THD_SUCCESS;
+ }
+-- 
+2.34.1
+


### PR DESCRIPTION
This change will disable thermal-daemon service for all unsupported platforms

Tracked-On: OAM-130114