### PR TITLE
Increase carpowerpolicyd connecting to VHAL timeout

### DIFF
--- a/aosp_diff/aaos_iasw/packages/services/Car/0001-Increase-carpowerpolicyd-connecting-to-VHAL-timeout.patch
+++ b/aosp_diff/aaos_iasw/packages/services/Car/0001-Increase-carpowerpolicyd-connecting-to-VHAL-timeout.patch
@@ -1,0 +1,31 @@
+From 2cb26d9d9a0141faa2e163d1f58302f2959172a4 Mon Sep 17 00:00:00 2001
+From: Yu Shan <shanyu@google.com>
+Date: Mon, 4 Nov 2024 19:36:35 +0000
+Subject: [PATCH] Increase carpowerpolicyd connecting to VHAL timeout.
+
+Increase the timeout to be 60s. 5s is too short for some VHAL implementation to init.
+
+Change-Id: I0e804ff905b481d8420384889b0cb1e534a45ff4
+Flag: EXEMPT minor native code change
+Tests: Presubmit
+Bug: 377315129
+---
+ cpp/powerpolicy/server/src/CarPowerPolicyServer.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cpp/powerpolicy/server/src/CarPowerPolicyServer.cpp b/cpp/powerpolicy/server/src/CarPowerPolicyServer.cpp
+index c6746afccd..45c4e2218f 100644
+--- a/cpp/powerpolicy/server/src/CarPowerPolicyServer.cpp
++++ b/cpp/powerpolicy/server/src/CarPowerPolicyServer.cpp
+@@ -87,7 +87,7 @@ namespace {
+ const int32_t MSG_CONNECT_TO_VHAL = 1;  // Message to request of connecting to VHAL.
+ 
+ const nsecs_t kConnectionRetryIntervalNs = 200000000;  // 200 milliseconds.
+-const int32_t kMaxConnectionRetry = 25;                // Retry up to 5 seconds.
++const int32_t kMaxConnectionRetry = 5 * 60;                // Retry up to 60 seconds.
+ 
+ constexpr const char kCarServiceInterface[] = "car_service";
+ constexpr const char kCarPowerPolicyServerInterface[] =
+-- 
+2.45.2
+


### PR DESCRIPTION
cherry-pick a fix from aosp.

Tracked-On: OAM-130917