### PR TITLE
WA-Set device to unlocked state to enable BM user

### DIFF
--- a/bsp_diff/caas/hardware/intel/kernelflinger/0002-WA-Set-device-to-unlocked-state-to-enable-BM-user.patch
+++ b/bsp_diff/caas/hardware/intel/kernelflinger/0002-WA-Set-device-to-unlocked-state-to-enable-BM-user.patch
@@ -1,6 +1,6 @@
-From 78a1aa9a52655f88287ac8743555c7f4af906430 Mon Sep 17 00:00:00 2001
-From: Salini Venate <salini.venate@intel.com>
-Date: Sat, 10 Aug 2024 12:40:57 +0000
+From 7146beff44f2aa9500bf900df10bfcaed398a661 Mon Sep 17 00:00:00 2001
+From: Gang G Chen <gang.g.chen@intel.com>
+Date: Fri, 7 Mar 2025 16:36:49 +0800
 Subject: [PATCH] WA-Set device to unlocked state to enable BM user
 
 This patch will disable flashing lock check for USER
@@ -8,33 +8,38 @@ build since Trusty and TPM is disabled.
 
 Tests Done: Build and boot USER BM image
 
-Tracked-On: OAM-123280
+Tracked-On: OAM-127732
 Signed-off-by: Salini Venate <salini.venate@intel.com>
+Signed-off-by: Gang G Chen <gang.g.chen@intel.com>
 ---
  libfastboot/fastboot_flashing.c | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/libfastboot/fastboot_flashing.c b/libfastboot/fastboot_flashing.c
-index 917cb00..13570a9 100644
+index 57c5114..f5f2ebd 100644
 --- a/libfastboot/fastboot_flashing.c
 +++ b/libfastboot/fastboot_flashing.c
-@@ -257,13 +257,13 @@ static void cmd_unlock(__attribute__((__unused__)) INTN argc,
+@@ -268,9 +268,9 @@ static void cmd_unlock(__attribute__((__unused__)) INTN argc,
  #endif
  		change_device_state(UNLOCKED, TRUE);
  	} else {
 -#ifdef USER
-+/*#ifdef USER
++//#ifdef USER
  		fastboot_fail("Unlocking device not allowed");
 -#else
-+#else*/
- 		fastboot_info("Unlock protection is set");
- 		fastboot_info("Unlocking anyway since this is not a User build");
- 		change_device_state(UNLOCKED, TRUE);
++//#else
+ 		/* user_build is from boot parameters to compatible for CIV and IVI */
+ 		if (user_build) {
+ 			fastboot_fail("Unlocking device not allowed");
+@@ -279,7 +279,7 @@ static void cmd_unlock(__attribute__((__unused__)) INTN argc,
+ 			fastboot_info("Unlocking anyway since this is not a User build");
+ 			change_device_state(UNLOCKED, TRUE);
+ 		}
 -#endif
 +//#endif
  	}
  }
  
 -- 
-2.34.1
+2.47.1
 


### PR DESCRIPTION
This patch will disable flashing lock check for USER build since Trusty and TPM is disabled.

Tests Done: Build and boot USER BM image

Tracked-On: OAM-127732