### PR TITLE
Fix CTS issue - c2.android.av1.encoder bitrate overshooted

### DIFF
--- a/aosp_diff/preliminary/frameworks/av/0008-Fix-CTS-issue-c2.android.av1.encoder-bitrate-oversho.patch
+++ b/aosp_diff/preliminary/frameworks/av/0008-Fix-CTS-issue-c2.android.av1.encoder-bitrate-oversho.patch
@@ -1,0 +1,37 @@
+From f4388df8b8c98b3f651aef94f61e9488601c336b Mon Sep 17 00:00:00 2001
+From: "Wan, Hao" <haox.wan@intel.com>
+Date: Fri, 11 Apr 2025 16:10:10 +0000
+Subject: [PATCH] Fix CTS issue - c2.android.av1.encoder bitrate overshooted
+
+CTS Module: MctsMediaCodecTestCases
+Test case:
+android.media.codec.cts.VideoCodecTest#testBasic[9_c2.android.av1.encoder_video/av01_1]
+
+Moderately increase the rc_min_quantizer value to reduce the resulting average bitrate.
+
+Tracked-On: OAM-130965
+Signed-off-by: Wan, Hao <haox.wan@intel.com>
+---
+ media/codec2/components/aom/C2SoftAomEnc.cpp | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/media/codec2/components/aom/C2SoftAomEnc.cpp b/media/codec2/components/aom/C2SoftAomEnc.cpp
+index 722b13a568..3fb6216091 100644
+--- a/media/codec2/components/aom/C2SoftAomEnc.cpp
++++ b/media/codec2/components/aom/C2SoftAomEnc.cpp
+@@ -733,7 +733,12 @@ status_t C2SoftAomEnc::initEncoder() {
+     }
+     if (mMinQuantizer > 0) {
+         mCodecConfiguration->rc_min_quantizer = mMinQuantizer;
++    } else {
++        if (mBitrateControlMode == AOM_VBR) {
++            mCodecConfiguration->rc_min_quantizer = 8;
++        }
+     }
++
+     if (mMaxQuantizer > 0) {
+         mCodecConfiguration->rc_max_quantizer = mMaxQuantizer;
+     } else {
+-- 
+2.34.1
+


### PR DESCRIPTION
CTS Module: MctsMediaCodecTestCases
Test case:
android.media.codec.cts.VideoCodecTest#testBasic[9_c2.android.av1.encoder_video/av01_1]

Moderately increase the rc_min_quantizer value to reduce the resulting average bitrate.

Tracked-On: OAM-130965