### PR TITLE
Fix for improper text alignment in bluetooth rename dialog box

### DIFF
--- a/aosp_diff/base_aaos/packages/apps/Car/Settings/0001-Fix-for-improper-text-alignment-in-bluetooth-rename-.patch
+++ b/aosp_diff/base_aaos/packages/apps/Car/Settings/0001-Fix-for-improper-text-alignment-in-bluetooth-rename-.patch
@@ -1,4 +1,4 @@
-From 092299773ac369ef4b93f6b44f147dcefb0b1073 Mon Sep 17 00:00:00 2001
+From c20f302a04238c9b0b0dccc349f53cdb2a78f24f Mon Sep 17 00:00:00 2001
 From: "Bhadouria, Aman" <aman.bhadouria@intel.com>
 Date: Wed, 20 Nov 2024 07:38:12 +0000
 Subject: [PATCH] Fix for improper text alignment in bluetooth rename dialog
@@ -7,8 +7,9 @@ Subject: [PATCH] Fix for improper text alignment in bluetooth rename dialog
 The default font size for the Bluetooth rename dialog box causes
 the text to become cropped.
 
-This issue is resolved by reducing the font size to fit the text
-field properly.
+This issue is resolved by reducing the font size to
+BLUETOOTH_DEFAULT_TEXT_SIZE, if the font size is more than the
+default size
 
 Test Done:
 1. Boot the device with changes.
@@ -17,31 +18,45 @@ Test Done:
 4. Rename the device name.
 5. Verify that the text is not cropped.
 
-Tracked-On: OAM-127240
+Tracked-On: OAM-130987
 Signed-off-by: Bhadouria, Aman <aman.bhadouria@intel.com>
 ---
- .../car/settings/bluetooth/BluetoothRenameDialogFragment.java | 4 ++++
- 1 file changed, 4 insertions(+)
+ .../bluetooth/BluetoothRenameDialogFragment.java         | 9 +++++++++
+ 1 file changed, 9 insertions(+)
 
 diff --git a/src/com/android/car/settings/bluetooth/BluetoothRenameDialogFragment.java b/src/com/android/car/settings/bluetooth/BluetoothRenameDialogFragment.java
-index 2f8d11004..2effdd824 100644
+index 2f8d11004..cbb80e39b 100644
 --- a/src/com/android/car/settings/bluetooth/BluetoothRenameDialogFragment.java
 +++ b/src/com/android/car/settings/bluetooth/BluetoothRenameDialogFragment.java
-@@ -51,6 +51,7 @@ public abstract class BluetoothRenameDialogFragment extends CarUiDialogFragment
+@@ -32,6 +32,7 @@ import android.view.inputmethod.InputMethodManager;
+ import android.widget.Button;
+ import android.widget.EditText;
+ import android.widget.TextView;
++import android.util.Log;
+ 
+ import androidx.annotation.NonNull;
+ import androidx.annotation.Nullable;
+@@ -49,8 +50,10 @@ public abstract class BluetoothRenameDialogFragment extends CarUiDialogFragment
+ 
+     // Keys to save the edited name and edit status for restoring after configuration change.
      private static final String KEY_NAME = "device_name";
++    private static final String TAG = "BluetoothRenameDialogFragment";
  
      private static final int BLUETOOTH_NAME_MAX_LENGTH_BYTES = 248;
-+    private static final float BLUETOOTH_RENAME_TEXT_OFFSET = 6.0f;
++    private static final float BLUETOOTH_DEFAULT_TEXT_SIZE = 26.0f;
  
      private AlertDialog mAlertDialog;
      private String mDeviceName;
-@@ -100,6 +101,9 @@ public abstract class BluetoothRenameDialogFragment extends CarUiDialogFragment
+@@ -100,6 +103,12 @@ public abstract class BluetoothRenameDialogFragment extends CarUiDialogFragment
  
              EditText deviceNameView = getDeviceNameView();
  
-+            // TODO: Decide the font size decrement dynamically
++            // TODO: Set the font size dynamically based on AlertDialog
 +            float textSize = deviceNameView.getTextSize();
-+            deviceNameView.setTextSize(textSize - BLUETOOTH_RENAME_TEXT_OFFSET);
++            if (textSize > BLUETOOTH_DEFAULT_TEXT_SIZE) {
++                Log.d(TAG, "Default Text Size: " + textSize);
++                deviceNameView.setTextSize(BLUETOOTH_DEFAULT_TEXT_SIZE);
++            }
              if (mDeviceName != null) {
                  deviceNameView.setSelection(mDeviceName.length());
              }


### PR DESCRIPTION
The default font size for the Bluetooth rename dialog box causes the text to become cropped.

This issue is resolved by reducing the font size to BLUETOOTH_DEFAULT_TEXT_SIZE, if the font size is more than the default size

Test Done:
1. Boot the device with changes.
2. Go to Settings.
3. Navigate to Bluetooth.
4. Rename the device name.
5. Verify that the text is not cropped.

Tracked-On: OAM-130987