### PR TITLE
rpmb_dev: socket creation for mock rpmb

### DIFF
--- a/aosp_diff/caas/system/core/0001-rpmb_dev-socket-creation-for-mock-rpmb.patch
+++ b/aosp_diff/caas/system/core/0001-rpmb_dev-socket-creation-for-mock-rpmb.patch
@@ -1,0 +1,26 @@
+From 9822ca22aaecf05ab23212c60edd8445c374a01c Mon Sep 17 00:00:00 2001
+From: Ravichandra Appegowda <ravichandra.appegowda@intel.com>
+Date: Mon, 16 Jun 2025 14:29:13 +0000
+Subject: [PATCH] rpmb_dev: socket creation for mock rpmb
+
+add socket creation for mock rpmb
+
+Tests Done:
+    1. Boot the device in ADL nuc.
+    2. storageproxyd service is running.
+---
+ trusty/utils/rpmb_dev/rpmb_dev.rc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/trusty/utils/rpmb_dev/rpmb_dev.rc b/trusty/utils/rpmb_dev/rpmb_dev.rc
+index 9e203b89c..cdbd21786 100644
+--- a/trusty/utils/rpmb_dev/rpmb_dev.rc
++++ b/trusty/utils/rpmb_dev/rpmb_dev.rc
+@@ -27,3 +27,4 @@ service rpmb_mock /vendor/bin/rpmb_dev --dev /data/vendor/ss/RPMB_DATA --sock /d
+     disabled
+     user system
+     group system
++    socket rpmb_mock stream 660 system system
+-- 
+2.34.1
+


### PR DESCRIPTION
add socket creation for mock rpmb

Tests Done:
    1. Boot the device in ADL nuc.
    2. storageproxyd service is running.

Tracked-On: OAM-133240