### PR TITLE
Disable notification heads up on automotive platform

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Car/Notification/0001-Disable-notification-heads-up-on-automotive-platform.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Car/Notification/0001-Disable-notification-heads-up-on-automotive-platform.patch
@@ -1,0 +1,44 @@
+From e6219e310f9c46fbe7b39ea41d394e6699fea542 Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Tue, 1 Apr 2025 12:38:45 +0800
+Subject: [PATCH] Disable notification heads up on automotive platform
+
+Heads up notification always pops up when the app receive notification
+broadcast. It will influence the driver, so we disable it.
+
+Tracked-On: OAM-131383
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ .../car/notification/CarHeadsUpNotificationManager.java   | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/com/android/car/notification/CarHeadsUpNotificationManager.java b/src/com/android/car/notification/CarHeadsUpNotificationManager.java
+index 32943695..af306415 100644
+--- a/src/com/android/car/notification/CarHeadsUpNotificationManager.java
++++ b/src/com/android/car/notification/CarHeadsUpNotificationManager.java
+@@ -696,18 +696,18 @@ public class CarHeadsUpNotificationManager
+ 
+         if (NotificationUtils.isSystemPrivilegedOrPlatformKey(mContext, alertEntry)) {
+             if (DEBUG) {
+-                Log.d(TAG, "Show as HUN: application is system privileged or signed with "
++                Log.d(TAG, "Don't show as HUN: application is system privileged or signed with "
+                         + "platform key");
+             }
+-            return true;
++            return false;
+         }
+ 
+         // Allow car messaging type.
+         if (isCarCompatibleMessagingNotification(alertEntry.getStatusBarNotification())) {
+             if (DEBUG) {
+-                Log.d(TAG, "Show as HUN: car messaging type notification");
++                Log.d(TAG, "Don't show as HUN: car messaging type notification");
+             }
+-            return true;
++            return false;
+         }
+ 
+         if (notification.category == null) {
+-- 
+2.34.1
+


### PR DESCRIPTION
Heads up notification always pops up when the app receive notification broadcast. It will influence the driver, so we disable it.

Tracked-On: OAM-131383