### PR TITLE
Enable 3.5mm audio

### DIFF
--- a/aosp_diff/caas/hardware/interfaces/0006-Enable-3.5mm-audio.patch
+++ b/aosp_diff/caas/hardware/interfaces/0006-Enable-3.5mm-audio.patch
@@ -1,0 +1,32 @@
+From 6f29dd555c0f3a20818bda300cc26fc23cda3d90 Mon Sep 17 00:00:00 2001
+From: padmashree mandri <padmashree.mandri@intel.com>
+Date: Wed, 9 Apr 2025 09:25:58 +0000
+Subject: [PATCH] Enable 3.5mm audio
+
+This patch enables 3.5mm audio for HDA sound card.
+
+Signed-off-by: padmashree mandri <padmashree.mandri@intel.com>
+---
+ audio/aidl/default/primary/StreamPrimary.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/audio/aidl/default/primary/StreamPrimary.cpp b/audio/aidl/default/primary/StreamPrimary.cpp
+index ebcfda36df..e9354d1627 100644
+--- a/audio/aidl/default/primary/StreamPrimary.cpp
++++ b/audio/aidl/default/primary/StreamPrimary.cpp
+@@ -113,9 +113,11 @@ std::vector<alsa::DeviceProfile> StreamPrimary::getDeviceProfiles() {
+     } else {
+         LOG(DEBUG) << "BT_SCO=OFF";
+         mCardAndDeviceId.first  = primary::PrimaryMixer::get_pcm_card("PCH");
+-        mCardAndDeviceId.second = primary::PrimaryMixer::get_pcm_device(mCardAndDeviceId.first);
++        mCardAndDeviceId.second = 0;
++        LOG(DEBUG) << "parsed with card: " << mCardAndDeviceId.first << "and Device: " << mCardAndDeviceId.second;
+ 	// fallback to Dummy card if no sound card is found in primary
+         if (mCardAndDeviceId.first == -1 || mCardAndDeviceId.second == -1 ) {
++            LOG(DEBUG) << "Fallback to dummy parsed with card: " << mCardAndDeviceId.first << "and Device: " << mCardAndDeviceId.second;
+             mCardAndDeviceId.first  = primary::PrimaryMixer::get_pcm_card("Dummy");
+             mCardAndDeviceId.second = 0;
+         }
+-- 
+2.34.1
+


### PR DESCRIPTION
This patch adds changes to enable 3.5mm playback/record for HDA sound card.