### PR TITLE
Fixing the STS failure related to CVE-2024_34742

### DIFF
--- a/aosp_diff/preliminary/frameworks/base/0028-Ensure-device_owners2.xml-is-always-written.patch
+++ b/aosp_diff/preliminary/frameworks/base/0028-Ensure-device_owners2.xml-is-always-written.patch
@@ -1,0 +1,34 @@
+From 67b805b8868c00bb42791d58716cf7948c95be94 Mon Sep 17 00:00:00 2001
+From: "Alam, Sahibex" <sahibex.alam@intel.com>
+Date: Mon, 3 Mar 2025 04:55:31 +0000
+Subject: [PATCH] Ensure device_owners2.xml is always written.
+
+Bug: 335232744
+Test: Manual, upgrading from T-QPR3
+(cherry picked from https://googleplex-android-review.googlesource.com/q/commit:3abc07421d5bed187589d6deb48da07e4c407203)
+Merged-In: I7a7dba56f2951e7e3699b19d2517d198dc8f9d35
+Change-Id: I7a7dba56f2951e7e3699b19d2517d198dc8f9d35
+
+Signed-off-by: Pavel Grafov <pgrafov@google.com>
+---
+ .../java/com/android/server/devicepolicy/OwnersData.java      | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/services/devicepolicy/java/com/android/server/devicepolicy/OwnersData.java b/services/devicepolicy/java/com/android/server/devicepolicy/OwnersData.java
+index 52a784559510..bf6e9c519dfa 100644
+--- a/services/devicepolicy/java/com/android/server/devicepolicy/OwnersData.java
++++ b/services/devicepolicy/java/com/android/server/devicepolicy/OwnersData.java
+@@ -361,9 +361,7 @@ class OwnersData {
+ 
+         @Override
+         boolean shouldWrite() {
+-            return Flags.alwaysPersistDo()
+-                    || (mDeviceOwner != null) || (mSystemUpdatePolicy != null)
+-                    || (mSystemUpdateInfo != null);
++	    return true;
+         }
+ 
+         @Override
+-- 
+2.34.1
+


### PR DESCRIPTION
Ensure that the device_owners2.xml is always written. 
cherry picked from: https://android.googlesource.com/platform/ \ frameworks/base/+/688e5c3012eb0a4ea88361588cf5026c10e4a42

Test Done: STS Test passed (module: StsHostTestCases,
Test: android.security.sts.CVE_2024_34742#testPocCVE_2024_34742)

Tracked-On: OAM-130275