### PR TITLE
Refine udisk mount function in recovery

### DIFF
--- a/aosp_diff/preliminary/bootable/recovery/04_0004-Refine-udisk-mount-function.patch
+++ b/aosp_diff/preliminary/bootable/recovery/04_0004-Refine-udisk-mount-function.patch
@@ -1,0 +1,81 @@
+From e5219bd84e9ea8a08e520d767cc04496eea99283 Mon Sep 17 00:00:00 2001
+From: Zhenlong Z Ji <zhenlong.z.ji@intel.com>
+Date: Thu, 27 Feb 2025 16:02:29 +0800
+Subject: [PATCH] Refine udisk mount function
+
+Signed-off-by: Zhenlong Z Ji <zhenlong.z.ji@intel.com>
+---
+ install/fuse_install_udisk.cpp | 48 +++++++++++++++++++++++++++-------
+ 1 file changed, 38 insertions(+), 10 deletions(-)
+
+diff --git a/install/fuse_install_udisk.cpp b/install/fuse_install_udisk.cpp
+index 298bb258..340c2d61 100644
+--- a/install/fuse_install_udisk.cpp
++++ b/install/fuse_install_udisk.cpp
+@@ -41,6 +41,18 @@
+ 
+ static constexpr const char* UDISKA_ROOT = "/udiska";
+ static constexpr const char* UDISKB_ROOT = "/udiskb";
++static const char *devices[] = { "/dev/block/sda",
++                                 "/dev/block/sda1",
++                                 "/dev/block/sda2",
++                                 "/dev/block/sdb",
++                                 "/dev/block/sdb1",
++                                 "/dev/block/sdb2",
++                                 "/dev/block/sdc",
++                                 "/dev/block/sdc1",
++                                 "/dev/block/sdc2",
++                                 NULL};
++static const char *fs_types[] = {"ext4", "vfat", NULL};
++
+ // How long (in seconds) we wait for the fuse-provided package file to
+ // appear, before timing out.
+ static constexpr int UDISK_INSTALL_TIMEOUT = 10;
+@@ -214,18 +226,34 @@ static InstallResult InstallWithFuseFromPathUdisk(std::string_view path, Device*
+   return result;
+ }
+ 
++int DeviceExists(const char *dev_path) {
++  return access(dev_path, F_OK) == 0;
++}
++
++// Function to try mounting a device with a given filesystem
++int TryMount(const char *device, const char *fs_type, const char *mnt_point) {
++  if (mount(device, mnt_point, fs_type, MS_NOATIME, NULL) == 0)
++    return 0;
++  else
++    return -1;
++}
++
+ InstallResult ApplyFromUdisk(Device* device) {
+   auto ui = device->GetUI();
+-  const char* udisk_root;
+-
+-  udisk_root = UDISKA_ROOT;
+-  if (ensure_path_mounted(udisk_root) != 0) {
+-    LOG(ERROR) << "\n-- Couldn't mount " << udisk_root << ".\n";
+-    udisk_root = UDISKB_ROOT;
+-    if (ensure_path_mounted(udisk_root) != 0) {
+-      LOG(ERROR) << "\n-- Couldn't mount " << udisk_root << ".\n";
+-      return INSTALL_ERROR;
+-    }
++  const char* udisk_root = UDISKA_ROOT;
++  int i = 0;
++
++  for (i = 0; devices[i] != NULL; i++) {
++    if (!DeviceExists(devices[i]))
++      continue;
++
++    for (int j = 0; fs_types[j] != NULL; j++)
++      if (TryMount(devices[i], fs_types[j], udisk_root) == 0)
++        break;
++  }
++
++  if (devices[i] == NULL) {
++    LOG(ERROR) << "\n-- Couldn't find one mountable udisk device.\n";
+   }
+ 
+   std::string path = BrowseDirectory(udisk_root, device, ui);
+-- 
+2.43.0
+


### PR DESCRIPTION
An udisk device name in android may be sda/sda1/sda2, sdb/sdb1/sdb2, or sdc/sdc1/sdc2 etc. But currently only udisk devices whose name are sda1/sdb1 can be mounted, this result in the udisk devices whose name are not sda1/sdb1 cannot be recognized by recovery UI.

Add mount function in recovery handle as many udisk devices as possible, and support both ext4 and vfat simultaneously.

Tracked-On: OAM-130565