### PR TITLE
Fix Potential Null Pointer Crash in CameraActivity

### DIFF
--- a/aosp_diff/preliminary/packages/apps/Camera2/07_0007-Fix-Potential-Null-Pointer-Crash-in-CameraActivity.patch
+++ b/aosp_diff/preliminary/packages/apps/Camera2/07_0007-Fix-Potential-Null-Pointer-Crash-in-CameraActivity.patch
@@ -1,0 +1,37 @@
+From d33dc8cb3ffc5684f3e43ad5123e2e9279b73c0d Mon Sep 17 00:00:00 2001
+From: NaveenVenturi1203 <venturi.naveen@intel.com>
+Date: Fri, 9 May 2025 11:03:03 +0000
+Subject: [PATCH] Fix Potential Null Pointer Crash in CameraActivity
+
+Uri Null pointer is not verified before getting type
+
+Validated URI before fetching mimetype
+
+Tracked-On: OAM-128685
+Signed-off-by: NaveenVenturi1203<venturi.naveen@intel.com>
+---
+ src/com/android/camera/CameraActivity.java | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/camera/CameraActivity.java b/src/com/android/camera/CameraActivity.java
+index eb5e71814..3133f57eb 100644
+--- a/src/com/android/camera/CameraActivity.java
++++ b/src/com/android/camera/CameraActivity.java
+@@ -1229,7 +1229,13 @@ public class CameraActivity extends QuickActivity
+ 
+         updateStorageSpaceAndHint(null);
+         ContentResolver cr = getContentResolver();
+-        String mimeType = cr.getType(uri);
++        String mimeType = null;
++        if(uri != null) {
++            mimeType = cr.getType(uri);
++        } else {
++            Log.e(TAG,"Invalid URI");
++            return;
++        }
+         FilmstripItem newData = null;
+         if (FilmstripItemUtils.isMimeTypeVideo(mimeType)) {
+             sendBroadcast(new Intent(CameraUtil.ACTION_NEW_VIDEO, uri));
+-- 
+2.34.1
+


### PR DESCRIPTION
Uri Null pointer is not verified before getting type

Validated URI before fetching mimetype

Tracked-On: OAM-128685