### PR TITLE
Fix the error that app can't be force stoppod sometimes

### DIFF
--- a/aosp_diff/aaos_iasw/packages/apps/Car/Settings/0001-Fix-the-error-that-app-can-t-be-force-stoppod-someti.patch
+++ b/aosp_diff/aaos_iasw/packages/apps/Car/Settings/0001-Fix-the-error-that-app-can-t-be-force-stoppod-someti.patch
@@ -1,0 +1,33 @@
+From 89e8da83d8df3568b0413ef5a0a646a71abc0c57 Mon Sep 17 00:00:00 2001
+From: Xu Bing <bing.xu@intel.com>
+Date: Wed, 25 Jun 2025 14:37:15 +0800
+Subject: [PATCH] Fix the error that app can't be force stoppod sometimes
+
+When we force stop one app on settings, then reopen the app, the force
+stop button is disabled in app info page, we should check the app info
+status before updating the button.
+
+Tracked-On: OAM-133131
+Signed-off-by: Xu Bing <bing.xu@intel.com>
+---
+ .../ApplicationActionButtonsPreferenceController.java         | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/com/android/car/settings/applications/ApplicationActionButtonsPreferenceController.java b/src/com/android/car/settings/applications/ApplicationActionButtonsPreferenceController.java
+index fa26d8ab1..12451fa8e 100644
+--- a/src/com/android/car/settings/applications/ApplicationActionButtonsPreferenceController.java
++++ b/src/com/android/car/settings/applications/ApplicationActionButtonsPreferenceController.java
+@@ -159,6 +159,10 @@ public class ApplicationActionButtonsPreferenceController extends
+         public void onReceive(Context context, Intent intent) {
+             boolean enabled = getResultCode() != Activity.RESULT_CANCELED;
+             LOG.d("Got broadcast response: Restart status for " + mPackageName + " " + enabled);
++            //app open again, enable force stop
++            if ((mAppEntry.info.flags & ApplicationInfo.FLAG_STOPPED) == 0) {
++                enabled = true;
++            }
+             updateForceStopButtonInner(enabled);
+         }
+     };
+-- 
+2.34.1
+


### PR DESCRIPTION
When we force stop one app on settings, then reopen the app, the force stop button is disabled in app info page, we should check the app info status before updating the button.

Tracked-On: OAM-133131