### PR TITLE
Use private drm_hwcomposer instead of external drm_hwcomposer.

### DIFF
--- a/aosp_diff/preliminary/external/drm_hwcomposer/0001-Use-private-drm_hwcomposer-instead-of-external-drm_h.patch
+++ b/aosp_diff/preliminary/external/drm_hwcomposer/0001-Use-private-drm_hwcomposer-instead-of-external-drm_h.patch
@@ -1,7 +1,7 @@
-From a58463c23d6191cc4d4fb7bad07cec175b8e5661 Mon Sep 17 00:00:00 2001
+From 0271f41e78da2e95e055fbba789497f2ff9da18b Mon Sep 17 00:00:00 2001
 From: svenate <salini.venate@intel.com>
 Date: Tue, 24 Dec 2024 05:30:19 +0000
-Subject: [PATCH] Use private drm_hwcomposer instead of external 
+Subject: [PATCH] Use private drm_hwcomposer instead of external
  drm_hwcomposer.
 
 Rename lib names to libxxx_orig, so that we use
@@ -10,12 +10,12 @@ drm_hwcomposer.
 
 Signed-off-by: svenate <salini.venate@intel.com>
 ---
- Android.bp       | 58 ++++++++++++++++++++++++------------------------
- tests/Android.bp | 20 ++++++++---------
- 2 files changed, 39 insertions(+), 39 deletions(-)
+ Android.bp       | 82 ++++++++++++++++++++++++------------------------
+ tests/Android.bp | 20 ++++++------
+ 2 files changed, 51 insertions(+), 51 deletions(-)
 
 diff --git a/Android.bp b/Android.bp
-index 24d4d99..38a4502 100644
+index 24d4d99..e36b355 100644
 --- a/Android.bp
 +++ b/Android.bp
 @@ -30,7 +30,7 @@ license {
@@ -151,7 +151,7 @@ index 24d4d99..38a4502 100644
      ],
  
      shared_libs: [
-@@ -217,31 +217,31 @@ cc_binary {
+@@ -217,36 +217,36 @@ cc_binary {
      relative_install_path: "hw",
      vendor: true,
  
@@ -189,6 +189,72 @@ index 24d4d99..38a4502 100644
      srcs: ["bufferinfo/legacy/BufferInfoMaliMediatek.cpp"],
  }
  
+ prebuilt_etc {
+-    name: "drm_hwcomposer_hwc3_apex_vintf",
++    name: "drm_hwcomposer_hwc3_apex_vintf_orig",
+     src: "hwc3/hwc3-drm.xml",
+     sub_dir: "vintf",
+     vendor: true,
+@@ -254,14 +254,14 @@ prebuilt_etc {
+ }
+ 
+ prebuilt_etc {
+-    name: "drm_hwcomposer_hwc3_apex_init_rc",
++    name: "drm_hwcomposer_hwc3_apex_init_rc_orig",
+     filename_from_src: true,
+     vendor: true,
+-    src: ":gen-drm_hwcomposer_hwc3_apex_init_rc",
++    src: ":gen-drm_hwcomposer_hwc3_apex_init_rc_orig",
+ }
+ 
+ genrule {
+-    name: "gen-drm_hwcomposer_hwc3_apex_init_rc",
++    name: "gen-drm_hwcomposer_hwc3_apex_init_rc_orig",
+     srcs: ["hwc3/hwc3-drm.rc"],
+     out: ["hwc3-drm.apex.rc"],
+     cmd: "sed " +
+@@ -271,33 +271,33 @@ genrule {
+ }
+ 
+ filegroup {
+-    name: "drm_hwcomposer_hwc3_apex_file_contexts",
++    name: "drm_hwcomposer_hwc3_apex_file_contexts_orig",
+     srcs: [
+         "hwc3/hwc3-apex-file-contexts",
+     ],
+ }
+ 
+ filegroup {
+-    name: "drm_hwcomposer_hwc3_apex_manifest",
++    name: "drm_hwcomposer_hwc3_apex_manifest_orig",
+     srcs: [
+         "hwc3/hwc3-apex-manifest.json",
+     ],
+ }
+ 
+ apex {
+-    name: "com.android.hardware.graphics.composer.drm_hwcomposer",
++    name: "com.android.hardware.graphics.composer.drm_hwcomposer_orig",
+     key: "com.android.hardware.key",
+     certificate: ":com.android.hardware.certificate",
+-    file_contexts: ":drm_hwcomposer_hwc3_apex_file_contexts",
+-    manifest: ":drm_hwcomposer_hwc3_apex_manifest",
++    file_contexts: ":drm_hwcomposer_hwc3_apex_file_contexts_orig",
++    manifest: ":drm_hwcomposer_hwc3_apex_manifest_orig",
+     vendor: true,
+     updatable: false,
+     soc_specific: true,
+     binaries: [
+-        "android.hardware.composer.hwc3-service.drm",
++        "android.hardware.composer.hwc3-service.drm_orig",
+     ],
+     prebuilts: [
+-        "drm_hwcomposer_hwc3_apex_init_rc",
+-        "drm_hwcomposer_hwc3_apex_vintf",
++        "drm_hwcomposer_hwc3_apex_init_rc_orig",
++        "drm_hwcomposer_hwc3_apex_vintf_orig",
+     ],
+ }
 diff --git a/tests/Android.bp b/tests/Android.bp
 index 43fd3fa..178838c 100644
 --- a/tests/Android.bp
@@ -235,5 +301,5 @@ index 43fd3fa..178838c 100644
      ],
      shared_libs: ["liblog"],
 -- 
-2.34.1
+2.25.1
 


### PR DESCRIPTION
Rename lib names to libxxx_orig, so that we use
vendor/intel/external/drm-hwcomposer instead of external drm_hwcomposer.

Tracked-On: OAM-131262