### PR TITLE
Enable wallpaper for letterbox background

### DIFF
--- a/aosp_diff/aaos_iasw/frameworks/base/0003-Force-to-set-letterbox-type-to-wallpaper.patch
+++ b/aosp_diff/aaos_iasw/frameworks/base/0003-Force-to-set-letterbox-type-to-wallpaper.patch
@@ -1,0 +1,34 @@
+From 4b146a15ac08be10870c3886f9fe681d261de268 Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Thu, 13 Mar 2025 09:04:50 +0800
+Subject: [PATCH] Force to set letterbox type to wallpaper
+
+Default type of letterbox is LETTERBOX_BACKGROUND_SOLID_COLOR, so
+letter box is dark, set type to LETTERBOX_BACKGROUND_WALLPAPER and
+force to show wallpaper.
+
+Tracked-on: OAM-130945
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ .../java/com/android/server/wm/LetterboxUiController.java    | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/services/core/java/com/android/server/wm/LetterboxUiController.java b/services/core/java/com/android/server/wm/LetterboxUiController.java
+index 735cbc4e4287..aafe1a6b08a7 100644
+--- a/services/core/java/com/android/server/wm/LetterboxUiController.java
++++ b/services/core/java/com/android/server/wm/LetterboxUiController.java
+@@ -1607,6 +1607,11 @@ final class LetterboxUiController {
+                         // Check that blur is supported by a device if blur radius is provided.
+                         && (getLetterboxWallpaperBlurRadiusPx() <= 0
+                                 || isLetterboxWallpaperBlurSupported());
++        //force set wallpaper when background type is LETTERBOX_BACKGROUND_WALLPAPER
++        if (letterboxBackgroundType == LETTERBOX_BACKGROUND_WALLPAPER) {
++            wallpaperShouldBeShown = true;
++            Slog.w(TAG, "set letterbox Wallpaper to be shown.....");
++        }
+         if (mShowWallpaperForLetterboxBackground != wallpaperShouldBeShown) {
+             mShowWallpaperForLetterboxBackground = wallpaperShouldBeShown;
+             mActivityRecord.requestUpdateWallpaperIfNeeded();
+-- 
+2.34.1
+

--- a/aosp_diff/aaos_iasw/packages/services/Car/0006-Enable-wallpaper-for-letterbox-background.patch
+++ b/aosp_diff/aaos_iasw/packages/services/Car/0006-Enable-wallpaper-for-letterbox-background.patch
@@ -1,0 +1,56 @@
+From ee0b7c47081caa5bc7a8dd1d1a535efc6dee797e Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Thu, 13 Mar 2025 09:34:12 +0800
+Subject: [PATCH] Enable wallpaper for letterbox background
+
+There are two conditions to enable wallper for letterbox background,
+one is enabling system wallpaper service, the other is setting the
+type of letterbox background to wallpaper.
+
+Tracked-On: OAM-130945
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ .../base/core/res/res/values/config.xml       | 27 +++++++++++++++++--
+ 1 file changed, 25 insertions(+), 2 deletions(-)
+
+diff --git a/car_product/overlay/frameworks/base/core/res/res/values/config.xml b/car_product/overlay/frameworks/base/core/res/res/values/config.xml
+index 59053739cc..3b27796610 100644
+--- a/car_product/overlay/frameworks/base/core/res/res/values/config.xml
++++ b/car_product/overlay/frameworks/base/core/res/res/values/config.xml
+@@ -121,8 +121,31 @@
+ 
+     <bool name="config_hideNavBarForKeyboard">true</bool>
+ 
+-    <!-- Turn off Wallpaper service -->
+-    <bool name="config_enableWallpaperService">false</bool>
++    <!-- Turn on Wallpaper service -->
++    <bool name="config_enableWallpaperService">true</bool>
++
++    <!-- Blur radius for the Option 3 in R.integer.config_letterboxBackgroundType. Values < 0 are
++        ignored and 0 is used. -->
++    <dimen name="config_letterboxBackgroundWallpaperBlurRadius">48dp</dimen>
++
++    <!-- Alpha of a black translucent scrim showed over wallpaper letterbox background when
++        the Option 3 is selected for R.integer.config_letterboxBackgroundType.
++        Values < 0 or >= 1 are ignored and 0.0 (transparent) is used instead. -->
++    <item name="config_letterboxBackgroundWallaperDarkScrimAlpha" format="float" type="dimen">
++        0.50
++    </item>
++
++    <!-- Corners appearance of the letterbox background.
++            0 - Solid background using color specified in R.color.config_letterboxBackgroundColor.
++            1 - Color specified in R.attr.colorBackground for the letterboxed application.
++            2 - Color specified in R.attr.colorBackgroundFloating for the letterboxed application.
++            3 - Wallpaper with dimmed with blur or/and dark scrim. At least one of the following
++            parameters should be > 0: config_letterboxBackgroundWallpaperBlurRadius,
++            config_letterboxBackgroundWallaperDarkScrimAlpha. If it's not the case or blur radius
++            provided but blur isn't supported by the device and this option
++            is selected then implementation will default to option 0.
++        If given value is outside of this range, the option 0 will be assummed. -->
++    <integer name="config_letterboxBackgroundType">3</integer>
+ 
+     <!-- Whether to only install system packages on a user if they're allowlisted for that user
+          type. Override the default value in framework config file.
+-- 
+2.34.1
+


### PR DESCRIPTION
There are two conditions to enable wallper for letterbox background, one is enabling system wallpaper service, the other is setting the type of letterbox background to wallpaper.

Tracked-On: OAM-130945