### PR TITLE
Add property to disable notification heads up on automotive platform

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Car/Notification/0001-Add-property-to-disable-notification-heads-up-on-aut.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Car/Notification/0001-Add-property-to-disable-notification-heads-up-on-aut.patch
@@ -1,0 +1,75 @@
+From 996c1ac98cf366c74e2c72d021d27c98cc74da2f Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Tue, 1 Apr 2025 12:38:45 +0800
+Subject: [PATCH] Add property to disable notification heads up on automotive
+ platform
+
+Heads up notification always pops up when the app receive notification
+broadcast. It will influence the driver, so we disable it.
+Add property "persist.disable.notification.headsup" to control heads up
+notification, when the property set to true, notification will be
+disabled.
+
+Tracked-On: OAM-131570
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ .../CarHeadsUpNotificationManager.java        | 30 ++++++++++++++-----
+ 1 file changed, 23 insertions(+), 7 deletions(-)
+
+diff --git a/src/com/android/car/notification/CarHeadsUpNotificationManager.java b/src/com/android/car/notification/CarHeadsUpNotificationManager.java
+index 32943695..eeabd64c 100644
+--- a/src/com/android/car/notification/CarHeadsUpNotificationManager.java
++++ b/src/com/android/car/notification/CarHeadsUpNotificationManager.java
+@@ -36,6 +36,7 @@ import android.car.drivingstate.CarUxRestrictions;
+ import android.car.drivingstate.CarUxRestrictionsManager;
+ import android.content.Context;
+ import android.os.Build;
++import android.os.SystemProperties;
+ import android.service.notification.NotificationListenerService;
+ import android.util.Log;
+ import android.util.Pair;
+@@ -695,19 +696,34 @@ public class CarHeadsUpNotificationManager
+         }
+ 
+         if (NotificationUtils.isSystemPrivilegedOrPlatformKey(mContext, alertEntry)) {
+-            if (DEBUG) {
+-                Log.d(TAG, "Show as HUN: application is system privileged or signed with "
+-                        + "platform key");
++            if (SystemProperties.getBoolean("persist.disable.notification.headsup", false)) {
++                if (DEBUG) {
++                    Log.d(TAG, "Don't show as HUN: application is system privileged or signed with "
++                            + "platform key");
++                }
++                return false;
++            } else {
++                if (DEBUG) {
++                    Log.d(TAG, "Show as HUN: application is system privileged or signed with "
++                            + "platform key");
++                }
++                return true;
+             }
+-            return true;
+         }
+ 
+         // Allow car messaging type.
+         if (isCarCompatibleMessagingNotification(alertEntry.getStatusBarNotification())) {
+-            if (DEBUG) {
+-                Log.d(TAG, "Show as HUN: car messaging type notification");
++            if (SystemProperties.getBoolean("persist.disable.notification.headsup", false)) {
++                if (DEBUG) {
++                    Log.d(TAG, "Don't show as HUN: car messaging type notification");
++                }
++                return false;
++            } else {
++                if (DEBUG) {
++                    Log.d(TAG, "Show as HUN: car messaging type notification");
++                }
++                return true;
+             }
+-            return true;
+         }
+ 
+         if (notification.category == null) {
+-- 
+2.34.1
+


### PR DESCRIPTION
Heads up notification always pops up when the app receive notification broadcast. It will influence the driver, so we disable it. Add property "persist.disable.notification.headsup" to control heads up notification, when the property set to true, notification will be disabled.

Tracked-On: OAM-131570