### PR TITLE
Fix the wrong routing when playing feedback ringtone

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Car/Settings/0003-Fix-the-wrong-routing-when-playing-feedback-ringtone.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Car/Settings/0003-Fix-the-wrong-routing-when-playing-feedback-ringtone.patch
@@ -1,0 +1,41 @@
+From 3cd3dd9537962cf3de409a93fd7111735dbc264f Mon Sep 17 00:00:00 2001
+From: "Wan, Xinxin" <xinxin.wan@intel.com>
+Date: Mon, 16 Jun 2025 14:49:04 +0000
+Subject: [PATCH] Fix the wrong routing when playing feedback ringtone
+
+Create the MediaPlayer instance for the Ringtone object before
+calling play() to avoid incorrect logic being triggered during
+ringtone playback. If the Ringtone is not created at this point,
+calling play() will check whether to use a RemotePlayer. The
+RemotePlayer is intended for certain system apps that want to play
+ringtones within the SystemUI process by invoking the setRemote()
+interface, which delegates playback to the system server side.
+
+Tracked-On: OAM-133048
+Signed-off-by: Wan, Xinxin <xinxin.wan@intel.com>
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ .../car/settings/sound/VolumeSettingsRingtoneManager.java  | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/com/android/car/settings/sound/VolumeSettingsRingtoneManager.java b/src/com/android/car/settings/sound/VolumeSettingsRingtoneManager.java
+index 8a6d0d0b7..ee19ad18b 100644
+--- a/src/com/android/car/settings/sound/VolumeSettingsRingtoneManager.java
++++ b/src/com/android/car/settings/sound/VolumeSettingsRingtoneManager.java
+@@ -129,7 +129,12 @@ public class VolumeSettingsRingtoneManager {
+             ringtone.setAudioAttributes(builder.build());
+             mGroupToRingtoneMap.put(group, ringtone);
+         }
+-        return mGroupToRingtoneMap.get(group);
++        Ringtone ringtone = mGroupToRingtoneMap.get(group);
++        if (!ringtone.createLocalMediaPlayer()) {
++                LOG.e("Failed to open ringtone " + getRingtoneUri(usage));
++                return null;
++        }
++        return ringtone;
+     }
+ 
+     // TODO: bundle car-specific audio sample assets in res/raw by usage
+-- 
+2.34.1
+


### PR DESCRIPTION
Create the MediaPlayer instance for the Ringtone object before calling play() to avoid incorrect logic being triggered during ringtone playback. If the Ringtone is not created at this point, calling play() will check whether to use a RemotePlayer. The RemotePlayer is intended for certain system apps that want to play ringtones within the SystemUI process by invoking the setRemote() interface, which delegates playback to the system server side.

Tracked-On: OAM-133048