### PR TITLE
Fix for android boot failure with trusty

### DIFF
--- a/bsp_diff/caas/hardware/intel/kernelflinger/0003-Fix-for-android-boot-failure-with-trusty.patch
+++ b/bsp_diff/caas/hardware/intel/kernelflinger/0003-Fix-for-android-boot-failure-with-trusty.patch
@@ -1,0 +1,43 @@
+From 9b263a9199df682cdc4789393bb761b004c58bb0 Mon Sep 17 00:00:00 2001
+From: "Bhadouria, Aman" <aman.bhadouria@intel.com>
+Date: Mon, 11 Nov 2024 04:14:28 +0000
+Subject: [PATCH] Fix for android boot failure with trusty
+
+Android fails to boot on MTL platforms when trusty is enabled,
+this is caused by a vmcall to activate VTD.
+
+After enabling VTD from the bios settings this vmcall is not
+required.
+
+Tests Done:
+1. Flash the image in MTL nuc and CiV
+2. Android is booting fine
+
+Tracked-On: OAM-127253
+Signed-off-by: Balaji, M <m.balaji@intel.com>
+Signed-off-by: Bhadouria, Aman <aman.bhadouria@intel.com>
+---
+ libkernelflinger/android.c | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/libkernelflinger/android.c b/libkernelflinger/android.c
+index e7b9c25..0912a93 100644
+--- a/libkernelflinger/android.c
++++ b/libkernelflinger/android.c
+@@ -471,13 +471,6 @@ static inline EFI_STATUS handover_jump(EFI_HANDLE image,
+ 
+ boot:
+ 
+-#ifdef USE_TRUSTY
+-        /*
+-         * Called after ExitBootService.
+-         */
+-        trusty_late_init();
+-#endif
+-
+ #if __LP64__
+         /* The 64-bit kernel entry is 512 bytes after the start. */
+         kernel_start += 512;
+-- 
+2.34.1
+


### PR DESCRIPTION
Android fails to boot on MTL platforms when trusty is enabled, this is caused by a vmcall to activate VTD.

After enabling VTD from the bios settings this vmcall is not required.

Tests Done:
1. Flash the image in MTL nuc and CiV
2. Android is booting fine

Tracked-On: OAM-132238