### PR TITLE
Fix for improper text alignment in bluetooth rename dialogbox

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Car/Settings/0001-Fix-for-improper-text-alignment-in-bluetooth-rename-.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Car/Settings/0001-Fix-for-improper-text-alignment-in-bluetooth-rename-.patch
@@ -1,0 +1,50 @@
+From 092299773ac369ef4b93f6b44f147dcefb0b1073 Mon Sep 17 00:00:00 2001
+From: "Bhadouria, Aman" <aman.bhadouria@intel.com>
+Date: Wed, 20 Nov 2024 07:38:12 +0000
+Subject: [PATCH] Fix for improper text alignment in bluetooth rename dialog
+ box
+
+The default font size for the Bluetooth rename dialog box causes
+the text to become cropped.
+
+This issue is resolved by reducing the font size to fit the text
+field properly.
+
+Test Done:
+1. Boot the device with changes.
+2. Go to Settings.
+3. Navigate to Bluetooth.
+4. Rename the device name.
+5. Verify that the text is not cropped.
+
+Tracked-On: OAM-127240
+Signed-off-by: Bhadouria, Aman <aman.bhadouria@intel.com>
+---
+ .../car/settings/bluetooth/BluetoothRenameDialogFragment.java | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/com/android/car/settings/bluetooth/BluetoothRenameDialogFragment.java b/src/com/android/car/settings/bluetooth/BluetoothRenameDialogFragment.java
+index 2f8d11004..2effdd824 100644
+--- a/src/com/android/car/settings/bluetooth/BluetoothRenameDialogFragment.java
++++ b/src/com/android/car/settings/bluetooth/BluetoothRenameDialogFragment.java
+@@ -51,6 +51,7 @@ public abstract class BluetoothRenameDialogFragment extends CarUiDialogFragment
+     private static final String KEY_NAME = "device_name";
+ 
+     private static final int BLUETOOTH_NAME_MAX_LENGTH_BYTES = 248;
++    private static final float BLUETOOTH_RENAME_TEXT_OFFSET = 6.0f;
+ 
+     private AlertDialog mAlertDialog;
+     private String mDeviceName;
+@@ -100,6 +101,9 @@ public abstract class BluetoothRenameDialogFragment extends CarUiDialogFragment
+ 
+             EditText deviceNameView = getDeviceNameView();
+ 
++            // TODO: Decide the font size decrement dynamically
++            float textSize = deviceNameView.getTextSize();
++            deviceNameView.setTextSize(textSize - BLUETOOTH_RENAME_TEXT_OFFSET);
+             if (mDeviceName != null) {
+                 deviceNameView.setSelection(mDeviceName.length());
+             }
+-- 
+2.34.1
+


### PR DESCRIPTION
The default font size for the Bluetooth rename dialog box causes the text to become cropped.

This issue is resolved by reducing the font size to fit the text field properly.

This bug was fixed by Bhadouria on base_aaos, now add it to iasw Tested on MBL platform

Tracked-On: OAM-131131