### PR TITLE
Fix the issue of MapsPlaceholderActivity disappearing abnormally

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Car/Launcher/0001-Fix-the-issue-of-MapsPlaceholderActivity-disappearin.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Car/Launcher/0001-Fix-the-issue-of-MapsPlaceholderActivity-disappearin.patch
@@ -1,0 +1,54 @@
+From c5a6638bad9dc767a25cfd81f5fc4feb3f831c2d Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Mon, 28 Apr 2025 12:16:48 +0800
+Subject: [PATCH] Fix the issue of MapsPlaceholderActivity disappearing
+ abnormally
+
+MapsPlaceholderActivity will be hid and it will be covered by
+red and white suface, so change the color to green.
+
+Tracked-ON: OAM-132415
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ app/src/com/android/car/carlauncher/CarLauncher.java          | 4 ++++
+ app/src/com/android/car/carlauncher/CarLauncherViewModel.java | 2 +-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/app/src/com/android/car/carlauncher/CarLauncher.java b/app/src/com/android/car/carlauncher/CarLauncher.java
+index 368e203c..85f6a6e0 100644
+--- a/app/src/com/android/car/carlauncher/CarLauncher.java
++++ b/app/src/com/android/car/carlauncher/CarLauncher.java
+@@ -39,6 +39,7 @@ import android.view.Display;
+ import android.view.View;
+ import android.view.ViewGroup;
+ import android.view.WindowManager;
++import android.graphics.Color;
+ 
+ import androidx.collection.ArraySet;
+ import androidx.fragment.app.FragmentActivity;
+@@ -200,6 +201,9 @@ public class CarLauncher extends FragmentActivity {
+             }
+             parent.removeAllViews(); // Just a defense against a dirty parent.
+             parent.addView(taskView);
++            //reset background color.
++            mCarLauncherViewModel.getRemoteCarTaskView().getValue()
++                    .setBackgroundColor(Color.rgb(65, 175, 106));
+         });
+     }
+ 
+diff --git a/app/src/com/android/car/carlauncher/CarLauncherViewModel.java b/app/src/com/android/car/carlauncher/CarLauncherViewModel.java
+index 2acbfa89..0f9a90d6 100644
+--- a/app/src/com/android/car/carlauncher/CarLauncherViewModel.java
++++ b/app/src/com/android/car/carlauncher/CarLauncherViewModel.java
+@@ -210,7 +210,7 @@ public final class CarLauncherViewModel extends ViewModel implements DefaultLife
+                 // that nothing is wrong with the task view but maps
+                 // in the task view has crashed. More details in
+                 // b/247156851.
+-                mRemoteCarTaskView.getValue().setBackgroundColor(Color.RED);
++                mRemoteCarTaskView.getValue().setBackgroundColor(Color.rgb(65, 175, 106));
+             }
+         }
+     }
+-- 
+2.34.1
+

--- a/aosp_diff/aaos_iasw/packages/services/Car/0002-Fix-the-issue-of-MapsPlaceholderActivity-disappearin.patch
+++ b/aosp_diff/aaos_iasw/packages/services/Car/0002-Fix-the-issue-of-MapsPlaceholderActivity-disappearin.patch
@@ -1,0 +1,67 @@
+From c5f2df614f7307d9a960f9f3ec440acdfa2104cd Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Mon, 28 Apr 2025 11:39:34 +0800
+Subject: [PATCH] Fix the issue of MapsPlaceholderActivity disappearing
+ abnormally
+
+When pluging and unpluging USB cable, home screen will refresh
+and the focus of MapsPlaceholderActivity will be lost, the
+activity will be set to hidden state. it's can't be shown when
+the activity is resumed, so we relaunch the activity when the
+activity has already run.
+
+Tracked-ON: OAM-130875
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ .../mapsplaceholder/MapsPlaceholderActivity.java | 16 +++++++++++++++-
+ 1 file changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/car-maps-placeholder/src/com/android/car/mapsplaceholder/MapsPlaceholderActivity.java b/car-maps-placeholder/src/com/android/car/mapsplaceholder/MapsPlaceholderActivity.java
+index 9bfd9c461f..e5a6980da5 100644
+--- a/car-maps-placeholder/src/com/android/car/mapsplaceholder/MapsPlaceholderActivity.java
++++ b/car-maps-placeholder/src/com/android/car/mapsplaceholder/MapsPlaceholderActivity.java
+@@ -25,6 +25,8 @@ import android.view.View;
+ import android.view.Window;
+ import android.view.WindowInsets;
+ import android.view.WindowManager;
++import android.content.Intent;
++import android.content.IntentFilter;
+ 
+ import androidx.core.view.WindowCompat;
+ import androidx.core.view.WindowInsetsControllerCompat;
+@@ -37,7 +39,6 @@ public class MapsPlaceholderActivity extends Activity {
+     protected void onCreate(Bundle savedInstanceState) {
+         super.onCreate(savedInstanceState);
+         setContentView(R.layout.maps_placeholder_activity);
+-
+         if (getResources().getConfiguration().orientation == ORIENTATION_PORTRAIT) {
+             showTransparentStatusBar(getWindow());
+             findViewById(android.R.id.content).getRootView()
+@@ -48,6 +49,12 @@ public class MapsPlaceholderActivity extends Activity {
+                         return insets;
+                     });
+         }
++        if(isactivityActive(this)){
++            Intent intent = getIntent();
++            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
++            startActivity(intent);
++            finish();
++        }
+     }
+ 
+     /** Configures the window to render behind a transparent status bar. */
+@@ -70,4 +77,11 @@ public class MapsPlaceholderActivity extends Activity {
+         window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+         window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+     }
++
++    private boolean isactivityActive(Activity activity) {
++        if (!activity.isFinishing() && !activity.isDestroyed()) {
++            return true;
++        }
++        return false;
++    }
+ }
+-- 
+2.34.1
+


### PR DESCRIPTION
When pluging and unpluging USB cable, home screen will refresh and the focus of MapsPlaceholderActivity will be lost, the activity will be set to hidden state. it's can't be shown when the activity is resumed, so we relaunch the activity when the activity has already run.

Tracked-On: OAM-132415