### PR TITLE
[WA]Fix the issue when the IME can't be hidden.

### DIFF
--- a/aosp_diff/aaos_iasw/frameworks/base/0002-WA-Fix-the-issue-when-the-IME-can-t-be-hidden.patch
+++ b/aosp_diff/aaos_iasw/frameworks/base/0002-WA-Fix-the-issue-when-the-IME-can-t-be-hidden.patch
@@ -1,0 +1,45 @@
+From 6df195480fa7079e1c0a8c76cee39df5d2c04b0e Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Mon, 3 Mar 2025 13:41:48 +0800
+Subject: [PATCH] [WA]Fix the issue when the IME can't be hidden.
+
+Different apps will start different IME instances, and there are two
+ways to hide the IME dialog, ome is dismissing the dialog view, the
+second is unbinding the IME token, when apps change frequently or
+press home menu quickly, the issue maybe happen.
+
+Tracked-On: OAM-129624
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ core/java/android/view/InsetsController.java | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/core/java/android/view/InsetsController.java b/core/java/android/view/InsetsController.java
+index 62243e2c8732..c5a5ee1b27d0 100644
+--- a/core/java/android/view/InsetsController.java
++++ b/core/java/android/view/InsetsController.java
+@@ -1211,16 +1211,18 @@ public class InsetsController implements WindowInsetsController, InsetsAnimation
+                 continue;
+             }
+             @AnimationType final int animationType = getAnimationType(type);
+-            final boolean requestedVisible = (type & mRequestedVisibleTypes) != 0;
++            //final boolean requestedVisible = (type & mRequestedVisibleTypes) != 0;
++            //WA for IME hide, force to hide while the ime instance is not finished.
++            final boolean requestedVisible = true;
+             final boolean isImeAnimation = type == ime();
+-            if (mPendingImeControlRequest != null && !requestedVisible) {
++            if (mPendingImeControlRequest != null) {
+                 // Remove the hide insets type from the pending show request.
+                 mPendingImeControlRequest.types &= ~type;
+                 if (mPendingImeControlRequest.types == 0) {
+                     abortPendingImeControlRequest();
+                 }
+             }
+-            if (isImeAnimation && !requestedVisible && animationType == ANIMATION_TYPE_NONE) {
++            if (isImeAnimation && animationType == ANIMATION_TYPE_NONE) {
+                 hasImeRequestedHidden = true;
+                 // Ensure to request hide IME in case there is any pending requested visible
+                 // being applied from setControl when receiving the insets control.
+-- 
+2.34.1
+


### PR DESCRIPTION
Different apps will start different IME instances, and there are two ways to hide the IME dialog, ome is dismissing the dialog view, the second is unbinding the IME token, when apps change frequently or press home menu quickly, the issue maybe happen.

Tracked-On: OAM-129624