### PR TITLE
Enable 3.5mm audio

### DIFF
--- a/bsp_diff/caas/hardware/interfaces/0006-Enable-3.5mm-audio.patch
+++ b/bsp_diff/caas/hardware/interfaces/0006-Enable-3.5mm-audio.patch
@@ -1,0 +1,29 @@
+From c2542c1b307a4114f68a90b98b6a5254250da149 Mon Sep 17 00:00:00 2001
+From: padmashree mandri <padmashree.mandri@intel.com>
+Date: Wed, 30 Apr 2025 03:23:44 +0000
+Subject: [PATCH] Enable 3.5mm audio
+
+This patch enables 3.5mm audio for HDA sound card.
+
+Tracked-On:
+Signed-off-by: padmashree mandri <padmashree.mandri@intel.com>
+---
+ audio/aidl/default/primary/StreamPrimary.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/audio/aidl/default/primary/StreamPrimary.cpp b/audio/aidl/default/primary/StreamPrimary.cpp
+index b7f0481d6c..210e81f88a 100644
+--- a/audio/aidl/default/primary/StreamPrimary.cpp
++++ b/audio/aidl/default/primary/StreamPrimary.cpp
+@@ -117,7 +117,7 @@ std::pair<int, int> StreamPrimary::getCardAndDeviceId(const std::vector<AudioDev
+     std::string deviceAddress = devices[0].address.get<AudioDeviceAddress::id>();
+     std::pair<int, int> cardAndDeviceId;
+     cardAndDeviceId.first  = primary::PrimaryMixer::get_pcm_card("PCH");
+-    cardAndDeviceId.second = primary::PrimaryMixer::get_pcm_device(cardAndDeviceId.first);
++    cardAndDeviceId.second = 0;
+     LOG(DEBUG) << __func__ << ": parsed with card id " << cardAndDeviceId.first << ", device id "
+                << cardAndDeviceId.second;
+     return cardAndDeviceId;
+-- 
+2.34.1
+


### PR DESCRIPTION
This patch adds changes to enable 3.5mm playback/record for HDA sound card.

Tracked-On