### PR TITLE
Configure scudo to use exclusive TSD

### DIFF
--- a/aosp_diff/preliminary/external/scudo/0001-Configure-scudo-to-use-exclusive-TSD.patch
+++ b/aosp_diff/preliminary/external/scudo/0001-Configure-scudo-to-use-exclusive-TSD.patch
@@ -1,0 +1,48 @@
+From ea1e403a9cc57c60f540b1fe68656f2a77c5dcc3 Mon Sep 17 00:00:00 2001
+From: "Alam, Sahibex" <sahibex.alam@intel.com>
+Date: Thu, 13 Mar 2025 05:25:18 +0000
+Subject: [PATCH] Configure scudo to use exclusive TSD
+
+Exclusive TSD reduces thread contention for allocation
+and improves multicore performance on Geekbench.
+
+Signed-off-by: Vinay Prasad Kompella <vinay.kompella@intel.com>
+---
+ Android.bp                    | 1 +
+ standalone/allocator_config.h | 7 ++++++-
+ 2 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/Android.bp b/Android.bp
+index 43955e9..4c29a44 100644
+--- a/Android.bp
++++ b/Android.bp
+@@ -169,6 +169,7 @@ cc_library_static {
+     defaults: ["libscudo_defaults"],
+     cflags: [
+       "-D_BIONIC=1",
++      "-DSCUDO_ANDROID_USE_EXCLUSIVETSD",
+       "-DSCUDO_HAS_PLATFORM_TLS_SLOT",
+     ],
+     visibility: [
+diff --git a/standalone/allocator_config.h b/standalone/allocator_config.h
+index d06f6df..63f46c0 100644
+--- a/standalone/allocator_config.h
++++ b/standalone/allocator_config.h
+@@ -126,8 +126,13 @@ struct AndroidConfig {
+   static const s32 SecondaryCacheMinReleaseToOsIntervalMs = 0;
+   static const s32 SecondaryCacheMaxReleaseToOsIntervalMs = 1000;
+ 
++  #ifdef SCUDO_ANDROID_USE_EXCLUSIVETSD
+   template <class A>
+-  using TSDRegistryT = TSDRegistrySharedT<A, 8U, 2U>; // Shared, max 8 TSDs.
++  using TSDRegistryT = TSDRegistryExT<A>; // Exclusive
++#else
++  template <class A>
++  using TSDRegistryT = TSDRegistrySharedT<A, 32U, 2U>; // Start with 2, max 32 TSDs
++#endif
+ };
+ 
+ struct AndroidSvelteConfig {
+-- 
+2.34.1
+


### PR DESCRIPTION
Exclusive TSD reduces thread contention for allocation and improves multicore performance on Geekbench.

Test Done: Build and boot success
No regration on standerd benchmarks.

Tracked-On: OAM-130952