### PR TITLE
Fix the error of sound output disorder

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Car/Settings/0001-Fix-the-error-of-sound-output-disorder.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Car/Settings/0001-Fix-the-error-of-sound-output-disorder.patch
@@ -1,0 +1,65 @@
+From 112effcca0369045f950ad8618f2501b0f0b77e7 Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Mon, 16 Jun 2025 14:19:29 +0800
+Subject: [PATCH] Fix the error of sound output disorder
+
+System will reuse the ringtone on multi-passenger mode when the ringtone
+has been used, but the sould will be closed when finishing to play,
+the sould will be played on remote and on another zone. so we always
+stop old sound and start to play new sound when adjusting the sound
+volumn.
+
+Tracked-On: OAM-133048
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ .../sound/VolumeSettingsRingtoneManager.java  | 32 +++++++++++--------
+ 1 file changed, 18 insertions(+), 14 deletions(-)
+
+diff --git a/src/com/android/car/settings/sound/VolumeSettingsRingtoneManager.java b/src/com/android/car/settings/sound/VolumeSettingsRingtoneManager.java
+index 8a6d0d0b7..e5bf0f1c6 100644
+--- a/src/com/android/car/settings/sound/VolumeSettingsRingtoneManager.java
++++ b/src/com/android/car/settings/sound/VolumeSettingsRingtoneManager.java
+@@ -113,22 +113,26 @@ public class VolumeSettingsRingtoneManager {
+ 
+     /** If we have already seen this ringtone, use it. Otherwise load when requested. */
+     private Ringtone lazyLoadRingtone(int group, int usage) {
+-        if (!mGroupToRingtoneMap.containsKey(group)) {
+-            Ringtone ringtone = RingtoneManager.getRingtone(mContext, getRingtoneUri(usage));
+-            if (ringtone == null) {
+-                return null;
+-            }
+-
+-            AudioAttributes.Builder builder = new AudioAttributes.Builder();
+-            if (AudioAttributes.isSystemUsage(usage)) {
+-                builder.setSystemUsage(usage);
+-            } else {
+-                builder.setUsage(usage);
+-            }
++        //Remove the group and recreate because mLocalPlayer is stopped on multi-zone
++        if (mGroupToRingtoneMap.containsKey(group)) {
++            stopCurrentRingtone();
++            mGroupToRingtoneMap.remove(group);
++        }
++        Ringtone ringtone = RingtoneManager.getRingtone(mContext, getRingtoneUri(usage));
++        if (ringtone == null) {
++            return null;
++        }
+ 
+-            ringtone.setAudioAttributes(builder.build());
+-            mGroupToRingtoneMap.put(group, ringtone);
++        AudioAttributes.Builder builder = new AudioAttributes.Builder();
++        if (AudioAttributes.isSystemUsage(usage)) {
++            builder.setSystemUsage(usage);
++        } else {
++            builder.setUsage(usage);
+         }
++
++        ringtone.setAudioAttributes(builder.build());
++        mGroupToRingtoneMap.put(group, ringtone);
++
+         return mGroupToRingtoneMap.get(group);
+     }
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
System will reuse the ringtone on multi-passenger mode when the ringtone has been used, but the sould will be closed when finishing to play, the sould will be played on remote and on another zone. so we always stop old sound and start to play new sound when adjusting the sound volumn.

Tracked-On: OAM-133048