### PR TITLE
Add "Select camera" menu on the settings of camera app

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Camera2/0001-Add-Select-camera-menu-on-the-settings-of-camera-app.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Camera2/0001-Add-Select-camera-menu-on-the-settings-of-camera-app.patch
@@ -1,0 +1,459 @@
+From ba5e23d1951fafa37d25ff3ffcd729ba8b78a65b Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Mon, 21 Apr 2025 14:23:59 +0800
+Subject: [PATCH] Add "Select camera" menu on the settings of camera app
+
+Open different cameras based on the settings value, including
+taking photos and recording videos, and remove the icons of
+selecting front and rear cameras for image preview and video
+preview.
+
+Tracked-On: OAM-132121
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ res/layout-land/mode_options.xml              |  5 --
+ res/layout-port/mode_options.xml              |  5 --
+ res/layout/photo_bottombar_buttons.xml        |  6 ---
+ res/layout/photo_intent_bottombar_buttons.xml |  6 ---
+ res/layout/video_bottombar_buttons.xml        |  6 ---
+ res/layout/video_intent_bottombar_buttons.xml |  6 ---
+ res/values/arrays.xml                         | 14 ++++++
+ res/values/strings.xml                        |  2 +
+ res/xml/camera_preferences.xml                |  7 +++
+ src/com/android/camera/ButtonManager.java     | 10 +---
+ src/com/android/camera/CaptureModule.java     | 10 ++++
+ src/com/android/camera/VideoModule.java       | 18 ++++++-
+ src/com/android/camera/app/CameraAppUI.java   | 20 --------
+ .../settings/CameraSettingsActivity.java      | 47 +++++++++++++++++++
+ src/com/android/camera/settings/Keys.java     |  1 +
+ 15 files changed, 98 insertions(+), 65 deletions(-)
+
+diff --git a/res/layout-land/mode_options.xml b/res/layout-land/mode_options.xml
+index 7e49f4557..5a9f7d392 100644
+--- a/res/layout-land/mode_options.xml
++++ b/res/layout-land/mode_options.xml
+@@ -92,11 +92,6 @@
+         android:clipChildren="false"
+         android:clipToPadding="false"
+         android:alpha="0.0" >
+-        <com.android.camera.MultiToggleImageButton
+-            android:id="@+id/camera_toggle_button"
+-            style="@style/ModeOption"
+-            camera:imageIds="@array/camera_id_icons"
+-            camera:contentDescriptionIds="@array/camera_id_descriptions" />
+         <com.android.camera.MultiToggleImageButton
+             android:id="@+id/flash_toggle_button"
+             style="@style/ModeOption"
+diff --git a/res/layout-port/mode_options.xml b/res/layout-port/mode_options.xml
+index d9508bf5e..2603b3087 100644
+--- a/res/layout-port/mode_options.xml
++++ b/res/layout-port/mode_options.xml
+@@ -117,10 +117,5 @@
+             style="@style/ModeOption"
+             camera:imageIds="@array/camera_flashmode_icons"
+             camera:contentDescriptionIds="@array/camera_flash_descriptions" />
+-        <com.android.camera.MultiToggleImageButton
+-            android:id="@+id/camera_toggle_button"
+-            style="@style/ModeOption"
+-            camera:imageIds="@array/camera_id_icons"
+-            camera:contentDescriptionIds="@array/camera_id_descriptions" />
+     </com.android.camera.ui.TopRightWeightedLayout>
+ </com.android.camera.widget.ModeOptions>
+diff --git a/res/layout/photo_bottombar_buttons.xml b/res/layout/photo_bottombar_buttons.xml
+index fea91e23c..b152820b2 100644
+--- a/res/layout/photo_bottombar_buttons.xml
++++ b/res/layout/photo_bottombar_buttons.xml
+@@ -24,12 +24,6 @@
+             android:layout_height="wrap_content"
+             android:background="@null"
+             camera:imageIds="@array/camera_flashmode_icons" />
+-        <com.android.camera.MultiToggleImageButton
+-            android:id="@+id/camera_toggle_button"
+-            android:layout_width="wrap_content"
+-            android:layout_height="wrap_content"
+-            android:background="@null"
+-            camera:imageIds="@array/camera_id_icons" />
+         <com.android.camera.MultiToggleImageButton
+             android:id="@+id/hdr_plus_toggle_button"
+             android:layout_width="wrap_content"
+diff --git a/res/layout/photo_intent_bottombar_buttons.xml b/res/layout/photo_intent_bottombar_buttons.xml
+index eecf3e35a..d351611ad 100644
+--- a/res/layout/photo_intent_bottombar_buttons.xml
++++ b/res/layout/photo_intent_bottombar_buttons.xml
+@@ -35,12 +35,6 @@
+             android:layout_height="wrap_content"
+             android:background="@null"
+             camera:imageIds="@array/camera_flashmode_icons" />
+-        <com.android.camera.MultiToggleImageButton
+-            android:id="@+id/camera_toggle_button"
+-            android:layout_width="wrap_content"
+-            android:layout_height="wrap_content"
+-            android:background="@null"
+-            camera:imageIds="@array/camera_id_icons" />
+         <com.android.camera.MultiToggleImageButton
+             android:id="@+id/hdr_plus_toggle_button"
+             android:layout_width="wrap_content"
+diff --git a/res/layout/video_bottombar_buttons.xml b/res/layout/video_bottombar_buttons.xml
+index 5780c5409..d1399f0c9 100644
+--- a/res/layout/video_bottombar_buttons.xml
++++ b/res/layout/video_bottombar_buttons.xml
+@@ -24,10 +24,4 @@
+             android:layout_height="wrap_content"
+             android:background="@null"
+             camera:imageIds="@array/video_flashmode_icons" />
+-        <com.android.camera.MultiToggleImageButton
+-            android:id="@+id/camera_toggle_button"
+-            android:layout_width="wrap_content"
+-            android:layout_height="wrap_content"
+-            android:background="@null"
+-            camera:imageIds="@array/camera_id_icons" />
+ </merge>
+\ No newline at end of file
+diff --git a/res/layout/video_intent_bottombar_buttons.xml b/res/layout/video_intent_bottombar_buttons.xml
+index a974cf2ba..2edfff19c 100644
+--- a/res/layout/video_intent_bottombar_buttons.xml
++++ b/res/layout/video_intent_bottombar_buttons.xml
+@@ -35,10 +35,4 @@
+             android:layout_height="wrap_content"
+             android:background="@null"
+             camera:imageIds="@array/video_flashmode_icons" />
+-        <com.android.camera.MultiToggleImageButton
+-            android:id="@+id/camera_toggle_button"
+-            android:layout_width="wrap_content"
+-            android:layout_height="wrap_content"
+-            android:background="@null"
+-            camera:imageIds="@array/camera_id_icons" />
+ </merge>
+diff --git a/res/values/arrays.xml b/res/values/arrays.xml
+index 487265780..ea3c2547f 100644
+--- a/res/values/arrays.xml
++++ b/res/values/arrays.xml
+@@ -58,6 +58,20 @@
+         <item>macro</item>
+     </string-array>
+ 
++    <string-array name="pref_camera_id_option_values" translatable="false">
++        <item>0</item>
++        <item>1</item>
++        <item>2</item>
++        <item>3</item>
++    </string-array>
++
++    <string-array name="pref_camera_id_option" translatable="false">
++        <item>camera id:</item>
++        <item>camera id:</item>
++        <item>camera id:</item>
++        <item>camera id:</item>
++    </string-array>
++
+     <string-array name="pref_camera_focusmode_labels" translatable="false">
+         <item>@string/pref_camera_focusmode_label_auto</item>
+         <item>@string/pref_camera_focusmode_label_infinity</item>
+diff --git a/res/values/strings.xml b/res/values/strings.xml
+index 923a068c4..19fd66ad9 100644
+--- a/res/values/strings.xml
++++ b/res/values/strings.xml
+@@ -826,6 +826,8 @@
+ 
+     <!-- Text shown in camera settings list for toggling photo location on or off [CHAR LIMIT=25] -->
+     <string name="setting_location">Location</string>
++    <!-- Camera settings title for back camera photo resolution. [CHAR LIMIT=25] -->
++    <string name="setting_camera_id_selection">Select camera</string>
+ 
+     <!-- Camera settings title for back camera photo resolution. [CHAR LIMIT=25] -->
+     <string name="setting_back_camera_photo">Back camera photo</string>
+diff --git a/res/xml/camera_preferences.xml b/res/xml/camera_preferences.xml
+index 9c2a1a274..824b78003 100644
+--- a/res/xml/camera_preferences.xml
++++ b/res/xml/camera_preferences.xml
+@@ -54,6 +54,13 @@
+     </PreferenceCategory>
+   </PreferenceScreen>
+ 
++<ListPreference
++    android:defaultValue="0"
++    android:entries="@array/pref_camera_id_option"
++    android:entryValues="@array/pref_camera_id_option_values"
++    android:key="pref_category_camera_id_select"
++    android:title="@string/setting_camera_id_selection" />
++
+   <!-- Location -->
+   <com.android.camera.settings.ManagedSwitchPreference
+       android:defaultValue="false"
+diff --git a/src/com/android/camera/ButtonManager.java b/src/com/android/camera/ButtonManager.java
+index 15d1acde0..e84656133 100644
+--- a/src/com/android/camera/ButtonManager.java
++++ b/src/com/android/camera/ButtonManager.java
+@@ -62,7 +62,6 @@ public class ButtonManager implements SettingsManager.OnSettingChangedListener {
+     private final SettingsManager mSettingsManager;
+ 
+     /** Bottom bar options toggle buttons. */
+-    private MultiToggleImageButton mButtonCamera;
+     private MultiToggleImageButton mButtonFlash;
+     private MultiToggleImageButton mButtonHdr;
+     private MultiToggleImageButton mButtonGridlines;
+@@ -149,8 +148,6 @@ public class ButtonManager implements SettingsManager.OnSettingChangedListener {
+      * Gets references to all known buttons.
+      */
+     private void getButtonsReferences(View root) {
+-        mButtonCamera
+-            = (MultiToggleImageButton) root.findViewById(R.id.camera_toggle_button);
+         mButtonFlash
+             = (MultiToggleImageButton) root.findViewById(R.id.flash_toggle_button);
+         mButtonHdr
+@@ -259,11 +256,6 @@ public class ButtonManager implements SettingsManager.OnSettingChangedListener {
+                     throw new IllegalStateException("Hdr plus torch button could not be found.");
+                 }
+                 return mButtonFlash;
+-            case BUTTON_CAMERA:
+-                if (mButtonCamera == null) {
+-                    throw new IllegalStateException("Camera button could not be found.");
+-                }
+-                return mButtonCamera;
+             case BUTTON_HDR_PLUS:
+                 if (mButtonHdr == null) {
+                     throw new IllegalStateException("Hdr plus button could not be found.");
+@@ -484,7 +476,7 @@ public class ButtonManager implements SettingsManager.OnSettingChangedListener {
+      */
+     public void enableButton(int buttonId) {
+         // If Camera Button is blocked, ignore the request.
+-        if(buttonId == BUTTON_CAMERA && mIsCameraButtonBlocked) {
++        if(buttonId == BUTTON_CAMERA) {
+             return;
+         }
+         ImageButton button;
+diff --git a/src/com/android/camera/CaptureModule.java b/src/com/android/camera/CaptureModule.java
+index 32417f60e..8541ec42c 100644
+--- a/src/com/android/camera/CaptureModule.java
++++ b/src/com/android/camera/CaptureModule.java
+@@ -16,7 +16,10 @@
+ 
+ package com.android.camera;
+ 
++import static com.android.camera.settings.Keys.KEY_CAMERA_ID_SELECTION;
++
+ import android.content.Context;
++import android.content.SharedPreferences;
+ import android.graphics.Matrix;
+ import android.graphics.Point;
+ import android.graphics.RectF;
+@@ -28,6 +31,7 @@ import android.os.AsyncTask;
+ import android.os.Handler;
+ import android.os.HandlerThread;
+ import android.os.SystemClock;
++import android.preference.PreferenceManager;
+ import android.view.GestureDetector;
+ import android.view.KeyEvent;
+ import android.view.MotionEvent;
+@@ -1385,6 +1389,12 @@ public class CaptureModule extends CameraModule implements
+         boolean useHdr = mHdrPlusEnabled && mCameraFacing == Facing.BACK;
+ 
+         CameraId cameraId = mOneCameraManager.findFirstCameraFacing(mCameraFacing);
++        SharedPreferences defaultPrefs = PreferenceManager.getDefaultSharedPreferences(mContext);
++        String value = defaultPrefs.getString(KEY_CAMERA_ID_SELECTION, "0");
++        Log.i(TAG, "openCameraAndStartPreview......... cameraid value: " + value);
++        if (cameraId.getValue() != value) {
++            cameraId = CameraId.from(value);
++        }
+         final String settingScope = SettingsManager.getCameraSettingScope(cameraId.getValue());
+ 
+         OneCameraCaptureSetting captureSetting;
+diff --git a/src/com/android/camera/VideoModule.java b/src/com/android/camera/VideoModule.java
+index 1c6581e63..49796fe8b 100644
+--- a/src/com/android/camera/VideoModule.java
++++ b/src/com/android/camera/VideoModule.java
+@@ -16,6 +16,8 @@
+ 
+ package com.android.camera;
+ 
++import static com.android.camera.settings.Keys.KEY_CAMERA_ID_SELECTION;
++
+ import android.app.Activity;
+ import android.content.ActivityNotFoundException;
+ import android.content.BroadcastReceiver;
+@@ -24,6 +26,7 @@ import android.content.ContentValues;
+ import android.content.Context;
+ import android.content.Intent;
+ import android.content.IntentFilter;
++import android.content.SharedPreferences;
+ import android.graphics.Bitmap;
+ import android.graphics.Point;
+ import android.graphics.SurfaceTexture;
+@@ -41,6 +44,7 @@ import android.os.Looper;
+ import android.os.Message;
+ import android.os.ParcelFileDescriptor;
+ import android.os.SystemClock;
++import android.preference.PreferenceManager;
+ import android.provider.MediaStore;
+ import android.provider.MediaStore.MediaColumns;
+ import android.provider.MediaStore.Video;
+@@ -339,8 +343,11 @@ public class VideoModule extends CameraModule
+         mActivity.setPreviewStatusListener(mUI);
+ 
+         SettingsManager settingsManager = mActivity.getSettingsManager();
+-        mCameraId = settingsManager.getInteger(mAppController.getModuleScope(),
+-                                               Keys.KEY_CAMERA_ID);
++        //get from camera select settings
++        SharedPreferences defaultPrefs =
++                PreferenceManager.getDefaultSharedPreferences(mAppController.getAndroidContext());
++        String value = defaultPrefs.getString(KEY_CAMERA_ID_SELECTION, "0");
++        mCameraId = Integer.parseInt(value);
+ 
+         /*
+          * To reduce startup time, we start the preview in another thread.
+@@ -1759,6 +1766,13 @@ public class VideoModule extends CameraModule
+ 
+         showVideoSnapshotUI(false);
+ 
++        //re-get from camera select settings to avoid value changed
++        SharedPreferences defaultPrefs =
++                PreferenceManager.getDefaultSharedPreferences(mAppController.getAndroidContext());
++        String value = defaultPrefs.getString(KEY_CAMERA_ID_SELECTION, "0");
++        Log.i(TAG, "resume........ cameraid value: " + value);
++        mCameraId = Integer.parseInt(value);
++
+         if (!mPreviewing) {
+             requestCamera(mCameraId);
+         } else {
+diff --git a/src/com/android/camera/app/CameraAppUI.java b/src/com/android/camera/app/CameraAppUI.java
+index 94bb69f09..508355099 100644
+--- a/src/com/android/camera/app/CameraAppUI.java
++++ b/src/com/android/camera/app/CameraAppUI.java
+@@ -2047,26 +2047,6 @@ public class CameraAppUI implements ModeListView.ModeSwitchListener,
+             mHdrSupportMode = settingsManager.getString(SettingsManager.SCOPE_GLOBAL,
+                     Keys.KEY_HDR_SUPPORT_MODE_BACK_CAMERA);
+ 
+-            /** Standard mode options */
+-            if (mController.getCameraProvider().getNumberOfCameras() > 1 &&
+-                    hardwareSpec.isFrontCameraSupported()) {
+-                if (bottomBarSpec.enableCamera) {
+-                    int hdrButtonId = ButtonManager.BUTTON_HDR;
+-                    if (mHdrSupportMode.equals(getResourceString(
+-                            R.string.pref_camera_hdr_supportmode_hdr_plus))) {
+-                        hdrButtonId = ButtonManager.BUTTON_HDR_PLUS;
+-                    }
+-                    buttonManager.initializeButton(ButtonManager.BUTTON_CAMERA,
+-                            bottomBarSpec.cameraCallback,
+-                            getDisableButtonCallback(hdrButtonId));
+-                } else {
+-                    buttonManager.disableButton(ButtonManager.BUTTON_CAMERA);
+-                }
+-            } else {
+-                // Hide camera icon if front camera not available.
+-                buttonManager.hideButton(ButtonManager.BUTTON_CAMERA);
+-            }
+-
+             boolean flashBackCamera = settingsManager.getBoolean(SettingsManager.SCOPE_GLOBAL,
+                     Keys.KEY_FLASH_SUPPORTED_BACK_CAMERA);
+             if (bottomBarSpec.hideFlash
+diff --git a/src/com/android/camera/settings/CameraSettingsActivity.java b/src/com/android/camera/settings/CameraSettingsActivity.java
+index 235577a30..e62d7b165 100644
+--- a/src/com/android/camera/settings/CameraSettingsActivity.java
++++ b/src/com/android/camera/settings/CameraSettingsActivity.java
+@@ -16,6 +16,8 @@
+ 
+ package com.android.camera.settings;
+ 
++import static com.android.camera.settings.Keys.KEY_CAMERA_ID_SELECTION;
++
+ import android.Manifest;
+ import android.app.ActionBar;
+ import android.app.Activity;
+@@ -24,6 +26,8 @@ import android.content.Intent;
+ import android.content.pm.PackageManager;
+ import android.content.SharedPreferences;
+ import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
++import android.hardware.camera2.CameraAccessException;
++import android.hardware.camera2.CameraManager;
+ import android.os.Bundle;
+ import android.preference.ListPreference;
+ import android.preference.Preference;
+@@ -53,15 +57,18 @@ import com.android.camera.one.OneCameraManager;
+ import com.android.camera.one.OneCameraModule;
+ import com.android.camera.settings.PictureSizeLoader.PictureSizes;
+ import com.android.camera.settings.SettingsUtil.SelectedVideoQualities;
++import com.android.camera.util.AndroidServices;
+ import com.android.camera.util.CameraSettingsActivityHelper;
+ import com.android.camera.util.GoogleHelpHelper;
+ import com.android.camera.util.Size;
+ import com.android.camera2.R;
+ import com.android.ex.camera2.portability.CameraAgentFactory;
+ import com.android.ex.camera2.portability.CameraDeviceInfo;
++import com.google.common.base.Optional;
+ 
+ import java.text.DecimalFormat;
+ import java.util.ArrayList;
++import java.util.Arrays;
+ import java.util.List;
+ 
+ /**
+@@ -236,7 +243,46 @@ public class CameraSettingsActivity extends FragmentActivity {
+             if (!mHideAdvancedScreen) {
+                 setPreferenceScreenIntent(advancedScreen);
+             }
++            CameraManager cameraManager;
++            ListPreference listPreference = (ListPreference) findPreference(KEY_CAMERA_ID_SELECTION);
++            List<String> validCameraIds = new ArrayList<>();
++            try {
++                cameraManager = AndroidServices.instance().provideCameraManager();
++                try {
++                    String[] allCameraIds = cameraManager.getCameraIdList();
++                    for (String cameraId : allCameraIds) {
++                        if (Integer.parseInt(cameraId) < 50) {
++                            validCameraIds.add(cameraId);
++                            Log.v(TAG, "Get camera : " + cameraId);
++                        } else {
++                            Log.v(TAG, "Skipping camera with ID >= 50: " + cameraId);
++                        }
++                    }
++                    int numOfCameras = validCameraIds.size();
+ 
++                    if (numOfCameras != 0) {
++                        String[] CameraArray = new String[numOfCameras];
++                        for(int i = 0; i < numOfCameras; i++ ){
++                            CameraArray[i] = "Camera ID:  " + String.valueOf(i);
++                        }
++
++                        listPreference.setEntries(CameraArray);
++                        listPreference.setEntryValues(validCameraIds.toArray(new String[0]));
++                    }
++                } catch (CameraAccessException ex) {
++                    Log.e(TAG, "Unable to read camera list.", ex);
++                }
++            } catch (IllegalStateException ex) {
++                Log.e(TAG, "camera2.CameraManager is not available.");
++            }
++
++            listPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
++                @Override
++                public boolean onPreferenceChange(Preference preference, Object newValue) {
++                    Log.d(TAG, "onPreferenceChange.....new camera id value: " + newValue);
++                    return true; // 返回true表示接受这个变化
++                }
++            });
+             getPreferenceScreen().getSharedPreferences()
+                     .registerOnSharedPreferenceChangeListener(this);
+         }
+@@ -384,6 +430,7 @@ public class CameraSettingsActivity extends FragmentActivity {
+          * to be a {@link ListPreference}
+          */
+         private void setEntries(Preference preference) {
++            Log.d(TAG, "setEntries.....");
+             if (!(preference instanceof ListPreference)) {
+                 return;
+             }
+diff --git a/src/com/android/camera/settings/Keys.java b/src/com/android/camera/settings/Keys.java
+index 0339ea6c7..4e9aea796 100644
+--- a/src/com/android/camera/settings/Keys.java
++++ b/src/com/android/camera/settings/Keys.java
+@@ -81,6 +81,7 @@ public class Keys {
+     public static final String KEY_SHOULD_SHOW_SETTINGS_BUTTON_CLING =
+             "pref_should_show_settings_button_cling";
+     public static final String KEY_HAS_SEEN_PERMISSIONS_DIALOGS = "pref_has_seen_permissions_dialogs";
++    public static final String KEY_CAMERA_ID_SELECTION = "pref_category_camera_id_select";
+ 
+     /**
+      * Set some number of defaults for the defined keys.
+-- 
+2.34.1
+


### PR DESCRIPTION
Open different cameras based on the settings value, including taking photos and recording videos, and remove the icons of selecting front and rear cameras for image preview and video preview.

Tracked-On: OAM-132121