### PR TITLE
Fix the issue of MapsPlaceholderActivity disappearing abnormally

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Car/Launcher/0001-Fix-the-issue-of-MapsPlaceholderActivity-disappearin.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Car/Launcher/0001-Fix-the-issue-of-MapsPlaceholderActivity-disappearin.patch
@@ -1,23 +1,46 @@
-From f6853fae52701dede431b07a51be4b39d152f5d7 Mon Sep 17 00:00:00 2001
+From c5a6638bad9dc767a25cfd81f5fc4feb3f831c2d Mon Sep 17 00:00:00 2001
 From: Xu Bing <bing.xu@intel.com>
 Date: Mon, 28 Apr 2025 12:16:48 +0800
 Subject: [PATCH] Fix the issue of MapsPlaceholderActivity disappearing
  abnormally
 
-MapsPlaceholderActivity will restart and it will be covered by
-red suface, so change the color to green.
+MapsPlaceholderActivity will be hid and it will be covered by
+red and white suface, so change the color to green.
 
-Tracked-ON: OAM-130875
+Tracked-ON: OAM-132415
 Signed-off-by: Xu Bing <bing.xu@intel.com>
 ---
+ app/src/com/android/car/carlauncher/CarLauncher.java          | 4 ++++
  app/src/com/android/car/carlauncher/CarLauncherViewModel.java | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ 2 files changed, 5 insertions(+), 1 deletion(-)
 
+diff --git a/app/src/com/android/car/carlauncher/CarLauncher.java b/app/src/com/android/car/carlauncher/CarLauncher.java
+index 368e203c..85f6a6e0 100644
+--- a/app/src/com/android/car/carlauncher/CarLauncher.java
++++ b/app/src/com/android/car/carlauncher/CarLauncher.java
+@@ -39,6 +39,7 @@ import android.view.Display;
+ import android.view.View;
+ import android.view.ViewGroup;
+ import android.view.WindowManager;
++import android.graphics.Color;
+ 
+ import androidx.collection.ArraySet;
+ import androidx.fragment.app.FragmentActivity;
+@@ -200,6 +201,9 @@ public class CarLauncher extends FragmentActivity {
+             }
+             parent.removeAllViews(); // Just a defense against a dirty parent.
+             parent.addView(taskView);
++            //reset background color.
++            mCarLauncherViewModel.getRemoteCarTaskView().getValue()
++                    .setBackgroundColor(Color.rgb(65, 175, 106));
+         });
+     }
+ 
 diff --git a/app/src/com/android/car/carlauncher/CarLauncherViewModel.java b/app/src/com/android/car/carlauncher/CarLauncherViewModel.java
-index 3b2b0813..8834c10c 100644
+index 2acbfa89..0f9a90d6 100644
 --- a/app/src/com/android/car/carlauncher/CarLauncherViewModel.java
 +++ b/app/src/com/android/car/carlauncher/CarLauncherViewModel.java
-@@ -194,7 +194,7 @@ public final class CarLauncherViewModel extends ViewModel implements DefaultLife
+@@ -210,7 +210,7 @@ public final class CarLauncherViewModel extends ViewModel implements DefaultLife
                  // that nothing is wrong with the task view but maps
                  // in the task view has crashed. More details in
                  // b/247156851.


### PR DESCRIPTION
When pluging and unpluging USB cable, home screen will refresh and the focus of MapsPlaceholderActivity will be lost, the activity will be set to hidden state. it's can't be shown when the activity is resumed, so we relaunch the activity when the activity has already run.

Tracked-On: OAM-130875