### PR TITLE
Fix too much useless log issue for DhcpClient

### DIFF
--- a/aosp_diff/preliminary/packages/modules/NetworkStack/0002-Fix-too-much-useless-log-issue-for-DhcpClient.patch
+++ b/aosp_diff/preliminary/packages/modules/NetworkStack/0002-Fix-too-much-useless-log-issue-for-DhcpClient.patch
@@ -1,0 +1,34 @@
+From 2c28118ca2b42c121e8e9633116a091c0f675ca4 Mon Sep 17 00:00:00 2001
+From: "Ye, Zhao" <zhao.ye@intel.com>
+Date: Wed, 11 Jun 2025 07:09:15 +0000
+Subject: [PATCH] Fix too much useless log issue for DhcpClient
+
+There is too much error block debuging.
+Adjust the log priority for below log:
+"DhcpClient: Can't parse packet: L2 packet too short, 273 < 278"
+
+Tests:
+no above log in daily build.
+
+Tracked-On: OAM-132946
+Signed-off-by: Ye, Zhao <zhao.ye@intel.com>
+---
+ src/android/net/dhcp/DhcpClient.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/android/net/dhcp/DhcpClient.java b/src/android/net/dhcp/DhcpClient.java
+index 7ef636470..78307246b 100644
+--- a/src/android/net/dhcp/DhcpClient.java
++++ b/src/android/net/dhcp/DhcpClient.java
+@@ -705,7 +705,7 @@ public class DhcpClient extends StateMachine {
+                 if (DBG) Log.d(TAG, "Received packet: " + packet);
+                 sendMessage(CMD_RECEIVED_PACKET, packet);
+             } catch (DhcpPacket.ParseException e) {
+-                Log.e(TAG, "Can't parse packet: " + e.getMessage());
++                if (VDBG) Log.d(TAG, "Can't parse packet: " + e.getMessage());
+                 if (PACKET_DBG) {
+                     Log.d(TAG, HexDump.dumpHexString(recvbuf, 0, length));
+                 }
+-- 
+2.34.1
+


### PR DESCRIPTION
There is too much error block debuging.
Adjust the log priority for below log:
"DhcpClient: Can't parse packet: L2 packet too short, 273 < 278"

Tests:
no above log in daily build.

Tracked-On: OAM-132946