### PR TITLE
Fix connection errors when hot pluging USB camera

### DIFF
--- a/0001-Fix-the-error-of-sound-output-disorder.patch
+++ b/0001-Fix-the-error-of-sound-output-disorder.patch
@@ -1,0 +1,92 @@
+From db49e8681b4a8b952a4c92b4298964359c78ebf8 Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Mon, 16 Jun 2025 14:58:30 +0800
+Subject: [PATCH] Fix the error of sound output disorder
+
+System will reuse the ringtone on multi-passenger mode when the ringtone
+has been used, but the sould will be closed when finishing to play,
+the sould will be played on remote and on another zone. so we always
+stop old sound and start to play new sound when adjusting the sound
+volumn.
+
+Tracked-On: OAM-133048
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ ...x-the-error-of-sound-output-disorder.patch | 65 +++++++++++++++++++
+ 1 file changed, 65 insertions(+)
+ create mode 100644 aosp_diff/aaos_iasw/packages/apps/Car/Settings/0001-Fix-the-error-of-sound-output-disorder.patch
+
+diff --git a/aosp_diff/aaos_iasw/packages/apps/Car/Settings/0001-Fix-the-error-of-sound-output-disorder.patch b/aosp_diff/aaos_iasw/packages/apps/Car/Settings/0001-Fix-the-error-of-sound-output-disorder.patch
+new file mode 100644
+index 0000000..d95c5d6
+--- /dev/null
++++ b/aosp_diff/aaos_iasw/packages/apps/Car/Settings/0001-Fix-the-error-of-sound-output-disorder.patch
+@@ -0,0 +1,65 @@
++From 112effcca0369045f950ad8618f2501b0f0b77e7 Mon Sep 17 00:00:00 2001
++From: Xu Bing <bing.xu@intel.com>
++Date: Mon, 16 Jun 2025 14:19:29 +0800
++Subject: [PATCH] Fix the error of sound output disorder
++
++System will reuse the ringtone on multi-passenger mode when the ringtone
++has been used, but the sould will be closed when finishing to play,
++the sould will be played on remote and on another zone. so we always
++stop old sound and start to play new sound when adjusting the sound
++volumn.
++
++Tracked-On: OAM-133048
++Signed-off-by: Xu Bing <bing.xu@intel.com>
++---
++ .../sound/VolumeSettingsRingtoneManager.java  | 32 +++++++++++--------
++ 1 file changed, 18 insertions(+), 14 deletions(-)
++
++diff --git a/src/com/android/car/settings/sound/VolumeSettingsRingtoneManager.java b/src/com/android/car/settings/sound/VolumeSettingsRingtoneManager.java
++index 8a6d0d0b7..e5bf0f1c6 100644
++--- a/src/com/android/car/settings/sound/VolumeSettingsRingtoneManager.java
+++++ b/src/com/android/car/settings/sound/VolumeSettingsRingtoneManager.java
++@@ -113,22 +113,26 @@ public class VolumeSettingsRingtoneManager {
++ 
++     /** If we have already seen this ringtone, use it. Otherwise load when requested. */
++     private Ringtone lazyLoadRingtone(int group, int usage) {
++-        if (!mGroupToRingtoneMap.containsKey(group)) {
++-            Ringtone ringtone = RingtoneManager.getRingtone(mContext, getRingtoneUri(usage));
++-            if (ringtone == null) {
++-                return null;
++-            }
++-
++-            AudioAttributes.Builder builder = new AudioAttributes.Builder();
++-            if (AudioAttributes.isSystemUsage(usage)) {
++-                builder.setSystemUsage(usage);
++-            } else {
++-                builder.setUsage(usage);
++-            }
+++        //Remove the group and recreate because mLocalPlayer is stopped on multi-zone
+++        if (mGroupToRingtoneMap.containsKey(group)) {
+++            stopCurrentRingtone();
+++            mGroupToRingtoneMap.remove(group);
+++        }
+++        Ringtone ringtone = RingtoneManager.getRingtone(mContext, getRingtoneUri(usage));
+++        if (ringtone == null) {
+++            return null;
+++        }
++ 
++-            ringtone.setAudioAttributes(builder.build());
++-            mGroupToRingtoneMap.put(group, ringtone);
+++        AudioAttributes.Builder builder = new AudioAttributes.Builder();
+++        if (AudioAttributes.isSystemUsage(usage)) {
+++            builder.setSystemUsage(usage);
+++        } else {
+++            builder.setUsage(usage);
++         }
+++
+++        ringtone.setAudioAttributes(builder.build());
+++        mGroupToRingtoneMap.put(group, ringtone);
+++
++         return mGroupToRingtoneMap.get(group);
++     }
++ 
++-- 
++2.34.1
++
+-- 
+2.34.1
+

--- a/aosp_diff/aaos_iasw/packages/apps/Camera2/0002-Fix-connection-errors-when-hot-pluging-USB-camera.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Camera2/0002-Fix-connection-errors-when-hot-pluging-USB-camera.patch
@@ -1,0 +1,33 @@
+From f8d9f26dd3de6e954987d6830f23def17938e21e Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Thu, 19 Jun 2025 15:06:51 +0800
+Subject: [PATCH] Fix connection errors when hot pluging USB camera
+
+system will throw CAMERA_ERROR_UNKNOWN error when hot pluging USB
+camera, It's a fatal error but Camera2 app think it's a normal
+error, correct it.
+
+Tracked-On: OAM-132658
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ src/com/android/camera/CameraActivity.java | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/com/android/camera/CameraActivity.java b/src/com/android/camera/CameraActivity.java
+index 3133f57eb..759f6664b 100644
+--- a/src/com/android/camera/CameraActivity.java
++++ b/src/com/android/camera/CameraActivity.java
+@@ -1366,6 +1366,10 @@ public class CameraActivity extends QuickActivity
+                 public void onCameraError(int errorCode) {
+                     // Not a fatal error. only do Log.e().
+                     Log.e(TAG, "Camera error callback. error=" + errorCode);
++                    if (errorCode == 1) {
++                        Log.e(TAG, "Camera error unknown, throw fatal error to reset!");
++                        onFatalError();
++                    }
+                 }
+                 @Override
+                 public void onCameraException(
+-- 
+2.34.1
+


### PR DESCRIPTION
system will throw CAMERA_ERROR_UNKNOWN error when hot pluging USB camera, It's a fatal error but Camera2 app think it's a normal error, correct it.

Tracked-On: OAM-132658