### PR TITLE
Allow canvas to be replaced on android 15

### DIFF
--- a/aosp_diff/aaos_iasw/frameworks/base/0001-Allow-canvas-to-be-replaced-on-android-15.patch
+++ b/aosp_diff/aaos_iasw/frameworks/base/0001-Allow-canvas-to-be-replaced-on-android-15.patch
@@ -1,0 +1,35 @@
+From 113c66ad8a03983d7198eb6865bc4180edef928a Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Tue, 6 May 2025 12:51:17 +0800
+Subject: [PATCH] Allow canvas to be replaced on android 15
+
+Sysytem will check canvas option on android 15, only INTERSECT and
+DIFFERENCE are allowed, ui will not update with these two options,
+add REPLACE option to update canvas.
+
+Tracked-On: OAM-132182
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ graphics/java/android/graphics/Canvas.java | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/graphics/java/android/graphics/Canvas.java b/graphics/java/android/graphics/Canvas.java
+index 28c2ca36fd2e..7d2f622f7673 100644
+--- a/graphics/java/android/graphics/Canvas.java
++++ b/graphics/java/android/graphics/Canvas.java
+@@ -846,9 +846,10 @@ public class Canvas extends BaseCanvas {
+ 
+     private static void checkValidClipOp(@NonNull Region.Op op) {
+         if (sCompatibilityVersion >= Build.VERSION_CODES.P
+-                && op != Region.Op.INTERSECT && op != Region.Op.DIFFERENCE) {
++                && op != Region.Op.INTERSECT && op != Region.Op.DIFFERENCE
++                && op != Region.Op.REPLACE) {
+             throw new IllegalArgumentException(
+-                    "Invalid Region.Op - only INTERSECT and DIFFERENCE are allowed");
++                    "Invalid Region.Op - only INTERSECT, REPLACE and DIFFERENCE are allowed");
+         }
+     }
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
Sysytem will check canvas option on android 15, only INTERSECT and DIFFERENCE are allowed, ui will not update with these two options, add REPLACE option to update canvas.

Tracked-On: OAM-132182